### PR TITLE
Add tableVersion to RelationMetadata.Table

### DIFF
--- a/server/src/main/java/io/crate/execution/ddl/SwapRelationsOperation.java
+++ b/server/src/main/java/io/crate/execution/ddl/SwapRelationsOperation.java
@@ -154,7 +154,8 @@ public class SwapRelationsOperation {
                     sourceRelation.primaryKeys(),
                     sourceRelation.partitionedBy(),
                     sourceRelation.state(),
-                    sourceRelation.indexUUIDs()
+                    sourceRelation.indexUUIDs(),
+                    sourceRelation.tableVersion() + 1
                 )
                 .setTable(
                     source,
@@ -170,7 +171,8 @@ public class SwapRelationsOperation {
                     targetRelation.primaryKeys(),
                     targetRelation.partitionedBy(),
                     targetRelation.state(),
-                    targetRelation.indexUUIDs()
+                    targetRelation.indexUUIDs(),
+                    targetRelation.tableVersion() + 1
                 );
         }
 

--- a/server/src/main/java/io/crate/execution/ddl/tables/TransportCloseTable.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/TransportCloseTable.java
@@ -190,7 +190,8 @@ public final class TransportCloseTable extends TransportMasterNodeAction<CloseTa
                 table.primaryKeys(),
                 table.partitionedBy(),
                 State.CLOSE,
-                table.indexUUIDs()
+                table.indexUUIDs(),
+                table.tableVersion() + 1
             );
         } else {
             PartitionName partitionName = new PartitionName(target.table(), partitionValues);

--- a/server/src/main/java/io/crate/execution/ddl/tables/TransportCreateTable.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/TransportCreateTable.java
@@ -213,7 +213,8 @@ public class TransportCreateTable extends TransportMasterNodeAction<CreateTableR
                         request.primaryKeys(),
                         request.partitionedBy(),
                         State.OPEN,
-                        indexUUIDs
+                        indexUUIDs,
+                        0
                     );
                 return ClusterState.builder(newState).metadata(newMetadata).build();
             }

--- a/server/src/main/java/io/crate/metadata/cluster/AlterTableClusterStateExecutor.java
+++ b/server/src/main/java/io/crate/metadata/cluster/AlterTableClusterStateExecutor.java
@@ -106,7 +106,9 @@ public class AlterTableClusterStateExecutor extends DDLClusterStateTaskExecutor<
                 table.primaryKeys(),
                 table.partitionedBy(),
                 table.state(),
-                table.indexUUIDs());
+                table.indexUUIDs(),
+                table.tableVersion() + 1
+            );
             currentState = ClusterState.builder(currentState)
                 .metadata(newMetadata)
                 .build();

--- a/server/src/main/java/io/crate/metadata/cluster/OpenTableClusterStateTaskExecutor.java
+++ b/server/src/main/java/io/crate/metadata/cluster/OpenTableClusterStateTaskExecutor.java
@@ -86,7 +86,8 @@ public class OpenTableClusterStateTaskExecutor extends DDLClusterStateTaskExecut
                 table.primaryKeys(),
                 table.partitionedBy(),
                 State.OPEN,
-                table.indexUUIDs()
+                table.indexUUIDs(),
+                table.tableVersion() + 1
             );
         } else if (closedIndices.isEmpty() && templateMetadata == null) {
             return currentState;

--- a/server/src/main/java/io/crate/metadata/cluster/RenameTableClusterStateExecutor.java
+++ b/server/src/main/java/io/crate/metadata/cluster/RenameTableClusterStateExecutor.java
@@ -157,7 +157,8 @@ public class RenameTableClusterStateExecutor {
                     table.primaryKeys(),
                     table.partitionedBy(),
                     table.state(),
-                    table.indexUUIDs()
+                    table.indexUUIDs(),
+                    table.tableVersion() + 1
                 );
         }
         ClusterState clusterStateAfterRename = ClusterState.builder(currentState)

