### PR TITLE
Replace TransportService.sendChildRequest with sendRequest

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/resync/TransportResyncReplicationAction.java
+++ b/server/src/main/java/org/elasticsearch/action/resync/TransportResyncReplicationAction.java
@@ -137,7 +137,7 @@ public class TransportResyncReplicationAction extends TransportWriteAction<Resyn
                      long primaryTerm,
                      ActionListener<ReplicationResponse> listener) {
         // skip reroute phase
-        transportService.sendChildRequest(
+        transportService.sendRequest(
             clusterService.localNode(),
             transportPrimaryAction,
             new ConcreteShardRequest<>(request, primaryAllocationId, primaryTerm),

--- a/server/src/main/java/org/elasticsearch/index/seqno/RetentionLeaseBackgroundSyncAction.java
+++ b/server/src/main/java/org/elasticsearch/index/seqno/RetentionLeaseBackgroundSyncAction.java
@@ -97,7 +97,7 @@ public class RetentionLeaseBackgroundSyncAction extends TransportReplicationActi
 
     final void backgroundSync(ShardId shardId, String primaryAllocationId, long primaryTerm, RetentionLeases retentionLeases) {
         final Request request = new Request(shardId, retentionLeases);
-        transportService.sendChildRequest(
+        transportService.sendRequest(
             clusterService.localNode(),
             transportPrimaryAction,
             new ConcreteShardRequest<>(request, primaryAllocationId, primaryTerm),

--- a/server/src/main/java/org/elasticsearch/index/seqno/RetentionLeaseSyncAction.java
+++ b/server/src/main/java/org/elasticsearch/index/seqno/RetentionLeaseSyncAction.java
@@ -95,7 +95,7 @@ public class RetentionLeaseSyncAction extends
     final void sync(ShardId shardId, String primaryAllocationId, long primaryTerm, RetentionLeases retentionLeases,
                     ActionListener<ReplicationResponse> listener) {
         final Request request = new Request(shardId, retentionLeases);
-        transportService.sendChildRequest(
+        transportService.sendRequest(
             clusterService.localNode(),
             transportPrimaryAction,
             new ConcreteShardRequest<>(request, primaryAllocationId, primaryTerm),

--- a/server/src/main/java/org/elasticsearch/transport/TransportService.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportService.java
@@ -457,7 +457,8 @@ public class TransportService extends AbstractLifecycleComponent implements Tran
         connectionManager.removeListener(listener);
     }
 
-    public <T extends TransportResponse> void sendRequest(final DiscoveryNode node, final String action,
+    public <T extends TransportResponse> void sendRequest(final DiscoveryNode node,
+                                                          final String action,
                                                           final TransportRequest request,
                                                           final TransportResponseHandler<T> handler) {
         final Transport.Connection connection;
@@ -555,37 +556,6 @@ public class TransportService extends AbstractLifecycleComponent implements Tran
         } else {
             return connectionManager.getConnection(node);
         }
-    }
-
-    public final <T extends TransportResponse> void sendChildRequest(final DiscoveryNode node,
-                                                                     final String action,
-                                                                     final TransportRequest request,
-                                                                     final TransportRequestOptions options,
-                                                                     final TransportResponseHandler<T> handler) {
-        final Transport.Connection connection;
-        try {
-            connection = getConnection(node);
-        } catch (NodeNotConnectedException ex) {
-            // the caller might not handle this so we invoke the handler
-            handler.handleException(ex);
-            return;
-        }
-        sendChildRequest(connection, action, request, options, handler);
-    }
-
-    public <T extends TransportResponse> void sendChildRequest(final Transport.Connection connection,
-                                                               final String action,
-                                                               final TransportRequest request,
-                                                               final TransportResponseHandler<T> handler) {
-        sendChildRequest(connection, action, request, TransportRequestOptions.EMPTY, handler);
-    }
-
-    public <T extends TransportResponse> void sendChildRequest(final Transport.Connection connection,
-                                                               final String action,
-                                                               final TransportRequest request,
-                                                               final TransportRequestOptions options,
-                                                               final TransportResponseHandler<T> handler) {
-        sendRequest(connection, action, request, options, handler);
     }
 
     private <T extends TransportResponse> void sendRequestInternal(final Transport.Connection connection,

--- a/server/src/test/java/org/elasticsearch/transport/TransportServiceDeserializationFailureTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TransportServiceDeserializationFailureTests.java
@@ -109,7 +109,7 @@ public class TransportServiceDeserializationFailureTests extends ESTestCase {
 
         {
 
-            transportService.sendChildRequest(otherNode, testActionName, TransportRequest.Empty.INSTANCE,
+            transportService.sendRequest(otherNode, testActionName, TransportRequest.Empty.INSTANCE,
                     TransportRequestOptions.EMPTY, new TransportResponseHandler<TransportResponse.Empty>() {
                         @Override
                         public void handleResponse(TransportResponse.Empty response) {


### PR DESCRIPTION
The `sendChildRequest` methods didn't do anything special but only
forwarded calls to `sendRequest`.
