### PR TITLE
Fix storageIdent for pre-oid doclookup references

### DIFF
--- a/docs/appendices/release-notes/5.10.6.rst
+++ b/docs/appendices/release-notes/5.10.6.rst
@@ -48,4 +48,6 @@ See the :ref:`version_5.10.0` release notes for a full list of changes in the
 Fixes
 =====
 
-None
+- Fixed a bug where references to a column initially created in versions of CrateDB
+  before 5.5 would return ``NULL`` instead of their actual value when the column was
+  addressed via ``doc['column']``

--- a/server/src/main/java/io/crate/metadata/Reference.java
+++ b/server/src/main/java/io/crate/metadata/Reference.java
@@ -40,6 +40,7 @@ import org.jetbrains.annotations.Nullable;
 
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolType;
+import io.crate.metadata.doc.SysColumns;
 import io.crate.sql.tree.ColumnDefinition;
 import io.crate.sql.tree.Expression;
 import io.crate.types.DataType;
@@ -113,7 +114,16 @@ public interface Reference extends Symbol {
      * Return the identifier of this column used inside the storage engine
      */
     default String storageIdent() {
-        return oid() == COLUMN_OID_UNASSIGNED ? column().fqn() : Long.toString(oid());
+        long oid = oid();
+        if (oid == COLUMN_OID_UNASSIGNED) {
+            ColumnIdent column = column();
+            if (column.isRoot() == false && column.name().equals(SysColumns.Names.DOC)) {
+                column = column.shiftRight();
+            }
+            return column.fqn();
+        } else {
+            return Long.toString(oid);
+        }
     }
 
     /**

--- a/server/src/test/java/io/crate/metadata/ReferenceTest.java
+++ b/server/src/test/java/io/crate/metadata/ReferenceTest.java
@@ -22,7 +22,6 @@
 package io.crate.metadata;
 
 import static io.crate.testing.Asserts.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.elasticsearch.cluster.metadata.Metadata.COLUMN_OID_UNASSIGNED;
 
 import java.io.IOException;
@@ -35,7 +34,6 @@ import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.junit.Test;
 
-import io.crate.common.collections.Maps;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.doc.DocTableInfo;
@@ -252,15 +250,27 @@ public class ReferenceTest extends CrateDummyClusterServiceUnitTest {
         assertThat(reference.defaultExpression()).isLiteral("foo");
     }
 
-    /**
-     * Rewrites OID explicitly as long (similar to logic in DocIndexMetadata) since
-     * Jackson optimizes writes of small long values as stores them as ints.
-     */
-    @SuppressWarnings("unchecked")
-    static Map<String, Object> columnMapping(Map<String, Object> sourceAsMap, String columnName) {
-        Map<String, Object> mapping = (Map<String, Object>) Maps.getByPath(sourceAsMap, columnName);
-        long oid = ((Number) mapping.getOrDefault("oid", COLUMN_OID_UNASSIGNED)).longValue();
-        mapping.put("oid", oid);
-        return mapping;
+    @Test
+    public void test_storage_ident_without_oid() {
+        RelationName relationName = new RelationName("doc", "test");
+        ReferenceIdent referenceIdent = new ReferenceIdent(relationName, "o");
+        var dataType = new ArrayType<>(ObjectType.of(ColumnPolicy.IGNORED)
+            .setInnerType("o2", ObjectType.of(ColumnPolicy.STRICT).build())
+            .build());
+        SimpleReference reference = new SimpleReference(
+            referenceIdent,
+            RowGranularity.DOC,
+            dataType,
+            IndexType.FULLTEXT,
+            false,
+            true,
+            0,
+            COLUMN_OID_UNASSIGNED,  // important! with an oid the storageIdent is the oid itself
+            false,
+            null
+        );
+
+        var docRef = DocReferences.toDocLookup(reference);
+        assertThat(docRef.storageIdent()).isEqualTo("o");
     }
 }


### PR DESCRIPTION
The lucene field name for fields created before the introduction of OIDs
is the column name itself. For doclookup references, we need to ensure
that this column name is not prefixed with `doc.`, otherwise we get a
mismatch between the expected and actual storage names.