### PR TITLE
Improve EXPLAIN printing for WindowAgg operator

### DIFF
--- a/server/src/main/java/io/crate/planner/operators/WindowAgg.java
+++ b/server/src/main/java/io/crate/planner/operators/WindowAgg.java
@@ -267,4 +267,18 @@ public class WindowAgg extends ForwardingLogicalPlan {
             "windowFunctions=[" + Lists.joinOn(", ", windowFunctions, WindowFunction::toString) + "]" +
             "}";
     }
+
+    @Override
+    public void print(PrintContext printContext) {
+        printContext
+            .text(getClass().getSimpleName())
+            .text("[")
+            .text(Lists.joinOn(", ", standalone, Symbol::toString))
+            .text("]")
+            .text(" | [")
+            .text(Lists.joinOn(", ", windowFunctions, Symbol::toString))
+            .text("]");
+        printStats(printContext);
+        printContext.nest(Lists.map(sources(), x -> x::print));
+    }
 }

--- a/server/src/test/java/io/crate/planner/SelectPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/SelectPlannerTest.java
@@ -24,7 +24,6 @@ package io.crate.planner;
 import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.Asserts.isReference;
 import static java.util.Collections.singletonList;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Collection;
@@ -1248,7 +1247,7 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
         String expectedPlan =
             """
             Eval[unnest, sum(unnest) OVER (ORDER BY power(unnest, 2.0) ASC RANGE BETWEEN 3 PRECEDING AND CURRENT ROW)]
-              └ WindowAgg[unnest, power(unnest, 2.0), sum(unnest) OVER (ORDER BY power(unnest, 2.0) ASC RANGE BETWEEN 3 PRECEDING AND CURRENT ROW)]
+              └ WindowAgg[unnest, power(unnest, 2.0)] | [sum(unnest) OVER (ORDER BY power(unnest, 2.0) ASC RANGE BETWEEN 3 PRECEDING AND CURRENT ROW)]
                 └ Eval[unnest, power(unnest, 2.0)]
                   └ Rename[unnest, unnest] AS t
                     └ TableFunction[unnest | [unnest, unnest] | true]

--- a/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
@@ -23,7 +23,6 @@ package io.crate.planner.operators;
 
 import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.MemoryLimits.assertMaxBytesAllocated;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -96,7 +95,7 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(plan).isEqualTo(
             """
             Eval[avg(x) OVER ()]
-              └ WindowAgg[x, avg(x) OVER ()]
+              └ WindowAgg[x] | [avg(x) OVER ()]
                 └ Collect[doc.t1 | [x] | true]
             """
         );
@@ -636,7 +635,7 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(plan).hasOperators(
             "Rename[i, avgx] AS vt",
             "  └ Eval[i, avg(x) OVER (ORDER BY i ASC) AS avgx]",
-            "    └ WindowAgg[i, x, avg(x) OVER (ORDER BY i ASC)]",
+            "    └ WindowAgg[i, x] | [avg(x) OVER (ORDER BY i ASC)]",
             "      └ Collect[doc.t1 | [i, x] | true]"
         );
     }

--- a/server/src/test/java/io/crate/planner/operators/PushDownTest.java
+++ b/server/src/test/java/io/crate/planner/operators/PushDownTest.java
@@ -434,7 +434,7 @@ public class PushDownTest extends CrateDummyClusterServiceUnitTest {
         var expectedPlan =
             """
             Rename[x, "sum(x) OVER (PARTITION BY x)"] AS sums
-              └ WindowAgg[x, sum(x) OVER (PARTITION BY x)]
+              └ WindowAgg[x] | [sum(x) OVER (PARTITION BY x)]
                 └ Collect[doc.t1 | [x] | (x = 10)]
             """;
         assertThat(plan).isEqualTo(expectedPlan);

--- a/server/src/test/java/io/crate/planner/operators/WindowAggTest.java
+++ b/server/src/test/java/io/crate/planner/operators/WindowAggTest.java
@@ -68,7 +68,7 @@ public class WindowAggTest extends CrateDummyClusterServiceUnitTest {
         var expectedPlan =
             """
             Eval[avg(x) OVER (PARTITION BY x), avg(x) OVER (PARTITION BY x)]
