### PR TITLE
Downsize blocks in HashJoinBatchIterator if circuit breaker is almost at limit

### DIFF
--- a/benchmarks/src/main/java/io/crate/data/join/RowsBatchIteratorBenchmark.java
+++ b/benchmarks/src/main/java/io/crate/data/join/RowsBatchIteratorBenchmark.java
@@ -32,6 +32,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.settings.Settings;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -157,6 +158,7 @@ public class RowsBatchIteratorBenchmark {
     @Benchmark
     public void measureConsumeHashInnerJoin(Blackhole blackhole) {
         BatchIterator<Row> leftJoin = new HashJoinBatchIterator(
+            new NoopCircuitBreaker("dummy"),
             InMemoryBatchIterator.of(oneThousandRows, SENTINEL, true),
             InMemoryBatchIterator.of(tenThousandRows, SENTINEL, true),
             rowAccounting,
@@ -175,6 +177,7 @@ public class RowsBatchIteratorBenchmark {
     @Benchmark
     public void measureConsumeHashInnerJoinWithHashCollisions(Blackhole blackhole) {
         BatchIterator<Row> leftJoin = new HashJoinBatchIterator(
+            new NoopCircuitBreaker("dummy"),
             InMemoryBatchIterator.of(oneThousandRows, SENTINEL, true),
             InMemoryBatchIterator.of(tenThousandRows, SENTINEL, true),
             rowAccounting,

--- a/server/src/main/java/io/crate/execution/engine/join/NestedLoopOperation.java
+++ b/server/src/main/java/io/crate/execution/engine/join/NestedLoopOperation.java
@@ -26,9 +26,9 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Predicate;
 
 import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.jetbrains.annotations.VisibleForTesting;
 
 import io.crate.breaker.TypedCellsAccounting;
-import org.jetbrains.annotations.VisibleForTesting;
 import io.crate.concurrent.CompletionListenable;
 import io.crate.data.BatchIterator;
 import io.crate.data.CapturingRowConsumer;

--- a/server/src/test/java/io/crate/execution/engine/join/HashInnerJoinBatchIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/join/HashInnerJoinBatchIteratorTest.java
@@ -33,6 +33,7 @@ import java.util.function.Supplier;
 import java.util.function.ToIntFunction;
 
 import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -130,6 +131,7 @@ public class HashInnerJoinBatchIteratorTest {
     @Test
     public void testInnerHashJoin() throws Exception {
         Supplier<BatchIterator<Row>> batchIteratorSupplier = () -> new HashJoinBatchIterator(
+            new NoopCircuitBreaker("dummy"),
             leftIterator.get(),
             rightIterator.get(),
             mock(RowAccounting.class),
@@ -147,6 +149,7 @@ public class HashInnerJoinBatchIteratorTest {
     @Test
     public void testInnerHashJoinWithHashCollisions() throws Exception {
         Supplier<BatchIterator<Row>> batchIteratorSupplier = () -> new HashJoinBatchIterator(
+            new NoopCircuitBreaker("dummy"),
             leftIterator.get(),
             rightIterator.get(),
             mock(RowAccounting.class),
@@ -164,6 +167,7 @@ public class HashInnerJoinBatchIteratorTest {
     @Test
     public void testInnerHashJoinWithBlockSizeSmallerThanDataSet() throws Exception {
         Supplier<BatchIterator<Row>> batchIteratorSupplier = () -> new HashJoinBatchIterator(
+            new NoopCircuitBreaker("dummy"),
             leftIterator.get(),
             rightIterator.get(),
             mock(RowAccounting.class),
@@ -181,6 +185,7 @@ public class HashInnerJoinBatchIteratorTest {
     @Test
     public void testInnerHashJoinWithBlockSizeBiggerThanIteratorBatchSize() throws Exception {
         Supplier<BatchIterator<Row>> batchIteratorSupplier = () -> new HashJoinBatchIterator(
+            new NoopCircuitBreaker("dummy"),
             leftIterator.get(),
             rightIterator.get(),
             mock(RowAccounting.class),

--- a/server/src/test/java/io/crate/execution/engine/join/HashJoinBatchIteratorBehaviouralTest.java
+++ b/server/src/test/java/io/crate/execution/engine/join/HashJoinBatchIteratorBehaviouralTest.java
@@ -28,6 +28,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -63,16 +64,17 @@ public class HashJoinBatchIteratorBehaviouralTest {
             TestingBatchIterators.ofValues(Arrays.asList(2, 0, 4, 5)), 2, 1, null);
 
         BatchIterator<Row> batchIterator = new HashJoinBatchIterator(
-                leftIterator,
-                rightIterator,
-                mock(RowAccounting.class),
-                new CombinedRow(1, 1),
-                row -> Objects.equals(row.get(0), row.get(1)),
-                row -> Objects.hash(row.get(0)),
-                row -> Objects.hash(row.get(0)),
-                ignored -> 2,
-                false
-            );
+            new NoopCircuitBreaker("dummy"),
+            leftIterator,
+            rightIterator,
+            mock(RowAccounting.class),
+            new CombinedRow(1, 1),
+            row -> Objects.equals(row.get(0), row.get(1)),
+            row -> Objects.hash(row.get(0)),
+            row -> Objects.hash(row.get(0)),
+            ignored -> 2,
+            false
+        );
 
         TestingRowConsumer consumer = new TestingRowConsumer();
         consumer.accept(batchIterator, null);
@@ -94,6 +96,7 @@ public class HashJoinBatchIteratorBehaviouralTest {
             TestingBatchIterators.ofValues(Arrays.asList(2, 0, 4, 5)), 2, 1, null);
 
         BatchIterator<Row> batchIterator = new HashJoinBatchIterator(
+            new NoopCircuitBreaker("dummy"),
             leftIterator,
             rightIterator,
             mock(RowAccounting.class),
@@ -119,6 +122,7 @@ public class HashJoinBatchIteratorBehaviouralTest {
             TestingBatchIterators.ofValues(Arrays.asList(2, 0, 4, 5)), 2, 1, null);
 
         BatchIterator<Row> batchIterator = new HashJoinBatchIterator(
+            new NoopCircuitBreaker("dummy"),
             leftIterator,
             rightIterator,
             mock(RowAccounting.class),
@@ -150,6 +154,7 @@ public class HashJoinBatchIteratorBehaviouralTest {
             TestingBatchIterators.ofValues(List.of(2, 0, 4, 5)), 2, 1, null);
 
         BatchIterator<Row> batchIterator = new HashJoinBatchIterator(
+            new NoopCircuitBreaker("dummy"),
             leftIterator,
             rightIterator,
             mock(RowAccounting.class),

--- a/server/src/test/java/io/crate/execution/engine/join/HashJoinBatchIteratorMemoryTest.java
+++ b/server/src/test/java/io/crate/execution/engine/join/HashJoinBatchIteratorMemoryTest.java
@@ -31,6 +31,7 @@ import java.util.function.Predicate;
 import java.util.function.ToIntFunction;
 
 import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -73,6 +74,7 @@ public class HashJoinBatchIteratorMemoryTest {
 
         RowAccounting<Object[]> rowAccounting = mock(RowAccounting.class);
         BatchIterator<Row> it = new HashJoinBatchIterator(
+            new NoopCircuitBreaker("dummy"),
             leftIterator,
             rightIterator,
             rowAccounting,
@@ -105,6 +107,7 @@ public class HashJoinBatchIteratorMemoryTest {
 
         RowAccounting<Object[]> rowAccounting = mock(RowAccounting.class);
         BatchIterator<Row> it = new HashJoinBatchIterator(
+            new NoopCircuitBreaker("dummy"),
             leftIterator,
             rightIterator,
             rowAccounting,

--- a/server/src/test/java/io/crate/execution/engine/join/LeftOuterHashJoinBatchIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/join/LeftOuterHashJoinBatchIteratorTest.java
@@ -33,6 +33,7 @@ import java.util.function.Supplier;
 import java.util.function.ToIntFunction;
 
 import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -115,6 +116,7 @@ public class LeftOuterHashJoinBatchIteratorTest {
     @Test
     public void test_left_outer_join() throws Exception {
         Supplier<BatchIterator<Row>> batchIteratorSupplier = () -> new HashJoinBatchIterator(
+            new NoopCircuitBreaker("dummy"),
             leftIterator.get(),
             rightIterator.get(),
             mock(RowAccounting.class),
@@ -132,6 +134,7 @@ public class LeftOuterHashJoinBatchIteratorTest {
     @Test
     public void test_left_outer_join_with_blocksize_smaller_than_dataset() throws Exception {
         Supplier<BatchIterator<Row>> batchIteratorSupplier = () -> new HashJoinBatchIterator(
+            new NoopCircuitBreaker("dummy"),
             leftIterator.get(),
             rightIterator.get(),
             mock(RowAccounting.class),
@@ -149,6 +152,7 @@ public class LeftOuterHashJoinBatchIteratorTest {
     @Test
     public void test_left_outer_join_with_blocksize_bigger_than_tterator_batchsize() throws Exception {
         Supplier<BatchIterator<Row>> batchIteratorSupplier = () -> new HashJoinBatchIterator(
+            new NoopCircuitBreaker("dummy"),
             leftIterator.get(),
             rightIterator.get(),
             mock(RowAccounting.class),
@@ -166,6 +170,7 @@ public class LeftOuterHashJoinBatchIteratorTest {
     @Test
     public void test_left_outer_join_with_collisions() throws Exception {
         Supplier<BatchIterator<Row>> batchIteratorSupplier = () -> new HashJoinBatchIterator(
+            new NoopCircuitBreaker("dummy"),
             leftIterator.get(),
             rightIterator.get(),
             mock(RowAccounting.class),


### PR DESCRIPTION
The block size calculation takes available memory into consideration,
but due to concurrent operations it can run out of memory during the
block building phase.

Before this resulted in an error, now it will short-circuit the block
building and continue with a smaller block.

This should fix benchmark job failures when running

    select t1."sourceIP" from uservisits_large t1 inner join uservisits_small t2 on t1."sourceIP" = t2."sourceIP" limit 1000

With concurrency 17 from:

https://github.com/crate/crate-benchmarks/blob/master/specs/select/hash_joins.toml