--- a/server/src/main/java/io/crate/metadata/cluster/SwapAndDropIndexExecutor.java
+++ b/server/src/main/java/io/crate/metadata/cluster/SwapAndDropIndexExecutor.java
@@ -100,7 +100,8 @@ public class SwapAndDropIndexExecutor extends DDLClusterStateTaskExecutor<SwapAn
                 table.primaryKeys(),
                 table.partitionedBy(),
                 table.state(),
-                newUUIDs
+                newUUIDs,
+                table.tableVersion() + 1
             );
         }
 

--- a/server/src/main/java/io/crate/metadata/doc/DocSchemaInfo.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocSchemaInfo.java
@@ -175,9 +175,8 @@ public class DocSchemaInfo implements SchemaInfo {
 
     private static long getTableVersion(Metadata metadata, RelationName name) {
         RelationMetadata relation = metadata.getRelation(name);
-        if (relation instanceof RelationMetadata.Table) {
-            // TODO: add versioning to table (tracked in https://github.com/crate/crate/issues/17518)
-            return 0;
+        if (relation instanceof RelationMetadata.Table table) {
+            return table.tableVersion();
         }
         String templateName = PartitionName.templateName(name.schema(), name.name());
         IndexTemplateMetadata indexTemplateMetadata = metadata.templates().get(templateName);

--- a/server/src/main/java/io/crate/metadata/doc/DocTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocTableInfo.java
@@ -838,7 +838,7 @@ public class DocTableInfo implements TableInfo, ShardedTable, StoredTable {
             versionUpgraded,
             closed,
             supportedOperations,
-            tableVersion
+            tableVersion + 1
         );
     }
 
@@ -910,7 +910,7 @@ public class DocTableInfo implements TableInfo, ShardedTable, StoredTable {
             versionUpgraded,
             closed,
             supportedOperations,
-            tableVersion
+            tableVersion + 1
         );
     }
 
@@ -1116,7 +1116,8 @@ public class DocTableInfo implements TableInfo, ShardedTable, StoredTable {
             primaryKeys,
             partitionedBy,
             closed ? State.CLOSE : State.OPEN,
-            indexUUIDs
+            indexUUIDs,
+            tableVersion
         );
     }
 
@@ -1272,7 +1273,7 @@ public class DocTableInfo implements TableInfo, ShardedTable, StoredTable {
             versionUpgraded,
             closed,
             supportedOperations,
-            tableVersion
+            tableVersion + 1    // increment version
         );
     }
 

--- a/server/src/main/java/io/crate/replication/logical/action/DropSubscriptionAction.java
+++ b/server/src/main/java/io/crate/replication/logical/action/DropSubscriptionAction.java
@@ -111,7 +111,8 @@ public class DropSubscriptionAction extends ActionType<AcknowledgedResponse> {
                     table.primaryKeys(),
                     table.partitionedBy(),
                     table.state(),
-                    table.indexUUIDs()
+                    table.indexUUIDs(),
+                    table.tableVersion() + 1
                 );
             }
         }

--- a/server/src/main/java/io/crate/replication/logical/repository/LogicalReplicationRepository.java
+++ b/server/src/main/java/io/crate/replication/logical/repository/LogicalReplicationRepository.java
@@ -184,7 +184,8 @@ public class LogicalReplicationRepository extends AbstractLifecycleComponent imp
                         table.primaryKeys(),
                         table.partitionedBy(),
                         table.state(),
-                        table.indexUUIDs()
+                        table.indexUUIDs(),
+                        table.tableVersion()
                     );
                 }
                 return metadataBuilder.build();

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/state/TransportClusterState.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/state/TransportClusterState.java
@@ -205,7 +205,8 @@ public class TransportClusterState extends TransportMasterNodeReadAction<Cluster
                             table.primaryKeys(),
                             table.partitionedBy(),
                             table.state(),
