### PR TITLE
Apply fail_fast on non-retryable IO errors

### DIFF
--- a/docs/appendices/release-notes/5.10.5.rst
+++ b/docs/appendices/release-notes/5.10.5.rst
@@ -71,3 +71,7 @@ Fixes
     
   now returns ``TRUE`` because ``''`` is padded with ``' '`` which is ``32`` in
   ``ASCII`` and ``e'\n'`` is ``10`` in ``ASCII``.
+
+- Fixed behavior of ``COPY ... FROM ... with (fail_fast = true)`` to stop on
+  non-retryable IO errors as well. Before the flag used to be applied only for
+  write errors.

--- a/server/src/main/java/io/crate/execution/engine/collect/files/FileReadingIterator.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/files/FileReadingIterator.java
@@ -21,12 +21,14 @@
 
 package io.crate.execution.engine.collect.files;
 
+import static io.crate.analyze.CopyStatementSettings.FAIL_FAST_SETTING;
 import static io.crate.common.exceptions.Exceptions.rethrowUnchecked;
 
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.UncheckedIOException;
 import java.net.SocketException;
 import java.net.SocketTimeoutException;
 import java.net.URI;
@@ -91,6 +93,7 @@ public class FileReadingIterator implements BatchIterator<FileReadingIterator.Li
     private final int numReaders;
     private final int readerNumber;
     private final boolean compressed;
+    private final boolean failFast;
     private final List<FileInput> fileInputs;
 
     private volatile Throwable killed;
@@ -188,6 +191,7 @@ public class FileReadingIterator implements BatchIterator<FileReadingIterator.Li
         this.fileInputFactories = fileInputFactories;
         this.cursor = new LineCursor();
         this.shared = shared;
+        this.failFast = FAIL_FAST_SETTING.get(withClauseOptions);
         this.numReaders = numReaders;
         this.readerNumber = readerNumber;
         this.scheduler = scheduler;
@@ -257,6 +261,11 @@ public class FileReadingIterator implements BatchIterator<FileReadingIterator.Li
         } catch (IOException e) {
             cursor.failure = e;
             closeReader();
+            if (failFast) {
+                // Treat IO error as a data error on fail_fast and stop consuming other URI-s.
+                // Bubble up to exception to the BatchIteratorBackpressureExecutor
+                throw new UncheckedIOException(e);
+            }
             // If IOError happens on file opening, let consumers collect the error
             // This is mostly for RETURN SUMMARY of COPY FROM
             if (cursor.lineNumber == 0) {
@@ -311,7 +320,8 @@ public class FileReadingIterator implements BatchIterator<FileReadingIterator.Li
         currentReader = createBufferedReader(stream);
     }
 
-    private void closeReader() {
+    @VisibleForTesting
+    void closeReader() {
         if (currentReader != null) {
             try {
                 currentReader.close();


### PR DESCRIPTION
Closes https://github.com/crate/crate/issues/17794

First commit is a pre-requisite - we sometimes throw an IOException to control workflow and I changed that in order not to stop operation in such cases (ie throw only on legit IO errors)

Short description: on non retryable `IOException` we throw if `fail_fast` enabled. Exception bubbles up to the catch block of the `BatchIteratorBackpressureExecutor.consumeIterator` which makes it essentially the same as handling `fail_fast` on write in `earlyTerminationCondition`: we close a `BatchIterator` and complete a future. 

I added some dummy changes to check with an integration test, confirmed that it's thrown and `BatchIteratorBackpressureExecutor` sees it, then reverted and added a unit test

----

Not sure if it should be a fix or a regular 6.0 change, for now added a fix entry.