### PR TITLE
Fix agg function resolution for non-registered types

### DIFF
--- a/extensions/functions/src/main/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregation.java
+++ b/extensions/functions/src/main/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregation.java
@@ -90,6 +90,7 @@ public class HyperLogLogDistinctAggregation extends AggregationFunction<HyperLog
                     .argumentTypes(supportedType.getTypeSignature())
                     .returnType(DataTypes.LONG.getTypeSignature())
                     .features(Scalar.Feature.DETERMINISTIC)
+                    .forbidCoercion()
                     .build(),
                 (signature, boundSignature) ->
                     new HyperLogLogDistinctAggregation(signature, boundSignature, supportedType)
@@ -100,6 +101,7 @@ public class HyperLogLogDistinctAggregation extends AggregationFunction<HyperLog
                         DataTypes.INTEGER.getTypeSignature())
                     .returnType(DataTypes.LONG.getTypeSignature())
                     .features(Scalar.Feature.DETERMINISTIC)
+                    .forbidCoercion()
                     .build(),
                 (signature, boundSignature) ->
                     new HyperLogLogDistinctAggregation(signature, boundSignature, supportedType)

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/ArbitraryAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/ArbitraryAggregation.java
@@ -75,21 +75,21 @@ public class ArbitraryAggregation extends AggregationFunction<Object, Object> {
     public static void register(Functions.Builder builder) {
         TypeSignature T = TypeSignature.parse("T");
         builder.add(
-                Signature.builder(NAME, FunctionType.AGGREGATE)
-                        .argumentTypes(T)
-                        .returnType(T)
-                        .features(Scalar.Feature.DETERMINISTIC)
-                        .typeVariableConstraints(TypeVariableConstraint.typeVariableOfAnyType("T"))
-                        .build(),
+            Signature.builder(NAME, FunctionType.AGGREGATE)
+                .argumentTypes(T)
+                .returnType(T)
+                .features(Scalar.Feature.DETERMINISTIC)
+                .typeVariableConstraints(TypeVariableConstraint.typeVariableOfAnyType("T"))
+                .build(),
             ArbitraryAggregation::new
         );
         builder.add(
-                Signature.builder(ALIAS, FunctionType.AGGREGATE)
-                        .argumentTypes(T)
-                        .returnType(T)
-                        .features(Scalar.Feature.DETERMINISTIC)
-                        .typeVariableConstraints(TypeVariableConstraint.typeVariableOfAnyType("T"))
-                        .build(),
+            Signature.builder(ALIAS, FunctionType.AGGREGATE)
+                .argumentTypes(T)
+                .returnType(T)
+                .features(Scalar.Feature.DETERMINISTIC)
+                .typeVariableConstraints(TypeVariableConstraint.typeVariableOfAnyType("T"))
+                .build(),
             ArbitraryAggregation::new
         );
     }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/CollectSetAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/CollectSetAggregation.java
@@ -59,12 +59,13 @@ public class CollectSetAggregation extends AggregationFunction<Map<Object, Objec
         for (DataType<?> supportedType : DataTypes.PRIMITIVE_TYPES) {
             var returnType = new ArrayType<>(supportedType);
             builder.add(
-                    Signature.builder(NAME, FunctionType.AGGREGATE)
-                            .argumentTypes(supportedType.getTypeSignature())
-                            .returnType(returnType.getTypeSignature())
-                            .features(Scalar.Feature.DETERMINISTIC)
-                            .build(),
-                    CollectSetAggregation::new
+                Signature.builder(NAME, FunctionType.AGGREGATE)
+                    .argumentTypes(supportedType.getTypeSignature())
+                    .returnType(returnType.getTypeSignature())
+                    .features(Scalar.Feature.DETERMINISTIC)
+                    .forbidCoercion()
+                    .build(),
+                CollectSetAggregation::new
             );
         }
     }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/GeometricMeanAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/GeometricMeanAggregation.java
