### PR TITLE
Resolve existing partitions by the new relations metadata api

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/create/TransportCreatePartitions.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/create/TransportCreatePartitions.java
@@ -76,7 +76,6 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
 import io.crate.common.collections.Lists;
-import io.crate.metadata.IndexName;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.RelationName;
 
@@ -382,18 +381,15 @@ public class TransportCreatePartitions extends TransportMasterNodeAction<CreateP
     }
 
     private static List<PartitionName> getPartitionsToCreate(ClusterState state, CreatePartitionsRequest request) {
+        Metadata metadata = state.metadata();
         ArrayList<PartitionName> partitions = new ArrayList<>(request.partitionValuesList().size());
         for (List<String> partitionValues : request.partitionValuesList()) {
-            PartitionName partition = new PartitionName(request.relationName(), partitionValues);
-            String indexName = partition.asIndexName();
-            if (state.metadata().hasIndex(indexName)) {
-                continue;
+            List<IndexMetadata> indices = metadata.getIndices(request.relationName(), partitionValues, true, imd -> imd);
+            if (indices.isEmpty()) {
+                PartitionName partition = new PartitionName(request.relationName(), partitionValues);
+                partitions.add(partition);
             }
-            if (state.routingTable().hasIndex(indexName)) {
-                continue;
-            }
-            IndexName.validate(indexName);
-            partitions.add(partition);
+            // else: exists already
         }
         return partitions;
     }


### PR DESCRIPTION
Use the new RelationsMetadata API to resolve existing partitions while creating new ones.

Supersedes #17839.
