### PR TITLE
Fix char comparisons to not stripTrailing for empty chars

### DIFF
--- a/server/src/main/java/io/crate/types/CharacterType.java
+++ b/server/src/main/java/io/crate/types/CharacterType.java
@@ -167,7 +167,7 @@ public class CharacterType extends StringType {
         }
         var string = cast(value);
         if (string.length() <= lengthLimit) {
-            return string;
+            return padEnd(string, lengthLimit, ' ');
         } else {
             return string.substring(0, lengthLimit);
         }
@@ -214,7 +214,11 @@ public class CharacterType extends StringType {
 
     @Override
     public int compare(String val1, String val2) {
-        return val1.stripTrailing().compareTo(val2.stripTrailing());
+        if (!val1.isBlank() && !val2.isBlank()) {
+            return val1.stripTrailing().compareTo(val2.stripTrailing());
+        } else {
+            return super.compare(val1, val2);
+        }
     }
 
     @Override


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes https://github.com/crate/crate/issues/17765.

## Checklist

 - [ ] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
