### PR TITLE
Rework HttpBlobHandler exception handling

### DIFF
--- a/server/src/test/java/org/elasticsearch/gateway/ReplicaShardAllocatorIT.java
+++ b/server/src/test/java/org/elasticsearch/gateway/ReplicaShardAllocatorIT.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.gateway;
 
 import static io.crate.testing.Asserts.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.Collection;


### PR DESCRIPTION
HttpBlobHandler should pass on any exceptions that it doesn't handle to the next Handler in the pipeline, rather than swallowing them.
