### PR TITLE
Remove unused Repository.getSnapshotIndexMetadata(... indexId)

### DIFF
--- a/server/src/main/java/io/crate/replication/logical/repository/LogicalReplicationRepository.java
+++ b/server/src/main/java/io/crate/replication/logical/repository/LogicalReplicationRepository.java
@@ -227,26 +227,6 @@ public class LogicalReplicationRepository extends AbstractLifecycleComponent imp
         });
     }
 
-    public CompletableFuture<IndexMetadata> getSnapshotIndexMetadata(RepositoryData repositoryData,
-                                                                     SnapshotId snapshotId,
-                                                                     IndexId index) {
-        assert SNAPSHOT_ID.equals(snapshotId) : "SubscriptionRepository only supports " + SNAPSHOT_ID + " as the SnapshotId";
-        RelationName relationName = IndexName.decode(index.getName()).toRelationName();
-        return getRemoteClusterState(relationName).thenApply(response -> {
-            ClusterState remoteClusterState = response.getState();
-            var indexMetadata = remoteClusterState.metadata().index(index.getName());
-            // Add replication specific settings, this setting will trigger a custom engine, see {@link SQLPlugin#getEngineFactory}
-            var builder = Settings.builder().put(indexMetadata.getSettings());
-            builder.put(REPLICATION_SUBSCRIPTION_NAME.getKey(), subscriptionName);
-            // Store publishers original index UUID to be able to resolve the original index later on
-            builder.put(PUBLISHER_INDEX_UUID.getKey(), indexMetadata.getIndexUUID());
-
-            var indexMdBuilder = IndexMetadata.builder(indexMetadata).settings(builder);
-            indexMetadata.getAliases().valuesIt().forEachRemaining(a -> indexMdBuilder.putAlias(a));
-            return indexMdBuilder.build();
-        });
-    }
-
     @Override
     public CompletableFuture<RepositoryData> getRepositoryData() {
         return getPublicationsState()

--- a/server/src/main/java/org/elasticsearch/repositories/Repository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/Repository.java
@@ -99,15 +99,6 @@ public interface Repository extends LifecycleComponent {
     CompletableFuture<Metadata> getSnapshotGlobalMetadata(SnapshotId snapshotId);
 
     /**
-     * Returns the index metadata associated with the snapshot.
-     *
-     * @param snapshotId the snapshot id to load the index metadata from
-     * @param indexId    the {@link IndexId} to load the metadata from
-     */
-    CompletableFuture<IndexMetadata> getSnapshotIndexMetadata(RepositoryData repositoryData, SnapshotId snapshotId, IndexId indexId);
-
-
-    /**
      * Returns index metadata associated with the snapshot.
      *
      * @param snapshotId the snapshot id to load the index metadata from

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -1090,17 +1090,6 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
         }
     }
 
-    public CompletableFuture<IndexMetadata> getSnapshotIndexMetadata(RepositoryData repositoryData, SnapshotId snapshotId, IndexId index) {
-        try {
-            IndexMetadata result = INDEX_METADATA_FORMAT.read(indexContainer(index),
-                repositoryData.indexMetaDataGenerations().indexMetaBlobId(snapshotId, index), namedWriteableRegistry, namedXContentRegistry);
-            return CompletableFuture.completedFuture(result);
-        } catch (IOException ex) {
-            return CompletableFuture.failedFuture(ex);
-        }
-    }
-
-
     @Override
     public CompletableFuture<Collection<IndexMetadata>> getSnapshotIndexMetadata(RepositoryData repositoryData, SnapshotId snapshotId, Collection<IndexId> indexIds) {
         try {

--- a/server/src/testFixtures/java/org/elasticsearch/index/shard/RestoreOnlyRepository.java
+++ b/server/src/testFixtures/java/org/elasticsearch/index/shard/RestoreOnlyRepository.java
@@ -75,13 +75,7 @@ public abstract class RestoreOnlyRepository implements Repository {
             new UnsupportedOperationException("getSnapshotGlobalMetadata not supported in RestoreOnlyRepository"));
     }
 
-    public CompletableFuture<IndexMetadata> getSnapshotIndexMetadata(RepositoryData repositoryData,
-                                                                     SnapshotId snapshotId,
-                                                                     IndexId indexId) {
-        return CompletableFuture.failedFuture(
-            new UnsupportedOperationException("getSnapshotIndexMetadata is not supported in RestoreOnlyRepository"));
-    }
-
+    @Override
     public CompletableFuture<Collection<IndexMetadata>> getSnapshotIndexMetadata(RepositoryData repositoryData,
                                                                                  SnapshotId snapshotId,
                                                                                  Collection<IndexId> indexIds) {

--- a/server/src/testFixtures/java/org/elasticsearch/repositories/blobstore/BlobStoreTestUtil.java
+++ b/server/src/testFixtures/java/org/elasticsearch/repositories/blobstore/BlobStoreTestUtil.java
@@ -220,7 +220,7 @@ public final class BlobStoreTestUtil {
                 assertThat(indexContainer.listBlobs()).containsKey(
                     String.format(Locale.ROOT, BlobStoreRepository.METADATA_NAME_FORMAT,
                         repositoryData.indexMetaDataGenerations().indexMetaBlobId(snapshotId, indexId)));
-                IndexMetadata indexMetadata = repository.getSnapshotIndexMetadata(repositoryData, snapshotId, indexId).get();
+                IndexMetadata indexMetadata = repository.getSnapshotIndexMetadata(repositoryData, snapshotId, List.of(indexId)).get().stream().toList().getFirst();
                 for (Map.Entry<String, BlobContainer> entry : indexContainer.children().entrySet()) {
                     // Skip Lucene MockFS extraN directory
                     if (entry.getKey().startsWith("extra")) {


### PR DESCRIPTION
The only usage was inside tests.

Simplifies refactoring related to #17518.