### PR TITLE
Add cross-references to table/cluster level allocation settings

### DIFF
--- a/docs/config/cluster.rst
+++ b/docs/config/cluster.rst
@@ -623,6 +623,14 @@ Routing allocation
    ``cluster.routing.allocation.enable`` is set to ``none``, nodes will recover
    their unassigned local primary shards immediately after restart.
 
+.. NOTE::
+
+   Since CrateDB 5.10.0, cluster setting is applied only when table setting
+   :ref:`routing.allocation.enable <sql-create-table-routing-allocation-enable>`
+   has non-default value, otherwise table setting wins.
+   For versions before 5.10.0, cluster setting was never applied and table
+   setting was always applied (either specified or default value).
+
 .. _cluster.routing.rebalance.enable:
 
 **cluster.routing.rebalance.enable**

--- a/docs/sql/statements/create-table.rst
+++ b/docs/sql/statements/create-table.rst
@@ -806,6 +806,14 @@ Can be set to:
 :none:
   No shard allocation allowed.
 
+.. NOTE::
+
+   Since CrateDB 5.10.0, table level setting is applied only when non-default
+   value is specified. Otherwise, cluster level setting
+   :ref:`cluster.routing.allocation.enable <cluster.routing.allocation.enable>`
+   is applied.
+   For versions before 5.10.0, cluster setting was never applied and table
+   setting was always applied (either specified or default value).
 
 .. _sql-create-table-allocation-max-retries:
 


### PR DESCRIPTION
https://github.com/crate/crate/commit/34da3ff213418b4180a0eea75eae759bd9a82713 fixed a bug:

Before 5.10. we used to store default values, and such EnableAllocationDecider.canAllocate never hit else branch in

if (INDEX_ROUTING_ALLOCATION_ENABLE_SETTING.exists(indexMetadata.getSettings())) {
    enable = INDEX_ROUTING_ALLOCATION_ENABLE_SETTING.get(indexMetadata.getSettings());
    usedIndexSetting = true;
} else {
    enable = this.enableAllocation;
    usedIndexSetting = false;
}

and table level setting (default or non-default) was taken and cluster level was ignored.

