### PR TITLE
Raise error while analyzing table elements on IGNORED column types

### DIFF
--- a/server/src/main/java/io/crate/analyze/TableElementsAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/TableElementsAnalyzer.java
@@ -589,6 +589,13 @@ public class TableElementsAnalyzer implements FieldProvider<Reference> {
                 }
             }
 
+            // Ensure detected type is storable and indexable if applicable
+            StorageSupport<?> storageSupport = builder.type.storageSupportSafe();
+            if (builder.indexType.equals(IndexType.NONE) == false && storageSupport.canBeIndexed() == false) {
+                throw new UnsupportedOperationException(
+                    "Type `" + builder.type.getName().toUpperCase(Locale.ROOT) + "` does not support storage using an index");
+            }
+
             return null;
         }
 

--- a/server/src/main/java/io/crate/types/StorageSupport.java
+++ b/server/src/main/java/io/crate/types/StorageSupport.java
@@ -95,6 +95,10 @@ public abstract class StorageSupport<T> {
         return false;
     }
 
+    public boolean canBeIndexed() {
+        return true;
+    }
+
     public boolean docValuesDefault() {
         return docValuesDefault;
     }

--- a/server/src/main/java/io/crate/types/UndefinedType.java
+++ b/server/src/main/java/io/crate/types/UndefinedType.java
@@ -126,6 +126,11 @@ public class UndefinedType extends DataType<Object> implements Streamer<Object> 
                     }
                 };
             }
+
+            @Override
+            public boolean canBeIndexed() {
+                return false;
+            }
         };
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/CreateTableAsIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/CreateTableAsIntegrationTest.java
@@ -162,7 +162,7 @@ public class CreateTableAsIntegrationTest extends IntegTestCase {
         // IGNORED (error while using an undefined column as it cannot be stored)
         assertThatThrownBy(() -> execute("CREATE TABLE test_ignored AS \n" +
             "SELECT '{\"field1\":123}'::OBJECT (IGNORED) AS (field1 BIGINT) ['field2']"))
-            .hasMessageContaining("Type `NOT SUPPORTED` does not support storage");
+            .hasMessageContaining("Type `UNDEFINED` does not support storage");
 
         try (Session session = sqlExecutor.newSession()) {
             execute("SET SESSION error_on_unknown_object_key=false", session);
@@ -170,7 +170,7 @@ public class CreateTableAsIntegrationTest extends IntegTestCase {
             // DYNAMIC (same as IGNORED, error while using an undefined column as it cannot be stored)
             assertThatThrownBy(() -> execute("CREATE TABLE test_dynamic AS \n" +
                 "SELECT '{\"field1\":123}'::OBJECT (DYNAMIC) AS (field1 BIGINT) ['field2']", session))
-                .hasMessageContaining("Type `NOT SUPPORTED` does not support storage");
+                .hasMessageContaining("Type `UNDEFINED` does not support storage");
         }
     }
 }


### PR DESCRIPTION
Ignored types cannot be stored if they aren't childs of an object or array. The table element analyzer will throw an exception now.

This works when using the IndexMetadata mapping as the main source of truth as the mapping is validated again on `DocTableInfo` creation and any `undefined` top level column type is converted to a `not supported` type in a bit hidden way.
When moving any mapping into the new RelationMetadata.Table, the hidden validation on `DocTableInfo` creation is gone as it builds it out of a `RelationMetadata.Table`. Thus, all validation must happen while analyzing (which we mainly anyhow already do).

Relates to #17518 and required by #17769.
