### PR TITLE
Jeeminso/char padding

### DIFF
--- a/server/src/main/java/io/crate/types/CharacterType.java
+++ b/server/src/main/java/io/crate/types/CharacterType.java
@@ -63,9 +63,9 @@ public class CharacterType extends StringType {
                     return null;
                 }
                 if (value instanceof String s) {
-                    return padEnd(s.stripTrailing(), lengthLimit, ' ');
+                    return padEnd(s.stripTrailing(), lengthLimit, Character.MIN_VALUE);
                 }
-                return padEnd(((BytesRef) value).utf8ToString().stripTrailing(), lengthLimit, ' ');
+                return padEnd(((BytesRef) value).utf8ToString().stripTrailing(), lengthLimit, Character.MIN_VALUE);
             })
         ) {
             @Override
@@ -137,7 +137,7 @@ public class CharacterType extends StringType {
         if (value.length() == lengthLimit) {
             return value;
         } else if (value.length() < lengthLimit) {
-            return padEnd(value, lengthLimit, ' ');
+            return padEnd(value, lengthLimit, Character.MIN_VALUE);
         } else {
             if (isBlank(value, lengthLimit, value.length())) {
                 return value.substring(0, lengthLimit);
@@ -155,7 +155,7 @@ public class CharacterType extends StringType {
     public String implicitCast(Object value) throws IllegalArgumentException, ClassCastException {
         var s = cast(value);
         if (s != null) {
-            return padEnd(s, lengthLimit, ' ');
+            return padEnd(s, lengthLimit, Character.MIN_VALUE);
         }
         return s;
     }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes https://github.com/crate/crate/issues/17765. 

For fixed length char fields (strings not affected), we have been right padding shorter chars with `' '`. Since `' '` is `32` in ascii, comparisons on such values like the reported scenario fail. They should be padded with `Character.MIN_VALUE`(`null` char) instead.

## Checklist

 - [ ] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