@@ -72,17 +72,18 @@ public class GeometricMeanAggregation extends AggregationFunction<GeometricMeanA
     }
 
     static final List<DataType<?>> SUPPORTED_TYPES = Lists.concat(
-        DataTypes.NUMERIC_PRIMITIVE_TYPES, DataTypes.TIMESTAMPZ);
+        DataTypes.NUMERIC_PRIMITIVE_TYPES, List.of(DataTypes.TIMESTAMP, DataTypes.TIMESTAMPZ));
 
     public static void register(Functions.Builder builder) {
         for (var supportedType : SUPPORTED_TYPES) {
             builder.add(
-                    Signature.builder(NAME, FunctionType.AGGREGATE)
-                            .argumentTypes(supportedType.getTypeSignature())
-                            .returnType(DataTypes.DOUBLE.getTypeSignature())
-                            .features(Scalar.Feature.DETERMINISTIC)
-                            .build(),
-                    GeometricMeanAggregation::new
+                Signature.builder(NAME, FunctionType.AGGREGATE)
+                    .argumentTypes(supportedType.getTypeSignature())
+                    .returnType(DataTypes.DOUBLE.getTypeSignature())
+                    .features(Scalar.Feature.DETERMINISTIC)
+                    .forbidCoercion()
+                    .build(),
+                GeometricMeanAggregation::new
             );
         }
     }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/IntervalSumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/IntervalSumAggregation.java
@@ -45,12 +45,13 @@ public class IntervalSumAggregation extends AggregationFunction<Period, Period> 
 
     public static void register(Functions.Builder builder) {
         builder.add(
-                Signature.builder(NAME, FunctionType.AGGREGATE)
-                        .argumentTypes(DataTypes.INTERVAL.getTypeSignature())
-                        .returnType(DataTypes.INTERVAL.getTypeSignature())
-                        .features(Scalar.Feature.DETERMINISTIC)
-                        .build(),
-                IntervalSumAggregation::new
+            Signature.builder(NAME, FunctionType.AGGREGATE)
+                .argumentTypes(DataTypes.INTERVAL.getTypeSignature())
+                .returnType(DataTypes.INTERVAL.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC)
+                .forbidCoercion()
+                .build(),
+            IntervalSumAggregation::new
         );
     }
 

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/MaximumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/MaximumAggregation.java
@@ -67,21 +67,23 @@ public abstract class MaximumAggregation extends AggregationFunction<Object, Obj
         .argumentTypes(DataTypes.NUMERIC.getTypeSignature())
         .returnType(DataTypes.NUMERIC.getTypeSignature())
         .features(Scalar.Feature.DETERMINISTIC)
