### PR TITLE
Add BlobTableInfo support to the translog indexer

### DIFF
--- a/server/src/main/java/io/crate/metadata/Schemas.java
+++ b/server/src/main/java/io/crate/metadata/Schemas.java
@@ -325,6 +325,15 @@ public class Schemas extends AbstractLifecycleComponent implements Iterable<Sche
         }
     }
 
+
+    public SchemaInfo getOrCreateSchemaInfo(String schemaName) {
+        SchemaInfo schemaInfo = schemas.get(schemaName);
+        if (schemaInfo == null) {
+            schemaInfo = getCustomSchemaInfo(schemaName);
+        }
+        return schemaInfo;
+    }
+
     @Nullable
     public SchemaInfo getSchemaInfo(String schemaName) {
         return schemas.get(schemaName);

--- a/server/src/main/java/io/crate/metadata/TableInfoFactory.java
+++ b/server/src/main/java/io/crate/metadata/TableInfoFactory.java
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.  You may
  * obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
@@ -19,38 +19,13 @@
  * software solely pursuant to the terms of the relevant commercial agreement.
  */
 
-package io.crate.metadata.table;
+package io.crate.metadata;
 
-import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.metadata.Metadata;
-import org.jetbrains.annotations.Nullable;
 
-import io.crate.metadata.RelationName;
-import io.crate.metadata.view.ViewInfo;
+import io.crate.metadata.table.TableInfo;
 
-public interface SchemaInfo extends AutoCloseable {
+public interface TableInfoFactory<T extends TableInfo> {
 
-    @Nullable
-    TableInfo getTableInfo(String name);
-
-    @Nullable
-    default ViewInfo getViewInfo(String name) {
-        return null;
-    }
-
-    String name();
-
-    /**
-     * Called when cluster state and so the table definitions changes.
-     */
-    void update(ClusterChangedEvent event);
-
-    Iterable<TableInfo> getTables();
-
-    Iterable<ViewInfo> getViews();
-
-    @Nullable
-    default TableInfo create(RelationName relationName, Metadata metadata) {
-        throw new UnsupportedOperationException("create() not supported on " + getClass().getName());
-    }
+    T create(RelationName ident, Metadata metadata);
 }

--- a/server/src/main/java/io/crate/metadata/blob/BlobSchemaInfo.java
+++ b/server/src/main/java/io/crate/metadata/blob/BlobSchemaInfo.java
@@ -26,6 +26,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
 
 import org.elasticsearch.cluster.ClusterChangedEvent;
+import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.service.ClusterService;
 
 import io.crate.blob.v2.BlobIndex;
@@ -54,7 +55,7 @@ public class BlobSchemaInfo implements SchemaInfo {
         try {
             return tableByName.computeIfAbsent(
                 name,
-                n -> blobTableInfoFactory.create(new RelationName(NAME, n), clusterService.state())
+                n -> blobTableInfoFactory.create(new RelationName(NAME, n), clusterService.state().metadata())
             );
         } catch (Exception e) {
             if (e instanceof ResourceUnknownException) {
@@ -92,5 +93,10 @@ public class BlobSchemaInfo implements SchemaInfo {
 
     @Override
     public void close() throws Exception {
+    }
+
+    @Override
+    public BlobTableInfo create(RelationName relationName, Metadata metadata) {
+        return blobTableInfoFactory.create(relationName, metadata);
     }
 }

--- a/server/src/main/java/io/crate/metadata/cluster/AlterTableClusterStateExecutor.java
+++ b/server/src/main/java/io/crate/metadata/cluster/AlterTableClusterStateExecutor.java
@@ -56,7 +56,7 @@ import io.crate.execution.ddl.tables.AlterTableRequest;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.RelationName;
-import io.crate.metadata.doc.DocTableInfoFactory;
+import io.crate.metadata.table.SchemaInfo;
 import io.crate.sql.tree.ColumnPolicy;
 
 public class AlterTableClusterStateExecutor extends DDLClusterStateTaskExecutor<AlterTableRequest> {
@@ -163,8 +163,10 @@ public class AlterTableClusterStateExecutor extends DDLClusterStateTaskExecutor<
             currentState = updateSettings(currentState, settings, partitions);
         }
 
-        // ensure the new table can still be parsed into a DocTableInfo to avoid breaking the table.
-        new DocTableInfoFactory(nodeContext).create(request.tableIdent(), currentState.metadata());
+        // ensure the new table can still be parsed into a Doc|BlobTableInfo to avoid breaking the table.
+        RelationName relationName = request.tableIdent();
+        SchemaInfo schemaInfo = nodeContext.schemas().getOrCreateSchemaInfo(relationName.schema());
+        schemaInfo.create(relationName, currentState.metadata());
 
         return currentState;
     }

--- a/server/src/main/java/io/crate/metadata/doc/DocSchemaInfo.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocSchemaInfo.java
@@ -168,6 +168,11 @@ public class DocSchemaInfo implements SchemaInfo {
         }
     }
 
+    @Override
+    public DocTableInfo create(RelationName relationName, Metadata metadata) {
+        return docTableInfoFactory.create(relationName, metadata);
+    }
+
     private static long getTableVersion(Metadata metadata, RelationName name) {
         RelationMetadata relation = metadata.getRelation(name);
         if (relation instanceof RelationMetadata.Table) {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -789,8 +789,8 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata> {
             return this;
         }
 
-        public Builder setBlobTable(RelationName name, String indexUUID) {
-            setRelation(new RelationMetadata.BlobTable(name, indexUUID));
+        public Builder setBlobTable(RelationName name, String indexUUID, Settings settings, State state) {
+            setRelation(new RelationMetadata.BlobTable(name, indexUUID, settings, state));
             return this;
         }
 

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
@@ -288,7 +288,7 @@ public class MetadataCreateIndexService {
                 .build();
             return indicesService.withTempIndexService(indexMetadata, indexService -> {
                 Metadata.Builder mdBuilder = Metadata.builder(currentState.metadata())
-                    .setBlobTable(request.name(), indexUUID);
+                    .setBlobTable(request.name(), indexUUID, settings, State.OPEN);
                 ClusterState updatedState = addIndex(
                     allocationService,
                     indexService,

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/RelationMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/RelationMetadata.java
@@ -61,20 +61,27 @@ public sealed interface RelationMetadata extends Writeable permits
         v.writeTo(out);
     }
 
-    record BlobTable(RelationName name, String indexUUID) implements RelationMetadata {
+    record BlobTable(RelationName name,
+                     String indexUUID,
+                     Settings settings,
+                     IndexMetadata.State state) implements RelationMetadata {
 
         private static final short ORD = 0;
 
         static BlobTable of(StreamInput in) throws IOException {
             RelationName name = new RelationName(in);
             String indexUUID = in.readString();
-            return new BlobTable(name, indexUUID);
+            Settings settings = Settings.readSettingsFromStream(in);
+            IndexMetadata.State state = in.readEnum(IndexMetadata.State.class);
+            return new BlobTable(name, indexUUID, settings, state);
         }
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             name.writeTo(out);
             out.writeString(indexUUID);
+            Settings.writeSettingsToStream(out, settings);
+            out.writeEnum(state);
         }
 
         @Override

--- a/server/src/testFixtures/java/io/crate/testing/SQLExecutor.java
+++ b/server/src/testFixtures/java/io/crate/testing/SQLExecutor.java
@@ -969,7 +969,7 @@ public class SQLExecutor {
         ).build();
 
         Metadata.Builder mdBuilder = Metadata.builder(prevState.metadata())
-            .setBlobTable(relationName, indexMetadata.getIndexUUID())
+            .setBlobTable(relationName, indexMetadata.getIndexUUID(), settings, State.OPEN)
             .put(indexMetadata, true);
         ClusterState state = ClusterState.builder(prevState)
             .metadata(mdBuilder)


### PR DESCRIPTION
Until now, a DocTableInfo was build for any IndexMetadata, even when belonging to a blob table.
This breaks once we move into using RelationMetadata as by this, a BlobTableInfo is correctly used.

Related to #17518, required by #17769.