### PR TITLE
Tweak error message if function is missing or is missing overload

### DIFF
--- a/extensions/functions/src/test/java/io/crate/window/NthValueFunctionsTest.java
+++ b/extensions/functions/src/test/java/io/crate/window/NthValueFunctionsTest.java
@@ -160,8 +160,7 @@ public class NthValueFunctionsTest extends AbstractWindowFunctionTest {
                                  new Object[] {3, 2},
                                  new Object[] {2, 3}))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessage("Unknown function: first_value(doc.t1.x, NULL), no overload found for matching argument types: " +
-                        "(integer, undefined). Possible candidates: first_value(E):E");
+            .hasMessage("Invalid arguments in: first_value(doc.t1.x, NULL) with (integer, undefined). Valid types: (E)");
     }
 
     @Test
@@ -175,8 +174,7 @@ public class NthValueFunctionsTest extends AbstractWindowFunctionTest {
                                  new Object[] {3, 2},
                                  new Object[] {2, 3}))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessage("Unknown function: last_value(doc.t1.x, NULL), no overload found for matching argument types: " +
-                        "(integer, undefined). Possible candidates: last_value(E):E");
+            .hasMessage("Invalid arguments in: last_value(doc.t1.x, NULL) with (integer, undefined). Valid types: (E)");
     }
 
     @Test

--- a/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
@@ -1724,7 +1724,7 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
     public void test_generated_column_arguments_are_detected_as_array_and_validation_fails_with_missing_overload() throws Exception {
         assertThatThrownBy(() -> analyze("CREATE TABLE tbl (xs int[], x as max(xs))"))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessageStartingWith("Unknown function: max(doc.tbl.xs), no overload found for matching argument types: (integer_array)");
+            .hasMessageStartingWith("Invalid arguments in: max(doc.tbl.xs) with (integer_array). Valid types: ");
     }
 
     @Test

--- a/server/src/test/java/io/crate/analyze/DeleteAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/DeleteAnalyzerTest.java
@@ -107,8 +107,7 @@ public class DeleteAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     public void testWhereClauseObjectArrayField() throws Exception {
         assertThatThrownBy(() -> e.analyze("delete from users where friends['id'] = 5"))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessageStartingWith("Unknown function: (doc.users.friends['id'] = 5)," +
-                                    " no overload found for matching argument types: (bigint_array, integer).");
+            .hasMessage("Invalid arguments in: (doc.users.friends['id'] = 5) with (bigint_array, integer). Valid types: (E, E)");
     }
 
     @Test

--- a/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -33,6 +33,7 @@ import static io.crate.testing.Asserts.isReference;
 import static io.crate.testing.Asserts.toCondition;
 import static io.crate.types.ArrayType.makeArray;
 import static org.assertj.core.api.Assertions.anyOf;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
@@ -770,8 +771,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
 
         assertThatThrownBy(() -> executor.analyze("select id, name from parted where not date"))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessageStartingWith("Unknown function: (NOT doc.parted.date), " +
-                                    "no overload found for matching argument types: (timestamp with time zone).");
+            .hasMessage("Invalid arguments in: (NOT doc.parted.date) with (timestamp with time zone). Valid types: (boolean)");
     }
 
     @Test
@@ -949,8 +949,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
             .addTable(TableDefinitions.USER_TABLE_DEFINITION);
         assertThatThrownBy(() -> executor.analyze("select * from users where 'George' = ANY (name)"))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessageStartingWith("Unknown function: ('George' = ANY(doc.users.name)), " +
-                                    "no overload found for matching argument types: (text, text).");
+            .hasMessage("Invalid arguments in: ('George' = ANY(doc.users.name)) with (text, text). Valid types: (E, array(E))");
     }
 
     @Test
@@ -1003,8 +1002,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         // ergo simple comparison does not work here
         assertThatThrownBy(() -> executor.analyze("select * from users where 5 = friends['id']"))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessageStartingWith("Unknown function: (doc.users.friends['id'] = 5), " +
-                                    "no overload found for matching argument types: (bigint_array, integer).");
+            .hasMessage("Invalid arguments in: (doc.users.friends['id'] = 5) with (bigint_array, integer). Valid types: (E, E)");
     }
 
     @Test
@@ -1186,8 +1184,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
             .addTable(TableDefinitions.USER_TABLE_DEFINITION);
         assertThatThrownBy(() -> executor.analyze("select * from users where 'awesome' LIKE ANY (name)"))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessageStartingWith("Unknown function: ('awesome' LIKE ANY(doc.users.name)), " +
-                                    "no overload found for matching argument types: (text, text).");
+            .hasMessage("Invalid arguments in: ('awesome' LIKE ANY(doc.users.name)) with (text, text). Valid types: (text, array(text))");
     }
 
     @Test
@@ -2047,8 +2044,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         var executor = SQLExecutor.of(clusterService);
         assertThatThrownBy(() -> executor.analyze("select * from unnest(1, 'foo')"))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessageStartingWith("Unknown function: unnest(1, 'foo'), " +
-                                    "no overload found for matching argument types: (integer, text).");
+            .hasMessage("Invalid arguments in: unnest(1, 'foo') with (integer, text). Valid types: (array(N)), ()");
     }
 
     @Test

