### PR TITLE
Try fix flaky testRecentPrimaryInformation

### DIFF
--- a/server/src/test/java/org/elasticsearch/gateway/ReplicaShardAllocatorIT.java
+++ b/server/src/test/java/org/elasticsearch/gateway/ReplicaShardAllocatorIT.java
@@ -113,7 +113,7 @@ public class ReplicaShardAllocatorIT extends IntegTestCase {
         try {
             cluster().startDataOnlyNode();
             recoveryStarted.await();
-            nodeWithReplica = cluster().startDataOnlyNode(nodeWithReplicaSettings);
+            String newNodeWithReplica = cluster().startDataOnlyNode(nodeWithReplicaSettings);
             // AllocationService only calls GatewayAllocator if there're unassigned shards
             execute("""
                 create table doc.dummy (x int)
@@ -122,8 +122,8 @@ public class ReplicaShardAllocatorIT extends IntegTestCase {
             assertBusy(() -> {
                 execute("select health from sys.health where table_name = 'test'");
                 assertThat(response).hasRows("GREEN");
+                assertThat(cluster().nodesInclude(indexName)).contains(newNodeWithReplica);
             });
-            assertThat(cluster().nodesInclude(indexName)).contains(nodeWithReplica);
             assertNoOpRecoveries(indexName);
             blockRecovery.countDown();
         } finally {
@@ -225,8 +225,8 @@ public class ReplicaShardAllocatorIT extends IntegTestCase {
             assertBusy(() -> {
                 execute("select health from sys.health where table_name = 'test'");
                 assertThat(response).hasRows("GREEN");
+                assertThat(cluster().nodesInclude(indexName)).contains(newNode);
             });
-            assertThat(cluster().nodesInclude(indexName)).contains(newNode);
 
             execute("select recovery['files'] from sys.shards where table_name = 'test'");
             for (var row : response.rows()) {


### PR DESCRIPTION
Can't reproduce it reliably locally so not sure if it helps, but it seems like the health check alone is not enough as there might still be pending cluster state updates.

The flakyness was likely introduced with https://github.com/crate/crate/commit/e3edf3f21def26120ee9c23e533659ca32379a9c or https://github.com/crate/crate/commit/0e4f2777debbaa14ad027bfb130da793d5418a13