### PR TITLE
Fix handling of generated columns in MATCH for geo shapes

### DIFF
--- a/docs/appendices/release-notes/5.10.5.rst
+++ b/docs/appendices/release-notes/5.10.5.rst
@@ -44,6 +44,9 @@ See the :ref:`version_5.10.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an issue that prevented ``MATCH (geo_shape_column, ...)`` from matching
+  any records if ``geo_shape_column`` is a generated column.
+
 - Fixed a race condition that could lead to a memory leak if nodes within the
   cluster were temporarily not reachable.
 

--- a/server/src/main/java/io/crate/expression/predicate/MatchPredicate.java
+++ b/server/src/main/java/io/crate/expression/predicate/MatchPredicate.java
@@ -70,6 +70,7 @@ import io.crate.lucene.match.ParsedOptions;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
+import io.crate.metadata.GeneratedReference;
 import io.crate.metadata.GeoReference;
 import io.crate.metadata.Reference;
 import io.crate.metadata.Scalar;
@@ -215,6 +216,9 @@ public class MatchPredicate implements FunctionImplementation, FunctionToQuery {
         String fieldName = fields.keySet().iterator().next();
 
         Reference ref = context.getRef(fieldName);
+        while (ref instanceof GeneratedReference genRef) {
+            ref = genRef.reference();
+        }
         if (ref == null || !(ref instanceof GeoReference geoRef)) {
             return Queries.newUnmappedFieldQuery(fieldName);
         }

--- a/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
@@ -321,6 +321,12 @@ public class CommonQueryBuilderTest extends LuceneQueryBuilderTest {
     }
 
     @Test
+    public void test_prefix_tree_backed_geo_shape_match_with_default_match_type_on_generated_column() throws Exception {
+        Query query = convert("match(shape_copy, 'POLYGON ((30 10, 40 40, 20 40, 10 20, 30 10))')");
+        assertThat(query).isExactlyInstanceOf(IntersectsPrefixTreeQuery.class);
+    }
+
+    @Test
     public void test_bkd_tree_backed_geo_shape_match_with_default_match_type() {
         Query query = convert("match(bkd_shape, 'POLYGON ((30 10, 40 40, 20 40, 10 20, 30 10))')");
         assertThat(query).isExactlyInstanceOf(ConstantScoreQuery.class);

--- a/server/src/test/java/io/crate/lucene/LuceneQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/LuceneQueryBuilderTest.java
@@ -95,6 +95,7 @@ public abstract class LuceneQueryBuilderTest extends CrateDummyClusterServiceUni
                " ts_array array(timestamp with time zone)," +
                " string_array array(string)," +
                " shape geo_shape," +
+               " shape_copy geo_shape generated always as shape," +
                " bkd_shape geo_shape index using bkdtree," +
                " point geo_point," +
                " ts timestamp with time zone," +


### PR DESCRIPTION
`instanceof GeoReference` was false because the reference is wrapped in
`GeneratedReference` - leading to a `MatchNoDocsQuery`.

Closes https://github.com/crate/crate/issues/17762
