### PR TITLE
Use pooled netty allocator to workaround ByteBuf leaks

### DIFF
--- a/app/src/main/dist/bin/crate
+++ b/app/src/main/dist/bin/crate
@@ -164,6 +164,9 @@ JAVA_OPTS="$JAVA_OPTS -Dio.netty.recycler.maxCapacityPerThread=0"
 # Netty uses Unsafe, disable warning, continue to allow it (See also https://github.com/netty/netty/pull/14975)
 JAVA_OPTS="$JAVA_OPTS --sun-misc-unsafe-memory-access=allow"
 
+# Netty 4.2.1 runs into leaks with the adaptive allocator, likely due to https://github.com/netty/netty/commit/1e228de839e083482138df8298a9ceb6c464cf0c
+JAVA_OPTS="$JAVA_OPTS -Dio.netty.allocator.type=pooled"
+
 # Lucene uses native access and vector module
 JAVA_OPTS="$JAVA_OPTS --enable-native-access=ALL-UNNAMED --add-modules jdk.incubator.vector"
 

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
           <!-- by default is false but is set to true by `serverTest` profile to avoid running tests
                for modules on which `server` module depends on, when running `mvn -Pserver test` -->
           <skip>${skipRunTests}</skip>
-          <argLine>@{argLine} -XX:+UseSerialGC -XX:TieredStopAtLevel=1 -XX:ReservedCodeCacheSize=512M --add-modules jdk.incubator.vector --enable-native-access=ALL-UNNAMED --sun-misc-unsafe-memory-access=allow</argLine>
+          <argLine>@{argLine} -XX:+UseSerialGC -XX:TieredStopAtLevel=1 -XX:ReservedCodeCacheSize=512M --add-modules jdk.incubator.vector --enable-native-access=ALL-UNNAMED --sun-misc-unsafe-memory-access=allow -Dio.netty.allocator.type=pooled</argLine>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
Since the netty 4.2 update `PgTunnelLogicalReplicationITest` is flaky,
failing with ByteBuf leaks.

It appears to be realted to the new adaptive allocator. Can't reproduce
the issue with the pooled allocator - so this switches back to pooled.

I suspect this will be fixed in 4.2.2 with
https://github.com/netty/netty/commit/1e228de839e083482138df8298a9ceb6c464cf0c
