### PR TITLE
Don't wrap ResponseHandler for better toString()

### DIFF
--- a/server/src/main/java/io/crate/blob/BlobTransferTarget.java
+++ b/server/src/main/java/io/crate/blob/BlobTransferTarget.java
@@ -172,7 +172,10 @@ public class BlobTransferTarget {
             BlobHeadRequestHandler.Actions.GET_TRANSFER_INFO,
             new BlobInfoRequest(senderNodeId, request.transferId),
             TransportRequestOptions.EMPTY,
-            new ActionListenerResponseHandler<>(listener, BlobTransferInfoResponse::new)
+            new ActionListenerResponseHandler<>(
+                BlobHeadRequestHandler.Actions.GET_TRANSFER_INFO,
+                listener,
+                BlobTransferInfoResponse::new)
         );
         BlobTransferInfoResponse transferInfoResponse = FutureUtils.get(listener);
 
@@ -197,7 +200,11 @@ public class BlobTransferTarget {
             BlobHeadRequestHandler.Actions.GET_BLOB_HEAD,
             new GetBlobHeadRequest(senderNodeId, request.transferId(), request.currentPos),
             TransportRequestOptions.EMPTY,
-            new ActionListenerResponseHandler<>(getBlobHeadListener, in -> TransportResponse.Empty.INSTANCE)
+            new ActionListenerResponseHandler<>(
+                BlobHeadRequestHandler.Actions.GET_BLOB_HEAD,
+                getBlobHeadListener,
+                _ -> TransportResponse.Empty.INSTANCE
+            )
         );
         FutureUtils.get(getBlobHeadListener);
         return status;

--- a/server/src/main/java/io/crate/blob/recovery/BlobRecoveryHandler.java
+++ b/server/src/main/java/io/crate/blob/recovery/BlobRecoveryHandler.java
@@ -115,7 +115,11 @@ public class BlobRecoveryHandler extends RecoverySourceHandler {
             BlobRecoveryTarget.Actions.START_PREFIX,
             new BlobStartPrefixSyncRequest(request.recoveryId(), request.shardId(), prefix),
             TransportRequestOptions.EMPTY,
-            new ActionListenerResponseHandler<>(listener, BlobStartPrefixResponse::new)
+            new ActionListenerResponseHandler<>(
+                BlobRecoveryTarget.Actions.START_PREFIX,
+                listener,
+                BlobStartPrefixResponse::new
+            )
         );
         BlobStartPrefixResponse response = FutureUtils.get(listener);
 
@@ -217,7 +221,11 @@ public class BlobRecoveryHandler extends RecoverySourceHandler {
             BlobRecoveryTarget.Actions.DELETE_FILE,
             new BlobRecoveryDeleteRequest(request.recoveryId(), digests),
             TransportRequestOptions.EMPTY,
-            new ActionListenerResponseHandler<>(listener, in -> TransportResponse.Empty.INSTANCE)
+            new ActionListenerResponseHandler<>(
+                BlobRecoveryTarget.Actions.DELETE_FILE,
+                listener,
+                _ -> TransportResponse.Empty.INSTANCE
+            )
         );
         FutureUtils.get(listener);
     }
@@ -229,7 +237,11 @@ public class BlobRecoveryHandler extends RecoverySourceHandler {
             BlobRecoveryTarget.Actions.FINALIZE_RECOVERY,
             new BlobFinalizeRecoveryRequest(request.recoveryId()),
             TransportRequestOptions.EMPTY,
-            new ActionListenerResponseHandler<>(listener, in -> TransportResponse.Empty.INSTANCE)
+            new ActionListenerResponseHandler<>(
+                BlobRecoveryTarget.Actions.FINALIZE_RECOVERY,
+                listener,
+                _ -> TransportResponse.Empty.INSTANCE
+            )
         );
         FutureUtils.get(listener);
     }