-                            table.indexUUIDs()
+                            table.indexUUIDs(),
+                            table.tableVersion()
                         );
                         for (String indexUUID : table.indexUUIDs()) {
                             IndexMetadata indexMetadata = currentState.metadata().indexByUUID(indexUUID);

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/create/TransportCreatePartitions.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/create/TransportCreatePartitions.java
@@ -324,7 +324,8 @@ public class TransportCreatePartitions extends TransportMasterNodeAction<CreateP
                     table.primaryKeys(),
                     table.partitionedBy(),
                     table.state(),
-                    Lists.concatUnique(table.indexUUIDs(), indexUUIDs)
+                    Lists.concatUnique(table.indexUUIDs(), indexUUIDs),
+                    table.tableVersion() + 1
                 );
             }
 

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -1111,7 +1111,7 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata> {
          * </p>
          *
          * oidSupplier is only parameterized for testing.
-         * For production code use {@link #setTable(RelationName, List, Settings, ColumnIdent, ColumnPolicy, String, Map, List, List, State, List)
+         * For production code use {@link #setTable(RelationName, List, Settings, ColumnIdent, ColumnPolicy, String, Map, List, List, State, List, long)
          **/
         @VisibleForTesting
         public Builder setTable(LongSupplier oidSupplier,
@@ -1125,7 +1125,8 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata> {
                                 List<ColumnIdent> primaryKeys,
                                 List<ColumnIdent> partitionedBy,
                                 State state,
-                                List<String> indexUUIDs) {
+                                List<String> indexUUIDs,
+                                long tableVersion) {
             AtomicInteger positions = new AtomicInteger(0);
             Map<ColumnIdent, Reference> columnMap = columns.stream()
                 .filter(ref -> !ref.isDropped())
@@ -1164,7 +1165,8 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata> {
                 primaryKeys,
                 partitionedBy,
                 state,
-                indexUUIDs
+                indexUUIDs,
+                tableVersion
             );
             setRelation(table);
             return this;
@@ -1183,7 +1185,8 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata> {
                                 List<ColumnIdent> primaryKeys,
                                 List<ColumnIdent> partitionedBy,
                                 State state,
-                                List<String> indexUUIDs) {
+                                List<String> indexUUIDs,
+                                long tableVersion) {
             return setTable(
                 columnOidSupplier,
                 relationName,
@@ -1196,7 +1199,8 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata> {
                 primaryKeys,
                 partitionedBy,
                 state,
-                indexUUIDs
+                indexUUIDs,
+                tableVersion
             );
         }
     }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
@@ -462,7 +462,8 @@ public class MetadataCreateIndexService {
                         table.primaryKeys(),
                         table.partitionedBy(),
                         table.state(),
-                        table.indexUUIDs()
+                        table.indexUUIDs(),
+                        table.tableVersion() + 1
                     );
                 }
             }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataDeleteIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataDeleteIndexService.java
@@ -137,7 +137,8 @@ public class MetadataDeleteIndexService {
                     table.primaryKeys(),
                     table.partitionedBy(),
                     table.state(),
-                    newIndexUUIDs
+                    newIndexUUIDs,
+                    table.tableVersion() + 1
                 );
             }
         }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataUpgradeService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataUpgradeService.java
@@ -141,7 +141,8 @@ public class MetadataUpgradeService {
                     docTable.primaryKey(),
                     docTable.partitionedBy(),
                     indexMetadata.getState(),
-                    indexUUIDs
+                    indexUUIDs,
+                    docTable.tableVersion()
                 );
             }
         }
@@ -179,7 +180,8 @@ public class MetadataUpgradeService {
                 docTable.primaryKey(),
                 docTable.partitionedBy(),
                 docTable.isClosed() ? IndexMetadata.State.CLOSE : IndexMetadata.State.OPEN,
-                indexUUIDs
+                indexUUIDs,
+                docTable.tableVersion()
             );
         }
         return newMetadata.build();

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/RelationMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/RelationMetadata.java
@@ -100,7 +100,8 @@ public sealed interface RelationMetadata extends Writeable permits
                  List<ColumnIdent> primaryKeys,
                  List<ColumnIdent> partitionedBy,
                  IndexMetadata.State state,
