### PR TITLE
Fix adding parent & child object sub-cols in one ALTER stmt

### DIFF
--- a/docs/appendices/release-notes/5.10.7.rst
+++ b/docs/appendices/release-notes/5.10.7.rst
@@ -47,6 +47,14 @@ See the :ref:`version_5.10.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an issue that would cause wrong column data type to be used when adding
+  parent and child object sub-columns in one
+  :ref:`ALTER TABLE <alter-table-add-column>` statement, e.g.::
+
+    ALTER TABLE tbl
+      ADD COLUMN obj['arr'] array(object(dynamic)),
+      ADD COLUMN obj['arr']['id'] integer;
+
 - Fixed an issue that would cause :ref:`window functions <window-functions>` to
   use inefficient execution plans, resulting in poor performance, when the
   :ref:`window definition <window-definition>` is using query parameters. e.g::

--- a/server/src/main/java/io/crate/analyze/TableElementsAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/TableElementsAnalyzer.java
@@ -538,7 +538,13 @@ public class TableElementsAnalyzer implements FieldProvider<Reference> {
                     parentBuilder.builtReference = parentRef;
                     columns.put(parent, parentBuilder);
                 } else {
-                    columns.put(parent, new RefBuilder(parent, ObjectType.UNTYPED));
+                    /*
+                      Parent can be missing in the table, but present in the same statement, e.g.:
+                      ALTER TABLE tbl
+                        ADD COLUMN obj['arr'] array(object(dynamic)),
+                        ADD COLUMN obj['arr']['id'] integer
+                     */
+                    columns.computeIfAbsent(parent, _ -> new RefBuilder(parent, ObjectType.UNTYPED));
                 }
             }
             Reference reference = table.getReference(columnName);


### PR DESCRIPTION
When adding multiple object sub columns where, one is a parent of another, the child one, would only try to find a parent in the original table schema, without checking if that parent is also defined in another `ADD COLUMNN` clause, thus ending up with the DEFAULT `object(dynamic)` type being set for the parent sub column.

Fixes: #17875