@@ -241,7 +253,11 @@ public class BlobRecoveryHandler extends RecoverySourceHandler {
             BlobRecoveryTarget.Actions.START_RECOVERY,
             new BlobStartRecoveryRequest(request.recoveryId(), request.shardId()),
             TransportRequestOptions.EMPTY,
-            new ActionListenerResponseHandler<>(listener, in -> TransportResponse.Empty.INSTANCE)
+            new ActionListenerResponseHandler<>(
+                BlobRecoveryTarget.Actions.START_RECOVERY,
+                listener,
+                _ -> TransportResponse.Empty.INSTANCE
+            )
         );
         FutureUtils.get(listener);
     }
@@ -300,7 +316,11 @@ public class BlobRecoveryHandler extends RecoverySourceHandler {
                             BlobRecoveryTarget.Actions.START_TRANSFER,
                             startTransferRequest,
                             TransportRequestOptions.EMPTY,
-                            new ActionListenerResponseHandler<>(listener, in -> TransportResponse.Empty.INSTANCE)
+                            new ActionListenerResponseHandler<>(
+                                BlobRecoveryTarget.Actions.START_TRANSFER,
+                                listener,
+                                _ -> TransportResponse.Empty.INSTANCE
+                            )
                         );
                         FutureUtils.get(listener);
 
@@ -326,7 +346,11 @@ public class BlobRecoveryHandler extends RecoverySourceHandler {
                                 new BlobRecoveryChunkRequest(request.recoveryId(),
                                     startTransferRequest.transferId(), content, isLast),
                                 TransportRequestOptions.EMPTY,
-                                new ActionListenerResponseHandler<>(transferChunkListener, in -> TransportResponse.Empty.INSTANCE)
+                                new ActionListenerResponseHandler<>(
+                                    BlobRecoveryTarget.Actions.TRANSFER_CHUNK,
+                                    transferChunkListener,
+                                    _ -> TransportResponse.Empty.INSTANCE
+                                )
                             );
                             FutureUtils.get(transferChunkListener);
                         }
@@ -340,7 +364,11 @@ public class BlobRecoveryHandler extends RecoverySourceHandler {
                                 new BlobRecoveryChunkRequest(request.recoveryId(),
                                     startTransferRequest.transferId(), BytesArray.EMPTY, true),
                                 TransportRequestOptions.EMPTY,
-                                new ActionListenerResponseHandler<>(transferMissingChunkListener, in -> TransportResponse.Empty.INSTANCE)
+                                new ActionListenerResponseHandler<>(
+                                    BlobRecoveryTarget.Actions.TRANSFER_CHUNK,
+                                    transferMissingChunkListener,
+                                    _ -> TransportResponse.Empty.INSTANCE
+                                )
                             );
                             FutureUtils.get(transferMissingChunkListener);
                         }

--- a/server/src/main/java/io/crate/blob/transfer/PutHeadChunkRunnable.java
+++ b/server/src/main/java/io/crate/blob/transfer/PutHeadChunkRunnable.java
@@ -119,7 +119,10 @@ public class PutHeadChunkRunnable implements Runnable {
                     BlobHeadRequestHandler.Actions.PUT_BLOB_HEAD_CHUNK,
                     new PutBlobHeadChunkRequest(transferId, new BytesArray(buffer, 0, bytesRead)),
                     TransportRequestOptions.EMPTY,
-                    new ActionListenerResponseHandler<>(listener, in -> TransportResponse.Empty.INSTANCE)
+                    new ActionListenerResponseHandler<>(
+                        BlobHeadRequestHandler.Actions.PUT_BLOB_HEAD_CHUNK,
+                        listener,
+                        _ -> TransportResponse.Empty.INSTANCE)
                 );
                 FutureUtils.get(listener);
             }

--- a/server/src/main/java/io/crate/cluster/decommission/TransportDecommissionNodeAction.java
+++ b/server/src/main/java/io/crate/cluster/decommission/TransportDecommissionNodeAction.java
@@ -21,10 +21,8 @@
 
 package io.crate.cluster.decommission;
 
