### PR TITLE
Update rules for versions mvn plugin to exlude `RC` versions + update junit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -318,8 +318,8 @@
     <versions.annotations>26.0.2</versions.annotations>
     <versions.log4j>2.24.3</versions.log4j>
     <versions.assertj>3.27.3</versions.assertj>
-    <versions.junit5>5.12.0</versions.junit5>
-    <versions.junit-platform-commons>1.12.0</versions.junit-platform-commons>
+    <versions.junit5>5.12.2</versions.junit5>
+    <versions.junit-platform-commons>1.12.2</versions.junit-platform-commons>
     <versions.junit>4.13.2</versions.junit>
     <versions.randomizedrunner>2.8.3</versions.randomizedrunner>
     <versions.jackson>2.19.0</versions.jackson>

--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
         <version>${versions.plugin.versions}</version>
         <configuration>
           <ruleSet>
-            <!-- ignore alpha, beta and M versions -->
+            <!-- ignore alpha, beta, M and RC versions -->
             <ignoreVersions>
               <ignoreVersion>
                 <type>regex</type>
@@ -145,6 +145,10 @@
               <ignoreVersion>
                 <type>regex</type>
                 <version>.+[\.|-]M.+</version>
+              </ignoreVersion>
+              <ignoreVersion>
+                <type>regex</type>
+                <version>.+[\.|-]RC.+</version>
               </ignoreVersion>
             </ignoreVersions>
             <rules>


### PR DESCRIPTION
- Update rules for versions mvn plugin to exlude `RC` versions
    
    for example, previously, running:
    `./mvnw versions:display-dependency-updates | grep -- "->" | sort |uniq`
    
    would include:
    
    ```
    [INFO]   org.junit.jupiter:junit-jupiter ................. 5.12.0 -> 5.13.0-RC1
    [INFO]   org.junit.jupiter:junit-jupiter-params .......... 5.12.0 -> 5.13.0-RC1
    [INFO]   org.junit.platform:junit-platform-commons ....... 1.12.0 -> 1.13.0-RC1
    [INFO]   org.junit.vintage:junit-vintage-engine .......... 5.12.0 -> 5.13.0-RC1
    ```
 
- Update junit libs to latest version
