### PR TITLE
Add statement_max_length setting; restrict sql statement length

### DIFF
--- a/docs/admin/system-information.rst
+++ b/docs/admin/system-information.rst
@@ -206,6 +206,7 @@ information about the currently applied cluster settings.
     | settings['replication']['logical']['recovery']                                    | object       |
     | settings['replication']['logical']['recovery']['chunk_size']                      | text         |
     | settings['replication']['logical']['recovery']['max_concurrent_file_chunks']      | integer      |
+    | settings['statement_max_length']                                                  | integer      |
     | settings['statement_timeout']                                                     | text         |
     | settings['stats']                                                                 | object       |
     | settings['stats']['breaker']                                                      | object       |

--- a/docs/appendices/release-notes/6.0.0.rst
+++ b/docs/appendices/release-notes/6.0.0.rst
@@ -155,6 +155,15 @@ Breaking Changes
        Because of this fix, users should re-create tables which have a
        ``BOOLEAN`` column in their ``PARTITIONED BY`` clause.
 
+- Added a :ref:`statement_max_length` setting to limit the length of allowed SQL
+  statements. It defaults to 262144. Statements exceeding this limit are rejected
+  because large statements consume a high amount of memory. Large statements are
+  typically caused by inline values or using a large number of ``VALUES``
+  clauses.
+  Instead, statements should be written using parameter symbols (``?``) and
+  inserting lots of values should be done using either bulk operations or a
+  ``INSERT INTO`` in combination with a ``SELECT FROM`` and ``UNNEST``.
+
 
 Deprecations
 ============

--- a/docs/config/node.rst
+++ b/docs/config/node.rst
@@ -120,6 +120,20 @@ General
    effect for new sessions.
 
 
+.. _statement_max_length:
+
+**statement_max_length**
+  | *Default:* ``262144``
+  | *Runtime:* ``no``
+
+  The maximum length of a SQL statement.
+
+.. WARNING::
+
+   Increasing this can lead to high memory consumption when parsing statements
+   exceeding the limit and can cause a node to crash with an ouf of memory
+   error.
+
 Networking
 ==========
 

--- a/server/src/main/java/io/crate/session/parser/SQLRequestParser.java
+++ b/server/src/main/java/io/crate/session/parser/SQLRequestParser.java
@@ -58,12 +58,6 @@ public final class SQLRequestParser {
     private SQLRequestParser() {
     }
 
-    private static void validate(SQLRequestParseContext parseContext) throws SQLParseSourceException {
-        if (parseContext.stmt() == null) {
-            throw new SQLParseSourceException("Field [stmt] was not defined");
-        }
-    }
-
     public static SQLRequestParseContext parseSource(BytesReference source) throws IOException {
         if (source.length() == 0) {
             throw new SQLParseException("Missing request body");
@@ -74,7 +68,9 @@ public final class SQLRequestParser {
             parser = XContentType.JSON.xContent().createParser(
                 NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, source.streamInput());
             parse(parseContext, parser);
-            validate(parseContext);
+            if (parseContext.stmt() == null) {
+                throw new SQLParseSourceException("Field [stmt] was not defined");
+            }
             return parseContext;
         } catch (Exception e) {
             String sSource = "_na_";
@@ -91,7 +87,7 @@ public final class SQLRequestParser {
         }
     }
 
-    public static void parse(SQLRequestParseContext parseContext, XContentParser parser) throws Exception {
+    private static void parse(SQLRequestParseContext parseContext, XContentParser parser) throws Exception {
         XContentParser.Token token;
         while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
             if (token == XContentParser.Token.FIELD_NAME) {

--- a/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -447,6 +447,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
         AnalyzerSettings.CUSTOM_ANALYSIS_SETTING_GROUP,
         Sessions.NODE_READ_ONLY_SETTING,
         Sessions.STATEMENT_TIMEOUT,
+        Sessions.STATEMENT_MAX_LENGTH,
         Sessions.MEMORY_LIMIT,
         Sessions.TEMP_ERROR_RETRY_COUNT,
         PostgresNetty.PSQL_ENABLED_SETTING,

--- a/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -24,6 +24,7 @@ package io.crate.integrationtests;
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
 import static io.crate.testing.Asserts.assertThat;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Collections;
 import java.util.List;
@@ -571,7 +572,7 @@ public class InformationSchemaTest extends IntegTestCase {
     @Test
     public void testDefaultColumns() {
         execute("select * from information_schema.columns order by table_schema, table_name");
-        assertThat(response.rowCount()).isEqualTo(1048);
+        assertThat(response.rowCount()).isEqualTo(1049);
     }
 
     @Test
@@ -830,7 +831,7 @@ public class InformationSchemaTest extends IntegTestCase {
         execute("select max(ordinal_position) from information_schema.columns");
         assertThat(response.rowCount()).isEqualTo(1);
 
-        assertThat(response.rows()[0][0]).isEqualTo(122);
+        assertThat(response.rows()[0][0]).isEqualTo(123);
 
         execute("create table t1 (id integer, col1 string)");
         execute("select max(ordinal_position) from information_schema.columns where table_schema = ?",


### PR DESCRIPTION
I'm not sure if the setting is warranted - I mostly added it to have an escape hatch.