-import io.crate.cluster.gracefulstop.DecommissioningService;
-import io.crate.execution.support.NodeActionRequestHandler;
-import io.crate.execution.support.NodeRequest;
-import io.crate.execution.support.Transports;
+import java.util.concurrent.CompletableFuture;
+
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionListenerResponseHandler;
 import org.elasticsearch.action.support.TransportAction;
@@ -34,7 +32,10 @@ import org.elasticsearch.common.inject.Singleton;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
-import java.util.concurrent.CompletableFuture;
+import io.crate.cluster.gracefulstop.DecommissioningService;
+import io.crate.execution.support.NodeActionRequestHandler;
+import io.crate.execution.support.NodeRequest;
+import io.crate.execution.support.Transports;
 
 @Singleton
 public class TransportDecommissionNodeAction extends TransportAction<NodeRequest<DecommissionRequest>, AcknowledgedResponse> {
@@ -64,13 +65,13 @@ public class TransportDecommissionNodeAction extends TransportAction<NodeRequest
             request.nodeId(),
             request.innerRequest(),
             listener,
-            new ActionListenerResponseHandler<>(listener, AcknowledgedResponse::new)
+            new ActionListenerResponseHandler<>(DecommissionNodeAction.NAME, listener, AcknowledgedResponse::new)
         );
     }
 
     private CompletableFuture<AcknowledgedResponse> nodeOperation(DecommissionRequest request) {
         try {
-            return decommissioningService.decommission().thenApply(aVoid -> new AcknowledgedResponse(true));
+            return decommissioningService.decommission().thenApply(_ -> new AcknowledgedResponse(true));
         } catch (Throwable t) {
             return CompletableFuture.failedFuture(t);
         }

--- a/server/src/main/java/io/crate/execution/engine/collect/stats/TransportNodeStatsAction.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/stats/TransportNodeStatsAction.java
@@ -21,10 +21,8 @@
 
 package io.crate.execution.engine.collect.stats;
 
-import io.crate.execution.support.NodeActionRequestHandler;
-import io.crate.execution.support.Transports;
-import io.crate.expression.reference.sys.node.NodeStatsContext;
-import io.crate.expression.reference.sys.node.NodeStatsContextFieldResolver;
+import java.util.concurrent.CompletableFuture;
+
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionListenerResponseHandler;
 import org.elasticsearch.action.support.TransportAction;
@@ -34,7 +32,10 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportRequestOptions;
 import org.elasticsearch.transport.TransportService;
 
-import java.util.concurrent.CompletableFuture;
+import io.crate.execution.support.NodeActionRequestHandler;
+import io.crate.execution.support.Transports;
+import io.crate.expression.reference.sys.node.NodeStatsContext;
+import io.crate.expression.reference.sys.node.NodeStatsContextFieldResolver;
 
 @Singleton
 public class TransportNodeStatsAction extends TransportAction<NodeStatsRequest, NodeStatsResponse> {
@@ -68,7 +69,7 @@ public class TransportNodeStatsAction extends TransportAction<NodeStatsRequest, 
             request.nodeId(),
             request.innerRequest(),
             listener,
-            new ActionListenerResponseHandler<>(listener, NodeStatsResponse::new),
+            new ActionListenerResponseHandler<>(NodeStatsAction.NAME, listener, NodeStatsResponse::new),
             options
         );
     }

--- a/server/src/main/java/io/crate/execution/engine/distribution/TransportDistributedResultAction.java
+++ b/server/src/main/java/io/crate/execution/engine/distribution/TransportDistributedResultAction.java
@@ -41,8 +41,8 @@ import org.elasticsearch.node.Node;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.jetbrains.annotations.Nullable;
-
 import org.jetbrains.annotations.VisibleForTesting;
+
 import io.crate.common.unit.TimeValue;
 import io.crate.exceptions.JobKilledException;
 import io.crate.exceptions.TaskMissing;
