### PR TITLE
Expose indices with non-active primary shards in publications

### DIFF
--- a/docs/appendices/release-notes/5.10.6.rst
+++ b/docs/appendices/release-notes/5.10.6.rst
@@ -51,3 +51,8 @@ Fixes
 - Fixed a bug where references to a column initially created in versions of CrateDB
   before 5.5 would return ``NULL`` instead of their actual value when the column was
   addressed via ``doc['column']``
+
+- Fixed a regression introduced in 5.6.0 that caused logical replication to
+  stop if a publisher cluster was restarted, for example on upgrade. Please
+  upgrade a subscriber cluster before upgrading a publisher cluster to apply
+  the fix correctly.

--- a/server/src/main/java/io/crate/replication/logical/MetadataTracker.java
+++ b/server/src/main/java/io/crate/replication/logical/MetadataTracker.java
@@ -360,7 +360,7 @@ public final class MetadataTracker implements Closeable {
                 ? Map.of()
                 : relationMetadata.indices()
                     .stream()
-                    .collect(Collectors.toMap(x -> x.getIndex().getName(), x -> x));
+                    .collect(Collectors.toMap(x -> x.indexMetadata().getIndex().getName(), x -> x.indexMetadata()));
             var publisherIndexMetadata = publisherIndices.get(followedTable.indexNameOrAlias());
             var subscriberIndexMetadata = subscriberClusterState.metadata().index(followedTable.indexNameOrAlias());
             if (publisherIndexMetadata != null && subscriberIndexMetadata != null) {
@@ -457,7 +457,7 @@ public final class MetadataTracker implements Closeable {
         HashSet<RelationName> relationNamesForStateUpdate = new HashSet<>();
         ArrayList<TableOrPartition> toRestore = new ArrayList<>();
         Metadata subscriberMetadata = subscriberState.metadata();
-        for (var indexName : stateResponse.concreteIndices()) {
+        for (var indexName : stateResponse.restorableIndices()) {
             IndexParts indexParts = IndexName.decode(indexName);
             RelationName relationName = indexParts.toRelationName();
             if (!subscriberMetadata.hasIndex(indexName)) {
@@ -505,7 +505,10 @@ public final class MetadataTracker implements Closeable {
             List<IndexMetadata> concreteIndices = subscriberMetadata.getIndices(relationName, List.of(), false, x -> x);
             for (IndexMetadata concreteIndex : concreteIndices) {
                 String indexUUID = PUBLISHER_INDEX_UUID.get(concreteIndex.getSettings());
-                boolean publisherContainsIndex = publisherRelationMetadata.indices().stream().anyMatch(x -> x.getIndexUUID().equals(indexUUID));
+                boolean publisherContainsIndex = publisherRelationMetadata
+                    .indices()
+                    .stream()
+                    .anyMatch(x -> x.indexMetadata().getIndexUUID().equals(indexUUID));
                 if (!publisherContainsIndex) {
                     partitionsToRemove.add(concreteIndex.getIndex());
                 }

--- a/server/src/main/java/io/crate/replication/logical/action/PublicationsStateAction.java
+++ b/server/src/main/java/io/crate/replication/logical/action/PublicationsStateAction.java
@@ -221,7 +221,15 @@ public class PublicationsStateAction extends ActionType<PublicationsStateAction.
         public List<String> concreteIndices() {
             return relationsInPublications.values().stream()
                 .flatMap(x -> x.indices().stream())
-                .map(x -> x.getIndex().getName())
+                .map(x -> x.indexMetadata().getIndex().getName())
+                .toList();
+        }
+
+        public List<String> restorableIndices() {
+            return relationsInPublications.values().stream()
+                .flatMap(x -> x.indices().stream())
+                .filter(replicatedIndex -> replicatedIndex.allPrimaryShardsActive())
+                .map(x -> x.indexMetadata().getIndex().getName())
                 .toList();
         }
 

--- a/server/src/main/java/io/crate/replication/logical/action/TransportCreateSubscription.java
+++ b/server/src/main/java/io/crate/replication/logical/action/TransportCreateSubscription.java
@@ -136,7 +136,7 @@ public class TransportCreateSubscription extends TransportMasterNodeAction<Creat
                         }
                         if (!relationMetadata.indices().isEmpty()) {
                             // All indices belong to the same table and has same metadata.
-                            IndexMetadata indexMetadata = relationMetadata.indices().get(0);
+                            IndexMetadata indexMetadata = relationMetadata.indices().get(0).indexMetadata();
                             checkVersionCompatibility(
                                 relationMetadata.name().fqn(),
                                 state.nodes().getMinNodeVersion(),

--- a/server/src/main/java/io/crate/replication/logical/metadata/Publication.java
+++ b/server/src/main/java/io/crate/replication/logical/metadata/Publication.java
@@ -161,7 +161,6 @@ public class Publication implements Writeable {
         }
 
         return relations.stream()
-            .filter(relationName -> indexFilter.test(relationName.indexNameOrAlias()))
             .filter(relationName -> userCanPublish(roles, relationName, publicationOwner, publicationName))
             .filter(relationName -> subscriberCanRead(roles, relationName, subscriber, publicationName))
             .map(relationName -> RelationMetadata.fromMetadata(relationName, state.metadata(), indexFilter))

--- a/server/src/test/java/io/crate/replication/logical/action/TransportCreateSubscriptionTest.java
+++ b/server/src/test/java/io/crate/replication/logical/action/TransportCreateSubscriptionTest.java
@@ -113,15 +113,18 @@ public class TransportCreateSubscriptionTest {
         RelationMetadata relationMetadata = new RelationMetadata(
             relationName,
             List.of(
-                IndexMetadata.builder("t1")
-                .settings(
-                    // Not necessary to set a valid version, only fact that version is higher than CURRENT is important for this test.
-                    Settings.builder()
-                        .put(IndexMetadata.SETTING_VERSION_CREATED, internalVersionId)
-                        .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 2) // must be supplied
-                        .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0) // must be supplied
+                new RelationMetadata.ReplicatedIndex(
+                    IndexMetadata.builder("t1")
+                    .settings(
+                        // Not necessary to set a valid version, only fact that version is higher than CURRENT is important for this test.
+                        Settings.builder()
+                            .put(IndexMetadata.SETTING_VERSION_CREATED, internalVersionId)
+                            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 2) // must be supplied
+                            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0) // must be supplied
+                    )
+                    .build(),
+                    true
                 )
-                .build()
             ),
             null
         );

--- a/server/src/test/java/io/crate/replication/logical/metadata/RelationMetadataTest.java
+++ b/server/src/test/java/io/crate/replication/logical/metadata/RelationMetadataTest.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.replication.logical.metadata;
+
+import static io.crate.testing.Asserts.assertThat;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.junit.Test;
+
+import io.crate.metadata.RelationName;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.SQLExecutor;
+
+public class RelationMetadataTest extends CrateDummyClusterServiceUnitTest {
+
+    @Test
+    public void test_streaming_current_version() throws Exception {
+        RelationName relationName = new RelationName("doc", "t1");
+        SQLExecutor.of(clusterService)
+            .addTable("CREATE TABLE doc.t1 (id int)");
+
+        boolean allPrimaryShardsActive = false;
+        // Verify that a new version writes and reads false flag
+        var relationMetadata =
+            RelationMetadata.fromMetadata(relationName, clusterService.state().metadata(), _ -> allPrimaryShardsActive);
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        relationMetadata.writeTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        var fromStream = new RelationMetadata(in);
+
+        assertThat(relationMetadata).isEqualTo(fromStream);
+    }
+
+    @Test
+    public void test_bwc_streaming() throws Exception {
+        RelationName relationName = new RelationName("doc", "t1");
+        SQLExecutor.of(clusterService)
+            .addTable("CREATE TABLE doc.t1 (id int)");
+
+        boolean allPrimaryShardsActive = false;
+        var relationMetadata =
+            RelationMetadata.fromMetadata(relationName, clusterService.state().metadata(), _ -> allPrimaryShardsActive);
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        out.setVersion(Version.V_5_10_5);
+        relationMetadata.writeTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        in.setVersion(Version.V_5_10_5);
+        var fromStream = new RelationMetadata(in);
+
+        assertThat(relationMetadata.name()).isEqualTo(fromStream.name());
+        for (int i = 0; i < relationMetadata.indices().size(); i++) {
+            assertThat(relationMetadata.indices().get(i).indexMetadata())
+                .isEqualTo(fromStream.indices().get(i).indexMetadata());
+
+            assertThat(relationMetadata.indices().get(i).allPrimaryShardsActive()).isFalse();
+            assertThat(fromStream.indices().get(i).allPrimaryShardsActive()).isTrue();
+        }
+    }
+
+
+}


### PR DESCRIPTION
Fixes https://github.com/crate/crate/issues/17734. 

Supersedes https://github.com/crate/crate/pull/17818

Follow up to https://github.com/crate/crate/commit/b6a8c5ed02730058b9eb53f7de0390b679a64dbc

If we don't expose some indices, a subscriber cluster treats them as dropped and stops tracking them.

After publisher restart, some indices might have non-active primaries, but we still expose them in order to keep replicating tables.

However, subscriber still shouldn't restore "not yet ready" indices, so we enrich `RelationMetadata` with an `allPrimaryShardsActive` flag to skip restoring of such indices