+        .forbidCoercion()
         .build();
 
     public static void register(Functions.Builder builder) {
         for (var supportedType : DataTypes.PRIMITIVE_TYPES) {
             var fixedWidthType = supportedType instanceof FixedWidthType;
             builder.add(
-                    Signature.builder(NAME, FunctionType.AGGREGATE)
-                            .argumentTypes(supportedType.getTypeSignature())
-                            .returnType(supportedType.getTypeSignature())
-                            .features(Scalar.Feature.DETERMINISTIC)
-                            .build(),
-                    (signature, boundSignature) ->
-                            fixedWidthType
-                                    ? new FixedMaximumAggregation(signature, boundSignature)
-                                    : new VariableMaximumAggregation(signature, boundSignature)
+                Signature.builder(NAME, FunctionType.AGGREGATE)
+                    .argumentTypes(supportedType.getTypeSignature())
+                    .returnType(supportedType.getTypeSignature())
+                    .features(Scalar.Feature.DETERMINISTIC)
+                    .forbidCoercion()
+                    .build(),
+                (signature, boundSignature) ->
+                    fixedWidthType
+                        ? new FixedMaximumAggregation(signature, boundSignature)
+                        : new VariableMaximumAggregation(signature, boundSignature)
             );
         }
         builder.add(NUMERIC_SIG, VariableMaximumAggregation::new);

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/MinimumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/MinimumAggregation.java
@@ -67,21 +67,23 @@ public abstract class MinimumAggregation extends AggregationFunction<Object, Obj
         .argumentTypes(DataTypes.NUMERIC.getTypeSignature())
         .returnType(DataTypes.NUMERIC.getTypeSignature())
         .features(Scalar.Feature.DETERMINISTIC)
+        .forbidCoercion()
         .build();
 
     public static void register(Functions.Builder builder) {
         for (var supportedType : DataTypes.PRIMITIVE_TYPES) {
             var fixedWidthType = supportedType instanceof FixedWidthType;
             builder.add(
-                    Signature.builder(NAME, FunctionType.AGGREGATE)
-                            .argumentTypes(supportedType.getTypeSignature())
-                            .returnType(supportedType.getTypeSignature())
-                            .features(Scalar.Feature.DETERMINISTIC)
-                            .build(),
-                    (signature, boundSignature) ->
-                            fixedWidthType
-                                    ? new FixedMinimumAggregation(signature, boundSignature)
-                                    : new VariableMinimumAggregation(signature, boundSignature)
+                Signature.builder(NAME, FunctionType.AGGREGATE)
+                    .argumentTypes(supportedType.getTypeSignature())
+                    .returnType(supportedType.getTypeSignature())
+                    .features(Scalar.Feature.DETERMINISTIC)
+                    .forbidCoercion()
+                    .build(),
+                (signature, boundSignature) ->
+                    fixedWidthType
+                        ? new FixedMinimumAggregation(signature, boundSignature)
+                        : new VariableMinimumAggregation(signature, boundSignature)
             );
         }
         builder.add(NUMERIC_SIG, VariableMinimumAggregation::new);

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/NumericSumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/NumericSumAggregation.java
@@ -64,10 +64,11 @@ public class NumericSumAggregation extends AggregationFunction<BigDecimal, BigDe
 
     public static final String NAME = "sum";
     public static final Signature SIGNATURE = Signature.builder(NAME, FunctionType.AGGREGATE)
-            .argumentTypes(DataTypes.NUMERIC.getTypeSignature())
-            .returnType(DataTypes.NUMERIC.getTypeSignature())
-            .features(Scalar.Feature.DETERMINISTIC)
-            .build();
+        .argumentTypes(DataTypes.NUMERIC.getTypeSignature())
+        .returnType(DataTypes.NUMERIC.getTypeSignature())
+        .features(Scalar.Feature.DETERMINISTIC)
+        .forbidCoercion()
+        .build();
     private static final long INIT_BIG_DECIMAL_SIZE = NumericType.size(BigDecimal.ZERO);
 
     public static void register(Functions.Builder builder) {

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/PercentileAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/PercentileAggregation.java
@@ -59,6 +59,7 @@ class PercentileAggregation extends AggregationFunction<TDigestState, Object> {
                     )
                     .returnType(DataTypes.DOUBLE.getTypeSignature())
                     .features(Scalar.Feature.DETERMINISTIC)
+                    .forbidCoercion()
                     .build(),
                 PercentileAggregation::new
             );
@@ -70,6 +71,7 @@ class PercentileAggregation extends AggregationFunction<TDigestState, Object> {
                     )
                     .returnType(DataTypes.DOUBLE_ARRAY.getTypeSignature())
                     .features(Scalar.Feature.DETERMINISTIC)
+                    .forbidCoercion()
                     .build(),
                 PercentileAggregation::new
             );
@@ -84,6 +86,7 @@ class PercentileAggregation extends AggregationFunction<TDigestState, Object> {
                     )
                     .returnType(DataTypes.DOUBLE.getTypeSignature())
                     .features(Scalar.Feature.DETERMINISTIC)
+                    .forbidCoercion()
                     .build(),
                 PercentileAggregation::new
             );
@@ -96,6 +99,7 @@ class PercentileAggregation extends AggregationFunction<TDigestState, Object> {
                     )
                     .returnType(DataTypes.DOUBLE_ARRAY.getTypeSignature())
                     .features(Scalar.Feature.DETERMINISTIC)
