### PR TITLE
Handle empty columns in jdbc fdw to support `select count(*) ...`

### DIFF
--- a/docs/appendices/release-notes/5.10.5.rst
+++ b/docs/appendices/release-notes/5.10.5.rst
@@ -43,3 +43,7 @@ See the :ref:`version_5.10.0` release notes for a full list of changes in the
 
 Fixes
 =====
+
+- Fixed an issue that led to an ``no viable alternative at input 'SELECT FROM'``
+  error when using ``SELECT count(*) FROM remote_tbl`` where ``remote_tbl`` is a
+  foreign table using the JDBC foreign data wrapper.

--- a/server/src/main/java/io/crate/fdw/JdbcBatchIterator.java
+++ b/server/src/main/java/io/crate/fdw/JdbcBatchIterator.java
@@ -119,12 +119,15 @@ public class JdbcBatchIterator implements BatchIterator<Row> {
             .append(table.name())
             .append(qs);
 
+        String columnsStr = columns.isEmpty()
+            ? "1"
+            : String.join(", ", Lists.mapLazy(
+                columns,
+                ref -> new QuotedReference(ref, qs).toString(Style.UNQUALIFIED)));
         var stmt = String.format(
             Locale.ENGLISH,
             "SELECT %s FROM %s WHERE %s",
-            String.join(", ", Lists.mapLazy(
-                columns,
-                ref -> new QuotedReference(ref, qs).toString(Style.UNQUALIFIED))),
+            columnsStr,
             relationName.toString(),
             RefReplacer.replaceRefs(
                 query,

--- a/server/src/test/java/io/crate/integrationtests/ForeignDataWrapperITest.java
+++ b/server/src/test/java/io/crate/integrationtests/ForeignDataWrapperITest.java
@@ -153,6 +153,16 @@ public class ForeignDataWrapperITest extends IntegTestCase {
             "  └ ForeignCollect[doc.dummy | [x, y] | true] (rows=unknown)"
         );
 
+        execute("explain select count(*) from doc.dummy");
+        assertThat(response).hasLines(
+            "HashAggregate[count(*)] (rows=1)",
+            "  └ ForeignCollect[doc.dummy | [] | true] (rows=unknown)"
+        );
+        execute("select count(*) from doc.dummy");
+        assertThat(response).hasRows(
+            "3"
+        );
+
         var roles = cluster().getInstance(Roles.class);
         Role trillian = roles.getUser("trillian");
         response = sqlExecutor.executeAs("select * from doc.dummy order by x asc", trillian);


### PR DESCRIPTION
Closes https://github.com/crate/crate/issues/17759
