### PR TITLE
UpdateToInsert doesn't need to return a whole IndexItem

### DIFF
--- a/server/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
+++ b/server/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
@@ -61,7 +61,6 @@ import io.crate.Constants;
 import io.crate.common.exceptions.Exceptions;
 import io.crate.execution.ddl.tables.AddColumnRequest;
 import io.crate.execution.ddl.tables.TransportAddColumn;
-import io.crate.execution.dml.IndexItem;
 import io.crate.execution.dml.Indexer;
 import io.crate.execution.dml.RawIndexer;
 import io.crate.execution.dml.ShardResponse;
@@ -443,9 +442,9 @@ public class TransportShardUpsertAction extends TransportShardAction<ShardUpsert
                         item.primaryTerm(),
                         actualTable);
                     version = doc.getVersion();
-                    IndexItem indexItem = updateToInsert.convert(doc, item.updateAssignments(), insertValues);
-                    item.pkValues(indexItem.pkValues());
-                    item.insertValues(indexItem.insertValues());
+                    UpdateToInsert.Update update = updateToInsert.convert(doc, item.updateAssignments(), insertValues);
+                    item.pkValues(update.pkValues());
+                    item.insertValues(update.insertValues());
                     request.insertColumns(updatingIndexer.insertColumns(updatingIndexer.columns()));
                 }
                 return insert(

--- a/server/src/test/java/io/crate/execution/dml/upsert/UpdateToInsertTest.java
+++ b/server/src/test/java/io/crate/execution/dml/upsert/UpdateToInsertTest.java
@@ -33,7 +33,6 @@ import org.elasticsearch.common.UUIDs;
 import org.junit.Test;
 
 import io.crate.analyze.Id;
-import io.crate.execution.dml.IndexItem;
 import io.crate.expression.reference.Doc;
 import io.crate.expression.reference.doc.lucene.StoredRow;
 import io.crate.expression.symbol.InputColumn;
@@ -77,7 +76,7 @@ public class UpdateToInsertTest extends CrateDummyClusterServiceUnitTest {
         Map<String, Object> source = Map.of("x", 10, "y", 5);
         Doc doc = doc(UUIDs.randomBase64UUID(), table.concreteIndices(e.getPlannerContext().clusterState().metadata())[0], source);
 
-        IndexItem item = updateToInsert.convert(
+        UpdateToInsert.Update item = updateToInsert.convert(
             doc,
             new Symbol[] { Literal.of(20) },
             new Object[0]
@@ -101,7 +100,7 @@ public class UpdateToInsertTest extends CrateDummyClusterServiceUnitTest {
         Map<String, Object> source = Map.of("x", 10, "y", 5);
         Doc doc = doc(UUIDs.randomBase64UUID(), table.concreteIndices(e.getPlannerContext().clusterState().metadata())[0], source);
 
-        IndexItem item = updateToInsert.convert(
+        UpdateToInsert.Update item = updateToInsert.convert(
             doc,
             new Symbol[] { new InputColumn(0) },
             new Object[] { 20 }
@@ -124,7 +123,7 @@ public class UpdateToInsertTest extends CrateDummyClusterServiceUnitTest {
         );
         Map<String, Object> source = Map.of("x", 1, "o", Map.of("y", 2));
         Doc doc = doc(UUIDs.randomBase64UUID(), table.concreteIndices(e.getPlannerContext().clusterState().metadata())[0], source);
-        IndexItem item = updateToInsert.convert(
+        UpdateToInsert.Update item = updateToInsert.convert(
             doc,
             new Symbol[] { Literal.of(3) },
             new Object[] {}
@@ -147,7 +146,7 @@ public class UpdateToInsertTest extends CrateDummyClusterServiceUnitTest {
         );
         Map<String, Object> source = Map.of("x", 1, "y", 5);
         Doc doc = doc(UUIDs.randomBase64UUID(), table.concreteIndices(e.getPlannerContext().clusterState().metadata())[0], source);
-        IndexItem item = updateToInsert.convert(
+        UpdateToInsert.Update item = updateToInsert.convert(
             doc,
             new Symbol[] { Literal.of(8) },
             new Object[] {}
@@ -175,7 +174,7 @@ public class UpdateToInsertTest extends CrateDummyClusterServiceUnitTest {
         Doc doc = doc(UUIDs.randomBase64UUID(), table.concreteIndices(e.getPlannerContext().clusterState().metadata())[0], source);
 
         Symbol[] assignments = new Symbol[] { Literal.of(8) };
-        IndexItem item = updateToInsert.convert(doc, assignments, new Object[0]);
+        UpdateToInsert.Update item = updateToInsert.convert(doc, assignments, new Object[0]);
         assertThat(item.insertValues())
             .containsExactly(8);
     }
@@ -194,7 +193,7 @@ public class UpdateToInsertTest extends CrateDummyClusterServiceUnitTest {
         );
         Map<String, Object> source = Map.of("x", 12);
         Doc doc = doc(UUIDs.randomBase64UUID(), table.concreteIndices(e.getPlannerContext().clusterState().metadata())[0], source);
-        IndexItem item = updateToInsert.convert(
+        UpdateToInsert.Update item = updateToInsert.convert(
             doc,
             new Symbol[] { Literal.of(1), Literal.of(2) },
             new Object[] {}
@@ -221,7 +220,7 @@ public class UpdateToInsertTest extends CrateDummyClusterServiceUnitTest {
         );
         Map<String, Object> source = Map.of("y", 1, "o", Map.of("x", 3));
         Doc doc = doc("3", table.concreteIndices(e.getPlannerContext().clusterState().metadata())[0], source);
-        IndexItem item = updateToInsert.convert(
+        UpdateToInsert.Update item = updateToInsert.convert(
             doc,
             new Symbol[] { Literal.of(1) },
             new Object[] {}
@@ -270,7 +269,7 @@ public class UpdateToInsertTest extends CrateDummyClusterServiceUnitTest {
 
         Map<String, Object> source = Map.of("x", 1, "y", 2, "z", 3);
         Doc doc = doc(UUIDs.randomBase64UUID(), table.concreteIndices(e.getPlannerContext().clusterState().metadata())[0], source);
-        IndexItem item = updateToInsert.convert(
+        UpdateToInsert.Update item = updateToInsert.convert(
             doc,
             new Symbol[] { Literal.of(20) },
             new Object[] { Literal.of(3) }
@@ -310,7 +309,7 @@ public class UpdateToInsertTest extends CrateDummyClusterServiceUnitTest {
         Map<String, Object> source = Map.of("x", 1, "y", Map.of("a", 2), "z", 3);
         String id = UUIDs.randomBase64UUID();
         Doc doc = doc(id, table.concreteIndices(e.getPlannerContext().clusterState().metadata())[0], source);
-        IndexItem item = updateToInsert.convert(
+        UpdateToInsert.Update item = updateToInsert.convert(
                 doc,
                 new Symbol[] { Literal.of(20) },
                 new Object[] { Literal.of(3) }
@@ -347,7 +346,7 @@ public class UpdateToInsertTest extends CrateDummyClusterServiceUnitTest {
         Map<String, Object> source = Map.of("x", 1, "y", 2, "z", 3);
         String id = Id.encode(List.of("1", "2"), -1);
         Doc doc = doc(id, table.concreteIndices(e.getPlannerContext().clusterState().metadata())[0], source);
-        IndexItem item = updateToInsert.convert(
+        UpdateToInsert.Update item = updateToInsert.convert(
             doc,
             new Symbol[] { new InputColumn(1) },
             new Object[] { 1, 20 }
@@ -394,7 +393,7 @@ public class UpdateToInsertTest extends CrateDummyClusterServiceUnitTest {
         );
         String id = Id.encode(List.of("1", "2"), -1);
         Doc doc = doc(id, table.concreteIndices(e.getPlannerContext().clusterState().metadata())[0], source);
-        IndexItem item = updateToInsert.convert(
+        UpdateToInsert.Update item = updateToInsert.convert(
             doc,
             new Symbol[] { new InputColumn(1) },
             new Object[] { 1, 20 }
@@ -435,7 +434,7 @@ public class UpdateToInsertTest extends CrateDummyClusterServiceUnitTest {
         );
         String id = Id.encode(List.of("1", "10"), -1);
         Doc doc = doc(id, table.concreteIndices(e.getPlannerContext().clusterState().metadata())[0], source);
-        IndexItem item = updateToInsert.convert(
+        UpdateToInsert.Update item = updateToInsert.convert(
             doc,
             new Symbol[] { new InputColumn(1) },
             new Object[] { 1, 20 }


### PR DESCRIPTION
We only use the primary key values and update values from the returned value, and ignore sequence number and primary term. This is confusing, especially as the item will get a new sequence number after it has been indexed on the primary, and it looks as though we are setting the incorrect value here.

Instead of returning an IndexItem containing inaccurate and ignored fields, return a record consisting of just the primary key values and update values.