+                    .forbidCoercion()
                     .build(),
                 PercentileAggregation::new
             );

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/StandardDeviationAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/StandardDeviationAggregation.java
@@ -69,18 +69,19 @@ public class StandardDeviationAggregation extends AggregationFunction<StandardDe
     }
 
     private static final List<DataType<?>> SUPPORTED_TYPES = Lists.concat(
-        DataTypes.NUMERIC_PRIMITIVE_TYPES, DataTypes.TIMESTAMPZ);
+        DataTypes.NUMERIC_PRIMITIVE_TYPES, List.of(DataTypes.TIMESTAMP, DataTypes.TIMESTAMPZ));
 
     public static void register(Functions.Builder builder) {
         for (var name: NAMES) {
             for (var supportedType : SUPPORTED_TYPES) {
                 builder.add(
-                        Signature.builder(name, FunctionType.AGGREGATE)
-                            .argumentTypes(supportedType.getTypeSignature())
-                            .returnType(DataTypes.DOUBLE.getTypeSignature())
-                            .features(Scalar.Feature.DETERMINISTIC)
-                            .build(),
-                        StandardDeviationAggregation::new
+                    Signature.builder(name, FunctionType.AGGREGATE)
+                        .argumentTypes(supportedType.getTypeSignature())
+                        .returnType(DataTypes.DOUBLE.getTypeSignature())
+                        .features(Scalar.Feature.DETERMINISTIC)
+                        .forbidCoercion()
+                        .build(),
+                    StandardDeviationAggregation::new
                 );
             }
         }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/StringAgg.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/StringAgg.java
@@ -54,11 +54,13 @@ public final class StringAgg extends AggregationFunction<StringAgg.StringAggStat
     private static final String NAME = "string_agg";
     public static final Signature SIGNATURE =
             Signature.builder(NAME, FunctionType.AGGREGATE)
-                    .argumentTypes(DataTypes.STRING.getTypeSignature(),
-                            DataTypes.STRING.getTypeSignature())
-                    .returnType(DataTypes.STRING.getTypeSignature())
-                    .features(Scalar.Feature.DETERMINISTIC)
-                    .build();
+                .argumentTypes(
+                    DataTypes.STRING.getTypeSignature(),
+                    DataTypes.STRING.getTypeSignature())
+                .returnType(DataTypes.STRING.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC)
+                .forbidCoercion()
+                .build();
 
 
     private static final int LIST_ENTRY_OVERHEAD = 32;

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/SumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/SumAggregation.java
@@ -73,30 +73,33 @@ public class SumAggregation<T extends Number> extends AggregationFunction<T, T> 
 
         builder.add(
                 Signature.builder(NAME, FunctionType.AGGREGATE)
-                        .argumentTypes(DataTypes.FLOAT.getTypeSignature())
-                        .returnType(DataTypes.FLOAT.getTypeSignature())
-                        .features(Scalar.Feature.DETERMINISTIC)
-                        .build(),
+                    .argumentTypes(DataTypes.FLOAT.getTypeSignature())
+                    .returnType(DataTypes.FLOAT.getTypeSignature())
+                    .features(Scalar.Feature.DETERMINISTIC)
+                    .forbidCoercion()
+                    .build(),
                 getSumAggregationForFloatFactory()
         );
         builder.add(
                 Signature.builder(NAME, FunctionType.AGGREGATE)
-                        .argumentTypes(DataTypes.DOUBLE.getTypeSignature())
-                        .returnType(DataTypes.DOUBLE.getTypeSignature())
-                        .features(Scalar.Feature.DETERMINISTIC)
-                        .build(),
+                    .argumentTypes(DataTypes.DOUBLE.getTypeSignature())
+                    .returnType(DataTypes.DOUBLE.getTypeSignature())
+                    .features(Scalar.Feature.DETERMINISTIC)
+                    .forbidCoercion()
+                    .build(),
                 getSumAggregationForDoubleFactory()
         );
 
         for (var supportedType : List.of(DataTypes.BYTE, DataTypes.SHORT, DataTypes.INTEGER, DataTypes.LONG)) {
             builder.add(
-                    Signature.builder(NAME, FunctionType.AGGREGATE)
-                            .argumentTypes(supportedType.getTypeSignature())
-                            .returnType(DataTypes.LONG.getTypeSignature())
-                            .features(Scalar.Feature.DETERMINISTIC)
-                            .build(),
-                    (signature, boundSignature) ->
-                            new SumAggregation<>(DataTypes.LONG, add, sub, signature, boundSignature)
+                Signature.builder(NAME, FunctionType.AGGREGATE)
+                    .argumentTypes(supportedType.getTypeSignature())
+                    .returnType(DataTypes.LONG.getTypeSignature())
+                    .features(Scalar.Feature.DETERMINISTIC)
+                    .forbidCoercion()
+                    .build(),
+                (signature, boundSignature) ->
+                    new SumAggregation<>(DataTypes.LONG, add, sub, signature, boundSignature)
             );
         }
     }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/VarianceAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/VarianceAggregation.java
