### PR TITLE
Fix 5.10.0 release notes

### DIFF
--- a/docs/appendices/release-notes/5.10.0.rst
+++ b/docs/appendices/release-notes/5.10.0.rst
@@ -116,12 +116,10 @@ Data Types
   arithmetic scalar functions: :ref:`ABS<scalar-abs>`, :ref:`CEIL<scalar-ceil>`,
   :ref:`FLOOR<scalar-floor>`, :ref:`ROUND<scalar-round>` (for the variation of
   only one argument), :ref:`EXP<scalar-exp>`, :ref:`SQRT<scalar-sqrt>`,
-  :ref:`LN<scalar-ln>`, :ref:`LOG<scalar-log>` (for the variation of only one
-  argument), :ref:`SIN`<scalar-sin>`, :ref:`SIN`<scalar-asin>`,
-  :ref:`COS`<scalar-cos>`, :ref:`ACOS`<scalar-acos>`, :ref:`tan`<scalar-tan>`,
-  :ref:`ATAN`<scalar-atan>`, :ref:`ATAN2`<scalar-atan2>`,
-  :ref:`COT`<scalar-cot>`, :ref:`LN<scalar-ln>` and :ref:`LOG<scalar-log>` (for
-  the variation of only one arguement).
+  :ref:`SIN`<scalar-sin>`, :ref:`COS`<scalar-cos>`, :ref:`ACOS`<scalar-acos>`,
+  :ref:`tan`<scalar-tan>`, :ref:`ATAN`<scalar-atan>`,
+  :ref:`ATAN2`<scalar-atan2>`, :ref:`COT`<scalar-cot>`, :ref:`LN<scalar-ln>` and
+  :ref:`LOG<scalar-log>` (for the variation of only one argument).
 
 Scalar and Aggregation Functions
 --------------------------------

--- a/docs/general/builtins/scalar-functions.rst
+++ b/docs/general/builtins/scalar-functions.rst
@@ -2253,7 +2253,7 @@ When the second argument (``b``) is provided it returns a value of type
 casted to ``double precision`` (thus, possibly loosing precision). When it's not
 provided, then the return value will be of type ``numeric`` with unspecified
 precision and scale, if the input value is of ``numeric`` type and of
-`double precision`` for any other arithmetic type.
+``double precision`` for any other arithmetic type.
 
 Examples::
 


### PR DESCRIPTION
- Remove duplicate entries regarding numeric support for scalar arithmetic functions.

- Missing backtick in scalar-functions.rst
