### PR TITLE
Fix issue with IP values normalization

### DIFF
--- a/docs/appendices/release-notes/6.0.0.rst
+++ b/docs/appendices/release-notes/6.0.0.rst
@@ -93,6 +93,49 @@ Breaking Changes
   a statement like ``GRANT DQL ON TABLE actually_a_view`` would succeed but not
   do anything.
 
+- Applied normalization for :ref:`IP <data-types-ip-addresses>` values so that
+  for example ``'::ffff:192.168.0.1'::IP``, becomes ``'192.168.0.1'``.
+  Previously, this normalization was already applied for all the values inserted
+  into a column of :ref:`IP <data-types-ip-addresses>`, but was not applied for
+  literal values in an SQL query, and was also **not** applied to the values
+  inserted into a column of ``IP`` data type, when this column was part of the
+  ``PRIMARY KEY`` of the table. This resulted in wrong behavior when trying to
+  filter on the table by it's ``IP`` (``PRIMARY KEY``), as the value stored
+  for the ``_id`` would have been the un-normalized one, whereas the value
+  for the table column would have been the normalized one. e.g.::
+
+    CREATE  TABLE  tbl(a IP , PRIMARY KEY(a));
+    INSERT INTO tbl(a) VALUES ('::ffff:192.168.0.1');
+    REFRESH TABLE tbl;
+    SELECT _id, a FROM tbl;
+
+  Would yield::
+
+    +--------------------+-------------+
+    | _id                | a           |
+    +--------------------+-------------+
+    | ::ffff:192.168.0.1 | 192.168.0.1 |
+    +--------------------+-------------+
+
+  So the query::
+
+    SELECT * FROM tbl WHERE a = '192.168.0.1'
+
+  would not return any results, as it will use the ``_id`` to try and match the
+  ``IP`` value in the ``WHERE`` clause. You can find more details about this
+  mechanism :ref:`here <concept-addressing-documents>`.
+
+  .. WARNING::
+
+      Because of this change, users are advised to re-create tables which have
+      an ``IP`` column as ``PRIMARY KEY`` or as part of the ``PRIMARY KEY``.
+      Since the string ``IP`` values will be automatically normalized before
+      stored as ``_id``, if for example a value: ``::ffff:192.168.0.1``
+      is already stored on the table, after upgrading to :ref:`version_6.0.0`,
+      it will be possible to re-insert the value on the table, without any
+      complaint from the ``PRIMARY KEY`` constraint check, as the value will be
+      stored, normalized, as ``192.168.0.1``.
+
 
 Deprecations
 ============

--- a/server/src/main/java/io/crate/types/IpType.java
+++ b/server/src/main/java/io/crate/types/IpType.java
@@ -35,6 +35,7 @@ import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.network.InetAddresses;
+import org.elasticsearch.common.network.NetworkAddress;
 
 import io.crate.Streamer;
 import io.crate.common.collections.Lists;
@@ -144,7 +145,8 @@ public class IpType extends DataType<String> implements Streamer<String> {
             return null;
         } else if (value instanceof String str) {
             validate(str);
-            return (String) value;
+            // Normalize the IP, so for example '::ffff:192.168.0.1' becomes '192.168.0.1'
+            return NetworkAddress.format(InetAddresses.forString((String) value));
         } else if (value instanceof Number number) {
             long longIp = number.longValue();
             if (longIp < 0) {

--- a/server/src/test/java/io/crate/types/IpTypeTest.java
+++ b/server/src/test/java/io/crate/types/IpTypeTest.java
@@ -63,4 +63,10 @@ public class IpTypeTest extends DataTypeTestCase<String> {
     public void test_reference_resolver_index_and_docvalues_off() throws Exception {
         assumeFalse("IpType cannot disable column store", true);
     }
+
+    @Test
+    public void test_cast_string_value_to_ip_normalized() {
+        assertThat(IpType.INSTANCE.implicitCast("::ffff:192.168.0.1"))
+            .hasToString("192.168.0.1");
+    }
 }


### PR DESCRIPTION
When a `String` value is stored on a table `IP` column is normalized in the `IpIndexer`, but this normalization was not applied to the value when the `IP` column is part of the `PRIMARY KEY` of the table and is encoded in the value stored as the `_id`. As a result, a value `::ffff:192.168.0.1` would be stored as is in the `_id` but would be stored as `192.168.0.1` (normalized) in the actual column of the table, and therefore `Collect` queries would yield different matching rows than `Get` queries since in one case the normalized value would be used, and in the latter the un-normalized value stored in `_id` would be used instead.

Always normalize the values in the `IpType#implicitCast()` method to resolve this issue.

Fixes: #17764

_______
*NOTE:*
This change has the following side-effect:
```
cr> select '::ffff:192.168.0.1'::ip;
+---------------+
| '192.168.0.1' |
+---------------+
| 192.168.0.1   |
+---------------+
SELECT 1 row in set (1.127 sec)
```
______
*NOTE:*
See discussion on: https://github.com/crate/crate/pull/17782