@@ -69,17 +69,18 @@ public class VarianceAggregation extends AggregationFunction<Variance, Double> {
     }
 
     static final List<DataType<?>> SUPPORTED_TYPES = Lists.concat(
-        DataTypes.NUMERIC_PRIMITIVE_TYPES, DataTypes.TIMESTAMPZ);
+        DataTypes.NUMERIC_PRIMITIVE_TYPES, List.of(DataTypes.TIMESTAMP, DataTypes.TIMESTAMPZ));
 
     public static void register(Functions.Builder builder) {
         for (var supportedType : SUPPORTED_TYPES) {
             builder.add(
-                    Signature.builder(NAME, FunctionType.AGGREGATE)
-                            .argumentTypes(supportedType.getTypeSignature())
-                            .returnType(DataTypes.DOUBLE.getTypeSignature())
-                            .features(Scalar.Feature.DETERMINISTIC)
-                            .build(),
-                    VarianceAggregation::new
+                Signature.builder(NAME, FunctionType.AGGREGATE)
+                    .argumentTypes(supportedType.getTypeSignature())
+                    .returnType(DataTypes.DOUBLE.getTypeSignature())
+                    .features(Scalar.Feature.DETERMINISTIC)
+                    .forbidCoercion()
+                    .build(),
+                VarianceAggregation::new
             );
         }
     }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/average/AverageAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/average/AverageAggregation.java
