### PR TITLE
Add retry handling to DistributingConsumer

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/distribution/DistributingConsumerFactory.java
+++ b/server/src/main/java/io/crate/execution/engine/distribution/DistributingConsumerFactory.java
@@ -49,6 +49,7 @@ public class DistributingConsumerFactory {
     private final ClusterService clusterService;
     private final Executor responseExecutor;
     private final ActionExecutor<NodeRequest<DistributedResultRequest>, DistributedResultResponse> distributedResultAction;
+    private final ThreadPool threadPool;
 
     @Inject
     public DistributingConsumerFactory(ClusterService clusterService,
@@ -57,6 +58,7 @@ public class DistributingConsumerFactory {
         this.clusterService = clusterService;
         this.responseExecutor = threadPool.executor(RESPONSE_EXECUTOR_NAME);
         this.distributedResultAction = req -> node.client().execute(DistributedResultAction.INSTANCE, req);
+        this.threadPool = threadPool;
     }
 
     public DistributingConsumer create(NodeOperation nodeOperation,
@@ -110,7 +112,8 @@ public class DistributingConsumerFactory {
             bucketIdx,
             nodeOperation.downstreamNodes(),
             distributedResultAction,
-            pageSize
+            pageSize,
+            threadPool
         );
     }
 

--- a/server/src/test/java/io/crate/execution/engine/distribution/DistributingConsumerTest.java
+++ b/server/src/test/java/io/crate/execution/engine/distribution/DistributingConsumerTest.java
@@ -40,6 +40,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -163,6 +164,7 @@ public class DistributingConsumerTest extends ESTestCase {
     }
 
     private DistributingConsumer createDistributingConsumer(Streamer<?>[] streamers, TransportDistributedResultAction distributedResultAction) {
+        int pageSize = 2;
         return new DistributingConsumer(
             executorService,
             UUID.randomUUID(),
@@ -172,7 +174,8 @@ public class DistributingConsumerTest extends ESTestCase {
             0,
             Collections.singletonList("n1"),
             distributedResultAction::execute,
-            2 // pageSize
+            pageSize,
+            mock(ThreadPool.class)
         );
     }
 

--- a/server/src/testFixtures/java/org/elasticsearch/test/IntegTestCase.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/IntegTestCase.java
@@ -1421,7 +1421,9 @@ public abstract class IntegTestCase extends ESTestCase {
                     throw new RuntimeException(ex);
                 }
             }
-            throw new AssertionError(errorMessageBuilder.toString(), e);
+            String errMsg = errorMessageBuilder.toString();
+            LOGGER.error("Open jobs={}", errMsg);
+            throw new AssertionError(errMsg, e);
         }
     }
 


### PR DESCRIPTION
Follow up to https://github.com/crate/crate/pull/17772

Fixes flaky `testRetentionLeasesSyncOnRecovery` in another scenario
where the disconnect monitor isn't triggered on node_s0 where the task
leaks because it can still reach the other nodes, the mocked disruption
is only blocking the communication from node_s1 to node_s0.


--- 

Not entirely sure about this. Afaik the scenario from the test shouldn't happen that way in production and is due to the way the disruption works. 
