### PR TITLE
docs: Fix link to elasticsearch discovery settings

### DIFF
--- a/docs/appendices/resiliency.rst
+++ b/docs/appendices/resiliency.rst
@@ -180,7 +180,7 @@ Version number representing ambiguous row versions
 A client is writing to a primary shard. The node holding the primary shard is
 partitioned from the cluster. It usually takes between 30 and 60 seconds
 (depending on `ping configuration
-<https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-discovery-zen.html>`_)
+<https://www.elastic.co/docs/reference/elasticsearch/configuration-reference/discovery-cluster-formation-settings>`_)
 before the master node notices the partition. During this time, the same row is
 updated on both the primary shard (partitioned) and a replica shard (not
 partitioned).
@@ -287,7 +287,7 @@ lost as data from the newly elected primary shard replaces it when it rejoins
 the cluster.
 
 The risk window depends on your `ping configuration
-<https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-discovery-zen.html>`_.
+<https://www.elastic.co/docs/reference/elasticsearch/configuration-reference/discovery-cluster-formation-settings>`_.
 The default configuration of a 30 second ping timeout with three retries
 corresponds to a 90 second risk window. However, it is very rare for a node to
 lose connectivity within the cluster but maintain connectivity with clients.
@@ -481,7 +481,7 @@ with has fallen below the configured minimum) it should step down as master and
 stop answering requests to perform cluster updates. There is a small risk
 window between losing quorum and noticing that quorum has been lost, depending
 on your `ping configuration
-<https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-discovery-zen.html>`_.
+<https://www.elastic.co/docs/reference/elasticsearch/configuration-reference/discovery-cluster-formation-settings>`_.
 
 .. rubric:: Consequence
 

--- a/docs/concepts/resiliency.rst
+++ b/docs/concepts/resiliency.rst
@@ -45,7 +45,7 @@ due to a network failure or the failure of a node in the cluster.
 
 The status is updated every few seconds (variable on your cluster `ping
 configuration
-<https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-discovery-zen.html>`_).
+<https://www.elastic.co/docs/reference/elasticsearch/configuration-reference/discovery-cluster-formation-settings>`_).
 
 
 .. _concept-resiliency-consistency:


### PR DESCRIPTION
The previous link doesn't work anymore.