-              └ WindowAgg[x, avg(x) OVER (PARTITION BY x)]
+              └ WindowAgg[x] | [avg(x) OVER (PARTITION BY x)]
                 └ Collect[doc.t1 | [x] | true]
             """;
         assertThat(plan).isEqualTo(expectedPlan);
@@ -80,7 +80,7 @@ public class WindowAggTest extends CrateDummyClusterServiceUnitTest {
         var expectedPlan =
             """
             Eval[min(x) OVER (PARTITION BY (x * $1)), avg(x) OVER (PARTITION BY (x * $1))]
-              └ WindowAgg[x, (x * $1), min(x) OVER (PARTITION BY (x * $1)), avg(x) OVER (PARTITION BY (x * $1))]
+              └ WindowAgg[x, (x * $1)] | [min(x) OVER (PARTITION BY (x * $1)), avg(x) OVER (PARTITION BY (x * $1))]
                 └ Collect[doc.t1 | [x, (x * $1)] | true]
             """;
         assertThat(plan).isEqualTo(expectedPlan);
@@ -95,8 +95,8 @@ public class WindowAggTest extends CrateDummyClusterServiceUnitTest {
         var expectedPlan =
             """
             Eval[avg(x) OVER (PARTITION BY x), avg(x) OVER (PARTITION BY y)]
-              └ WindowAgg[x, y, avg(x) OVER (PARTITION BY x), avg(x) OVER (PARTITION BY y)]
-                └ WindowAgg[x, y, avg(x) OVER (PARTITION BY x)]
+              └ WindowAgg[x, y, avg(x) OVER (PARTITION BY x)] | [avg(x) OVER (PARTITION BY y)]
+                └ WindowAgg[x, y] | [avg(x) OVER (PARTITION BY x)]
                   └ Collect[doc.t1 | [x, y] | true]
             """;
         assertThat(plan).isEqualTo(expectedPlan);
@@ -108,7 +108,7 @@ public class WindowAggTest extends CrateDummyClusterServiceUnitTest {
         var expectedPlan =
             """
             Eval[y, avg(x) FILTER (WHERE (x > 1)) OVER ()]
-              └ WindowAgg[x, (x > 1), y, avg(x) FILTER (WHERE (x > 1)) OVER ()]
+              └ WindowAgg[x, (x > 1), y] | [avg(x) FILTER (WHERE (x > 1)) OVER ()]
                 └ Collect[doc.t1 | [x, (x > 1), y] | true]
             """;
         assertThat(plan).isEqualTo(expectedPlan);
@@ -120,7 +120,7 @@ public class WindowAggTest extends CrateDummyClusterServiceUnitTest {
         var expectedPlan =
             """
             Eval[x, count(*) FILTER (WHERE (y > 1)) OVER ()]
-              └ WindowAgg[(y > 1), x, count(*) FILTER (WHERE (y > 1)) OVER ()]
+              └ WindowAgg[(y > 1), x] | [count(*) FILTER (WHERE (y > 1)) OVER ()]
                 └ Collect[doc.t1 | [(y > 1), x] | true]
             """;
         assertThat(plan).isEqualTo(expectedPlan);

--- a/server/src/test/java/io/crate/planner/optimizer/rule/MoveFilterBeneathWindowAggTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/rule/MoveFilterBeneathWindowAggTest.java
@@ -123,7 +123,7 @@ public class MoveFilterBeneathWindowAggTest extends CrateDummyClusterServiceUnit
         );
         var expectedPlan =
             """
-            WindowAgg[id, row_number() OVER (PARTITION BY id)]
+            WindowAgg[id] | [row_number() OVER (PARTITION BY id)]
               └ Filter[(id = 10)]
                 └ Collect[doc.t1 | [id] | true]
             """;
@@ -155,7 +155,7 @@ public class MoveFilterBeneathWindowAggTest extends CrateDummyClusterServiceUnit
         var expectedPlan =
             """
             Filter[((row_number() OVER (PARTITION BY id) = 2) AND (x = 1))]
-              └ WindowAgg[id, row_number() OVER (PARTITION BY id)]
+              └ WindowAgg[id] | [row_number() OVER (PARTITION BY id)]
                 └ Filter[(id = 10)]
                   └ Collect[doc.t1 | [id] | true]
             """;


### PR DESCRIPTION
Instead of printing one list of outputs, which can be confusing, print the list of the standalone outputs, and the list of window functions implemented in the WindowAgg operator, separated with a `|`.
