### PR TITLE
Add bug issues to "Support" project

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -2,6 +2,8 @@ name: 🐞 Bug Report
 description: Tell us about something that's not working the way you think it should
 labels:
   - triage
+projects:
+  - 59
 body:
   - type: input
     id: cratedb_version


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

As a replacement for #17510 we now only add the bugs to the Support project by default (and I will manually remove those that are not from customers).


