### PR TITLE
Close transports before tearing down netty event loop in PgClientTest

### DIFF
--- a/server/src/test/java/io/crate/protocols/postgres/PgClientTest.java
+++ b/server/src/test/java/io/crate/protocols/postgres/PgClientTest.java
@@ -69,7 +69,7 @@ public class PgClientTest extends CrateDummyClusterServiceUnitTest {
 
     @After
     public void stop() throws Exception {
-        for (var lifecycleComponent : toClose) {
+        for (var lifecycleComponent : toClose.reversed()) {
             lifecycleComponent.close();
         }
         assertBusy(() -> {


### PR DESCRIPTION
GHA got stuck on PgClientTest in https://github.com/crate/crate/pull/17739
Seems like netty became more sensitive about the channel/event loop tear
down order. We must make sure that we close the channels before we're
closing the event loop.