--- a/server/src/test/java/io/crate/analyze/UpdateAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/UpdateAnalyzerTest.java
@@ -384,8 +384,7 @@ public class UpdateAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     public void testWhereClauseObjectArrayField() throws Exception {
         assertThatThrownBy(() -> analyze("update users set awesome=true where friends['id'] = 5"))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessageStartingWith("Unknown function: (doc.users.friends['id'] = 5), " +
-                                    "no overload found for matching argument types: (bigint_array, integer).");
+            .hasMessage("Invalid arguments in: (doc.users.friends['id'] = 5) with (bigint_array, integer). Valid types: (E, E)");
     }
 
     @Test

--- a/server/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
@@ -26,6 +26,7 @@ import static io.crate.testing.Asserts.exactlyInstanceOf;
 import static io.crate.testing.Asserts.isFunction;
 import static io.crate.testing.Asserts.isLiteral;
 import static io.crate.testing.Asserts.isReference;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
@@ -329,8 +330,7 @@ public class ExpressionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     public void testAnyWithArrayOnBothSidesResultsInNiceErrorMessage() {
         assertThatThrownBy(() -> executor.analyze("select * from tarr where xs = ANY([10, 20])"))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessageStartingWith("Unknown function: (doc.tarr.xs = ANY([10, 20]))," +
-                        " no overload found for matching argument types: (integer_array, integer_array).");
+            .hasMessage("Invalid arguments in: (doc.tarr.xs = ANY([10, 20])) with (integer_array, integer_array). Valid types: (E, array(E))");
     }
 
     @Test

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/AverageAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/AverageAggregationTest.java
@@ -181,7 +181,7 @@ public class AverageAggregationTest extends AggregationTestCase {
     public void testUnsupportedType() throws Exception {
         assertThatThrownBy(() -> executeAvgAgg(DataTypes.GEO_POINT, new Object[][]{}))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessageStartingWith("Unknown function: avg(INPUT(0)), no overload found for matching argument types: (geo_point).");
+            .hasMessageStartingWith("Invalid arguments in: avg(INPUT(0)) with (geo_point). Valid types: ");
     }
 
     @Test

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/GeometricMeanAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/GeometricMeanAggregationTest.java
@@ -21,7 +21,7 @@
 
 package io.crate.execution.engine.aggregation.impl;
 
-import static io.crate.testing.Asserts.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
@@ -123,7 +123,6 @@ public class GeometricMeanAggregationTest extends AggregationTestCase {
     public void testUnsupportedType() throws Exception {
         assertThatThrownBy(() -> executeAggregation(DataTypes.BOOLEAN, new Object[][]{}))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessageStartingWith("Unknown function: geometric_mean(INPUT(0))," +
-                                     " no overload found for matching argument types: (boolean).");
+            .hasMessageStartingWith("Invalid arguments in: geometric_mean(INPUT(0)) with (boolean). Valid types: ");
     }
 }

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/MaximumAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/MaximumAggregationTest.java
@@ -159,6 +159,6 @@ public class MaximumAggregationTest extends AggregationTestCase {
     public void testUnsupportedType() throws Exception {
         assertThatThrownBy(() -> executeAggregation(DataTypes.UNTYPED_OBJECT, new Object[][]{{new Object()}}))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessageStartingWith("Unknown function: max(INPUT(0)), no overload found for matching argument types: (object).");
+            .hasMessageStartingWith("Invalid arguments in: max(INPUT(0)) with (object). Valid types: ");
     }
 }

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/MinimumAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/MinimumAggregationTest.java
@@ -133,6 +133,6 @@ public class MinimumAggregationTest extends AggregationTestCase {
     public void testUnsupportedType() throws Exception {
         assertThatThrownBy(() -> executeAggregation(DataTypes.UNTYPED_OBJECT, new Object[][]{{new Object()}}))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessageStartingWith("Unknown function: min(INPUT(0)), no overload found for matching argument types: (object).");
+            .hasMessageStartingWith("Invalid arguments in: min(INPUT(0)) with (object). Valid types: ");
     }
 }

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/PercentileAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/PercentileAggregationTest.java
@@ -190,8 +190,7 @@ public class PercentileAggregationTest extends AggregationTestCase {
     public void testUnsupportedType() throws Exception {
         assertThatThrownBy(() -> execSingleFractionPercentile(DataTypes.GEO_POINT, new Object[][]{}))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessageStartingWith("Unknown function: percentile(INPUT(0), INPUT(0)), " +
-                                    "no overload found for matching argument types: (geo_point, double precision).");
+            .hasMessageStartingWith("Invalid arguments in: percentile(INPUT(0), INPUT(0)) with (geo_point, double precision). Valid types: ");
     }
 
     @Test

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/StdDevAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/StdDevAggregationTest.java
@@ -29,7 +29,6 @@ import java.util.stream.Stream;
 
 import org.junit.Test;
 
-import io.crate.execution.engine.aggregation.impl.StandardDeviationAggregation;
 import io.crate.exceptions.UnsupportedFunctionException;
 import io.crate.expression.symbol.Literal;
 import io.crate.metadata.FunctionImplementation;
@@ -124,7 +123,6 @@ public class StdDevAggregationTest extends AggregationTestCase {
     public void testUnsupportedType() {
         assertThatThrownBy(() -> executeAggregation(DataTypes.GEO_POINT, new Object[][]{}))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessageStartingWith("Unknown function: stddev_pop(INPUT(0))," +
-                " no overload found for matching argument types: (geo_point).");
+            .hasMessageStartingWith("Invalid arguments in: stddev_pop(INPUT(0)) with (geo_point). Valid types: ");
     }
 }

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/SumAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/SumAggregationTest.java
@@ -203,8 +203,7 @@ public class SumAggregationTest extends AggregationTestCase {
         assertThatThrownBy(() -> getSum(DataTypes.GEO_POINT))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
             .hasMessageStartingWith(
-                "Unknown function: sum(NULL)," +
-                " no overload found for matching argument types: (geo_point).");
+                "Invalid arguments in: sum(NULL) with (geo_point). Valid types: ");
     }
 
     @Test

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/VarianceAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/VarianceAggregationTest.java
@@ -125,7 +125,6 @@ public class VarianceAggregationTest extends AggregationTestCase {
     public void testUnsupportedType() throws Exception {
         assertThatThrownBy(() -> executeAggregation(DataTypes.GEO_POINT, new Object[][] {}))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessageStartingWith("Unknown function: variance(INPUT(0))," +
-                    " no overload found for matching argument types: (geo_point).");
+            .hasMessage("Invalid arguments in: variance(INPUT(0)) with (geo_point). Valid types: (double precision), (real), (byte), (smallint), (integer), (bigint), (timestamp with time zone)");
     }
 }

--- a/server/src/test/java/io/crate/expression/operator/CIDROperatorTest.java
+++ b/server/src/test/java/io/crate/expression/operator/CIDROperatorTest.java
@@ -76,8 +76,7 @@ public class CIDROperatorTest extends ScalarTestCase {
     public void test_both_operands_are_of_wrong_type() {
         assertThatThrownBy(() -> assertEvaluate("1.2 << { cidr = '192.168.0.0/24'}", false))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessageStartingWith("Unknown function: (1.2 << {cidr = '192.168.0.0/24'}), " +
-                "no overload found for matching argument types: (double precision, object).");
+            .hasMessage("Invalid arguments in: (1.2 << {cidr = '192.168.0.0/24'}) with (double precision, object). Valid types: (ip, text)");
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/scalar/AgeFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/AgeFunctionTest.java
@@ -127,8 +127,8 @@ public class AgeFunctionTest extends ScalarTestCase {
         assertThatThrownBy(
             () -> assertEvaluate("pg_catalog.age(null, null, null)", null))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessage("Unknown function: pg_catalog.age(NULL, NULL, NULL), no overload found for matching argument types: (undefined, undefined, undefined). " +
-                "Possible candidates: pg_catalog.age(timestamp without time zone):interval, " +
-                "pg_catalog.age(timestamp without time zone, timestamp without time zone):interval");
+            .hasMessage(
+                "Invalid arguments in: pg_catalog.age(NULL, NULL, NULL) with (undefined, undefined, undefined). "
+                + "Valid types: (timestamp without time zone), (timestamp without time zone, timestamp without time zone)");
     }
 }

--- a/server/src/test/java/io/crate/expression/scalar/ArrayCatFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArrayCatFunctionTest.java
@@ -58,24 +58,21 @@ public class ArrayCatFunctionTest extends ScalarTestCase {
     public void testZeroArguments() throws Exception {
         assertThatThrownBy(() -> assertEvaluateNull("array_cat()"))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessageStartingWith("Unknown function: array_cat(). " +
-                                    "Possible candidates: array_cat(array(E), array(E)):array(E)");
+            .hasMessage("Invalid arguments in: array_cat(). Valid types: (array(E), array(E))");
     }
 
     @Test
     public void testOneArgument() {
         assertThatThrownBy(() -> assertEvaluateNull("array_cat([1])"))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessageStartingWith("Unknown function: array_cat([1]), " +
-                                    "no overload found for matching argument types: (integer_array).");
+            .hasMessage("Invalid arguments in: array_cat([1]) with (integer_array). Valid types: (array(E), array(E))");
     }
 
     @Test
     public void testThreeArguments() throws Exception {
         assertThatThrownBy(() -> assertEvaluateNull("array_cat([1], [2], [3])"))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessageStartingWith("Unknown function: array_cat([1], [2], [3]), " +
-                    "no overload found for matching argument types: (integer_array, integer_array, integer_array).");
+            .hasMessageStartingWith("Invalid arguments in: array_cat([1], [2], [3]) with (integer_array, integer_array, integer_array).");
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/scalar/ArrayDifferenceFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArrayDifferenceFunctionTest.java
@@ -94,16 +94,14 @@ public class ArrayDifferenceFunctionTest extends ScalarTestCase {
     public void testZeroArguments() throws Exception {
         assertThatThrownBy(() -> assertNormalize("array_difference()", isNull()))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessage("Unknown function: array_difference(). " +
-                        "Possible candidates: array_difference(array(E), array(E)):array(E)");
+            .hasMessage("Invalid arguments in: array_difference(). Valid types: (array(E), array(E))");
     }
 
     @Test
     public void testOneArgument() {
         assertThatThrownBy(() -> assertNormalize("array_difference([1])", isNull()))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessageStartingWith("Unknown function: array_difference([1]), " +
-                                    "no overload found for matching argument types: (integer_array).");
+            .hasMessage("Invalid arguments in: array_difference([1]) with (integer_array). Valid types: (array(E), array(E))");
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/scalar/ArrayLowerFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArrayLowerFunctionTest.java
@@ -92,32 +92,28 @@ public class ArrayLowerFunctionTest extends ScalarTestCase {
     public void testZeroArguments() {
         assertThatThrownBy(() -> assertEvaluateNull("array_lower()"))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessageStartingWith("Unknown function: array_lower(). " +
-                                    "Possible candidates: array_lower(array(E), integer):integer");
+            .hasMessage("Invalid arguments in: array_lower(). Valid types: (array(E), integer)");
     }
 
     @Test
     public void testOneArgument() {
         assertThatThrownBy(() -> assertEvaluateNull("array_lower([1])"))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessageStartingWith("Unknown function: array_lower([1]), " +
-                                    "no overload found for matching argument types: (integer_array).");
+            .hasMessage("Invalid arguments in: array_lower([1]) with (integer_array). Valid types: (array(E), integer)");
     }
 
     @Test
     public void testThreeArguments() {
         assertThatThrownBy(() -> assertEvaluateNull("array_lower([1], 2, [3])"))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessageStartingWith("Unknown function: array_lower([1], 2, [3]), " +
-                    "no overload found for matching argument types: (integer_array, integer, integer_array).");
+            .hasMessage("Invalid arguments in: array_lower([1], 2, [3]) with (integer_array, integer, integer_array). Valid types: (array(E), integer)");
     }
 
     @Test
     public void testSecondArgumentNotANumber() {
         assertThatThrownBy(() -> assertEvaluateNull("array_lower([1], [2])"))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessageStartingWith("Unknown function: array_lower([1], [2]), " +
-                    "no overload found for matching argument types: (integer_array, integer_array).");
+            .hasMessage("Invalid arguments in: array_lower([1], [2]) with (integer_array, integer_array). Valid types: (array(E), integer)");
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/scalar/ArrayMaxFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArrayMaxFunctionTest.java
@@ -85,7 +85,7 @@ public class ArrayMaxFunctionTest extends ScalarTestCase {
         Assertions.assertThatThrownBy(() -> assertEvaluate("array_max([])", null))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
             .hasMessageContaining(
-                    "Unknown function: array_max([]), no overload found for matching argument types: (undefined_array).");
+                "Invalid arguments in: array_max([]) with (undefined_array). Valid types: ");
     }
 
 }

--- a/server/src/test/java/io/crate/expression/scalar/ArraySliceFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArraySliceFunctionTest.java
@@ -125,8 +125,8 @@ public class ArraySliceFunctionTest extends ScalarTestCase {
     public void testBaseIsNotAnArray() {
         assertThatThrownBy(() -> assertEvaluateNull("'not an array'[1:3]"))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessageStartingWith(
-                "Unknown function: array_slice('not an array', 1, 3), no overload found for matching argument types");
+            .hasMessage(
+                "Invalid arguments in: array_slice('not an array', 1, 3) with (text, integer, integer). Valid types: (array(E), integer, integer)");
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/scalar/ArrayToStringFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArrayToStringFunctionTest.java
@@ -33,15 +33,14 @@ public class ArrayToStringFunctionTest extends ScalarTestCase {
     public void testZeroArguments() {
         assertThatThrownBy(() -> assertEvaluateNull("array_to_string()"))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessageStartingWith("Unknown function: array_to_string()");
+            .hasMessage("Invalid arguments in: array_to_string(). Valid types: (array(E), text), (array(E), text, text)");
     }
 
     @Test
     public void testOneArgument() {
         assertThatThrownBy(() -> assertEvaluateNull("array_to_string([1, 2])"))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessageStartingWith("Unknown function: array_to_string([1, 2]), " +
-                                    "no overload found for matching argument types: (integer_array).");
+            .hasMessage("Invalid arguments in: array_to_string([1, 2]) with (integer_array). Valid types: (array(E), text), (array(E), text, text)");
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/scalar/ArrayUniqueFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArrayUniqueFunctionTest.java
@@ -84,7 +84,7 @@ public class ArrayUniqueFunctionTest extends ScalarTestCase {
     public void testZeroArguments() throws Exception {
         assertThatThrownBy(() -> assertEvaluateNull("array_unique()"))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessageStartingWith("Unknown function: array_unique().");
+            .hasMessage("Invalid arguments in: array_unique(). Valid types: (array(E)), (array(E), array(E))");
     }
 
     @Test
@@ -115,8 +115,7 @@ public class ArrayUniqueFunctionTest extends ScalarTestCase {
     public void testDifferentUnconvertableInnerTypes() throws Exception {
         assertThatThrownBy(() -> assertEvaluateNull("array_unique([geopoint], [true])"))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessageStartingWith("Unknown function: array_unique([doc.users.geopoint], [true]), " +
-                    "no overload found for matching argument types: (geo_point_array, boolean_array).");
+            .hasMessage("Invalid arguments in: array_unique([doc.users.geopoint], [true]) with (geo_point_array, boolean_array). Valid types: (array(E)), (array(E), array(E))");
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/scalar/ArrayUpperFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArrayUpperFunctionTest.java
@@ -93,32 +93,28 @@ public class ArrayUpperFunctionTest extends ScalarTestCase {
     public void testZeroArguments() {
         assertThatThrownBy(() -> assertEvaluateNull("array_upper()"))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessageStartingWith("Unknown function: array_upper(). " +
-                                    "Possible candidates: array_upper(array(E), integer):integer");
+            .hasMessage("Invalid arguments in: array_upper(). Valid types: (array(E), integer)");
     }
 
     @Test
     public void testOneArgument() {
         assertThatThrownBy(() -> assertEvaluateNull("array_upper([1])"))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessageStartingWith("Unknown function: array_upper([1]), " +
-                                    "no overload found for matching argument types: (integer_array).");
+            .hasMessage("Invalid arguments in: array_upper([1]) with (integer_array). Valid types: (array(E), integer)");
     }
 
     @Test
     public void testThreeArguments() {
         assertThatThrownBy(() -> assertEvaluateNull("array_upper([1], 2, [3])"))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessageStartingWith("Unknown function: array_upper([1], 2, [3]), " +
-                "no overload found for matching argument types: (integer_array, integer, integer_array).");
+            .hasMessage("Invalid arguments in: array_upper([1], 2, [3]) with (integer_array, integer, integer_array). Valid types: (array(E), integer)");
     }
 
     @Test
     public void testSecondArgumentNotANumber() {
         assertThatThrownBy(() -> assertEvaluateNull("array_upper([1], [2])"))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessageStartingWith("Unknown function: array_upper([1], [2]), " +
-                "no overload found for matching argument types: (integer_array, integer_array).");
+            .hasMessage("Invalid arguments in: array_upper([1], [2]) with (integer_array, integer_array). Valid types: (array(E), integer)");
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/scalar/ConcatFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ConcatFunctionTest.java
@@ -46,8 +46,7 @@ public class ConcatFunctionTest extends ScalarTestCase {
     public void testArgumentThatHasNoStringRepr() {
         assertThatThrownBy(() -> assertNormalize("concat('foo', [1])", isNull()))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessageStartingWith("Unknown function: concat('foo', [1]), " +
-                                    "no overload found for matching argument types: (text, integer_array).");
+            .hasMessageStartingWith("Invalid arguments in: concat('foo', [1]) with (text, integer_array).");
     }
 
 
@@ -95,8 +94,8 @@ public class ConcatFunctionTest extends ScalarTestCase {
     public void testTwoArraysOfIncompatibleInnerTypes() {
         assertThatThrownBy(() -> assertNormalize("concat([1, 2], [[1, 2]])", isNull()))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessageStartingWith("Unknown function: concat([1, 2], [[1, 2]]), " +
-                "no overload found for matching argument types: (integer_array, integer_array_array).");
+            .hasMessageStartingWith(
+                "Invalid arguments in: concat([1, 2], [[1, 2]]) with (integer_array, integer_array_array).");
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/scalar/ConcatWsFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ConcatWsFunctionTest.java
@@ -70,8 +70,6 @@ public class ConcatWsFunctionTest extends ScalarTestCase {
     public void testInvalidArrayArgument() {
         assertThatThrownBy(() -> assertNormalize("concat_ws(',' , 'foo', [])", isNull()))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessage("Unknown function: concat_ws(',', 'foo', []), " +
-                        "no overload found for matching argument types: (text, text, undefined_array). " +
-                        "Possible candidates: concat_ws(text):text");
+            .hasMessage("Invalid arguments in: concat_ws(',', 'foo', []) with (text, text, undefined_array). Valid types: (text)");
     }
 }

--- a/server/src/test/java/io/crate/expression/scalar/ExtractFunctionsTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ExtractFunctionsTest.java
@@ -47,7 +47,7 @@ public class ExtractFunctionsTest extends ScalarTestCase {
     private void assertEvaluateIntervalException(String timeUnit) {
         assertThatThrownBy(() -> assertEvaluate("extract(" + timeUnit + " from INTERVAL '10 days')", -1))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessageStartingWith("Unknown function: extract(" + timeUnit.toUpperCase(Locale.ENGLISH) + " FROM");
+            .hasMessageStartingWith("Invalid arguments in: extract(" + timeUnit.toUpperCase(Locale.ENGLISH) + " FROM");
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/scalar/StringToArrayFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/StringToArrayFunctionTest.java
@@ -41,15 +41,14 @@ public class StringToArrayFunctionTest extends ScalarTestCase {
     public void testZeroArguments() {
         assertThatThrownBy(() -> assertEvaluateNull("string_to_array()"))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessageStartingWith("Unknown function: string_to_array()");
+            .hasMessage("Invalid arguments in: string_to_array(). Valid types: (text, text), (text, text, text)");
     }
 
     @Test
     public void testOneArgument() {
         assertThatThrownBy(() -> assertEvaluateNull("string_to_array('xyz')"))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessageStartingWith("Unknown function: string_to_array('xyz'), " +
-                                    "no overload found for matching argument types: (text).");
+            .hasMessage("Invalid arguments in: string_to_array('xyz') with (text). Valid types: (text, text), (text, text, text)");
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/IntervalFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/IntervalFunctionTest.java
@@ -148,8 +148,8 @@ public class IntervalFunctionTest extends ScalarTestCase {
         assertThatThrownBy(
             () -> assertEvaluate("null / interval '1 second'", null))
                 .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessageStartingWith("Unknown function: (NULL / cast('1 second' AS INTERVAL)), " +
-                                    "no overload found for matching argument types: (undefined, interval).");
+            .hasMessageStartingWith(
+                "Invalid arguments in: (NULL / cast('1 second' AS INTERVAL)) with (undefined, interval).");
     }
 
     @Test
@@ -176,6 +176,7 @@ public class IntervalFunctionTest extends ScalarTestCase {
         assertThatThrownBy(
             () -> assertEvaluate("interval '1 second' - '86401000'::timestamptz", 86400000L))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessageStartingWith("Unknown function: (cast('1 second' AS INTERVAL) - cast('86401000' AS TIMESTAMP WITH TIME ZONE)), ");
+            .hasMessageStartingWith(
+                "Invalid arguments in: (cast('1 second' AS INTERVAL) - cast('86401000' AS TIMESTAMP WITH TIME ZONE)) with (interval, timestamp with time zone).");
     }
 }

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/MapFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/MapFunctionTest.java
@@ -38,8 +38,8 @@ public class MapFunctionTest extends ScalarTestCase {
     public void testMapWithWrongNumOfArguments() {
         assertThatThrownBy(() -> assertEvaluateNull("_map('foo', 1, 'bar')"))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessageStartingWith("Unknown function: {foo = 1}, " +
-                                    "no overload found for matching argument types: (text, integer, text).");
+            .hasMessage(
+                "Invalid arguments in: {foo = 1} with (text, integer, text). Valid types: (text, V)");
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/NegateFunctionsTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/NegateFunctionsTest.java
@@ -43,8 +43,8 @@ public class NegateFunctionsTest extends ScalarTestCase {
     public void testNegateOnStringResultsInError() {
         assertThatThrownBy(() -> assertEvaluate("- name", null, Literal.of("foo")))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessageStartingWith("Unknown function: - doc.users.name, " +
-                                    "no overload found for matching argument types: (text).");
+            .hasMessageStartingWith(
+                "Invalid arguments in: - doc.users.name with (text). Valid types: (double precision), ");
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/PowerFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/PowerFunctionTest.java
@@ -67,7 +67,7 @@ public class PowerFunctionTest extends ScalarTestCase {
     @Test
     public void testInvalidNumberOfArguments() {
         assertThatThrownBy(() -> assertEvaluateNull("power(2)"))
-            .hasMessageStartingWith("Unknown function: power(2), " +
-                                    "no overload found for matching argument types: (integer).");
+            .hasMessage(
+                "Invalid arguments in: power(2) with (integer). Valid types: (double precision, double precision)");
     }
 }

--- a/server/src/test/java/io/crate/expression/scalar/conditional/ConditionalFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/conditional/ConditionalFunctionTest.java
@@ -68,8 +68,8 @@ public class ConditionalFunctionTest extends ScalarTestCase {
     public void testNullIfInvalidArgsLength() throws Exception {
         assertThatThrownBy(() -> assertEvaluateNull("nullif(1, 2, 3)"))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessageStartingWith("Unknown function: nullif(1, 2, 3)," +
-                                    " no overload found for matching argument types: (integer, integer, integer).");
+            .hasMessage(
+                "Invalid arguments in: nullif(1, 2, 3) with (integer, integer, integer). Valid types: (E, E)");
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/scalar/geo/AreaFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/geo/AreaFunctionTest.java
@@ -81,16 +81,15 @@ public class AreaFunctionTest extends ScalarTestCase {
     public void testWithTooManyArguments() {
         assertThatThrownBy(() -> assertNormalize("area(geoShape, 'foo')", isNull()))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessage("Unknown function: area(doc.users.geoshape, 'foo'), no overload found for matching argument " +
-                        "types: (geo_shape, text). Possible candidates: area(geo_shape):double precision");
+            .hasMessage(
+                "Invalid arguments in: area(doc.users.geoshape, 'foo') with (geo_shape, text). Valid types: (geo_shape)");
     }
 
     @Test
     public void testResolveWithInvalidType() throws Exception {
         assertThatThrownBy(() -> assertEvaluateNull("area(1)"))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessage("Unknown function: area(1), no overload found for matching argument types: (integer). " +
-                        "Possible candidates: area(geo_shape):double precision");
+            .hasMessage("Invalid arguments in: area(1) with (integer). Valid types: (geo_shape)");
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/scalar/geo/CoordinateFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/geo/CoordinateFunctionTest.java
@@ -77,8 +77,8 @@ public class CoordinateFunctionTest extends ScalarTestCase {
     public void testWithTooManyArguments() throws Exception {
         assertThatThrownBy(() -> assertNormalize("latitude('POINT (10 20)', 'foo')", isNull()))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessageStartingWith("Unknown function: latitude('POINT (10 20)', 'foo'), " +
-                                    "no overload found for matching argument types: (text, text).");
+            .hasMessage(
+                "Invalid arguments in: latitude('POINT (10 20)', 'foo') with (text, text). Valid types: (geo_point)");
     }
 
     @Test
@@ -86,7 +86,7 @@ public class CoordinateFunctionTest extends ScalarTestCase {
         assertThatThrownBy(() -> assertEvaluateNull("longitude(1)"))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
             .hasMessageStartingWith(
-                "Unknown function: longitude(1), no overload found for matching argument types: (integer)");
+                "Invalid arguments in: longitude(1) with (integer). Valid types: (geo_point)");
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/scalar/geo/DistanceFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/geo/DistanceFunctionTest.java
@@ -42,8 +42,8 @@ public class DistanceFunctionTest extends ScalarTestCase {
         assertThatThrownBy(() ->
                 assertNormalize("distance('POINT (10 20)', 'POINT (11 21)', 'foo')", s -> assertThat(s).isNull()))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessageStartingWith("Unknown function: distance('POINT (10 20)', 'POINT (11 21)', 'foo'), " +
-                                    "no overload found for matching argument types: (text, text, text).");
+            .hasMessage(
+                "Invalid arguments in: distance('POINT (10 20)', 'POINT (11 21)', 'foo') with (text, text, text). Valid types: (geo_point, geo_point)");
     }
 
     @Test
@@ -51,8 +51,8 @@ public class DistanceFunctionTest extends ScalarTestCase {
         assertThatThrownBy(() ->
                 assertNormalize("distance(1, 'POINT (11 21)')", s -> assertThat(s).isNull()))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessageStartingWith("Unknown function: distance(1, 'POINT (11 21)'), " +
-                                    "no overload found for matching argument types: (integer, text).");
+            .hasMessage(
+                "Invalid arguments in: distance(1, 'POINT (11 21)') with (integer, text). Valid types: (geo_point, geo_point)");
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/scalar/geo/GeoHashFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/geo/GeoHashFunctionTest.java
@@ -60,8 +60,8 @@ public class GeoHashFunctionTest extends ScalarTestCase {
     public void testWithTooManyArguments() {
         assertThatThrownBy(() -> assertNormalize("geohash('POINT (10 20)', 'foo')", s -> assertThat(s).isNull()))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessageStartingWith("Unknown function: geohash('POINT (10 20)', 'foo'), " +
-                                    "no overload found for matching argument types: (text, text).");
+            .hasMessageStartingWith(
+                "Invalid arguments in: geohash('POINT (10 20)', 'foo') with (text, text). Valid types: (geo_point)");
     }
 
     @Test
@@ -69,7 +69,7 @@ public class GeoHashFunctionTest extends ScalarTestCase {
         assertThatThrownBy(() -> assertEvaluateNull("geohash(1)"))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
             .hasMessageStartingWith(
-                "Unknown function: geohash(1), no overload found for matching argument types: (integer)");
+                "Invalid arguments in: geohash(1) with (integer). Valid types: (geo_point)");
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/scalar/geo/WithinFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/geo/WithinFunctionTest.java
@@ -142,16 +142,16 @@ public class WithinFunctionTest extends ScalarTestCase {
     public void testFirstArgumentWithInvalidType() throws Exception {
         assertThatThrownBy(() -> getFunction(FNAME, List.of(DataTypes.LONG, DataTypes.GEO_POINT)))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessageStartingWith("Unknown function: within(INPUT(0), INPUT(0)), " +
-                                    "no overload found for matching argument types: (bigint, geo_point).");
+            .hasMessageStartingWith(
+                "Invalid arguments in: within(INPUT(0), INPUT(0)) with (bigint, geo_point).");
     }
 
     @Test
     public void testSecondArgumentWithInvalidType() throws Exception {
         assertThatThrownBy(() -> getFunction(FNAME, List.of(DataTypes.GEO_POINT, DataTypes.LONG)))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessageStartingWith("Unknown function: within(INPUT(0), INPUT(0)), " +
-                                    "no overload found for matching argument types: (geo_point, bigint).");
+            .hasMessageStartingWith(
+                "Invalid arguments in: within(INPUT(0), INPUT(0)) with (geo_point, bigint).");
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/scalar/object/ObjectKeysFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/object/ObjectKeysFunctionTest.java
@@ -41,9 +41,7 @@ public class ObjectKeysFunctionTest extends ScalarTestCase {
     public void test_array_input() {
         assertThatThrownBy(() -> assertEvaluateNull("object_keys([1])"))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessage("Unknown function: object_keys([1]), no overload found for " +
-                        "matching argument types: (integer_array). Possible candidates: " +
-                        "object_keys(object):array(text)");
+            .hasMessage("Invalid arguments in: object_keys([1]) with (integer_array). Valid types: (object)");
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/scalar/postgres/PgBackendPidFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/postgres/PgBackendPidFunctionTest.java
@@ -44,7 +44,7 @@ public class PgBackendPidFunctionTest extends ScalarTestCase {
     @Test
     public void testInvalidType() throws Exception {
         assertThatThrownBy(() -> sqlExpressions.asSymbol("pg_backend_pid(null)"))
-            .hasMessageStartingWith("Unknown function: pg_backend_pid(NULL), " +
-                                    "no overload found for matching argument types: (undefined).");
+            .hasMessage(
+                "Invalid arguments in: pg_backend_pid(NULL) with (undefined). Valid types: ()");
     }
 }

--- a/server/src/test/java/io/crate/expression/scalar/regex/RegexpReplaceFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/regex/RegexpReplaceFunctionTest.java
@@ -94,7 +94,7 @@ public class RegexpReplaceFunctionTest extends ScalarTestCase {
         assertThatThrownBy(() ->
                 assertNormalize("regexp_replace('foobar', '.*', [1,2])", isLiteral("")))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessageStartingWith("Unknown function: regexp_replace('foobar', '.*', [1, 2]), " +
-                                    "no overload found for matching argument types: (text, text, integer_array).");
+            .hasMessageStartingWith(
+                "Invalid arguments in: regexp_replace('foobar', '.*', [1, 2]) with (text, text, integer_array).");
     }
 }

--- a/server/src/test/java/io/crate/expression/scalar/string/ChrFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/string/ChrFunctionTest.java
@@ -60,7 +60,7 @@ public class ChrFunctionTest extends ScalarTestCase {
     public void test_empty_value_throws_exception() throws Exception {
         assertThatThrownBy(() -> assertEvaluate("chr()", ""))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessage("Unknown function: chr(). Possible candidates: chr(integer):text");
+            .hasMessage("Invalid arguments in: chr(). Valid types: (integer)");
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/scalar/string/QuoteIdentFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/string/QuoteIdentFunctionTest.java
@@ -42,8 +42,7 @@ public class QuoteIdentFunctionTest extends ScalarTestCase {
     public void testZeroArguments() {
         assertThatThrownBy(() -> assertEvaluateNull("quote_ident()"))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessage("Unknown function: quote_ident(). " +
-                        "Possible candidates: pg_catalog.quote_ident(text):text");
+            .hasMessage("Invalid arguments in: quote_ident(). Valid types: (text)");
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/tablefunctions/ValuesFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/tablefunctions/ValuesFunctionTest.java
@@ -107,8 +107,8 @@ public class ValuesFunctionTest extends AbstractTableFunctionsTest {
     public void test_function_arguments_must_have_array_types() {
         assertThatThrownBy(() -> assertExecute("_values(200)", ""))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessageStartingWith("Unknown function: _values(200), " +
-                                    "no overload found for matching argument types: (integer).");
+            .hasMessageStartingWith(
+                "Invalid arguments in: _values(200) with (integer). Valid types: (array(E))");
     }
 
     @Test

--- a/server/src/test/java/io/crate/lucene/BitStringEqQueryTest.java
+++ b/server/src/test/java/io/crate/lucene/BitStringEqQueryTest.java
@@ -73,12 +73,12 @@ public class BitStringEqQueryTest extends LuceneQueryBuilderTest {
         assertThatThrownBy(
             () -> convert("a1 < " + BIT_STRING))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessageStartingWith("Unknown function: (doc.m.a1 < B'001'), no overload found for matching argument types: (bit, bit).");
+            .hasMessageStartingWith("Invalid arguments in: (doc.m.a1 < B'001') with (bit, bit). Valid types: (");
 
         assertThatThrownBy(
             () -> convert("a2 >= " + BIT_STRING))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessageStartingWith("Unknown function: (doc.m.a2 >= B'001'), no overload found for matching argument types: (bit, bit).");
+            .hasMessageStartingWith("Invalid arguments in: (doc.m.a2 >= B'001') with (bit, bit). Valid types: (");
     }
 
     @Test

--- a/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
@@ -414,8 +414,7 @@ public class CommonQueryBuilderTest extends LuceneQueryBuilderTest {
         assertThatThrownBy(() -> convert("_doc > {\"name\"='foo'}"))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
             .hasMessageStartingWith(
-                "Unknown function: (doc.users._doc > {name = 'foo'})," +
-                " no overload found for matching argument types: (object, object).");
+                "Invalid arguments in: (doc.users._doc > {name = 'foo'}) with (object, object).");
 
     }
 

--- a/server/src/test/java/io/crate/metadata/FunctionsTest.java
+++ b/server/src/test/java/io/crate/metadata/FunctionsTest.java
@@ -342,7 +342,7 @@ public class FunctionsTest extends ESTestCase {
                             .returnType(DataTypes.STRING.getTypeSignature())
                             .features(Scalar.Feature.DETERMINISTIC)
                             .build(),
-                        ((signature, dataTypes) -> null)
+                        ((_, _) -> null)
                     ),
                     new FunctionProvider(
                         Signature.builder(new FunctionName("foo", "bar"), FunctionType.SCALAR)
@@ -350,13 +350,12 @@ public class FunctionsTest extends ESTestCase {
                             .returnType(DataTypes.DOUBLE.getTypeSignature())
                             .features(Scalar.Feature.DETERMINISTIC)
                             .build(),
-                        ((signature, dataTypes) -> null)
+                        ((_, _) -> null)
                     )
                 )
             )
         ).hasMessage(
-            "Unknown function: foo.bar()." +
-            " Possible candidates: foo.bar(text):text, foo.bar(double precision):double precision");
+            "Invalid arguments in: foo.bar(). Valid types: (text), (double precision)");
     }
 
     @Test
@@ -373,7 +372,7 @@ public class FunctionsTest extends ESTestCase {
                             .returnType(DataTypes.STRING.getTypeSignature())
                             .features(Scalar.Feature.DETERMINISTIC)
                             .build(),
-                        ((signature, dataTypes) -> null)
+                        ((_, _) -> null)
                     ),
                     new FunctionProvider(
                         Signature.builder(new FunctionName("foo", "bar"), FunctionType.SCALAR)
@@ -381,13 +380,11 @@ public class FunctionsTest extends ESTestCase {
                             .returnType(DataTypes.DOUBLE.getTypeSignature())
                             .features(Scalar.Feature.DETERMINISTIC)
                             .build(),
-                        ((signature, dataTypes) -> null)
+                        ((_, _) -> null)
                     )
                 )
             )
         ).hasMessage(
-            "Unknown function: foo.bar(1, 2)," +
-            " no overload found for matching argument types: (integer, integer)." +
-            " Possible candidates: foo.bar(text):text, foo.bar(double precision):double precision");
+            "Invalid arguments in: foo.bar(1, 2) with (integer, integer). Valid types: (text), (double precision)");
     }
 }


### PR DESCRIPTION
The error message returned if a function is missing or doesn't have an
overload for the given arguments could leak internal function names.
This changes the message to only show the signature for the candidates.

The function itself is already included once which goes through
`function.toString` to have special formatting where appropriate.

Relates to https://github.com/crate/crate/issues/17827
