### PR TITLE
Don't schedule onto search threadpool in InterceptingRowConsumer

### DIFF
--- a/blackbox/test_jmx.py
+++ b/blackbox/test_jmx.py
@@ -78,7 +78,7 @@ class JmxClient:
 
     def query_jmx(self, bean, attribute):
         env = os.environ.copy()
-        env.setdefault('JAVA_HOME', '/usr/lib/jvm/java-11-openjdk')
+        env.setdefault('JAVA_HOME', '/usr/lib/jvm/java-17-openjdk')
         with Popen(
             [
                 'java',
@@ -193,8 +193,8 @@ class JmxIntegrationTest(unittest.TestCase):
         jmx_client = JmxClient(JMX_PORT)
         stdout, stderr = jmx_client.query_jmx(
             'io.crate.monitoring:type=NodeInfo', 'ClusterStateVersion')
-        self.assertGreater(int(stdout), 0)
         self.assertEqual(stderr, '')
+        self.assertGreater(int(stdout), 0)
 
     def test_number_of_open_connections(self):
         jmx_client = JmxClient(JMX_PORT)
@@ -211,10 +211,10 @@ class JmxIntegrationTest(unittest.TestCase):
         lines = [line.strip() for line in stdout.split('\n')]
         expected = [
             'active:          0',
-            'completed:       1',
-            'largestPoolSize: 1',
+            'completed:       0',
+            'largestPoolSize: 0',
             'name:            search',
-            'poolSize:        1',
+            'poolSize:        0',
             'queueSize:       0',
             'rejected:        0',
         ]

--- a/server/src/main/java/io/crate/execution/engine/JobLauncher.java
+++ b/server/src/main/java/io/crate/execution/engine/JobLauncher.java
@@ -32,7 +32,6 @@ import java.util.ListIterator;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executor;
 import java.util.stream.Collectors;
 
 import org.elasticsearch.cluster.service.ClusterService;
@@ -116,7 +115,6 @@ public class JobLauncher {
     private final TasksService tasksService;
     private final IndicesService indicesService;
     private final boolean enableProfiling;
-    private final Executor executor;
 
     private boolean hasDirectResponse;
 
@@ -128,8 +126,7 @@ public class JobLauncher {
                 ActionExecutor<NodeRequest<JobRequest>, JobResponse> transportJobAction,
                 ActionExecutor<KillJobsNodeRequest, KillResponse> killNodeAction,
                 List<NodeOperationTree> nodeOperationTrees,
-                boolean enableProfiling,
-                Executor executor) {
+                boolean enableProfiling) {
         this.jobId = jobId;
         this.clusterService = clusterService;
         this.jobSetup = jobSetup;
@@ -139,7 +136,6 @@ public class JobLauncher {
         this.killNodeAction = killNodeAction;
         this.nodeOperationTrees = nodeOperationTrees;
         this.enableProfiling = enableProfiling;
-        this.executor = executor;
 
         for (NodeOperationTree nodeOperationTree : nodeOperationTrees) {
             for (NodeOperation nodeOperation : nodeOperationTree.nodeOperations()) {
@@ -340,7 +336,6 @@ public class JobLauncher {
                 jobId,
                 consumerIt.next(),
                 initializationTracker,
-                executor,
                 killNodeAction
             );
             handlerPhaseAndReceiver.add(new HandlerPhase(handlerPhase, interceptingBatchConsumer));

--- a/server/src/main/java/io/crate/execution/engine/PhasesTaskFactory.java
+++ b/server/src/main/java/io/crate/execution/engine/PhasesTaskFactory.java
@@ -21,6 +21,15 @@
 
 package io.crate.execution.engine;
 
+import java.util.List;
+import java.util.UUID;
+
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.inject.Singleton;
+import org.elasticsearch.indices.IndicesService;
+import org.elasticsearch.node.Node;
+
 import io.crate.execution.dsl.phases.NodeOperationTree;
 import io.crate.execution.jobs.JobSetup;
 import io.crate.execution.jobs.TasksService;
@@ -33,17 +42,6 @@ import io.crate.execution.jobs.transport.JobResponse;
 import io.crate.execution.support.ActionExecutor;
 import io.crate.execution.support.NodeRequest;
 
-import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.inject.Singleton;
-import org.elasticsearch.indices.IndicesService;
-import org.elasticsearch.node.Node;
-import org.elasticsearch.threadpool.ThreadPool;
-
-import java.util.List;
-import java.util.UUID;
-import java.util.concurrent.Executor;
-
 @Singleton
 public final class PhasesTaskFactory {
 
@@ -53,11 +51,9 @@ public final class PhasesTaskFactory {
     private final IndicesService indicesService;
     private final ActionExecutor<NodeRequest<JobRequest>, JobResponse> jobAction;
     private final ActionExecutor<KillJobsNodeRequest, KillResponse> killNodeAction;
-    private final Executor searchExecutor;
 
     @Inject
     public PhasesTaskFactory(ClusterService clusterService,
-                             ThreadPool threadPool,
                              JobSetup jobSetup,
                              TasksService tasksService,
                              IndicesService indicesService,
@@ -68,7 +64,6 @@ public final class PhasesTaskFactory {
         this.indicesService = indicesService;
         this.jobAction = req -> node.client().execute(JobAction.INSTANCE, req);
         this.killNodeAction = req -> node.client().execute(KillJobsNodeAction.INSTANCE, req);
-        this.searchExecutor = threadPool.executor(ThreadPool.Names.SEARCH);
     }
 
     public JobLauncher create(UUID jobId, List<NodeOperationTree> nodeOperationTreeList) {
@@ -85,8 +80,7 @@ public final class PhasesTaskFactory {
             jobAction,
             killNodeAction,
             nodeOperationTreeList,
-            enableProfiling,
-            searchExecutor
+            enableProfiling
         );
     }
 }

--- a/server/src/main/java/io/crate/execution/engine/collect/DocValuesAggregates.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/DocValuesAggregates.java
@@ -111,7 +111,8 @@ public final class DocValuesAggregates {
             indexService.indexAnalyzers(),
             table,
             indexShard.getVersionCreated(),
-            indexService.cache()
+            indexService.cache(),
+            collectTask::raiseIfKilled
         );
 
         AtomicReference<Throwable> killed = new AtomicReference<>();

--- a/server/src/main/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIterator.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIterator.java
@@ -152,7 +152,8 @@ final class DocValuesGroupByOptimizedIterator {
             indexService.indexAnalyzers(),
             table,
             shardCreatedVersion,
-            indexService.cache()
+            indexService.cache(),
+            collectTask::raiseIfKilled
         );
 
         if (columnKeyRefs.size() == 1) {

--- a/server/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
@@ -175,7 +175,8 @@ final class GroupByOptimizedIterator {
             indexService.indexAnalyzers(),
             table,
             shardCreatedVersion,
-            indexService.cache()
+            indexService.cache(),
+            collectTask::raiseIfKilled
         );
 
         return getIterator(

--- a/server/src/main/java/io/crate/execution/engine/collect/LuceneShardCollectorProvider.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/LuceneShardCollectorProvider.java
@@ -139,7 +139,8 @@ public class LuceneShardCollectorProvider extends ShardCollectorProvider {
             indexService.indexAnalyzers(),
             table,
             shardCreatedVersion,
-            indexService.cache()
+            indexService.cache(),
+            collectTask::raiseIfKilled
         );
         InputFactory.Context<? extends LuceneCollectorExpression<?>> docCtx =
             docInputFactory.extractImplementations(collectTask.txnCtx(), collectPhase);
@@ -215,7 +216,8 @@ public class LuceneShardCollectorProvider extends ShardCollectorProvider {
             indexService.indexAnalyzers(),
             table,
             shardCreatedVersion,
-            indexService.cache()
+            indexService.cache(),
+            collectTask::raiseIfKilled
         );
         ctx = docInputFactory.extractImplementations(collectTask.txnCtx(), phase);
         collectorContext = new CollectorContext(

--- a/server/src/test/java/io/crate/execution/engine/JobLauncherWaitForCompletionTest.java
+++ b/server/src/test/java/io/crate/execution/engine/JobLauncherWaitForCompletionTest.java
@@ -21,7 +21,7 @@
 
 package io.crate.execution.engine;
 
-import static io.crate.testing.Asserts.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
@@ -61,8 +61,7 @@ public class JobLauncherWaitForCompletionTest extends CrateDummyClusterServiceUn
             null,
             null,
             List.of(),
-            false,
-            THREAD_POOL.generic()
+            false
         ) {
             @Override
             public void execute(RowConsumer consumer, TransactionContext txnCtx){

--- a/server/src/test/java/io/crate/expression/predicate/IsNullPredicateTest.java
+++ b/server/src/test/java/io/crate/expression/predicate/IsNullPredicateTest.java
@@ -69,7 +69,8 @@ public class IsNullPredicateTest extends ScalarTestCase {
                 indexEnv.indexService().indexAnalyzers(),
                 table,
                 Version.CURRENT,
-                indexEnv.queryCache()
+                indexEnv.queryCache(),
+                () -> {}
             );
             SimpleReference ref = new SimpleReference(
                 new ReferenceIdent(table.ident(), "obj"),
@@ -100,7 +101,8 @@ public class IsNullPredicateTest extends ScalarTestCase {
                 indexEnv.indexService().indexAnalyzers(),
                 table,
                 Version.CURRENT,
-                indexEnv.queryCache()
+                indexEnv.queryCache(),
+                () -> {}
             ).query();
             assertThat(query).isExactlyInstanceOf(GenericFunctionQuery.class);
             assertThat(query.toString()).isEqualTo("(_doc['obj_ignored']['x'] IS NULL)");

--- a/server/src/test/java/io/crate/integrationtests/CorrelatedSubqueryITest.java
+++ b/server/src/test/java/io/crate/integrationtests/CorrelatedSubqueryITest.java
@@ -23,6 +23,7 @@ package io.crate.integrationtests;
 
 
 import static io.crate.testing.Asserts.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.sql.DriverManager;
@@ -186,20 +187,20 @@ public class CorrelatedSubqueryITest extends IntegTestCase {
             SELECT
                 (SELECT t1.mountain)
             FROM
-                sys.summits t1
+                (select mountain from sys.summits limit 10) t1
             UNION ALL
             SELECT
                 (SELECT t2.mountain)
-            FROM sys.summits t2
+            FROM (select mountain from sys.summits limit 10) t2
             ORDER BY 1 DESC
             LIMIT 4
             """;
         execute(stmt);
         assertThat(response).hasRows(
-            "Špik",
-            "Špik",
-            "Škrlatica",
-            "Škrlatica"
+            "Zinalrothorn",
+            "Zinalrothorn",
+            "Weisshorn",
+            "Weisshorn"
         );
     }
 

--- a/server/src/testFixtures/java/io/crate/testing/QueryTester.java
+++ b/server/src/testFixtures/java/io/crate/testing/QueryTester.java
@@ -216,7 +216,8 @@ public final class QueryTester implements AutoCloseable {
                     indexEnv.indexService().indexAnalyzers(),
                     table,
                     indexVersion,
-                    indexEnv.queryCache()
+                    indexEnv.queryCache(),
+                    () -> {}
                 ).query(),
                 table,
                 indexEnv


### PR DESCRIPTION
See commits for details - first one solves unresponsiveness issue. Second is to improve `KILL` while running generic function queries.

No new release notes entry because this is a follow up to https://github.com/crate/crate/pull/17700
