### PR TITLE
If the translog fails to sync, log the error at WARN rather than DEBUG

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/AsyncIOProcessor.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/AsyncIOProcessor.java
@@ -106,7 +106,7 @@ public abstract class AsyncIOProcessor<Item> {
             try {
                 write(candidates);
             } catch (Exception ex) { // if this fails we are in deep shit - fail the request
-                logger.debug("failed to write candidates", ex);
+                logger.warn("failed to write candidates", ex);
                 // this exception is passed to all listeners - we don't retry. if this doesn't work we are in deep shit
                 exception = ex;
             }


### PR DESCRIPTION
We've seen instances of stuck transaction logs on replicas, with little to no indication of why they are stuck.  If the translog does not sync properly due to an exception, this merits more than a DEBUG level log.