### PR TITLE
Add errorOnUnknownObjectKey from session setting to views

### DIFF
--- a/docs/appendices/release-notes/5.10.6.rst
+++ b/docs/appendices/release-notes/5.10.6.rst
@@ -48,6 +48,10 @@ See the :ref:`version_5.10.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed a bug where the session setting ``SET error_on_unknown_object_key = FALSE``
+  was ignored on views. Previously created views need to recreated to apply the
+  setting successfully.
+
 - ``LIKE ANY`` now behaves the same as any other operators used with ``ANY`` and
   automatically levels the dimensions by wrapping the right side in an
   ``array_unnest`` as necessary - as documented.

--- a/pom.xml
+++ b/pom.xml
@@ -310,7 +310,7 @@
     <!-- see surefire plugin configuration for explanation -->
     <skipRunTests>false</skipRunTests>
 
-    <versions.jdk>24.0.1</versions.jdk>
+    <versions.jdk>24</versions.jdk>
     <versions.annotations>26.0.2</versions.annotations>
     <versions.log4j>2.24.3</versions.log4j>
     <versions.assertj>3.27.3</versions.assertj>

--- a/server/src/main/java/io/crate/analyze/CreateViewStmt.java
+++ b/server/src/main/java/io/crate/analyze/CreateViewStmt.java
@@ -40,17 +40,20 @@ public final class CreateViewStmt implements AnalyzedStatement {
     private final boolean replaceExisting;
     @Nullable
     private final Role owner;
+    private final boolean errorOnUnknownObjectKey;
 
     CreateViewStmt(RelationName name,
                    AnalyzedRelation analyzedQuery,
                    Query query,
                    boolean replaceExisting,
-                   @Nullable Role owner) {
+                   @Nullable Role owner,
+                   boolean errorOnUnknownObjectKey) {
         this.name = name;
         this.analyzedQuery = analyzedQuery;
         this.query = query;
         this.replaceExisting = replaceExisting;
         this.owner = owner;
+        this.errorOnUnknownObjectKey = errorOnUnknownObjectKey;
     }
 
     public Query query() {
@@ -88,5 +91,9 @@ public final class CreateViewStmt implements AnalyzedStatement {
     @Override
     public boolean isWriteOperation() {
         return true;
+    }
+
+    public boolean errorOnUnknownObjectKey() {
+        return errorOnUnknownObjectKey;
     }
 }

--- a/server/src/main/java/io/crate/analyze/ViewAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/ViewAnalyzer.java
@@ -83,8 +83,9 @@ public final class ViewAnalyzer {
             query,
             createView.query(),
             createView.replaceExisting(),
-            txnCtx.sessionSettings().sessionUser()
-        );
+            txnCtx.sessionSettings().sessionUser(),
+            txnCtx.sessionSettings().errorOnUnknownObjectKey()
+            );
     }
 
     public AnalyzedDropView analyze(DropView dropView, CoordinatorTxnCtx txnCtx) {

--- a/server/src/main/java/io/crate/execution/ddl/views/CreateViewRequest.java
+++ b/server/src/main/java/io/crate/execution/ddl/views/CreateViewRequest.java
@@ -102,7 +102,7 @@ public final class CreateViewRequest extends MasterNodeRequest<CreateViewRequest
         } else {
             searchPath = SearchPath.pathWithPGCatalogAndDoc();
         }
-        if (version.after(Version.V_5_10_4)) {
+        if (version.after(Version.V_5_10_5)) {
             errorOnUnknownObjectKey = in.readBoolean();
         } else {
             errorOnUnknownObjectKey = false;
@@ -120,7 +120,7 @@ public final class CreateViewRequest extends MasterNodeRequest<CreateViewRequest
         if (version.after(Version.V_5_3_4) && !version.equals(Version.V_5_4_0)) {
             searchPath.writeTo(out);
         }
-        if (version.after(Version.V_5_10_4)) {
+        if (version.after(Version.V_5_10_5)) {
             out.writeBoolean(errorOnUnknownObjectKey);
         }
     }

--- a/server/src/main/java/io/crate/execution/ddl/views/CreateViewRequest.java
+++ b/server/src/main/java/io/crate/execution/ddl/views/CreateViewRequest.java
@@ -44,17 +44,20 @@ public final class CreateViewRequest extends MasterNodeRequest<CreateViewRequest
     private final SearchPath searchPath;
     @Nullable
     private final String owner;
+    private final boolean errorOnUnknownObjectKey;
 
     public CreateViewRequest(RelationName name,
                              String query,
                              boolean replaceExisting,
                              SearchPath searchPath,
-                             @Nullable String owner) {
+                             @Nullable String owner,
+                             boolean errorOnUnknownObjectKey) {
         this.name = name;
         this.query = query;
         this.replaceExisting = replaceExisting;
         this.searchPath = searchPath;
         this.owner = owner;
+        this.errorOnUnknownObjectKey = errorOnUnknownObjectKey;
     }
 
     public RelationName name() {
@@ -71,6 +74,10 @@ public final class CreateViewRequest extends MasterNodeRequest<CreateViewRequest
 
     public SearchPath searchPath() {
         return searchPath;
+    }
+
+    public boolean errorOnUnknownObjectKey() {
+        return errorOnUnknownObjectKey;
     }
 
     @Nullable
@@ -95,6 +102,11 @@ public final class CreateViewRequest extends MasterNodeRequest<CreateViewRequest
         } else {
             searchPath = SearchPath.pathWithPGCatalogAndDoc();
         }
+        if (version.after(Version.V_5_10_0)) {
+            errorOnUnknownObjectKey = in.readBoolean();
+        } else {
+            errorOnUnknownObjectKey = false;
+        }
     }
 
     @Override
@@ -107,6 +119,9 @@ public final class CreateViewRequest extends MasterNodeRequest<CreateViewRequest
         Version version = out.getVersion();
         if (version.after(Version.V_5_3_4) && !version.equals(Version.V_5_4_0)) {
             searchPath.writeTo(out);
+        }
+        if (version.after(Version.V_5_10_0)) {
+            out.writeBoolean(errorOnUnknownObjectKey);
         }
     }
 }

--- a/server/src/main/java/io/crate/execution/ddl/views/CreateViewRequest.java
+++ b/server/src/main/java/io/crate/execution/ddl/views/CreateViewRequest.java
@@ -105,7 +105,7 @@ public final class CreateViewRequest extends MasterNodeRequest<CreateViewRequest
         if (version.after(Version.V_5_10_5)) {
             errorOnUnknownObjectKey = in.readBoolean();
         } else {
-            errorOnUnknownObjectKey = false;
+            errorOnUnknownObjectKey = true;
         }
     }
 

--- a/server/src/main/java/io/crate/execution/ddl/views/CreateViewRequest.java
+++ b/server/src/main/java/io/crate/execution/ddl/views/CreateViewRequest.java
@@ -102,7 +102,7 @@ public final class CreateViewRequest extends MasterNodeRequest<CreateViewRequest
         } else {
             searchPath = SearchPath.pathWithPGCatalogAndDoc();
         }
-        if (version.after(Version.V_5_10_0)) {
+        if (version.after(Version.V_5_10_4)) {
             errorOnUnknownObjectKey = in.readBoolean();
         } else {
             errorOnUnknownObjectKey = false;
@@ -120,7 +120,7 @@ public final class CreateViewRequest extends MasterNodeRequest<CreateViewRequest
         if (version.after(Version.V_5_3_4) && !version.equals(Version.V_5_4_0)) {
             searchPath.writeTo(out);
         }
-        if (version.after(Version.V_5_10_0)) {
+        if (version.after(Version.V_5_10_4)) {
             out.writeBoolean(errorOnUnknownObjectKey);
         }
     }

--- a/server/src/main/java/io/crate/execution/ddl/views/TransportCreateView.java
+++ b/server/src/main/java/io/crate/execution/ddl/views/TransportCreateView.java
@@ -108,7 +108,8 @@ public final class TransportCreateView extends TransportMasterNodeAction<CreateV
                                             request.name(),
                                             request.query(),
                                             request.owner(),
-                                            request.searchPath()))
+                                            request.searchPath(),
+                                            request.errorOnUnknownObjectKey()))
                                     .build()
                             ).build();
                     }

--- a/server/src/main/java/io/crate/metadata/view/ViewInfo.java
+++ b/server/src/main/java/io/crate/metadata/view/ViewInfo.java
@@ -48,9 +48,15 @@ public class ViewInfo implements RelationInfo {
     private final List<Reference> references;
     private final String owner;
     private final SearchPath searchPath;
+    private final boolean errorOnUnknownObjectKey;
 
     @VisibleForTesting
-    public ViewInfo(RelationName ident, String definition, List<Reference> references, @Nullable String owner, SearchPath searchPath) {
+    public ViewInfo(RelationName ident,
+                    String definition,
+                    List<Reference> references,
+                    @Nullable String owner,
+                    SearchPath searchPath,
+                    boolean errorOnUnknownObjectKey) {
         this.ident = ident;
         this.definition = definition;
         this.references = references
@@ -62,6 +68,7 @@ public class ViewInfo implements RelationInfo {
             .toList();
         this.owner = owner;
         this.searchPath = searchPath;
+        this.errorOnUnknownObjectKey = errorOnUnknownObjectKey;
     }
 
     @Override
@@ -120,5 +127,9 @@ public class ViewInfo implements RelationInfo {
 
     public SearchPath searchPath() {
         return searchPath;
+    }
+
+    public boolean errorOnUnknownObjectKey() {
+        return errorOnUnknownObjectKey;
     }
 }

--- a/server/src/main/java/io/crate/metadata/view/ViewInfoFactory.java
+++ b/server/src/main/java/io/crate/metadata/view/ViewInfoFactory.java
@@ -65,6 +65,7 @@ public class ViewInfoFactory {
         try {
             CoordinatorTxnCtx transactionContext = CoordinatorTxnCtx.systemTransactionContext();
             transactionContext.sessionSettings().setSearchPath(view.searchPath());
+            transactionContext.sessionSettings().setErrorOnUnknownObjectKey(false);
             AnalyzedRelation relation = analyzerProvider.analyze(
                 (Query) SqlParser.createStatement(view.stmt()),
                 transactionContext,

--- a/server/src/main/java/io/crate/metadata/view/ViewInfoFactory.java
+++ b/server/src/main/java/io/crate/metadata/view/ViewInfoFactory.java
@@ -61,11 +61,12 @@ public class ViewInfoFactory {
             return null;
         }
         List<Reference> columns;
+        CoordinatorTxnCtx transactionContext = CoordinatorTxnCtx.systemTransactionContext();
+        transactionContext.sessionSettings().setSearchPath(view.searchPath());
+        transactionContext.sessionSettings().setErrorOnUnknownObjectKey(view.errorOnUnknownObjectKey());
         boolean analyzeError = false;
         try {
-            CoordinatorTxnCtx transactionContext = CoordinatorTxnCtx.systemTransactionContext();
-            transactionContext.sessionSettings().setSearchPath(view.searchPath());
-            transactionContext.sessionSettings().setErrorOnUnknownObjectKey(false);
+
             AnalyzedRelation relation = analyzerProvider.analyze(
                 (Query) SqlParser.createStatement(view.stmt()),
                 transactionContext,
@@ -102,7 +103,7 @@ public class ViewInfoFactory {
             analyzeError = true;
         }
         String viewDefinition = analyzeError ? String.format(Locale.ENGLISH, "/* Corrupted view, needs fix */\n%s", view.stmt()) : view.stmt();
-        return new ViewInfo(ident, viewDefinition, columns, view.owner(), view.searchPath());
+        return new ViewInfo(ident, viewDefinition, columns, view.owner(), view.searchPath(), transactionContext.sessionSettings().errorOnUnknownObjectKey());
     }
 
     private static int addSubColumns(List<Reference> subColumns,

--- a/server/src/main/java/io/crate/metadata/view/ViewMetadata.java
+++ b/server/src/main/java/io/crate/metadata/view/ViewMetadata.java
@@ -34,7 +34,8 @@ import io.crate.metadata.SearchPath;
 public record ViewMetadata(
         String stmt,
         @Nullable String owner,
-        SearchPath searchPath) implements Writeable {
+        SearchPath searchPath,
+        boolean errorOnUnknownObjectKey) implements Writeable {
 
     public static ViewMetadata of(StreamInput in) throws IOException {
         String stmt = in.readString();
@@ -46,7 +47,8 @@ public record ViewMetadata(
         } else {
             searchPath = SearchPath.pathWithPGCatalogAndDoc();
         }
-        return new ViewMetadata(stmt, owner, searchPath);
+        boolean errorOnUnknownObjectKey = in.readBoolean();
+        return new ViewMetadata(stmt, owner, searchPath, errorOnUnknownObjectKey);
     }
 
     @Override
@@ -57,5 +59,6 @@ public record ViewMetadata(
         if (version.onOrAfter(Version.V_5_3_5) && !version.equals(Version.V_5_4_0)) {
             searchPath.writeTo(out);
         }
+        out.writeBoolean(errorOnUnknownObjectKey);
     }
 }

--- a/server/src/main/java/io/crate/metadata/view/ViewMetadata.java
+++ b/server/src/main/java/io/crate/metadata/view/ViewMetadata.java
@@ -47,7 +47,12 @@ public record ViewMetadata(
         } else {
             searchPath = SearchPath.pathWithPGCatalogAndDoc();
         }
-        boolean errorOnUnknownObjectKey = in.readBoolean();
+        boolean errorOnUnknownObjectKey;
+        if (version.after(Version.V_5_10_5)) {
+            errorOnUnknownObjectKey = in.readBoolean();
+        } else {
+            errorOnUnknownObjectKey = true;
+        }
         return new ViewMetadata(stmt, owner, searchPath, errorOnUnknownObjectKey);
     }
 

--- a/server/src/main/java/io/crate/metadata/view/ViewMetadata.java
+++ b/server/src/main/java/io/crate/metadata/view/ViewMetadata.java
@@ -59,6 +59,8 @@ public record ViewMetadata(
         if (version.onOrAfter(Version.V_5_3_5) && !version.equals(Version.V_5_4_0)) {
             searchPath.writeTo(out);
         }
-        out.writeBoolean(errorOnUnknownObjectKey);
+        if (version.after(Version.V_5_10_5)) {
+            out.writeBoolean(errorOnUnknownObjectKey);
+        }
     }
 }

--- a/server/src/main/java/io/crate/metadata/view/ViewsMetadata.java
+++ b/server/src/main/java/io/crate/metadata/view/ViewsMetadata.java
@@ -186,14 +186,15 @@ public class ViewsMetadata extends AbstractNamedDiffable<Metadata.Custom> implem
                                              RelationName name,
                                              String query,
                                              @Nullable String owner,
-                                             SearchPath searchPath) {
+                                             SearchPath searchPath,
+                                             boolean errorOnUnknownObjectKey) {
         HashMap<String, ViewMetadata> queryByName;
         if (prevViews == null) {
             queryByName = new HashMap<>();
         } else {
             queryByName = new HashMap<>(prevViews.viewByName);
         }
-        queryByName.put(name.fqn(), new ViewMetadata(query, owner, searchPath, false));
+        queryByName.put(name.fqn(), new ViewMetadata(query, owner, searchPath, errorOnUnknownObjectKey));
         return new ViewsMetadata(queryByName);
     }
 

--- a/server/src/main/java/io/crate/metadata/view/ViewsMetadata.java
+++ b/server/src/main/java/io/crate/metadata/view/ViewsMetadata.java
@@ -140,7 +140,8 @@ public class ViewsMetadata extends AbstractNamedDiffable<Metadata.Custom> implem
                         ViewMetadata viewMetadata = new ViewMetadata(
                             stmt,
                             owner,
-                            searchPath == null ? SearchPath.pathWithPGCatalogAndDoc() : searchPath
+                            searchPath == null ? SearchPath.pathWithPGCatalogAndDoc() : searchPath,
+                            false
                         );
                         views.put(viewName, viewMetadata);
                     }
@@ -192,7 +193,7 @@ public class ViewsMetadata extends AbstractNamedDiffable<Metadata.Custom> implem
         } else {
             queryByName = new HashMap<>(prevViews.viewByName);
         }
-        queryByName.put(name.fqn(), new ViewMetadata(query, owner, searchPath));
+        queryByName.put(name.fqn(), new ViewMetadata(query, owner, searchPath, false));
         return new ViewsMetadata(queryByName);
     }
 

--- a/server/src/main/java/io/crate/planner/CreateViewPlan.java
+++ b/server/src/main/java/io/crate/planner/CreateViewPlan.java
@@ -86,8 +86,9 @@ public final class CreateViewPlan implements Plan {
             formattedQuery,
             createViewStmt.replaceExisting(),
             plannerContext.transactionContext().sessionSettings().searchPath(),
-            owner == null ? null : owner.name()
-        );
+            owner == null ? null : owner.name(),
+            plannerContext.transactionContext().sessionSettings().errorOnUnknownObjectKey()
+            );
         dependencies.client().execute(TransportCreateView.ACTION, request).whenComplete(
             new OneRowActionListener<>(consumer, resp -> {
                 if (resp.alreadyExistsFailure()) {

--- a/server/src/main/java/io/crate/planner/CreateViewPlan.java
+++ b/server/src/main/java/io/crate/planner/CreateViewPlan.java
@@ -88,7 +88,8 @@ public final class CreateViewPlan implements Plan {
             plannerContext.transactionContext().sessionSettings().searchPath(),
             owner == null ? null : owner.name(),
             plannerContext.transactionContext().sessionSettings().errorOnUnknownObjectKey()
-            );
+        );
+
         dependencies.client().execute(TransportCreateView.ACTION, request).whenComplete(
             new OneRowActionListener<>(consumer, resp -> {
                 if (resp.alreadyExistsFailure()) {

--- a/server/src/test/java/io/crate/execution/ddl/views/CreateViewRequestTest.java
+++ b/server/src/test/java/io/crate/execution/ddl/views/CreateViewRequestTest.java
@@ -40,7 +40,8 @@ public class CreateViewRequestTest {
             "select * from t1",
             true,
             SearchPath.createSearchPathFrom("custom"),
-            null
+            null,
+            false
         );
         try (BytesStreamOutput out = new BytesStreamOutput()) {
             out.setVersion(Version.V_5_4_0);

--- a/server/src/test/java/io/crate/execution/ddl/views/CreateViewRequestTest.java
+++ b/server/src/test/java/io/crate/execution/ddl/views/CreateViewRequestTest.java
@@ -50,6 +50,7 @@ public class CreateViewRequestTest {
             in.setVersion(Version.V_5_4_0);
             CreateViewRequest fromStream = new CreateViewRequest(in);
             assertThat(fromStream.searchPath()).isEqualTo(SearchPath.pathWithPGCatalogAndDoc());
+            assertThat(fromStream.errorOnUnknownObjectKey()).isEqualTo(true);
         }
 
         try (BytesStreamOutput out = new BytesStreamOutput()) {
@@ -59,6 +60,7 @@ public class CreateViewRequestTest {
             in.setVersion(Version.V_5_4_1);
             CreateViewRequest fromStream = new CreateViewRequest(in);
             assertThat(fromStream.searchPath()).isEqualTo(createView.searchPath());
+            assertThat(fromStream.errorOnUnknownObjectKey()).isEqualTo(true);
         }
 
         try (BytesStreamOutput out = new BytesStreamOutput()) {
@@ -68,6 +70,15 @@ public class CreateViewRequestTest {
             in.setVersion(Version.V_5_3_5);
             CreateViewRequest fromStream = new CreateViewRequest(in);
             assertThat(fromStream.searchPath()).isEqualTo(createView.searchPath());
+            assertThat(fromStream.errorOnUnknownObjectKey()).isEqualTo(true);
+        }
+
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            createView.writeTo(out);
+            StreamInput in = out.bytes().streamInput();
+            CreateViewRequest fromStream = new CreateViewRequest(in);
+            assertThat(fromStream.searchPath()).isEqualTo(createView.searchPath());
+            assertThat(fromStream.errorOnUnknownObjectKey()).isEqualTo(false);
         }
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/BaseRolesIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/BaseRolesIntegrationTest.java
@@ -27,12 +27,6 @@ import org.elasticsearch.test.IntegTestCase;
 import org.junit.After;
 import org.junit.Before;
 
-import io.crate.session.Session;
-import io.crate.session.Sessions;
-import io.crate.auth.Protocol;
-import io.crate.protocols.postgres.ConnectionProperties;
-import io.crate.role.Role;
-import io.crate.role.Roles;
 import io.crate.testing.SQLResponse;
 
 public abstract class BaseRolesIntegrationTest extends IntegTestCase {
@@ -66,16 +60,6 @@ public abstract class BaseRolesIntegrationTest extends IntegTestCase {
 
     public SQLResponse executeAsSuperuser(String stmt, Object[] args) {
         return execute(stmt, args);
-    }
-
-    public SQLResponse executeAs(String stmt, String userName) {
-        Sessions sqlOperations = cluster().getInstance(Sessions.class);
-        Roles roles = cluster().getInstance(Roles.class);
-        Role user = roles.getUser(userName);
-        try (Session session = sqlOperations.newSession(
-            new ConnectionProperties(null, null, Protocol.HTTP, null), null, user)) {
-            return execute(stmt, null, session);
-        }
     }
 
     protected void assertUserIsCreated(String userName) {

--- a/server/src/test/java/io/crate/integrationtests/ViewsITest.java
+++ b/server/src/test/java/io/crate/integrationtests/ViewsITest.java
@@ -316,6 +316,7 @@ public class ViewsITest extends IntegTestCase {
     @Test
     public void test_error_on_unknown_object_key_on_authenticated_user() {
         try (var session = sqlExecutor.newSession()) {
+            execute("SET error_on_unknown_object_key=false", session);
             execute("CREATE TABLE doc.tbl1 (obj OBJECT(DYNAMIC))", session);
             execute("CREATE USER user1", session);
             execute("ALTER USER user1 SET (\"error_on_unknown_object_key\"=false)", session);

--- a/server/src/test/java/io/crate/integrationtests/ViewsITest.java
+++ b/server/src/test/java/io/crate/integrationtests/ViewsITest.java
@@ -40,17 +40,9 @@ import org.junit.Test;
 import io.crate.exceptions.RelationAlreadyExists;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.view.ViewsMetadata;
-import io.crate.protocols.postgres.ConnectionProperties;
 import io.crate.protocols.postgres.PGErrorStatus;
-import io.crate.role.Role;
-import io.crate.role.Roles;
-import io.crate.session.Session;
-import io.crate.session.Sessions;
 import io.crate.testing.Asserts;
-import io.crate.testing.SQLResponse;
-import io.crate.testing.UseJdbc;
 import io.netty.handler.codec.http.HttpResponseStatus;
-import io.crate.auth.Protocol;
 
 public class ViewsITest extends IntegTestCase {
 
@@ -312,7 +304,9 @@ public class ViewsITest extends IntegTestCase {
         );
     }
 
-    @UseJdbc(0)
+    /*
+     * https://github.com/crate/crate/issues/17836
+     */
     @Test
     public void test_error_on_unknown_object_key_on_authenticated_user() {
         try (var session = sqlExecutor.newSession()) {
@@ -322,22 +316,12 @@ public class ViewsITest extends IntegTestCase {
             execute("ALTER USER user1 SET (\"error_on_unknown_object_key\"=false)", session);
             execute("GRANT ALL TO user1", session);
             execute("SET SESSION AUTHORIZATION user1", session);
-            executeAs("CREATE VIEW vw1 AS SELECT obj['not_existing'] FROM doc.tbl1;",  "user1");
+            executeAs("CREATE VIEW vw1 AS SELECT obj['not_existing'] FROM doc.tbl1;", "user1");
             executeAs("select view_definition from information_schema.views where table_name='vw1';", "user1");
             assertThat(response).hasRows(
                 "SELECT \"obj\"['not_existing']\n" +
-                "FROM \"doc\".\"tbl1\"\n"
+                    "FROM \"doc\".\"tbl1\"\n"
             );
-        }
-    }
-
-    public SQLResponse executeAs(String stmt, String userName) {
-        Sessions sqlOperations = cluster().getInstance(Sessions.class);
-        Roles roles = cluster().getInstance(Roles.class);
-        Role user = roles.getUser(userName);
-        try (Session session = sqlOperations.newSession(
-            new ConnectionProperties(null, null, Protocol.HTTP, null), null, user)) {
-            return execute(stmt, null, session);
         }
     }
 }

--- a/server/src/test/java/io/crate/metadata/pgcatalog/OidHashTest.java
+++ b/server/src/test/java/io/crate/metadata/pgcatalog/OidHashTest.java
@@ -46,7 +46,7 @@ import io.crate.types.TypeSignature;
 
 public class OidHashTest extends CrateDummyClusterServiceUnitTest {
 
-    private static final RelationInfo VIEW_INFO = new ViewInfo(T1, "", Collections.emptyList(), null, SearchPath.pathWithPGCatalogAndDoc(), false);
+    private static final RelationInfo VIEW_INFO = new ViewInfo(T1, "", Collections.emptyList(), null, SearchPath.pathWithPGCatalogAndDoc(), true);
     private RelationInfo t1Info;
 
     @Before

--- a/server/src/test/java/io/crate/metadata/pgcatalog/OidHashTest.java
+++ b/server/src/test/java/io/crate/metadata/pgcatalog/OidHashTest.java
@@ -46,7 +46,7 @@ import io.crate.types.TypeSignature;
 
 public class OidHashTest extends CrateDummyClusterServiceUnitTest {
 
-    private static final RelationInfo VIEW_INFO = new ViewInfo(T1, "", Collections.emptyList(), null, SearchPath.pathWithPGCatalogAndDoc());
+    private static final RelationInfo VIEW_INFO = new ViewInfo(T1, "", Collections.emptyList(), null, SearchPath.pathWithPGCatalogAndDoc(), false);
     private RelationInfo t1Info;
 
     @Before

--- a/server/src/test/java/io/crate/metadata/view/ViewInfoFactoryTest.java
+++ b/server/src/test/java/io/crate/metadata/view/ViewInfoFactoryTest.java
@@ -47,7 +47,7 @@ public class ViewInfoFactoryTest {
 
         String statement = "SELECT * FROM users";
         RelationName ident = new RelationName(null, "test");
-        ViewMetadata viewMetadata = new ViewMetadata(statement, null, SearchPath.pathWithPGCatalogAndDoc());
+        ViewMetadata viewMetadata = new ViewMetadata(statement, null, SearchPath.pathWithPGCatalogAndDoc(), false);
         ViewsMetadata views = new ViewsMetadata(Map.of(ident.fqn(), viewMetadata));
 
         ClusterState state = ClusterState.builder(ClusterState.EMPTY_STATE)

--- a/server/src/test/java/io/crate/metadata/view/ViewMetadataTest.java
+++ b/server/src/test/java/io/crate/metadata/view/ViewMetadataTest.java
@@ -37,7 +37,8 @@ public class ViewMetadataTest {
         var viewMetadata = new ViewMetadata(
             "select 1",
             "me",
-            SearchPath.createSearchPathFrom("foo", "bar")
+            SearchPath.createSearchPathFrom("foo", "bar"),
+            false
         );
         try (BytesStreamOutput out = new BytesStreamOutput()) {
             out.setVersion(Version.V_5_4_0);

--- a/server/src/test/java/io/crate/metadata/view/ViewMetadataTest.java
+++ b/server/src/test/java/io/crate/metadata/view/ViewMetadataTest.java
@@ -38,7 +38,7 @@ public class ViewMetadataTest {
             "select 1",
             "me",
             SearchPath.createSearchPathFrom("foo", "bar"),
-            false
+            true
         );
         try (BytesStreamOutput out = new BytesStreamOutput()) {
             out.setVersion(Version.V_5_4_0);

--- a/server/src/test/java/io/crate/metadata/view/ViewsMetadataTest.java
+++ b/server/src/test/java/io/crate/metadata/view/ViewsMetadataTest.java
@@ -43,9 +43,9 @@ public class ViewsMetadataTest extends ESTestCase {
         SearchPath searchPath1 = SearchPath.createSearchPathFrom("foo", "bar", "doc");
         Map<String, ViewMetadata> map = Map.of(
             "doc.my_view",
-            new ViewMetadata("SELECT x, y FROM t1 WHERE z = 'a'", "user_a", searchPath1, false),
+            new ViewMetadata("SELECT x, y FROM t1 WHERE z = 'a'", "user_a", searchPath1, true),
             "my_schema.other_view",
-            new ViewMetadata("SELECT a, b FROM t2 WHERE c = 1", "user_b", searchPath1, false));
+            new ViewMetadata("SELECT a, b FROM t2 WHERE c = 1", "user_b", searchPath1, true));
         return new ViewsMetadata(map);
     }
 

--- a/server/src/test/java/io/crate/metadata/view/ViewsMetadataTest.java
+++ b/server/src/test/java/io/crate/metadata/view/ViewsMetadataTest.java
@@ -43,9 +43,9 @@ public class ViewsMetadataTest extends ESTestCase {
         SearchPath searchPath1 = SearchPath.createSearchPathFrom("foo", "bar", "doc");
         Map<String, ViewMetadata> map = Map.of(
             "doc.my_view",
-            new ViewMetadata("SELECT x, y FROM t1 WHERE z = 'a'", "user_a", searchPath1),
+            new ViewMetadata("SELECT x, y FROM t1 WHERE z = 'a'", "user_a", searchPath1, false),
             "my_schema.other_view",
-            new ViewMetadata("SELECT a, b FROM t2 WHERE c = 1", "user_b", searchPath1));
+            new ViewMetadata("SELECT a, b FROM t2 WHERE c = 1", "user_b", searchPath1, false));
         return new ViewsMetadata(map);
     }
 

--- a/server/src/testFixtures/java/io/crate/testing/SQLExecutor.java
+++ b/server/src/testFixtures/java/io/crate/testing/SQLExecutor.java
@@ -895,7 +895,8 @@ public class SQLExecutor {
             name,
             query,
             user == null ? null : user.name(),
-            SearchPath.createSearchPathFrom(searchPath)
+            SearchPath.createSearchPathFrom(searchPath),
+            coordinatorTxnCtx.sessionSettings().errorOnUnknownObjectKey()
         );
 
         Metadata newMetadata = Metadata.builder(prevState.metadata()).putCustom(ViewsMetadata.TYPE, newViews).build();

--- a/server/src/testFixtures/java/org/elasticsearch/test/IntegTestCase.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/IntegTestCase.java
@@ -1520,6 +1520,23 @@ public abstract class IntegTestCase extends ESTestCase {
     }
 
     /**
+     * Execute an SQL Statement as an authenticated user
+     *
+     * @param stmt the SQL Statement
+     * @param userName The name of the authenticated user
+     * @return the SQLResponse
+     */
+    public SQLResponse executeAs(String stmt, String userName) {
+        Sessions sqlOperations = cluster().getInstance(Sessions.class);
+        Roles roles = cluster().getInstance(Roles.class);
+        Role user = roles.getUser(userName);
+        try (Session session = sqlOperations.newSession(
+            new ConnectionProperties(null, null, Protocol.HTTP, null), null, user)) {
+            return execute(stmt, null, session);
+        }
+    }
+
+    /**
      * Execute an SQL Statement on a random node of the cluster
      *
      * @param stmt    the SQL Statement


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Fixes https://github.com/crate/crate/issues/17836


## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
