### PR TITLE
Cancel statement_timeout interrupts on result completion to release memory eagerly

### DIFF
--- a/docs/appendices/release-notes/5.10.5.rst
+++ b/docs/appendices/release-notes/5.10.5.rst
@@ -44,6 +44,11 @@ See the :ref:`version_5.10.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Improved the handling of ``statement_timeout`` to reduce memory consumption.
+  Before it would consume extra memory per executed query for the full
+  ``statement_duration`` even if the query finished early. Now the memory is
+  released once a query finishes.
+
 - Fixed an issue that prevented ``MATCH (geo_shape_column, ...)`` from matching
   any records if ``geo_shape_column`` is a generated column.
 

--- a/server/src/main/java/io/crate/session/Session.java
+++ b/server/src/main/java/io/crate/session/Session.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 
@@ -654,7 +655,8 @@ public class Session implements AutoCloseable {
             executor.client().execute(KillJobsNodeAction.INSTANCE, request);
         };
         ScheduledExecutorService scheduler = executor.scheduler();
-        scheduler.schedule(kill, remainingTimeoutMs, TimeUnit.MILLISECONDS);
+        ScheduledFuture<?> schedule = scheduler.schedule(kill, remainingTimeoutMs, TimeUnit.MILLISECONDS);
+        result.whenComplete((_, _) -> schedule.cancel(false));
     }
 
     private CompletableFuture<?> triggerDeferredExecutions() {


### PR DESCRIPTION
With long `statement_timeout` values the scheduler queue could grow and
lead to a OOM because the interrupt tasks were kept alive for the full
`statement_timeout` duration.

Now they're also removed if the query finishes execution first.
