### PR TITLE
Update netty to 4.1.121

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -324,7 +324,7 @@
     <versions.antlr>4.13.2</versions.antlr>
     <versions.quickcheck>1.0</versions.quickcheck>
     <versions.hppc>0.8.2</versions.hppc>
-    <versions.netty>4.1.119.Final</versions.netty>
+    <versions.netty>4.1.121.Final</versions.netty>
     <versions.lucene>10.2.0</versions.lucene>
     <versions.spatial4j>0.8</versions.spatial4j>
     <versions.jts>1.20.0</versions.jts>


### PR DESCRIPTION
- https://netty.io/news/2025/04/23/4-1-120-Final.html
- https://netty.io/news/2025/04/24/4-1-121-Final.html

Note that in regards to:

> Disable sun.misc.Unsafe by default on Java 24+

We're still using it due to https://github.com/crate/crate/commit/b142ac04d0ca44dd44b15c542c1194c53b8f1026
So this shouldn't cause any perf regressions
