### PR TITLE
Resolve existing partitions on creation without being strict

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/create/TransportCreatePartitions.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/create/TransportCreatePartitions.java
@@ -384,7 +384,8 @@ public class TransportCreatePartitions extends TransportMasterNodeAction<CreateP
         Metadata metadata = state.metadata();
         ArrayList<PartitionName> partitions = new ArrayList<>(request.partitionValuesList().size());
         for (List<String> partitionValues : request.partitionValuesList()) {
-            List<IndexMetadata> indices = metadata.getIndices(request.relationName(), partitionValues, true, imd -> imd);
+            // Don't be strict, it should not fail if the partition already exists
+            List<IndexMetadata> indices = metadata.getIndices(request.relationName(), partitionValues, false, imd -> imd);
             if (indices.isEmpty()) {
                 PartitionName partition = new PartitionName(request.relationName(), partitionValues);
                 partitions.add(partition);


### PR DESCRIPTION
If strict is enabled, the current resolving will throw an exception if the partition already exists. But an existing partition is expected due to concurrent creation.

Follow up of #17885.