### PR TITLE
Turn TransportRequestOptions into record without builder

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/collect/stats/TransportNodeStatsAction.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/stats/TransportNodeStatsAction.java
@@ -60,10 +60,7 @@ public class TransportNodeStatsAction extends TransportAction<NodeStatsRequest, 
 
     @Override
     public void doExecute(NodeStatsRequest request, ActionListener<NodeStatsResponse> listener) {
-        TransportRequestOptions options = TransportRequestOptions.builder()
-            .withTimeout(request.timeout())
-            .build();
-
+        TransportRequestOptions options = new TransportRequestOptions(request.timeout());
         transports.sendRequest(
             NodeStatsAction.NAME,
             request.nodeId(),

--- a/server/src/main/java/org/elasticsearch/action/support/nodes/TransportNodesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/nodes/TransportNodesAction.java
@@ -19,6 +19,13 @@
 
 package org.elasticsearch.action.support.nodes;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReferenceArray;
+
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.FailedNodeException;
@@ -36,13 +43,6 @@ import org.elasticsearch.transport.TransportRequestHandler;
 import org.elasticsearch.transport.TransportRequestOptions;
 import org.elasticsearch.transport.TransportResponseHandler;
 import org.elasticsearch.transport.TransportService;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReferenceArray;
 
 public abstract class TransportNodesAction<NodesRequest extends BaseNodesRequest<NodesRequest>,
                                            NodesResponse extends BaseNodesResponse,
@@ -145,10 +145,7 @@ public abstract class TransportNodesAction<NodesRequest extends BaseNodesRequest
                 threadPool.generic().execute(() -> listener.onResponse(newResponse(request, responses)));
                 return;
             }
-            TransportRequestOptions.Builder builder = TransportRequestOptions.builder();
-            if (request.timeout() != null) {
-                builder.withTimeout(request.timeout());
-            }
+            TransportRequestOptions requestOptions = new TransportRequestOptions(request.timeout());
             for (int i = 0; i < nodes.length; i++) {
                 final int idx = i;
                 final DiscoveryNode node = nodes[i];
@@ -159,7 +156,7 @@ public abstract class TransportNodesAction<NodesRequest extends BaseNodesRequest
                         node,
                         transportNodeAction,
                         nodeRequest,
-                        builder.build(),
+                        requestOptions,
                         new TransportResponseHandler<NodeResponse>() {
 
                             @Override

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/FollowersChecker.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/FollowersChecker.java
@@ -299,8 +299,11 @@ public class FollowersChecker {
             final FollowerCheckRequest request = new FollowerCheckRequest(fastResponseState.term, transportService.getLocalNode());
             LOGGER.trace("handleWakeUp: checking {} with {}", discoveryNode, request);
 
-            transportService.sendRequest(discoveryNode, FOLLOWER_CHECK_ACTION_NAME, request,
-                TransportRequestOptions.builder().withTimeout(followerCheckTimeout).withType(Type.PING).build(),
+            transportService.sendRequest(
+                discoveryNode,
+                FOLLOWER_CHECK_ACTION_NAME,
+                request,
+                new TransportRequestOptions(followerCheckTimeout, Type.PING),
                 new TransportResponseHandler<Empty>() {
                     @Override
                     public Empty read(StreamInput in) {

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/JoinHelper.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/JoinHelper.java
@@ -269,8 +269,11 @@ public class JoinHelper {
         final Tuple<DiscoveryNode, JoinRequest> dedupKey = new Tuple<>(destination, joinRequest);
         if (pendingOutgoingJoins.add(dedupKey)) {
             LOGGER.debug("attempting to join {} with {}", destination, joinRequest);
-            transportService.sendRequest(destination, JOIN_ACTION_NAME, joinRequest,
-                TransportRequestOptions.builder().withTimeout(joinTimeout).build(),
+            transportService.sendRequest(
+                destination,
+                JOIN_ACTION_NAME,
+                joinRequest,
+                new TransportRequestOptions(joinTimeout),
                 new TransportResponseHandler<Empty>() {
                     @Override
                     public Empty read(StreamInput in) {
@@ -332,7 +335,7 @@ public class JoinHelper {
     void sendValidateJoinRequest(DiscoveryNode node, ClusterState state, ActionListener<TransportResponse.Empty> listener) {
         transportService.sendRequest(node, VALIDATE_JOIN_ACTION_NAME,
             new ValidateJoinRequest(state),
-            TransportRequestOptions.builder().withTimeout(joinTimeout).build(),
+            new TransportRequestOptions(joinTimeout),
             new ActionListenerResponseHandler<>(VALIDATE_JOIN_ACTION_NAME, listener, i -> Empty.INSTANCE, ThreadPool.Names.GENERIC));
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/PublicationTransportHandler.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/PublicationTransportHandler.java
@@ -55,6 +55,7 @@ import org.elasticsearch.transport.BytesTransportRequest;
 import org.elasticsearch.transport.TransportChannel;
 import org.elasticsearch.transport.TransportException;
 import org.elasticsearch.transport.TransportRequestOptions;
+import org.elasticsearch.transport.TransportRequestOptions.Type;
 import org.elasticsearch.transport.TransportResponse;
 import org.elasticsearch.transport.TransportResponseHandler;
 import org.elasticsearch.transport.TransportService;
@@ -86,8 +87,7 @@ public class PublicationTransportHandler {
     private final AtomicLong compatibleClusterStateDiffReceivedCount = new AtomicLong();
     // -> no need to put a timeout on the options here, because we want the response to eventually be received
     //  and not log an error if it arrives after the timeout
-    private final TransportRequestOptions stateRequestOptions = TransportRequestOptions.builder()
-        .withType(TransportRequestOptions.Type.STATE).build();
+    private final TransportRequestOptions stateRequestOptions = new TransportRequestOptions(null, Type.STATE);
 
     public PublicationTransportHandler(TransportService transportService, NamedWriteableRegistry namedWriteableRegistry,
                                        Function<PublishRequest, PublishWithJoinResponse> handlePublishRequest,

--- a/server/src/main/java/org/elasticsearch/discovery/PeerFinder.java
+++ b/server/src/main/java/org/elasticsearch/discovery/PeerFinder.java
@@ -436,7 +436,7 @@ public abstract class PeerFinder {
             };
             transportService.sendRequest(discoveryNode, REQUEST_PEERS_ACTION_NAME,
                 new PeersRequest(getLocalNode(), knownNodes),
-                TransportRequestOptions.builder().withTimeout(requestPeersTimeout).build(),
+                new TransportRequestOptions(requestPeersTimeout),
                 peersResponseHandler);
         }
 

--- a/server/src/main/java/org/elasticsearch/transport/TransportRequestOptions.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportRequestOptions.java
@@ -20,27 +20,21 @@
 package org.elasticsearch.transport;
 
 
+import org.jetbrains.annotations.Nullable;
+
 import io.crate.common.unit.TimeValue;
 
-public class TransportRequestOptions {
+public record TransportRequestOptions(@Nullable TimeValue timeout, Type type) {
 
-    private final TimeValue timeout;
-    private final Type type;
+    public static final TransportRequestOptions EMPTY = new TransportRequestOptions(null, Type.REG);
 
-    private TransportRequestOptions(TimeValue timeout, Type type) {
-        this.timeout = timeout;
-        this.type = type;
+    public TransportRequestOptions(@Nullable long timeoutInMs) {
+        this(TimeValue.timeValueMillis(timeoutInMs), Type.REG);
     }
 
-    public TimeValue timeout() {
-        return this.timeout;
+    public TransportRequestOptions(@Nullable TimeValue timeout) {
+        this(timeout, Type.REG);
     }
-
-    public Type type() {
-        return this.type;
-    }
-
-    public static final TransportRequestOptions EMPTY = new TransportRequestOptions.Builder().build();
 
     public enum Type {
         RECOVERY,
@@ -48,39 +42,5 @@ public class TransportRequestOptions {
         REG,
         STATE,
         PING
-    }
-
-    public static Builder builder() {
-        return new Builder();
-    }
-
-    public static Builder builder(TransportRequestOptions options) {
-        return new Builder().withTimeout(options.timeout).withType(options.type());
-    }
-
-    public static class Builder {
-        private TimeValue timeout;
-        private Type type = Type.REG;
-
-        private Builder() {
-        }
-
-        public Builder withTimeout(long timeout) {
-            return withTimeout(TimeValue.timeValueMillis(timeout));
-        }
-
-        public Builder withTimeout(TimeValue timeout) {
-            this.timeout = timeout;
-            return this;
-        }
-
-        public Builder withType(Type type) {
-            this.type = type;
-            return this;
-        }
-
-        public TransportRequestOptions build() {
-            return new TransportRequestOptions(timeout, type);
-        }
     }
 }

--- a/server/src/main/java/org/elasticsearch/transport/TransportService.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportService.java
@@ -356,7 +356,7 @@ public class TransportService extends AbstractLifecycleComponent implements Tran
             connection,
             HANDSHAKE_ACTION_NAME,
             HandshakeRequest.INSTANCE,
-            TransportRequestOptions.builder().withTimeout(handshakeTimeout).build(),
+            new TransportRequestOptions(handshakeTimeout),
             new ActionListenerResponseHandler<>(
                 HANDSHAKE_ACTION_NAME,
                 new ActionListener<>() {


### PR DESCRIPTION
The builder wasn't really justified. The call-sites are simpler without
it.
