### PR TITLE
DELETE must be retried on temporal errors and not be retried on non-retryable errors.

### DIFF
--- a/docs/appendices/release-notes/5.10.7.rst
+++ b/docs/appendices/release-notes/5.10.7.rst
@@ -51,3 +51,7 @@ Fixes
   :ref:`conf-session-error_on_unknown_object_key` was not persisted into a view,
   and such not taken into account when executing the view. Previously created
   views need to be recreated to apply the setting successfully.
+
+- Fixed an issue that caused ``DELETE`` statements to not be retried on
+  temporal errors (for instance, a shard being unavailable) and instead
+  being retried on permanent errors. Now it's an other way around.


### PR DESCRIPTION
Spot this while looking into https://github.com/crate/support/issues/626

Both INSERT and DELETE are TransportShardAction-s. 

However, on INSERT we retry (throw) on temporal errors and on DELETE we do it vice versa, we throw on non-retyable errors. This change aligns DELETE with INSERT.