### PR TITLE
Fix issue with adding object sub-cols on insert on old table

### DIFF
--- a/server/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
+++ b/server/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
@@ -486,17 +486,7 @@ public class TransportShardUpsertAction extends TransportShardAction<ShardUpsert
         throw lastException;
     }
 
-    static class IndexItemResponse {
-        @Nullable
-        final Translog.Location translog;
-        @Nullable
-        final Object[] returnValues;
-
-        IndexItemResponse(@Nullable Translog.Location translog, @Nullable Object[] returnValues) {
-            this.translog = translog;
-            this.returnValues = returnValues;
-        }
-    }
+    public record IndexItemResponse(@Nullable Translog.Location translog, @Nullable Object[] returnValues) {}
 
     @VisibleForTesting
     protected IndexItemResponse insert(Indexer indexer,

--- a/server/src/main/java/io/crate/metadata/doc/DocTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocTableInfo.java
@@ -22,6 +22,7 @@
 package io.crate.metadata.doc;
 
 import static io.crate.expression.reference.doc.lucene.SourceParser.UNKNOWN_COLUMN_PREFIX;
+import static org.elasticsearch.cluster.metadata.Metadata.Builder.NO_OID_COLUMN_OID_SUPPLIER;
 import static org.elasticsearch.cluster.metadata.Metadata.COLUMN_OID_UNASSIGNED;
 
 import java.io.IOException;
@@ -1101,22 +1102,22 @@ public class DocTableInfo implements TableInfo, ShardedTable, StoredTable {
                 .build();
             metadataBuilder.put(template);
         }
-        if (versionCreated.onOrAfter(Version.V_6_0_0)) {
-            metadataBuilder.setTable(
-                ident,
-                allColumns,
-                tableParameters,
-                clusteredBy,
-                columnPolicy,
-                pkConstraintName,
-                checkConstraintMap,
-                primaryKeys,
-                partitionedBy,
-                closed ? State.CLOSE : State.OPEN,
-                indexUUIDs
-            );
-        }
-        return metadataBuilder;
+        return metadataBuilder.setTable(
+            versionCreated.before(DocTableInfo.COLUMN_OID_VERSION)
+                ? NO_OID_COLUMN_OID_SUPPLIER
+                : metadataBuilder.columnOidSupplier(),
+            ident,
+            allColumns,
+            tableParameters,
+            clusteredBy,
+            columnPolicy,
+            pkConstraintName,
+            checkConstraintMap,
+            primaryKeys,
+            partitionedBy,
+            closed ? State.CLOSE : State.OPEN,
+            indexUUIDs
+        );
     }
 
     private boolean addNewReferences(LongSupplier acquireOid,

--- a/server/src/test/java/io/crate/metadata/upgrade/MetadataIndexUpgraderTest.java
+++ b/server/src/test/java/io/crate/metadata/upgrade/MetadataIndexUpgraderTest.java
@@ -45,19 +45,17 @@ import io.crate.metadata.RelationName;
 
 public class MetadataIndexUpgraderTest extends ESTestCase {
 
-
-
     @Test
     public void testDynamicStringTemplateIsPurged() throws IOException {
         MetadataIndexUpgrader metadataIndexUpgrader = new MetadataIndexUpgrader();
         MappingMetadata mappingMetadata = new MappingMetadata(createDynamicStringMappingTemplate());
-        MappingMetadata newMappingMetadata = metadataIndexUpgrader.createUpdatedIndexMetadata(mappingMetadata, "dummy", null);
+        MappingMetadata newMappingMetadata = metadataIndexUpgrader.createUpdatedIndexMetadata(mappingMetadata, null);
 
         Object dynamicTemplates = newMappingMetadata.sourceAsMap().get("dynamic_templates");
         assertThat(dynamicTemplates).isNull();
 
         // Check that the new metadata still has the root "default" element
-        assertThat("{\"default\":{}}").isEqualTo(newMappingMetadata.source().toString());
+        assertThat(newMappingMetadata.source()).hasToString("{\"default\":{}}");
     }
 
     @Test
@@ -186,7 +184,7 @@ public class MetadataIndexUpgraderTest extends ESTestCase {
         Map<String, Object> indexMapping = Map.of("properties", Map.of("a", a));
         MetadataIndexUpgrader.populateColumnPositionsImpl(indexMapping,
             Map.of("properties", Map.of("a", Map.of("position", 10))));
-        assertThat(a.get("position")).isEqualTo(10);
+        assertThat(a).containsEntry("position", 10);
     }
 
     @Test
@@ -230,9 +228,9 @@ public class MetadataIndexUpgraderTest extends ESTestCase {
                             "properties", Map.of(
                                 "d", Map.of("position", 3,
                                     "properties", Map.of()))))))));
-        assertThat(map2.get("position")).isEqualTo(1);
-        assertThat(map4.get("position")).isEqualTo(2);
-        assertThat(map6.get("position")).isEqualTo(3);
+        assertThat(map2).containsEntry("position", 1);
+        assertThat(map4).containsEntry("position", 2);
+        assertThat(map6).containsEntry("position", 3);
 
 
         Map<String, Object> a = new HashMap<>();
@@ -261,10 +259,10 @@ public class MetadataIndexUpgraderTest extends ESTestCase {
                 )
             ));
 
-        assertThat(a.get("position")).isEqualTo(1);
-        assertThat(b.get("position")).isEqualTo(2);
-        assertThat(c.get("position")).isEqualTo(3);
-        assertThat(d.get("position")).isEqualTo(4);
+        assertThat(a).containsEntry("position", 1);
+        assertThat(b).containsEntry("position", 2);
+        assertThat(c).containsEntry("position", 3);
+        assertThat(d).containsEntry("position", 4);
     }
 
     @Test
@@ -283,7 +281,7 @@ public class MetadataIndexUpgraderTest extends ESTestCase {
                 "a", Map.of("position", 3),
                 "b", Map.of("position", 4))));
 
-        assertThat(a.get("position")).isEqualTo(3);
-        assertThat(b.get("position")).isEqualTo(4);
+        assertThat(a).containsExactlyEntriesOf(Map.of("position", 3));
+        assertThat(b).containsExactlyEntriesOf(Map.of("position", 4));
     }
 }


### PR DESCRIPTION
Since tables crated on < 6.0.0 are migrated to RelationMetada with: #17670,
when writing the `RelationMetadata` we need to do it regardless of the
`versionCreated` of the table, since the `RelationMetadata` is now the
source of truth for the cluster.

Previously, because of the conditional `if` check on the
`versionCreated`, on a >= 2 nodes cluster, when inserting values into a
table which will dynamically create new cols, those new cols where only
visible in `IndexMetadata`, so the node holding a replica shard of the
table and only reading `RelationMetadata` to see the cols of the table,
would never see the new col added and therefore always fail with:
https://github.com/crate/crate/blob/master/server/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java#L367
    
Fixes: #17791

___________________
2nd commit: Some minor code cleanup
3rd commit: Some minor code cleanup
