### PR TITLE
Auto level LIKE ANY same as other ANY operators

### DIFF
--- a/docs/appendices/release-notes/5.10.6.rst
+++ b/docs/appendices/release-notes/5.10.6.rst
@@ -48,6 +48,10 @@ See the :ref:`version_5.10.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- ``LIKE ANY`` now behaves the same as any other operators used with ``ANY`` and
+  automatically levels the dimensions by wrapping the right side in an
+  ``array_unnest`` as necessary - as documented.
+
 - Fixed a bug where references to a column initially created in versions of CrateDB
   before 5.5 would return ``NULL`` instead of their actual value when the column was
   addressed via ``doc['column']``

--- a/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
@@ -907,11 +907,15 @@ public class ExpressionAnalyzer {
             if (node.getEscape() != null) {
                 throw new UnsupportedOperationException("ESCAPE is not supported.");
             }
-            Symbol arraySymbol = node.getValue().accept(this, context);
-            Symbol leftSymbol = node.getPattern().accept(this, context);
+            Symbol value = node.getValue().accept(this, context);
+            Symbol pattern = node.getPattern().accept(this, context);
+            int valueDimensions = ArrayType.dimensions(value.valueType());
+            int patternDimensions = ArrayType.dimensions(pattern.valueType());
+            int diff = valueDimensions - patternDimensions;
+            value = ArrayUnnestFunction.unnest(value, diff - 1);
             return allocateFunction(
                 LikeOperators.arrayOperatorName(node.quantifier(), node.inverse(), node.ignoreCase()),
-                List.of(leftSymbol, arraySymbol),
+                List.of(pattern, value),
                 context);
         }
 

--- a/server/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
@@ -521,6 +521,8 @@ public class ExpressionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     public void test_any_automatically_levels_array_dimensions() throws Exception {
         assertThat(executor.asSymbol("1 = ANY([1, 2])")).isLiteral(true);
         assertThat(executor.asSymbol("3 = ANY([1, 2])")).isLiteral(false);
+        assertThat(executor.asSymbol("'Hello' LIKE ANY(['Hell%', 'No'])")).isLiteral(true);
+        assertThat(executor.asSymbol("'Hello' LIKE ANY([['Hell', 'No'], ['Hell_']])")).isLiteral(true);
 
         assertThat(executor.asSymbol("[1, 2] = ANY([[3, 4], [1, 2]])")).isLiteral(true);
         assertThat(executor.asSymbol("[1, 3] = ANY([[3, 4], [1, 2]])")).isLiteral(false);

--- a/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
@@ -526,6 +526,12 @@ public class CommonQueryBuilderTest extends LuceneQueryBuilderTest {
     }
 
     @Test
+    public void test_like_any_on_nested_array() throws Exception {
+        assertThat(convert("'Hello' LIKE ANY(o_array['xs'])"))
+            .hasToString("('Hello' LIKE ANY(array_unnest(o_array['xs'])))");
+    }
+
+    @Test
     public void testGtAnyOnNestedArrayIsNotSupported() {
         assertThatThrownBy(() -> convert("[1, 2] > any(o_array['xs'])"))
             .hasMessage("Cannot use `> ANY` if left side is an array");


### PR DESCRIPTION
https://github.com/crate/crate/pull/14090 documented:

> ``ANY`` automatically unnests the array argument to the number of
> dimensions required::

But this wasn't the case for LIKE

Note that this doesn't optimize the generated query, it uses the generic
function query (very slow). The use-case is uncommon as the right side
are the patterns.

More useful would be to match a single pattern against a (nested)
collection of values.
