### PR TITLE
Expose indices with non-active primary shards in publications

### DIFF
--- a/docs/appendices/release-notes/5.10.6.rst
+++ b/docs/appendices/release-notes/5.10.6.rst
@@ -51,3 +51,6 @@ Fixes
 - Fixed a bug where references to a column initially created in versions of CrateDB
   before 5.5 would return ``NULL`` instead of their actual value when the column was
   addressed via ``doc['column']``
+
+- Fixed a regression introduced in 5.6.0 that caused logical replication to
+  stop if a publisher cluster was restarted.

--- a/server/src/main/java/io/crate/replication/logical/action/ShardChangesAction.java
+++ b/server/src/main/java/io/crate/replication/logical/action/ShardChangesAction.java
@@ -252,8 +252,7 @@ public class ShardChangesAction extends ActionType<ShardChangesAction.Response> 
                                                  ShardId shardId,
                                                  @Nullable ActionListener<Response> listener) {
             var routingTable = state.routingTable().index(shardId.getIndexName());
-            assert routingTable != null : "routingTable must not be null";
-            if (routingTable.allPrimaryShardsActive() == false) {
+            if (routingTable != null && routingTable.allPrimaryShardsActive() == false) {
                 // Throw or fail a listener with an appropriate exception that is listed in SQLExceptions.maybeTemporary,
                 // so that ShardReplicationChangesTracker won't stop and retry later.
                 if (listener == null) {

--- a/server/src/main/java/io/crate/replication/logical/metadata/RelationMetadata.java
+++ b/server/src/main/java/io/crate/replication/logical/metadata/RelationMetadata.java
@@ -24,7 +24,6 @@ package io.crate.replication.logical.metadata;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Predicate;
 
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
@@ -58,7 +57,7 @@ public record RelationMetadata(RelationName name,
         out.writeOptionalWriteable(template);
     }
 
-    public static RelationMetadata fromMetadata(RelationName table, Metadata metadata, Predicate<String> filter) {
+    public static RelationMetadata fromMetadata(RelationName table, Metadata metadata) {
         String indexNameOrAlias = table.indexNameOrAlias();
         var indexMetadata = metadata.index(indexNameOrAlias);
         if (indexMetadata == null) {
@@ -71,9 +70,7 @@ public record RelationMetadata(RelationName name,
             );
             ArrayList<IndexMetadata> indicesMetadata = new ArrayList<>(concreteIndices.length);
             for (String concreteIndex : concreteIndices) {
-                if (filter.test(concreteIndex)) {
-                    indicesMetadata.add(metadata.index(concreteIndex));
-                }
+                indicesMetadata.add(metadata.index(concreteIndex));
             }
             return new RelationMetadata(table, indicesMetadata, templateMetadata);
         }

--- a/server/src/test/java/io/crate/replication/logical/MetadataTrackerTest.java
+++ b/server/src/test/java/io/crate/replication/logical/MetadataTrackerTest.java
@@ -251,7 +251,7 @@ public class MetadataTrackerTest extends ESTestCase {
         testTable = new RelationName("doc", "test");
         publicationsStateResponse = new Response(Map.of(
             testTable,
-            RelationMetadata.fromMetadata(testTable, PUBLISHER_CLUSTER_STATE.metadata(), _ -> true)), List.of());
+            RelationMetadata.fromMetadata(testTable, PUBLISHER_CLUSTER_STATE.metadata())), List.of());
 
         SUBSCRIBER_CLUSTER_STATE = new Builder("subscriber")
             .addReplicatingTable("sub1", "test", Map.of("1", "one"), Settings.EMPTY)
@@ -281,7 +281,7 @@ public class MetadataTrackerTest extends ESTestCase {
         var updatedResponse = new Response(
             Map.of(
                 testTable,
-                RelationMetadata.fromMetadata(testTable, updatedPublisherClusterState.metadata(), _ -> true)
+                RelationMetadata.fromMetadata(testTable, updatedPublisherClusterState.metadata())
             ),
             List.of()
         );
@@ -311,7 +311,7 @@ public class MetadataTrackerTest extends ESTestCase {
         var updatedResponse = new Response(
             Map.of(
                 testTable,
-                RelationMetadata.fromMetadata(testTable, updatedPublisherClusterState.metadata(), _ -> true)
+                RelationMetadata.fromMetadata(testTable, updatedPublisherClusterState.metadata())
             ),
             List.of()
         );
@@ -338,7 +338,7 @@ public class MetadataTrackerTest extends ESTestCase {
         var updatedResponse = new Response(
             Map.of(
                 testTable,
-                RelationMetadata.fromMetadata(testTable, updatedPublisherClusterState.metadata(), _ -> true)
+                RelationMetadata.fromMetadata(testTable, updatedPublisherClusterState.metadata())
             ),
             List.of()
         );
@@ -364,7 +364,7 @@ public class MetadataTrackerTest extends ESTestCase {
         var updatedResponse = new Response(
             Map.of(
                 testTable,
-                RelationMetadata.fromMetadata(testTable, updatedPublisherClusterState.metadata(), _ -> true)
+                RelationMetadata.fromMetadata(testTable, updatedPublisherClusterState.metadata())
             ),
             List.of()
         );
@@ -406,7 +406,7 @@ public class MetadataTrackerTest extends ESTestCase {
         var updatedResponse = new Response(
             Map.of(
                 table,
-                RelationMetadata.fromMetadata(table, publisherState.metadata(), _ -> true)
+                RelationMetadata.fromMetadata(table, publisherState.metadata())
             ),
             List.of()
         );
@@ -433,7 +433,7 @@ public class MetadataTrackerTest extends ESTestCase {
             .addPublication("pub1", List.of(p1.indexNameOrAlias()))
             .build();
         var publisherStateResponse = new Response(
-            Map.of(p1, RelationMetadata.fromMetadata(p1, publisherState.metadata(), _ -> true)),
+            Map.of(p1, RelationMetadata.fromMetadata(p1, publisherState.metadata())),
             List.of()
         );
 
@@ -459,7 +459,7 @@ public class MetadataTrackerTest extends ESTestCase {
             .addPublication("pub1", List.of(newRelation.indexNameOrAlias()))
             .addPartitionedTable(newRelation, List.of(newPartitionName))
             .build();
-        RelationMetadata relationMetadata = RelationMetadata.fromMetadata(newRelation, publisherState.metadata(), _ -> true);
+        RelationMetadata relationMetadata = RelationMetadata.fromMetadata(newRelation, publisherState.metadata());
         var publisherStateResponse = new Response(Map.of(newRelation, relationMetadata), List.of());
 
         var restoreDiff = MetadataTracker.getRestoreDiff(
@@ -486,7 +486,7 @@ public class MetadataTrackerTest extends ESTestCase {
             .addPublication("pub1", List.of(relationName.indexNameOrAlias()))
             .addPartitionedTable(relationName, List.of(newPartitionName))
             .build();
-        RelationMetadata relationMetadata = RelationMetadata.fromMetadata(relationName, publisherState.metadata(), _ -> true);
+        RelationMetadata relationMetadata = RelationMetadata.fromMetadata(relationName, publisherState.metadata());
         var publisherStateResponse = new Response(Map.of(relationName, relationMetadata), List.of());
 
         var restoreDiff = MetadataTracker.getRestoreDiff(

--- a/server/src/test/java/io/crate/replication/logical/action/ShardChangesActionTest.java
+++ b/server/src/test/java/io/crate/replication/logical/action/ShardChangesActionTest.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.replication.logical.action;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.NoShardAvailableActionException;
+import org.elasticsearch.common.UUIDs;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.IndexService;
+import org.elasticsearch.index.shard.IndexShard;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.indices.IndicesService;
+import org.elasticsearch.test.transport.MockTransportService;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.crate.netty.NettyBootstrap;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.SQLExecutor;
+
+public class ShardChangesActionTest extends CrateDummyClusterServiceUnitTest {
+
+    private static final Index INDEX = new Index("t2", UUIDs.randomBase64UUID());
+    protected final ShardId shardId = new ShardId(INDEX, 0);
+
+    private ShardChangesAction.TransportAction transportAction;
+    private IndexShard indexShard;
+    private NettyBootstrap nettyBootstrap;
+
+    @Before
+    public void prepare() throws Exception {
+        nettyBootstrap = new NettyBootstrap(Settings.EMPTY);
+        nettyBootstrap.start();
+
+        IndicesService indicesService = mock(IndicesService.class);
+        IndexService indexService = mock(IndexService.class);
+
+        when(indicesService.indexServiceSafe(INDEX)).thenReturn(indexService);
+        indexShard = mock(IndexShard.class);
+        when(indexService.getShard(0)).thenReturn(indexShard);
+        when(indexShard.shardId()).thenReturn(shardId);
+
+        transportAction = new ShardChangesAction.TransportAction(
+            THREAD_POOL,
+            clusterService,
+            MockTransportService.createNewService(
+                Settings.EMPTY,
+                Version.CURRENT,
+                THREAD_POOL,
+                nettyBootstrap,
+                clusterService.getClusterSettings()
+            ),
+            indicesService
+        );
+
+        SQLExecutor.of(clusterService)
+            .addTable("CREATE TABLE doc.t1 (id int)")
+            .addTable("CREATE TABLE doc.t2 (id int)")
+            .startShards("doc.t1");      // <- only t1 has active primary shards;
+    }
+
+    @Test
+    public void test_sync_poll_changes_throws_retryable_error_for_index_with_non_active_primary_shards() {
+        var request = new ShardChangesAction.Request(shardId, 1, 2);
+        assertThatThrownBy(
+            () -> transportAction.shardOperation(request, shardId))
+            .isExactlyInstanceOf(NoShardAvailableActionException.class);
+    }
+
+    @Test
+    public void test_async_poll_changes_throws_retryable_error_for_index_with_non_active_primary_shards() throws Exception {
+        var request = new ShardChangesAction.Request(shardId, 1, 2);
+        ActionListener<ShardChangesAction.Response> listener = mock(ActionListener.class);
+        transportAction.asyncShardOperation(request, shardId, listener);
+        verify(listener, times(1)).onFailure(any(NoShardAvailableActionException.class));
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/crate/crate/issues/17734

Reverts https://github.com/crate/crate/commit/b6a8c5ed02730058b9eb53f7de0390b679a64dbc as it introduced a regression.

If we don't expose some indices, a subscriber cluster thinks that index is gone and stops tracking. See https://github.com/crate/crate/commit/40c12fb23d2dbace52a951e714ccc0189c795281 for details.

This change goes with an alternative way - publisher keeps exposing all relevant indices and subscriber keeps polling shard changes. However, publisher throws an error so that subscriber can keep the index and retry later.

Redundant exposure lasts only for a short time window (typically after the publisher restart) when primaries are not yet assigned.

