### PR TITLE
Set object depth limit to 100

### DIFF
--- a/docs/appendices/release-notes/6.0.0.rst
+++ b/docs/appendices/release-notes/6.0.0.rst
@@ -349,5 +349,11 @@ Administration and Operations
 - Added ``last_write_before`` column to the sys.shards table, reporting a
   timestamp before which the last write operation to the shard has taken place.
 
+- Re-enabled :ref:`mapping.depth.limit <sql-create-table-mapping-depth-limit>`
+  setting to enforce a maximum nesting depth for object columns when adding new
+  columns to a table. The default value is ``100``. The limit can be increased
+  if necessary, but use caution;deeply nested structures may lead to long
+  execution times or stack overflow errors.
+
 Client interfaces
 -----------------

--- a/docs/sql/statements/create-table.rst
+++ b/docs/sql/statements/create-table.rst
@@ -728,6 +728,21 @@ Sets the maximum number of columns that is allowed for a table. Default is
   user facing mapping (columns) and internal fields.
 
 
+.. _sql-create-table-mapping-depth-limit:
+
+``mapping.depth.limit``
+-----------------------
+
+Sets the maximum allowed nesting depth for object columns when adding new
+columns to a table. Default is ``100``.
+
+.. CAUTION::
+
+    Increasing this limit may lead to significantly longer execution times or
+    stack overflow errors, as certain queries recurse through the deeply nested
+    object structures.
+
+
 .. _sql-create-table-translog:
 
 .. _sql-create-table-translog-flush-threshold-size:

--- a/server/src/main/java/io/crate/analyze/TableParameters.java
+++ b/server/src/main/java/io/crate/analyze/TableParameters.java
@@ -109,6 +109,7 @@ public class TableParameters {
             IndexSettings.INDEX_TRANSLOG_DURABILITY_SETTING,
             ShardsLimitAllocationDecider.INDEX_TOTAL_SHARDS_PER_NODE_SETTING,
             DocTableInfo.TOTAL_COLUMNS_LIMIT,
+            DocTableInfo.DEPTH_LIMIT_SETTING,
             UnassignedInfo.INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING,
             IndexMetadata.SETTING_WAIT_FOR_ACTIVE_SHARDS,
             MaxRetryAllocationDecider.SETTING_ALLOCATION_MAX_RETRY,

--- a/server/src/main/java/io/crate/execution/ddl/tables/TransportCreateTable.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/TransportCreateTable.java
@@ -150,6 +150,13 @@ public class TransportCreateTable extends TransportMasterNodeAction<CreateTableR
         Settings normalizedSettings = settingsBuilder.build();
 
         indexScopedSettings.validate(normalizedSettings, true);
+        try {
+            DocTableInfo.checkTotalColumnsLimit(relationName, normalizedSettings, request.references().stream());
+            DocTableInfo.checkObjectDepthLimit(relationName, normalizedSettings, request.references());
+        } catch (Exception e) {
+            listener.onFailure(e);
+            return;
+        }
 
         boolean isPartitioned = !request.partitionedBy().isEmpty();
         ActionListener<ClusterStateUpdateResponse> stateUpdateListener;

--- a/server/src/main/java/io/crate/metadata/information/InformationPartitionsTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/information/InformationPartitionsTableInfo.java
@@ -111,6 +111,9 @@ public class InformationPartitionsTableInfo {
                 .startObject("total_fields")
                     .add("limit", INTEGER, fromSetting(DocTableInfo.TOTAL_COLUMNS_LIMIT, INTEGER::sanitizeValue))
                 .endObject()
+                .startObject("depth")
+                    .add("limit", INTEGER, fromSetting(DocTableInfo.DEPTH_LIMIT_SETTING, INTEGER::sanitizeValue))
+                .endObject()
             .endObject()
 
             .startObject("merge")

--- a/server/src/main/java/io/crate/metadata/information/InformationTablesTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/information/InformationTablesTableInfo.java
@@ -208,6 +208,9 @@ public class InformationTablesTableInfo {
                 .startObject("total_fields")
                     .add("limit", INTEGER, fromSetting(DocTableInfo.TOTAL_COLUMNS_LIMIT, INTEGER::sanitizeValue))
                 .endObject()
+                .startObject("depth")
+                    .add("limit", INTEGER, fromSetting(DocTableInfo.DEPTH_LIMIT_SETTING, INTEGER::sanitizeValue))
+                .endObject()
             .endObject()
 
             .startObject("merge")

--- a/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
@@ -296,6 +296,15 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
     }
 
     @Test
+    public void testCreateTableWithMaxDepthLimit() {
+        BoundCreateTable analysis = analyze(
+            "CREATE TABLE foo (id int primary key) " +
+                "with (\"mapping.depth.limit\"=101)");
+        assertThat(analysis.settings().get(DocTableInfo.DEPTH_LIMIT_SETTING.getKey()))
+            .isEqualTo("101");
+    }
+
+    @Test
     public void testCreateTableWithRefreshInterval() {
         BoundCreateTable analysis = analyze(
             "CREATE TABLE foo (id int primary key, content string) " +
@@ -351,6 +360,22 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
             "ALTER TABLE users " +
             "RESET (\"mapping.total_fields.limit\")");
         assertThat(analysisReset.settings().get(DocTableInfo.TOTAL_COLUMNS_LIMIT.getKey()))
+            .isNull();
+    }
+
+    @Test
+    public void testMaxDepthLimitCanBeUsedWithAlterTable() {
+        BoundAlterTable analysisSet = analyze(
+            "ALTER TABLE users " +
+                "SET (\"mapping.depth.limit\" = '101')");
+        assertThat(analysisSet.settings().get(DocTableInfo.DEPTH_LIMIT_SETTING.getKey()))
+            .isEqualTo("101");
+
+        // Check if resetting total_fields results in default value
+        BoundAlterTable analysisReset = analyze(
+            "ALTER TABLE users " +
+                "RESET (\"mapping.depth.limit\")");
+        assertThat(analysisReset.settings().get(DocTableInfo.DEPTH_LIMIT_SETTING.getKey()))
             .isNull();
     }
 

--- a/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -571,7 +571,7 @@ public class InformationSchemaTest extends IntegTestCase {
     @Test
     public void testDefaultColumns() {
         execute("select * from information_schema.columns order by table_schema, table_name");
-        assertThat(response.rowCount()).isEqualTo(1050);
+        assertThat(response.rowCount()).isEqualTo(1054);
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/PrivilegesIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/PrivilegesIntegrationTest.java
@@ -659,7 +659,7 @@ public class PrivilegesIntegrationTest extends BaseRolesIntegrationTest {
         //make sure a new user has default accesses to pg tables with information and pg catalog schema related entries
         try (Session testUserSession = testUserSession()) {
             execute("select * from pg_catalog.pg_attribute order by attname", null, testUserSession);
-            assertThat(response).hasRowCount(583L);
+            assertThat(response).hasRowCount(587L);
 
             //create a table with an attribute that a new user is not privileged to access
             executeAsSuperuser("create table test_schema.my_table (my_col int)");


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Resolves https://github.com/crate/crate/issues/16043, cherry-picked https://github.com/crate/crate/commit/e507647a7da3563ff8fcf0c141b8250bb60cbc07. (Please see https://github.com/crate/crate/pull/17808 for experiments with queries likely to cause stack overflow due to the depth)

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