@@ -125,7 +125,7 @@ public class TransportDistributedResultAction extends TransportAction<NodeReques
             request.nodeId(),
             request.innerRequest(),
             listener,
-            new ActionListenerResponseHandler<>(listener, DistributedResultResponse::new)
+            new ActionListenerResponseHandler<>(DistributedResultAction.NAME, listener, DistributedResultResponse::new)
         );
     }
 

--- a/server/src/main/java/io/crate/execution/engine/fetch/TransportFetchNodeAction.java
+++ b/server/src/main/java/io/crate/execution/engine/fetch/TransportFetchNodeAction.java
@@ -24,8 +24,6 @@ package io.crate.execution.engine.fetch;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ThreadPoolExecutor;
 
-import com.carrotsearch.hppc.IntObjectMap;
-
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionListenerResponseHandler;
 import org.elasticsearch.action.support.TransportAction;
@@ -37,6 +35,8 @@ import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.indices.breaker.HierarchyCircuitBreakerService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
+
+import com.carrotsearch.hppc.IntObjectMap;
 
 import io.crate.execution.engine.collect.stats.JobsLogs;
 import io.crate.execution.engine.distribution.StreamBucket;
@@ -89,7 +89,7 @@ public class TransportFetchNodeAction extends TransportAction<NodeFetchRequest, 
             nodeFetchRequest.nodeId(),
             nodeFetchRequest.innerRequest(),
             listener,
-            new ActionListenerResponseHandler<>(listener, nodeFetchRequest.createResponseReader())
+            new ActionListenerResponseHandler<>(FetchNodeAction.NAME, listener, nodeFetchRequest.createResponseReader())
         );
     }
 

--- a/server/src/main/java/io/crate/execution/engine/profile/TransportCollectProfileNodeAction.java
+++ b/server/src/main/java/io/crate/execution/engine/profile/TransportCollectProfileNodeAction.java
@@ -21,11 +21,10 @@
 
 package io.crate.execution.engine.profile;
 