-                 List<String> indexUUIDs) implements RelationMetadata {
+                 List<String> indexUUIDs,
+                 long tableVersion) implements RelationMetadata {
 
         private static final short ORD = 1;
 
@@ -122,6 +123,7 @@ public sealed interface RelationMetadata extends Writeable permits
             List<ColumnIdent> partitionedBy = in.readList(ColumnIdent::of);
             State state = in.readEnum(State.class);
             List<String> indexUUIDs = in.readStringList();
+            long tableVersion = in.readLong();
             return new Table(
                 name,
                 columns,
@@ -133,7 +135,8 @@ public sealed interface RelationMetadata extends Writeable permits
                 primaryKeys,
                 partitionedBy,
                 state,
-                indexUUIDs
+                indexUUIDs,
+                tableVersion
             );
         }
 
@@ -150,6 +153,7 @@ public sealed interface RelationMetadata extends Writeable permits
             out.writeList(partitionedBy);
             out.writeEnum(state);
             out.writeStringCollection(indexUUIDs);
+            out.writeLong(tableVersion);
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -573,7 +573,8 @@ public class RestoreService implements ClusterStateApplier {
                         table.primaryKeys(),
                         table.partitionedBy(),
                         table.state(),
-                        Lists.concatUnique(existingTable.indexUUIDs(), indexUUIDs)
+                        Lists.concatUnique(existingTable.indexUUIDs(), indexUUIDs),
+                        table.tableVersion()
                     );
                 } else if (existingRelation == null) {
                     if (snapshotRelation instanceof RelationMetadata.Table table) {
@@ -588,7 +589,8 @@ public class RestoreService implements ClusterStateApplier {
                             table.primaryKeys(),
                             table.partitionedBy(),
                             table.state(),
-                            indexUUIDs
+                            indexUUIDs,
+                            table.tableVersion()
                         );
                     }
                 } else {

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/state/TransportClusterStateTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/state/TransportClusterStateTests.java
@@ -82,7 +82,8 @@ public class TransportClusterStateTests extends ESTestCase {
                     List.of(),
                     List.of(),
                     IndexMetadata.State.OPEN,
-                    List.of(indexUUID1)
+                    List.of(indexUUID1),
+                    0
                 )
                 .setTable(
                     relationName2,
@@ -98,7 +99,8 @@ public class TransportClusterStateTests extends ESTestCase {
                     List.of(),
                     List.of(ColumnIdent.of("parted")),
                     IndexMetadata.State.OPEN,
-                    List.of(indexUUID2)
+                    List.of(indexUUID2),
+                    0
                 )
                 .put(IndexMetadata.builder(relationName1.indexNameOrAlias())
                         .settings(settings(Version.CURRENT)

--- a/server/src/test/java/org/elasticsearch/gateway/GatewayMetaStateTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/GatewayMetaStateTests.java
@@ -172,7 +172,9 @@ public class GatewayMetaStateTests extends ESTestCase {
                     List.of(),
                     List.of(),
                     IndexMetadata.State.OPEN,
-                    List.of());
+                    List.of(),
+                    0
+                );
             }
         }
         return builder.build();

--- a/server/src/testFixtures/java/io/crate/testing/SQLExecutor.java
+++ b/server/src/testFixtures/java/io/crate/testing/SQLExecutor.java
@@ -803,7 +803,8 @@ public class SQLExecutor {
                 Lists.map(boundCreateTable.primaryKeys(), Reference::column),
                 Lists.map(boundCreateTable.partitionedBy(), Reference::toColumn),
                 State.OPEN,
-                indexUUIDs
+                indexUUIDs,
+                0
             );
         }
         ClusterState newState = ClusterState.builder(prevState)
@@ -865,7 +866,8 @@ public class SQLExecutor {
                 table.primaryKeys(),
                 table.partitionedBy(),
                 State.CLOSE,
-                table.indexUUIDs()
+                table.indexUUIDs(),
+                table.tableVersion()
             );
         }
         ClusterBlocks.Builder blocksBuilder = ClusterBlocks.builder()


### PR DESCRIPTION
The RelationMetadata will become the source of truth for all table definitions, such any changes must be trackable by a table version.
This replaces any table version stored inside the IndexMetadata and IndexTemplateMetadata once RelationMetadata is becoming the main entity.

Relates to #17518.