### PR TITLE
Log all errors of sys.snapshots

### DIFF
--- a/server/src/main/java/io/crate/expression/reference/sys/snapshot/SysSnapshots.java
+++ b/server/src/main/java/io/crate/expression/reference/sys/snapshot/SysSnapshots.java
@@ -96,10 +96,10 @@ public class SysSnapshots {
             .thenCombine(repository.getSnapshotInfo(snapshotId), (metadata, info) -> SysSnapshot.of(metadata, repoName, info))
             .exceptionally(t -> {
                 var err = SQLExceptions.unwrap(t);
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.debug("Couldn't retrieve snapshotId={} error={}", snapshotId, err);
+                }
                 if (err instanceof SnapshotException) {
-                    if (LOGGER.isDebugEnabled()) {
-                        LOGGER.debug("Couldn't retrieve snapshotId={} error={}", snapshotId, err);
-                    }
                     return SysSnapshot.ofMissingInfo(repository.getMetadata().name(), snapshotId);
                 }
                 throw Exceptions.toRuntimeException(err);


### PR DESCRIPTION
Mainly to debug flaky tests (they all fail on asserting sys.snapshots result or relying on it to return some rows).

[BlobStoreIncrementalityIT.testForceMergeCausesFullSnapshot](https://wacklig.pipifein.dev/github/crate/crate/9e4c74f4-0143-469d-83c1-4d17b4e4636d/89e14501-4e91-4a5a-a4d9-9b6e9433cff7)
[BlobStoreIncrementalityIT.testIncrementalBehaviorOnPrimaryFailover](https://wacklig.pipifein.dev/github/crate/crate/350be4c4-8a08-4943-bc8e-9aae59ef9986/e2c54441-50db-4e9b-a0ad-53f7fd5e2247)
[SnapshotRestoreIntegrationTest.testCreateSnapshot](https://wacklig.pipifein.dev/github/crate/crate/08291390-fd8a-4b65-a501-8a890aef01f9/ba100c7b-4e1e-48cf-82a3-d35fc3b6b2be)
[SnapshotRestoreIntegrationTest.testCreateSnapshotFromPartition](https://wacklig.pipifein.dev/github/crate/crate/e3a76d0c-0209-4e8f-b1c3-2dcfcb636286/008b0ac0-9a37-4f87-ad57-0cab85661866)
[SnapshotRestoreIntegrationTest.test_snapshot_with_corrupted_shard_index_file](https://wacklig.pipifein.dev/github/crate/crate/case/io.crate.integrationtests.SnapshotRestoreIntegrationTest/test_snapshot_with_corrupted_shard_index_file)
[SysSnapshotsTest.test_sys_snapshots_returns_table_partition_information](https://wacklig.pipifein.dev/github/crate/crate/case/io.crate.integrationtests.SysSnapshotsTest/test_sys_snapshots_returns_table_partition_information)

I can reproduce [SysSnapshotsTest.test_sys_snapshots_returns_table_partition_information](https://wacklig.pipifein.dev/github/crate/crate/case/io.crate.integrationtests.SysSnapshotsTest/test_sys_snapshots_returns_table_partition_information) if I put a breakpoint in the `SysSnapshots.currentSnapshots `
at  `var futureSnapshots = repository.getRepositoryData()` and step into `getRepositoryData` and `thenCompose`. 

Getting a failed assertion
`java.lang.AssertionError: Expected current thread [Thread[#28,Time-limited test,5,TGRP-SysSnapshotsTest]] to be the snapshot or generic thread.`

--------

I think my "reproduction" is actually a debugging artefact, ie stepping into completion phase causes the debugger to intervene and execute code in the test thread (as shown in the assertion). 

However, extra logging can give us some clue what's going on in CI failures - we can revert this once we have some more info in our hands