@@ -71,7 +71,7 @@ public class AverageAggregation extends AggregationFunction<AverageAggregation.A
     }
 
     static final List<DataType<?>> SUPPORTED_TYPES = Lists.concat(
-        DataTypes.NUMERIC_PRIMITIVE_TYPES, DataTypes.TIMESTAMPZ);
+        DataTypes.NUMERIC_PRIMITIVE_TYPES, List.of(DataTypes.TIMESTAMP, DataTypes.TIMESTAMPZ));
 
     /**
      * register as "avg" and "mean"
@@ -80,14 +80,15 @@ public class AverageAggregation extends AggregationFunction<AverageAggregation.A
         for (var functionName : NAMES) {
             for (var supportedType : SUPPORTED_TYPES) {
                 builder.add(
-                        Signature.builder(functionName, FunctionType.AGGREGATE)
-                                .argumentTypes(supportedType.getTypeSignature())
-                                .returnType(DataTypes.DOUBLE.getTypeSignature())
-                                .features(Scalar.Feature.DETERMINISTIC)
-                                .build(),
-                        (signature, boundSignature) ->
-                                new AverageAggregation(signature, boundSignature,
-                                        supportedType.id() != DataTypes.FLOAT.id() && supportedType.id() != DataTypes.DOUBLE.id())
+                    Signature.builder(functionName, FunctionType.AGGREGATE)
+                        .argumentTypes(supportedType.getTypeSignature())
+                        .returnType(DataTypes.DOUBLE.getTypeSignature())
+                        .features(Scalar.Feature.DETERMINISTIC)
+                        .forbidCoercion()
+                        .build(),
+                    (signature, boundSignature) ->
+                        new AverageAggregation(signature, boundSignature,
+                                supportedType.id() != DataTypes.FLOAT.id() && supportedType.id() != DataTypes.DOUBLE.id())
                 );
             }
         }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/average/IntervalAverageAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/average/IntervalAverageAggregation.java
@@ -69,12 +69,13 @@ public class IntervalAverageAggregation extends AggregationFunction<IntervalAver
     public static void register(Functions.Builder builder) {
         for (var functionName : NAMES) {
             builder.add(
-                    Signature.builder(functionName, FunctionType.AGGREGATE)
-                            .argumentTypes(DataTypes.INTERVAL.getTypeSignature())
-                            .returnType(DataTypes.INTERVAL.getTypeSignature())
-                            .features(Scalar.Feature.DETERMINISTIC)
-                            .build(),
-                    IntervalAverageAggregation::new
+                Signature.builder(functionName, FunctionType.AGGREGATE)
+                    .returnType(DataTypes.INTERVAL.getTypeSignature())
+                    .argumentTypes(DataTypes.INTERVAL.getTypeSignature())
+                    .features(Scalar.Feature.DETERMINISTIC)
+                    .forbidCoercion()
+                    .build(),
+                IntervalAverageAggregation::new
             );
         }
     }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/average/numeric/NumericAverageAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/average/numeric/NumericAverageAggregation.java
@@ -72,12 +72,13 @@ public class NumericAverageAggregation extends AggregationFunction<NumericAverag
     public static void register(Functions.Builder builder) {
         for (var functionName : NAMES) {
             builder.add(
-                    Signature.builder(functionName, FunctionType.AGGREGATE)
-                            .argumentTypes(DataTypes.NUMERIC.getTypeSignature())
-                            .returnType(DataTypes.NUMERIC.getTypeSignature())
-                            .features(Scalar.Feature.DETERMINISTIC)
-                            .build(),
-                    NumericAverageAggregation::new
+                Signature.builder(functionName, FunctionType.AGGREGATE)
+                    .argumentTypes(DataTypes.NUMERIC.getTypeSignature())
+                    .returnType(DataTypes.NUMERIC.getTypeSignature())
+                    .features(Scalar.Feature.DETERMINISTIC)
+                    .forbidCoercion()
+                    .build(),
+                NumericAverageAggregation::new
             );
         }
     }

--- a/server/src/test/java/io/crate/analyze/relations/GroupByScalarAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/relations/GroupByScalarAnalyzerTest.java
@@ -76,11 +76,11 @@ public class GroupByScalarAnalyzerTest extends CrateDummyClusterServiceUnitTest 
 
     @Test
     public void testValidGroupByAllClause() throws Exception {
-        AnalyzedRelation relation = executor.analyze("select id, id + 10, sum(no_index) as sum_index, name from users group by All");
+        AnalyzedRelation relation = executor.analyze("select id, id + 10, sum(other_id), name from users group by All");
         List<Symbol> groupBySymbols = ((QueriedSelectRelation) relation).groupBy();
         assertThat(groupBySymbols).hasSize(3);
-        assertThat(groupBySymbols.get(0).equals("id"));
-        assertThat(groupBySymbols.get(1).equals("name"));
+        assertThat(groupBySymbols.get(0).toColumn().sqlFqn()).isEqualTo("id");
+        assertThat(groupBySymbols.get(1).toColumn().sqlFqn()).isEqualTo("(id + 10::bigint)");
+        assertThat(groupBySymbols.get(2).toColumn().sqlFqn()).isEqualTo("name");
     }
-
 }

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/PercentileAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/PercentileAggregationTest.java
@@ -333,4 +333,11 @@ public class PercentileAggregationTest extends AggregationTestCase {
         // Let's assert a concrete value to get failures if the implementation changes and reveals a different result
         assertThat((double) resultCustom).isEqualTo(113.066, within(0.01));
     }
+
+    @Test
+    public void test_numeric_type_is_unsupported() throws Exception {
+        assertThatThrownBy(() -> execSingleFractionPercentile(DataTypes.NUMERIC, new Object[][]{{new Object()}}))
+            .isExactlyInstanceOf(UnsupportedFunctionException.class)
+            .hasMessageStartingWith("Invalid arguments in: percentile(INPUT(0), INPUT(0)) with (numeric, double precision). Valid types:");
+    }
 }

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/VarianceAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/VarianceAggregationTest.java
@@ -125,6 +125,6 @@ public class VarianceAggregationTest extends AggregationTestCase {
     public void testUnsupportedType() throws Exception {
         assertThatThrownBy(() -> executeAggregation(DataTypes.GEO_POINT, new Object[][] {}))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessage("Invalid arguments in: variance(INPUT(0)) with (geo_point). Valid types: (double precision), (real), (byte), (smallint), (integer), (bigint), (timestamp with time zone)");
+            .hasMessageStartingWith("Invalid arguments in: variance(INPUT(0)) with (geo_point). Valid types: ");
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/GroupByAggregateTest.java
+++ b/server/src/test/java/io/crate/integrationtests/GroupByAggregateTest.java
@@ -26,7 +26,6 @@ import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
 import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.TestingHelpers.printedTable;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
 import java.util.Arrays;
@@ -737,7 +736,7 @@ public class GroupByAggregateTest extends IntegTestCase {
     @Test
     public void testAggregateNonExistingColumn() throws Exception {
         this.setup.groupBySetup();
-        execute("select max(details_ignored['lol']), race from characters group by race order by race");
+        execute("select arbitrary(details_ignored['lol']), race from characters group by race order by race");
         assertThat(response).hasRows(
             "NULL| Android",
             "NULL| Human",


### PR DESCRIPTION
Previously, agg functions would support coersion so if for example an agg function is not registered for `NUMERIC` arg types, it would try to resolve another matching signature. Because coersion was previously supported, it would iterate over the support types (actually the relevant signatures) and by using `Functions#isMoreSpecificThan()` it would end up using the the first in `SUPPORTED_TYPES` which is `byte` and fail later on with:
```
SQLParseException[Cannot cast value 3.212to typebyte]
```

Fixes: #17870
