### PR TITLE
Cleanup of Transport actions

### DIFF
--- a/server/src/main/java/io/crate/blob/TransportDeleteBlob.java
+++ b/server/src/main/java/io/crate/blob/TransportDeleteBlob.java
@@ -41,7 +41,7 @@ import io.crate.blob.v2.BlobShard;
 
 public class TransportDeleteBlob extends TransportReplicationAction<DeleteBlobRequest, DeleteBlobRequest, DeleteBlobResponse> {
 
-    public static final TransportDeleteBlob.Action ACTION = new TransportDeleteBlob.Action();
+    public static final Action ACTION = new Action();
     private final BlobIndicesService blobIndicesService;
 
     public static class Action extends ActionType<DeleteBlobResponse> {

--- a/server/src/main/java/io/crate/blob/TransportPutChunk.java
+++ b/server/src/main/java/io/crate/blob/TransportPutChunk.java
@@ -38,7 +38,7 @@ import org.elasticsearch.transport.TransportService;
 
 public class TransportPutChunk extends TransportReplicationAction<PutChunkRequest, PutChunkReplicaRequest, PutChunkResponse> {
 
-    public static final TransportPutChunk.Action ACTION = new TransportPutChunk.Action();
+    public static final Action ACTION = new Action();
     private final BlobTransferTarget transferTarget;
 
     public static class Action extends ActionType<PutChunkResponse> {

--- a/server/src/main/java/io/crate/blob/TransportStartBlob.java
+++ b/server/src/main/java/io/crate/blob/TransportStartBlob.java
@@ -38,7 +38,7 @@ import org.elasticsearch.transport.TransportService;
 
 public class TransportStartBlob extends TransportReplicationAction<StartBlobRequest, StartBlobRequest, StartBlobResponse> {
 
-    public static final TransportStartBlob.Action ACTION = new TransportStartBlob.Action();
+    public static final Action ACTION = new Action();
     private final BlobTransferTarget transferTarget;
 
     public static class Action extends ActionType<StartBlobResponse> {

--- a/server/src/main/java/io/crate/execution/ddl/tables/CreateTableClient.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/CreateTableClient.java
@@ -79,7 +79,7 @@ public class CreateTableClient {
         } else {
             throw new UnsupportedOperationException("All nodes in the cluster must at least have version 5.4.0");
         }
-        return client.execute(TransportCreateTableAction.ACTION, createTableRequest).thenApply(resp -> {
+        return client.execute(TransportCreateTable.ACTION, createTableRequest).thenApply(resp -> {
             if (!resp.isAllShardsAcked() && LOGGER.isWarnEnabled()) {
                 LOGGER.warn("CREATE TABLE `{}` was not acknowledged. This could lead to inconsistent state.", relationName.fqn());
             }

--- a/server/src/main/java/io/crate/execution/ddl/tables/TransportAddColumn.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/TransportAddColumn.java
@@ -30,7 +30,6 @@ import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.inject.Singleton;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.jetbrains.annotations.VisibleForTesting;
@@ -40,10 +39,9 @@ import io.crate.metadata.FulltextAnalyzerResolver;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.doc.DocTableInfo;
 
-@Singleton
 public class TransportAddColumn extends AbstractDDLTransportAction<AddColumnRequest, AcknowledgedResponse> {
 
-    public static final TransportAddColumn.Action ACTION = new TransportAddColumn.Action();
+    public static final Action ACTION = new Action();
 
     public static class Action extends ActionType<AcknowledgedResponse> {
         private static final String NAME = "internal:crate:sql/table/add_column";
@@ -90,7 +88,6 @@ public class TransportAddColumn extends AbstractDDLTransportAction<AddColumnRequ
     public ClusterStateTaskExecutor<AddColumnRequest> clusterStateTaskExecutor(AddColumnRequest request) {
         return new AlterTableTask<>(nodeContext, request.relationName(), fulltextAnalyzerResolver, ADD_COLUMN_OPERATOR);
     }
-
 
     @Override
     public ClusterBlockException checkBlock(AddColumnRequest request, ClusterState state) {

--- a/server/src/main/java/io/crate/execution/ddl/tables/TransportAlterTable.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/TransportAlterTable.java
@@ -32,7 +32,6 @@ import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.MetadataUpdateSettingsService;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.inject.Singleton;
 import org.elasticsearch.common.settings.IndexScopedSettings;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
@@ -41,10 +40,9 @@ import io.crate.execution.ddl.AbstractDDLTransportAction;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.cluster.AlterTableClusterStateExecutor;
 
-@Singleton
 public class TransportAlterTable extends AbstractDDLTransportAction<AlterTableRequest, AcknowledgedResponse> {
 
-    public static final TransportAlterTable.Action ACTION = new TransportAlterTable.Action();
+    public static final Action ACTION = new Action();
 
     public static class Action extends ActionType<AcknowledgedResponse> {
         private static final String NAME = "internal:crate:sql/table/alter";

--- a/server/src/main/java/io/crate/execution/ddl/tables/TransportCloseTable.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/TransportCloseTable.java
@@ -91,7 +91,7 @@ import io.crate.metadata.cluster.DDLClusterStateService;
 
 public final class TransportCloseTable extends TransportMasterNodeAction<CloseTableRequest, AcknowledgedResponse> {
 
-    public static final TransportCloseTable.Action ACTION = new TransportCloseTable.Action();
+    public static final Action ACTION = new Action();
 
     public static class Action extends ActionType<AcknowledgedResponse> {
         private static final String NAME = "internal:crate:sql/table_or_partition/close";

--- a/server/src/main/java/io/crate/execution/ddl/tables/TransportCreateTable.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/TransportCreateTable.java
@@ -41,7 +41,6 @@ import org.elasticsearch.cluster.metadata.MetadataCreateIndexService;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.inject.Singleton;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.IndexScopedSettings;
 import org.elasticsearch.common.settings.Settings;
@@ -68,8 +67,7 @@ import io.crate.metadata.doc.DocTableInfoFactory;
  *
  * See also: {@link TransportCreateView}
  */
-@Singleton
-public class TransportCreateTableAction extends TransportMasterNodeAction<CreateTableRequest, CreateTableResponse> {
+public class TransportCreateTable extends TransportMasterNodeAction<CreateTableRequest, CreateTableResponse> {
 
     public static final Action ACTION = new Action();
 
@@ -87,13 +85,13 @@ public class TransportCreateTableAction extends TransportMasterNodeAction<Create
     private final DocTableInfoFactory docTableInfoFactory;
 
     @Inject
-    public TransportCreateTableAction(TransportService transportService,
-                                      ClusterService clusterService,
-                                      NodeContext nodeContext,
-                                      ThreadPool threadPool,
-                                      IndicesService indicesService,
-                                      IndexScopedSettings indexScopedSettings,
-                                      MetadataCreateIndexService createIndexService) {
+    public TransportCreateTable(TransportService transportService,
+                                ClusterService clusterService,
+                                NodeContext nodeContext,
+                                ThreadPool threadPool,
+                                IndicesService indicesService,
+                                IndexScopedSettings indexScopedSettings,
+                                MetadataCreateIndexService createIndexService) {
         super(
             ACTION.name(),
             transportService,

--- a/server/src/main/java/io/crate/execution/ddl/tables/TransportDropColumn.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/TransportDropColumn.java
@@ -29,7 +29,6 @@ import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.inject.Singleton;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.jetbrains.annotations.VisibleForTesting;
@@ -37,10 +36,9 @@ import org.jetbrains.annotations.VisibleForTesting;
 import io.crate.execution.ddl.AbstractDDLTransportAction;
 import io.crate.metadata.NodeContext;
 
-@Singleton
 public class TransportDropColumn extends AbstractDDLTransportAction<DropColumnRequest, AcknowledgedResponse> {
 
-    public static final TransportDropColumn.Action ACTION = new TransportDropColumn.Action();
+    public static final Action ACTION = new Action();
 
     public static class Action extends ActionType<AcknowledgedResponse> {
         private static final String NAME = "internal:crate:sql/table/drop_column";

--- a/server/src/main/java/io/crate/execution/ddl/tables/TransportDropConstraint.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/TransportDropConstraint.java
@@ -29,17 +29,15 @@ import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.inject.Singleton;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
 import io.crate.execution.ddl.AbstractDDLTransportAction;
 import io.crate.metadata.NodeContext;
 
-@Singleton
 public class TransportDropConstraint extends AbstractDDLTransportAction<DropConstraintRequest, AcknowledgedResponse> {
 
-    public static final TransportDropConstraint.Action ACTION = new TransportDropConstraint.Action();
+    public static final Action ACTION = new Action();
 
     public static class Action extends ActionType<AcknowledgedResponse> {
         private static final String NAME = "internal:crate:sql/table/drop_constraint";

--- a/server/src/main/java/io/crate/execution/ddl/tables/TransportOpenTable.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/TransportOpenTable.java
@@ -33,7 +33,6 @@ import org.elasticsearch.cluster.metadata.MetadataUpgradeService;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.inject.Singleton;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
@@ -43,10 +42,9 @@ import io.crate.metadata.RelationName;
 import io.crate.metadata.cluster.DDLClusterStateService;
 import io.crate.metadata.cluster.OpenTableClusterStateTaskExecutor;
 
-@Singleton
 public class TransportOpenTable extends AbstractDDLTransportAction<OpenTableRequest, AcknowledgedResponse> {
 
-    public static final TransportOpenTable.Action ACTION = new TransportOpenTable.Action();
+    public static final Action ACTION = new Action();
 
     public static class Action extends ActionType<AcknowledgedResponse> {
         private static final String NAME = "internal:crate:sql/table_or_partition/open_close";

--- a/server/src/main/java/io/crate/execution/ddl/tables/TransportRenameColumn.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/TransportRenameColumn.java
@@ -29,7 +29,6 @@ import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.inject.Singleton;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.jetbrains.annotations.VisibleForTesting;
@@ -37,10 +36,9 @@ import org.jetbrains.annotations.VisibleForTesting;
 import io.crate.execution.ddl.AbstractDDLTransportAction;
 import io.crate.metadata.NodeContext;
 
-@Singleton
 public class TransportRenameColumn extends AbstractDDLTransportAction<RenameColumnRequest, AcknowledgedResponse> {
 
-    public static final TransportRenameColumn.Action ACTION = new TransportRenameColumn.Action();
+    public static final Action ACTION = new Action();
 
     public static class Action extends ActionType<AcknowledgedResponse> {
         private static final String NAME = "internal:crate:sql/table/rename_column";

--- a/server/src/main/java/io/crate/execution/ddl/tables/TransportRenameTable.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/TransportRenameTable.java
@@ -39,7 +39,6 @@ import org.elasticsearch.cluster.routing.allocation.AllocationService;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.inject.Singleton;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
@@ -49,10 +48,9 @@ import io.crate.metadata.cluster.DDLClusterStateService;
 import io.crate.metadata.cluster.RenameTableClusterStateExecutor;
 import io.crate.metadata.view.ViewsMetadata;
 
-@Singleton
 public class TransportRenameTable extends TransportMasterNodeAction<RenameTableRequest, AcknowledgedResponse> {
 
-    public static final TransportRenameTable.Action ACTION = new TransportRenameTable.Action();
+    public static final Action ACTION = new Action();
 
     public static class Action extends ActionType<AcknowledgedResponse> {
         private static final String NAME = "internal:crate:sql/table/rename";

--- a/server/src/main/java/org/elasticsearch/action/ActionModule.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionModule.java
@@ -84,7 +84,7 @@ import io.crate.execution.ddl.tables.TransportAddColumn;
 import io.crate.execution.ddl.tables.TransportAlterTable;
 import io.crate.execution.ddl.tables.TransportCloseTable;
 import io.crate.execution.ddl.tables.TransportCreateBlobTable;
-import io.crate.execution.ddl.tables.TransportCreateTableAction;
+import io.crate.execution.ddl.tables.TransportCreateTable;
 import io.crate.execution.ddl.tables.TransportDropColumn;
 import io.crate.execution.ddl.tables.TransportDropConstraint;
 import io.crate.execution.ddl.tables.TransportDropPartitionsAction;
@@ -167,7 +167,7 @@ public class ActionModule extends AbstractModule {
         ActionRegistry actions = new ActionRegistry();
 
         // Table actions
-        actions.register(TransportCreateTableAction.ACTION, TransportCreateTableAction.class);
+        actions.register(TransportCreateTable.ACTION, TransportCreateTable.class);
         actions.register(TransportCreatePartitions.ACTION, TransportCreatePartitions.class);
         actions.register(TransportDropTable.ACTION, TransportDropTable.class);
         actions.register(TransportDropPartitionsAction.ACTION, TransportDropPartitionsAction.class);

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/create/TransportCreatePartitions.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/create/TransportCreatePartitions.java
@@ -61,7 +61,6 @@ import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.inject.Singleton;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.Index;
@@ -93,10 +92,9 @@ import io.crate.metadata.RelationName;
  *   which must be the case for partitions anyway.
  * - and alias / mappings / etc. are not taken from the request
  */
-@Singleton
 public class TransportCreatePartitions extends TransportMasterNodeAction<CreatePartitionsRequest, AcknowledgedResponse> {
 
-    public static final TransportCreatePartitions.Action ACTION = new TransportCreatePartitions.Action();
+    public static final Action ACTION = new Action();
 
     public static class Action extends ActionType<AcknowledgedResponse> {
         private static final String NAME = "indices:admin/bulk_create";

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/delete/TransportDeleteIndex.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/delete/TransportDeleteIndex.java
@@ -44,7 +44,7 @@ import org.elasticsearch.transport.TransportService;
  */
 public class TransportDeleteIndex extends TransportMasterNodeAction<DeleteIndexRequest, AcknowledgedResponse> {
 
-    public static final TransportDeleteIndex.Action ACTION = new TransportDeleteIndex.Action();
+    public static final Action ACTION = new Action();
     private final MetadataDeleteIndexService deleteIndexService;
 
     public static class Action extends ActionType<AcknowledgedResponse> {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/refresh/TransportRefresh.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/refresh/TransportRefresh.java
@@ -38,7 +38,7 @@ import org.elasticsearch.transport.TransportService;
  */
 public class TransportRefresh extends TransportBroadcastReplicationAction<RefreshRequest, RefreshResponse, BasicReplicationRequest, ReplicationResponse> {
 
-    public static final TransportRefresh.Action ACTION = new TransportRefresh.Action();
+    public static final Action ACTION = new Action();
 
     public static class Action extends ActionType<RefreshResponse> {
         private static final String NAME = "indices:admin/refresh";

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/settings/put/TransportUpdateSettings.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/settings/put/TransportUpdateSettings.java
@@ -45,7 +45,7 @@ import org.elasticsearch.transport.TransportService;
 
 public class TransportUpdateSettings extends TransportMasterNodeAction<UpdateSettingsRequest, AcknowledgedResponse> {
 
-    public static final TransportUpdateSettings.Action ACTION = new TransportUpdateSettings.Action();
+    public static final Action ACTION = new Action();
     private final MetadataUpdateSettingsService updateSettingsService;
 
     public static class Action extends ActionType<AcknowledgedResponse> {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/shrink/TransportResize.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/shrink/TransportResize.java
@@ -47,7 +47,7 @@ import io.crate.metadata.PartitionName;
  */
 public class TransportResize extends TransportMasterNodeAction<ResizeRequest, ResizeResponse> {
 
-    public static final TransportResize.Action ACTION = new TransportResize.Action();
+    public static final Action ACTION = new Action();
 
     public static class Action extends ActionType<ResizeResponse> {
         private static final String NAME = "indices:admin/resize";

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/stats/TransportIndicesStats.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/stats/TransportIndicesStats.java
@@ -47,7 +47,7 @@ import org.elasticsearch.transport.TransportService;
 
 public class TransportIndicesStats extends TransportBroadcastByNodeAction<IndicesStatsRequest, IndicesStatsResponse, ShardStats> {
 
-    public static final TransportIndicesStats.Action ACTION = new TransportIndicesStats.Action();
+    public static final Action ACTION = new Action();
     private final IndicesService indicesService;
 
     public static class Action extends ActionType<IndicesStatsResponse> {


### PR DESCRIPTION
- Remove unecessary prefix from ACTION instances.
- Remove Action suffix from TransportCreateTableAction
- Remove `@Singleton` since they are registered as singletons in the `ActionModule`.