-import io.crate.execution.jobs.RootTask;
-import io.crate.execution.jobs.TasksService;
-import io.crate.execution.support.NodeActionRequestHandler;
-import io.crate.execution.support.NodeRequest;
-import io.crate.execution.support.Transports;
+import java.util.Collections;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionListenerResponseHandler;
@@ -35,10 +34,11 @@ import org.elasticsearch.common.inject.Singleton;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
-import java.util.Collections;
-import java.util.Map;
-import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
+import io.crate.execution.jobs.RootTask;
+import io.crate.execution.jobs.TasksService;
+import io.crate.execution.support.NodeActionRequestHandler;
+import io.crate.execution.support.NodeRequest;
+import io.crate.execution.support.Transports;
 
 /**
  * Transport action to collect profiling results from the {@link RootTask}.
@@ -98,7 +98,7 @@ public class TransportCollectProfileNodeAction extends TransportAction<NodeReque
             request.nodeId(),
             request.innerRequest(),
             listener,
-            new ActionListenerResponseHandler<>(listener, NodeCollectProfileResponse::new)
+            new ActionListenerResponseHandler<>(CollectProfileNodeAction.NAME, listener, NodeCollectProfileResponse::new)
         );
     }
 }

--- a/server/src/main/java/io/crate/execution/jobs/kill/TransportKillNodeAction.java
+++ b/server/src/main/java/io/crate/execution/jobs/kill/TransportKillNodeAction.java
@@ -59,7 +59,7 @@ public final class TransportKillNodeAction {
                                       listener);
 
         TransportResponseHandler<KillResponse> responseHandler =
-            new ActionListenerResponseHandler<>(multiListener, KillResponse::new);
+            new ActionListenerResponseHandler<>(actionName, multiListener, KillResponse::new);
         for (DiscoveryNode node : filteredNodes) {
             transportService.sendRequest(node, actionName, request, responseHandler);
         }

--- a/server/src/main/java/io/crate/execution/jobs/transport/TransportCancelAction.java
+++ b/server/src/main/java/io/crate/execution/jobs/transport/TransportCancelAction.java
@@ -35,10 +35,10 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportResponse;
 import org.elasticsearch.transport.TransportService;
 
-import io.crate.session.Sessions;
 import io.crate.execution.support.MultiActionListener;
 import io.crate.execution.support.NodeAction;
 import io.crate.execution.support.NodeActionRequestHandler;
+import io.crate.session.Sessions;
 
 /**
  * Action that broadcasts a cancel to all *other* nodes.
@@ -87,7 +87,7 @@ public class TransportCancelAction extends TransportAction<CancelRequest, Acknow
                 node,
                 NAME,
                 request,
-                new ActionListenerResponseHandler<>(multiActionListener, AcknowledgedResponse::new)
+                new ActionListenerResponseHandler<>(NAME, multiActionListener, AcknowledgedResponse::new)
             );
         }
     }

--- a/server/src/main/java/io/crate/execution/jobs/transport/TransportJobAction.java
+++ b/server/src/main/java/io/crate/execution/jobs/transport/TransportJobAction.java
@@ -82,7 +82,7 @@ public class TransportJobAction extends TransportAction<NodeRequest<JobRequest>,
             request.nodeId(),
             request.innerRequest(),
             listener,
-            new ActionListenerResponseHandler<>(listener, JobResponse::new)
+            new ActionListenerResponseHandler<>(JobAction.NAME, listener, JobResponse::new)
         );
     }
 

--- a/server/src/main/java/io/crate/protocols/postgres/PgClient.java
+++ b/server/src/main/java/io/crate/protocols/postgres/PgClient.java
@@ -626,7 +626,7 @@ public class PgClient extends AbstractClient {
                     action.name(),
                     request,
                     TransportRequestOptions.EMPTY,
-                    new ActionListenerResponseHandler<>(future, action.getResponseReader())
+                    new ActionListenerResponseHandler<>(action.name(), future, action.getResponseReader())
                 );
             } else {
                 transportService.sendRequest(
@@ -634,7 +634,7 @@ public class PgClient extends AbstractClient {
                     action.name(),
                     request,
                     TransportRequestOptions.EMPTY,
-                    new ActionListenerResponseHandler<>(future, action.getResponseReader())
+                    new ActionListenerResponseHandler<>(action.name(), future, action.getResponseReader())
                 );
             }
             return future;

--- a/server/src/main/java/io/crate/statistics/TransportAnalyzeAction.java
+++ b/server/src/main/java/io/crate/statistics/TransportAnalyzeAction.java
@@ -158,6 +158,7 @@ public final class TransportAnalyzeAction {
             listener
         );
         var responseHandler = new ActionListenerResponseHandler<>(
+            RECEIVE_TABLE_STATS,
             multiListener,
             AcknowledgedResponse::new,
             ThreadPool.Names.SAME
@@ -180,6 +181,7 @@ public final class TransportAnalyzeAction {
             listener
         );
         ActionListenerResponseHandler<FetchSampleResponse> responseHandler = new ActionListenerResponseHandler<>(
+            FETCH_SAMPLES,
             multiListener,
             in -> new FetchSampleResponse(columns, in),
             ThreadPool.Names.SAME

--- a/server/src/main/java/org/elasticsearch/action/ActionListenerResponseHandler.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionListenerResponseHandler.java
@@ -19,6 +19,9 @@
 
 package org.elasticsearch.action;
 
+import java.io.IOException;
+import java.util.Objects;
+
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -26,30 +29,31 @@ import org.elasticsearch.transport.TransportException;
 import org.elasticsearch.transport.TransportResponse;
 import org.elasticsearch.transport.TransportResponseHandler;
 
-import java.io.IOException;
-import java.util.Objects;
-
 /**
  * A simple base class for action response listeners, defaulting to using the SAME executor (as its
  * very common on response handlers).
  */
 public class ActionListenerResponseHandler<Response extends TransportResponse> implements TransportResponseHandler<Response> {
 
+    private final String action;
     private final ActionListener<? super Response> listener;
     private final Writeable.Reader<Response> reader;
     private final String executor;
 
-    public ActionListenerResponseHandler(ActionListener<? super Response> listener,
+    public ActionListenerResponseHandler(String action,
+                                         ActionListener<? super Response> listener,
                                          Writeable.Reader<Response> reader,
                                          String executor) {
+        this.action = action;
         this.listener = Objects.requireNonNull(listener);
         this.reader = Objects.requireNonNull(reader);
         this.executor = Objects.requireNonNull(executor);
     }
 
-    public ActionListenerResponseHandler(ActionListener<? super Response> listener,
+    public ActionListenerResponseHandler(String action,
+                                         ActionListener<? super Response> listener,
                                          Writeable.Reader<Response> reader) {
-        this(listener, reader, ThreadPool.Names.SAME);
+        this(action, listener, reader, ThreadPool.Names.SAME);
     }
 
     @Override
@@ -70,5 +74,10 @@ public class ActionListenerResponseHandler<Response extends TransportResponse> i
     @Override
     public String executor() {
         return executor;
+    }
+
+    @Override
+    public String toString() {
+        return "ActionResponseHandler{" + action + ", executor=" + executor + "}";
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/support/master/TransportMasterNodeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/master/TransportMasterNodeAction.java
@@ -183,8 +183,11 @@ public abstract class TransportMasterNodeAction<Request extends MasterNodeReques
                     } else {
                         DiscoveryNode masterNode = nodes.getMasterNode();
                         final String actionName = getMasterActionName(masterNode);
-                        transportService.sendRequest(masterNode, actionName, request, new ActionListenerResponseHandler<Response>(listener,
-                            TransportMasterNodeAction.this::read) {
+                        ActionListenerResponseHandler<Response> handler = new ActionListenerResponseHandler<Response>(
+                                actionName,
+                                listener,
+                                TransportMasterNodeAction.this::read) {
+
                             @Override
                             public void handleException(final TransportException exp) {
                                 Throwable cause = exp.unwrapCause();
@@ -199,7 +202,8 @@ public abstract class TransportMasterNodeAction<Request extends MasterNodeReques
                                     listener.onFailure(exp);
                                 }
                             }
-                        });
+                        };
+                        transportService.sendRequest(masterNode, actionName, request, handler);
                     }
                 }
             } catch (Exception e) {

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/JoinHelper.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/JoinHelper.java
@@ -333,7 +333,7 @@ public class JoinHelper {
         transportService.sendRequest(node, VALIDATE_JOIN_ACTION_NAME,
             new ValidateJoinRequest(state),
             TransportRequestOptions.builder().withTimeout(joinTimeout).build(),
-            new ActionListenerResponseHandler<>(listener, i -> Empty.INSTANCE, ThreadPool.Names.GENERIC));
+            new ActionListenerResponseHandler<>(VALIDATE_JOIN_ACTION_NAME, listener, i -> Empty.INSTANCE, ThreadPool.Names.GENERIC));
     }
 
     public interface JoinCallback {

--- a/server/src/main/java/org/elasticsearch/gateway/LocalAllocateDangledIndices.java
+++ b/server/src/main/java/org/elasticsearch/gateway/LocalAllocateDangledIndices.java
@@ -100,7 +100,7 @@ public class LocalAllocateDangledIndices {
             masterNode,
             ACTION_NAME,
             request,
-            new ActionListenerResponseHandler<>(listener, AllocateDangledResponse::new, ThreadPool.Names.SAME)
+            new ActionListenerResponseHandler<>(ACTION_NAME, listener, AllocateDangledResponse::new, ThreadPool.Names.SAME)
         );
     }
 

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RemoteRecoveryTargetHandler.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RemoteRecoveryTargetHandler.java
@@ -137,6 +137,7 @@ public class RemoteRecoveryTargetHandler implements RecoveryTargetHandler {
     public void handoffPrimaryContext(final ReplicationTracker.PrimaryContext primaryContext) {
         FutureActionListener<TransportResponse.Empty> future = new FutureActionListener<>();
         ActionListenerResponseHandler<TransportResponse.Empty> handler = new ActionListenerResponseHandler<>(
+            PeerRecoveryTargetService.Actions.HANDOFF_PRIMARY_CONTEXT,
             future,
             in -> TransportResponse.Empty.INSTANCE,
             ThreadPool.Names.SAME
@@ -289,7 +290,7 @@ public class RemoteRecoveryTargetHandler implements RecoveryTargetHandler {
             @Override
             public void tryAction(ActionListener<T> listener) {
                 transportService.sendRequest(targetNode, action, request, options,
-                    new ActionListenerResponseHandler<>(listener, reader, ThreadPool.Names.GENERIC));
+                    new ActionListenerResponseHandler<>(action, listener, reader, ThreadPool.Names.GENERIC));
             }
 
             @Override

--- a/server/src/main/java/org/elasticsearch/transport/SniffRemoteClient.java
+++ b/server/src/main/java/org/elasticsearch/transport/SniffRemoteClient.java
@@ -309,7 +309,7 @@ public final class SniffRemoteClient extends AbstractClient {
                 action.name(),
                 request,
                 TransportRequestOptions.EMPTY,
-                new ActionListenerResponseHandler<>(future, action.getResponseReader())
+                new ActionListenerResponseHandler<>(action.name(), future, action.getResponseReader())
             );
             return future;
         });

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/JoinHelperTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/JoinHelperTests.java
@@ -176,7 +176,7 @@ public class JoinHelperTests extends ESTestCase {
         final PlainFuture<TransportResponse.Empty> future = new PlainFuture<>();
         transportService.sendRequest(localNode, actionName,
             new ValidateJoinRequest(otherClusterState),
-            new ActionListenerResponseHandler<>(future, in -> TransportResponse.Empty.INSTANCE));
+            new ActionListenerResponseHandler<>(actionName, future, in -> TransportResponse.Empty.INSTANCE));
         deterministicTaskQueue.runAllTasks();
 
         assertThatThrownBy(future::get)

--- a/server/src/test/java/org/elasticsearch/transport/TransportServiceDeserializationFailureTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TransportServiceDeserializationFailureTests.java
@@ -35,9 +35,11 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.transport.MockTransport;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.junit.Test;
 
 public class TransportServiceDeserializationFailureTests extends ESTestCase {
 
+    @Test
     public void testDeserializationFailureLogIdentifiesListener() {
         final DiscoveryNode localNode = new DiscoveryNode("local", buildNewFakeTransportAddress(), Version.CURRENT);
         final DiscoveryNode otherNode = new DiscoveryNode("other", buildNewFakeTransportAddress(), Version.CURRENT);
@@ -141,7 +143,7 @@ public class TransportServiceDeserializationFailureTests extends ESTestCase {
                     = transport.getResponseHandlers().prune(ignored -> true);
             assertThat(responseContexts).hasSize(1);
             final TransportResponseHandler<? extends TransportResponse> handler = responseContexts.get(0).handler();
-            assertThat(handler.toString()).contains("test handler with parent", testActionName);
+            assertThat(handler.toString()).endsWith("test handler with parent");
         }
     }
 


### PR DESCRIPTION
The TransportService wrapped each response handler with one that
extended the `toString()` implementation.

This removes the wrapper and instead extends the `toString()`
implementation of the `ActionListenerResponseHandler` implementation to
avoid the need for the wrapper.

---

Not sure if worth doing. I first thought the delegate was unnecessary until I realized it was for the `toString()`.
