### PR TITLE
Remove indexVersionCreated from `newState()` method

### DIFF
--- a/benchmarks/src/main/java/io/crate/execution/engine/aggregation/AggregateCollectorBenchmark.java
+++ b/benchmarks/src/main/java/io/crate/execution/engine/aggregation/AggregateCollectorBenchmark.java
@@ -87,7 +87,6 @@ public class AggregateCollectorBenchmark {
             Version.CURRENT,
             AggregateMode.ITER_FINAL,
             new AggregationFunction[] { sumAggregation },
-            Version.CURRENT,
             new Input[][] { {inExpr0 } },
             new Input[] { Literal.BOOLEAN_TRUE }
         );

--- a/benchmarks/src/main/java/io/crate/execution/engine/aggregation/GroupingLongCollectorBenchmark.java
+++ b/benchmarks/src/main/java/io/crate/execution/engine/aggregation/GroupingLongCollectorBenchmark.java
@@ -144,8 +144,7 @@ public class GroupingLongCollectorBenchmark {
             memoryManager,
             Version.CURRENT,
             keyInputs.getFirst(),
-            DataTypes.LONG,
-            Version.CURRENT
+            DataTypes.LONG
         );
     }
 

--- a/benchmarks/src/main/java/io/crate/execution/engine/aggregation/GroupingStringCollectorBenchmark.java
+++ b/benchmarks/src/main/java/io/crate/execution/engine/aggregation/GroupingStringCollectorBenchmark.java
@@ -113,8 +113,7 @@ public class GroupingStringCollectorBenchmark {
             memoryManager,
             Version.CURRENT,
             keyInputs.get(0),
-            DataTypes.STRING,
-            Version.CURRENT
+            DataTypes.STRING
         );
     }
 

--- a/benchmarks/src/main/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregationBenchmark.java
+++ b/benchmarks/src/main/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregationBenchmark.java
@@ -104,7 +104,6 @@ public class HyperLogLogDistinctAggregationBenchmark {
             Version.CURRENT,
             AggregateMode.ITER_FINAL,
             new AggregationFunction[] { hllAggregation },
-            Version.CURRENT,
             new Input[][] { { inExpr0 } },
             new Input[] { Literal.BOOLEAN_TRUE }
         );
@@ -115,7 +114,6 @@ public class HyperLogLogDistinctAggregationBenchmark {
             Version.CURRENT,
             AggregateMode.ITER_FINAL,
             new AggregationFunction[] { hllAggregation },
-            Version.CURRENT,
             new Input[][] { { inExpr0 } },
             new Input[] { Literal.BOOLEAN_TRUE }
         );

--- a/benchmarks/src/main/java/io/crate/operation/aggregation/IntervalAggregationBenchmark.java
+++ b/benchmarks/src/main/java/io/crate/operation/aggregation/IntervalAggregationBenchmark.java
@@ -120,7 +120,6 @@ public class IntervalAggregationBenchmark {
             Version.CURRENT,
             AggregateMode.ITER_FINAL,
             new AggregationFunction[] { intervalSumAggregation },
-            Version.CURRENT,
             new Input[][] { { inExpr0 } },
             new Input[] { Literal.BOOLEAN_TRUE }
         );
@@ -131,7 +130,6 @@ public class IntervalAggregationBenchmark {
             Version.CURRENT,
             AggregateMode.ITER_FINAL,
             new AggregationFunction[] { intervalAvgAggregation },
-            Version.CURRENT,
             new Input[][] { { inExpr0 } },
             new Input[] { Literal.BOOLEAN_TRUE }
         );

--- a/extensions/functions/src/main/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregation.java
+++ b/extensions/functions/src/main/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregation.java
@@ -122,7 +122,6 @@ public class HyperLogLogDistinctAggregation extends AggregationFunction<HyperLog
     @Nullable
     @Override
     public HllState newState(RamAccounting ramAccounting,
-                             Version indexVersionCreated,
                              Version minNodeInCluster,
                              MemoryManager memoryManager) {
         return new HllState(dataType, minNodeInCluster.onOrAfter(Version.V_4_1_0));

--- a/server/src/main/java/io/crate/execution/engine/aggregation/AggregationFunction.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/AggregationFunction.java
@@ -49,12 +49,11 @@ public abstract class AggregationFunction<TPartial, TFinal> implements FunctionI
      * Called once per "aggregation cycle" to create an initial partial-state-value.
      *
      * @param ramAccounting used to account the memory used for the state.
-     * @param indexVersionCreated the version the current index was created on, this is useful for BWC
+     * @param minNodeInCluster the version the oldest node in the cluster, this is useful for BWC
      * @return a new state instance or null
      */
     @Nullable
     public abstract TPartial newState(RamAccounting ramAccounting,
-                                      Version indexVersionCreated,
                                       Version minNodeInCluster,
                                       MemoryManager memoryManager);
 

--- a/server/src/main/java/io/crate/execution/engine/aggregation/AggregationPipe.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/AggregationPipe.java
@@ -21,6 +21,10 @@
 
 package io.crate.execution.engine.aggregation;
 
+import java.util.List;
+
+import org.elasticsearch.Version;
+
 import io.crate.data.BatchIterator;
 import io.crate.data.CollectingBatchIterator;
 import io.crate.data.Input;
@@ -30,9 +34,6 @@ import io.crate.data.breaker.RamAccounting;
 import io.crate.execution.engine.collect.CollectExpression;
 import io.crate.expression.symbol.AggregateMode;
 import io.crate.memory.MemoryManager;
-import org.elasticsearch.Version;
-
-import java.util.List;
 
 public class AggregationPipe implements Projector {
 
@@ -43,10 +44,9 @@ public class AggregationPipe implements Projector {
                            AggregationContext[] aggregations,
                            RamAccounting ramAccounting,
                            MemoryManager memoryManager,
-                           Version minNodeVersion,
-                           Version indexVersionCreated) {
-        AggregationFunction[] functions = new AggregationFunction[aggregations.length];
-        Input[][] inputs = new Input[aggregations.length][];
+                           Version minNodeVersion) {
+        AggregationFunction<?, ?>[] functions = new AggregationFunction[aggregations.length];
+        Input<?>[][] inputs = new Input[aggregations.length][];
         Input[] filters = new Input[aggregations.length];
         for (int i = 0; i < aggregations.length; i++) {
             AggregationContext aggregation = aggregations[i];
@@ -62,7 +62,6 @@ public class AggregationPipe implements Projector {
             minNodeVersion,
             aggregateMode,
             functions,
-            indexVersionCreated,
             inputs,
             filters
         );

--- a/server/src/main/java/io/crate/execution/engine/aggregation/GroupingProjector.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/GroupingProjector.java
@@ -21,6 +21,13 @@
 
 package io.crate.execution.engine.aggregation;
 
+import static io.crate.expression.symbol.Symbols.typeView;
+
+import java.util.List;
+import java.util.stream.Collector;
+
+import org.elasticsearch.Version;
+
 import io.crate.data.BatchIterator;
 import io.crate.data.CollectingBatchIterator;
 import io.crate.data.Input;
@@ -31,12 +38,6 @@ import io.crate.execution.engine.collect.CollectExpression;
 import io.crate.expression.symbol.AggregateMode;
 import io.crate.expression.symbol.Symbol;
 import io.crate.memory.MemoryManager;
-import org.elasticsearch.Version;
-
-import java.util.List;
-import java.util.stream.Collector;
-
-import static io.crate.expression.symbol.Symbols.typeView;
 
 public class GroupingProjector implements Projector {
 
@@ -50,8 +51,7 @@ public class GroupingProjector implements Projector {
                              AggregationContext[] aggregations,
                              RamAccounting ramAccounting,
                              MemoryManager memoryManager,
-                             Version minNodeVersion,
-                             Version indexVersionCreated) {
+                             Version minNodeVersion) {
         assert keys.size() == keyInputs.size() : "number of key types must match with number of key inputs";
 
         AggregationFunction[] functions = new AggregationFunction[aggregations.length];
@@ -75,8 +75,7 @@ public class GroupingProjector implements Projector {
                 memoryManager,
                 minNodeVersion,
                 keyInputs.get(0),
-                key.valueType(),
-                indexVersionCreated
+                key.valueType()
             );
         } else {
             //noinspection unchecked
@@ -90,8 +89,7 @@ public class GroupingProjector implements Projector {
                 memoryManager,
                 minNodeVersion,
                 keyInputs,
-                typeView(keys),
-                indexVersionCreated
+                typeView(keys)
             );
         }
     }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/ArbitraryAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/ArbitraryAggregation.java
@@ -123,7 +123,6 @@ public class ArbitraryAggregation extends AggregationFunction<Object, Object> {
     @Nullable
     @Override
     public Object newState(RamAccounting ramAccounting,
-                           Version indexVersionCreated,
                            Version minNodeInCluster,
                            MemoryManager memoryManager) {
         return null;

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/ArrayAgg.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/ArrayAgg.java
@@ -79,7 +79,6 @@ public final class ArrayAgg extends AggregationFunction<List<Object>, List<Objec
 
     @Override
     public List<Object> newState(RamAccounting ramAccounting,
-                                 Version indexVersionCreated,
                                  Version minNodeInCluster,
                                  MemoryManager memoryManager) {
         return new ArrayList<>();

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/CmpByAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/CmpByAggregation.java
@@ -32,7 +32,6 @@ import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
-import org.jetbrains.annotations.Nullable;
 
 import io.crate.data.Input;
 import io.crate.data.breaker.RamAccounting;
@@ -209,9 +208,7 @@ public final class CmpByAggregation extends AggregationFunction<CmpByAggregation
     }
 
     @Override
-    @Nullable
     public CompareBy newState(RamAccounting ramAccounting,
-                              Version indexVersionCreated,
                               Version minNodeInCluster,
                               MemoryManager memoryManager) {
         ramAccounting.addBytes(CompareBy.SHALLOW_SIZE);

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/CollectSetAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/CollectSetAggregation.java
@@ -118,7 +118,6 @@ public class CollectSetAggregation extends AggregationFunction<Map<Object, Objec
     @Nullable
     @Override
     public Map<Object, Object> newState(RamAccounting ramAccounting,
-                                        Version indexVersionCreated,
                                         Version minNodeInCluster,
                                         MemoryManager memoryManager) {
         ramAccounting.addBytes(RamUsageEstimator.alignObjectSize(64L)); // overhead for HashMap: 32 * 0 + 16 * 4 bytes
@@ -185,7 +184,6 @@ public class CollectSetAggregation extends AggregationFunction<Map<Object, Objec
         @Nullable
         @Override
         public Map<Object, Long> newState(RamAccounting ramAccounting,
-                                          Version indexVersionCreated,
                                           Version minNodeInCluster,
                                           MemoryManager memoryManager) {
             ramAccounting.addBytes(RamUsageEstimator.alignObjectSize(64L)); // overhead for HashMap: 32 * 0 + 16 * 4 bytes

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/CountAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/CountAggregation.java
@@ -129,7 +129,6 @@ public class CountAggregation extends AggregationFunction<MutableLong, Long> {
     @Nullable
     @Override
     public MutableLong newState(RamAccounting ramAccounting,
-                                Version indexVersionCreated,
                                 Version minNodeInCluster,
                                 MemoryManager memoryManager) {
         ramAccounting.addBytes(LongStateType.INSTANCE.fixedSize());

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/GeometricMeanAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/GeometricMeanAggregation.java
@@ -230,7 +230,6 @@ public class GeometricMeanAggregation extends AggregationFunction<GeometricMeanA
     @Nullable
     @Override
     public GeometricMeanState newState(RamAccounting ramAccounting,
-                                       Version indexVersionCreated,
                                        Version minNodeInCluster,
                                        MemoryManager memoryManager) {
         ramAccounting.addBytes(GeometricMeanStateType.INSTANCE.fixedSize());

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/IntervalSumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/IntervalSumAggregation.java
@@ -24,9 +24,9 @@ package io.crate.execution.engine.aggregation.impl;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.VisibleForTesting;
 import org.joda.time.Period;
 
-import org.jetbrains.annotations.VisibleForTesting;
 import io.crate.data.Input;
 import io.crate.data.breaker.RamAccounting;
 import io.crate.execution.engine.aggregation.AggregationFunction;
@@ -68,7 +68,6 @@ public class IntervalSumAggregation extends AggregationFunction<Period, Period> 
     @Nullable
     @Override
     public Period newState(RamAccounting ramAccounting,
-                      Version indexVersionCreated,
                       Version minNodeInCluster,
                       MemoryManager memoryManager) {
         ramAccounting.addBytes(bytesSize);

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/MaximumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/MaximumAggregation.java
@@ -260,7 +260,6 @@ public abstract class MaximumAggregation extends AggregationFunction<Object, Obj
         @Nullable
         @Override
         public Object newState(RamAccounting ramAccounting,
-                               Version indexVersionCreated,
                                Version minNodeInCluster,
                                MemoryManager memoryManager) {
             ramAccounting.addBytes(size);
@@ -293,7 +292,6 @@ public abstract class MaximumAggregation extends AggregationFunction<Object, Obj
         @Nullable
         @Override
         public Object newState(RamAccounting ramAccounting,
-                               Version indexVersionCreated,
                                Version minNodeInCluster,
                                MemoryManager memoryManager) {
             return null;

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/MinimumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/MinimumAggregation.java
@@ -220,7 +220,6 @@ public abstract class MinimumAggregation extends AggregationFunction<Object, Obj
         @Nullable
         @Override
         public Object newState(RamAccounting ramAccounting,
-                               Version indexVersionCreated,
                                Version minNodeInCluster,
                                MemoryManager memoryManager) {
             return null;
@@ -292,7 +291,6 @@ public abstract class MinimumAggregation extends AggregationFunction<Object, Obj
         @Nullable
         @Override
         public Object newState(RamAccounting ramAccounting,
-                               Version indexVersionCreated,
                                Version minNodeInCluster,
                                MemoryManager memoryManager) {
             ramAccounting.addBytes(size);

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/NumericSumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/NumericSumAggregation.java
@@ -32,8 +32,8 @@ import org.apache.lucene.util.NumericUtils;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.jetbrains.annotations.Nullable;
-
 import org.jetbrains.annotations.VisibleForTesting;
+
 import io.crate.data.Input;
 import io.crate.data.breaker.RamAccounting;
 import io.crate.execution.engine.aggregation.AggregationFunction;
@@ -97,7 +97,6 @@ public class NumericSumAggregation extends AggregationFunction<BigDecimal, BigDe
     @Nullable
     @Override
     public BigDecimal newState(RamAccounting ramAccounting,
-                               Version indexVersionCreated,
                                Version minNodeInCluster,
                                MemoryManager memoryManager) {
         ramAccounting.addBytes(INIT_BIG_DECIMAL_SIZE);

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/PercentileAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/PercentileAggregation.java
@@ -123,7 +123,6 @@ class PercentileAggregation extends AggregationFunction<TDigestState, Object> {
     @Nullable
     @Override
     public TDigestState newState(RamAccounting ramAccounting,
-                                 Version indexVersionCreated,
                                  Version minNodeInCluster,
                                  MemoryManager memoryManager) {
         ramAccounting.addBytes(TDigestState.SHALLOW_SIZE);

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/StandardDeviationAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/StandardDeviationAggregation.java
@@ -164,7 +164,6 @@ public class StandardDeviationAggregation extends AggregationFunction<StandardDe
     @Nullable
     @Override
     public StandardDeviation newState(RamAccounting ramAccounting,
-                                      Version indexVersionCreated,
                                       Version minNodeInCluster,
                                       MemoryManager memoryManager) {
         ramAccounting.addBytes(StdDevStateType.INSTANCE.fixedSize());

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/StringAgg.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/StringAgg.java
@@ -155,7 +155,6 @@ public final class StringAgg extends AggregationFunction<StringAgg.StringAggStat
 
     @Override
     public StringAggState newState(RamAccounting ramAccounting,
-                                   Version indexVersionCreated,
                                    Version minNodeInCluster,
                                    MemoryManager memoryManager) {
         return new StringAggState();

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/SumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/SumAggregation.java
@@ -32,11 +32,11 @@ import org.apache.lucene.util.NumericUtils;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.VisibleForTesting;
 
 import io.crate.common.MutableDouble;
 import io.crate.common.MutableFloat;
 import io.crate.common.MutableLong;
-import org.jetbrains.annotations.VisibleForTesting;
 import io.crate.data.Input;
 import io.crate.data.breaker.RamAccounting;
 import io.crate.execution.engine.aggregation.AggregationFunction;
@@ -133,7 +133,6 @@ public class SumAggregation<T extends Number> extends AggregationFunction<T, T> 
     @Nullable
     @Override
     public T newState(RamAccounting ramAccounting,
-                      Version indexVersionCreated,
                       Version minNodeInCluster,
                       MemoryManager memoryManager) {
         ramAccounting.addBytes(bytesSize);

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/TopKAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/TopKAggregation.java
@@ -164,7 +164,6 @@ public class TopKAggregation extends AggregationFunction<TopKAggregation.State, 
     @Nullable
     @Override
     public State newState(RamAccounting ramAccounting,
-                          Version indexVersionCreated,
                           Version minNodeInCluster,
                           MemoryManager memoryManager) {
         return State.EMPTY;

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/VarianceAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/VarianceAggregation.java
@@ -151,7 +151,6 @@ public class VarianceAggregation extends AggregationFunction<Variance, Double> {
     @Nullable
     @Override
     public Variance newState(RamAccounting ramAccounting,
-                             Version indexVersionCreated,
                              Version minNodeInCluster,
                              MemoryManager memoryManager) {
         ramAccounting.addBytes(VarianceStateType.INSTANCE.fixedSize());

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/average/AverageAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/average/AverageAggregation.java
@@ -283,7 +283,6 @@ public class AverageAggregation extends AggregationFunction<AverageAggregation.A
     @Nullable
     @Override
     public AverageState newState(RamAccounting ramAccounting,
-                                 Version indexVersionCreated,
                                  Version minNodeInCluster,
                                  MemoryManager memoryManager) {
         ramAccounting.addBytes(AverageStateType.INSTANCE.fixedSize());

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/average/IntervalAverageAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/average/IntervalAverageAggregation.java
@@ -295,7 +295,6 @@ public class IntervalAverageAggregation extends AggregationFunction<IntervalAver
     @Nullable
     @Override
     public IntervalAverageState newState(RamAccounting ramAccounting,
-                                         Version indexVersionCreated,
                                          Version minNodeInCluster,
                                          MemoryManager memoryManager) {
         ramAccounting.addBytes(IntervalAverageStateType.INSTANCE.fixedSize());

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/average/numeric/NumericAverageAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/average/numeric/NumericAverageAggregation.java
@@ -107,7 +107,6 @@ public class NumericAverageAggregation extends AggregationFunction<NumericAverag
     @Nullable
     @Override
     public NumericAverageState<?> newState(RamAccounting ramAccounting,
-                                           Version indexVersionCreated,
                                            Version minNodeInCluster,
                                            MemoryManager memoryManager) {
         ramAccounting.addBytes(INIT_SIZE);

--- a/server/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
@@ -416,7 +416,7 @@ final class GroupByOptimizedIterator {
             AggregationContext aggregation = aggregations.get(i);
             AggregationFunction function = aggregation.function();
 
-            var newState = function.newState(ramAccounting, Version.CURRENT, minNodeVersion, memoryManager);
+            var newState = function.newState(ramAccounting, minNodeVersion, memoryManager);
             if (InputCondition.matches(aggregation.filter())) {
                 //noinspection unchecked
                 states[i] = function.iterate(

--- a/server/src/main/java/io/crate/execution/engine/collect/ShardCollectorProvider.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/ShardCollectorProvider.java
@@ -91,7 +91,6 @@ public abstract class ShardCollectorProvider {
             shardNormalizer,
             t -> null,
             t -> null,
-            indexShard.indexSettings().getIndexVersionCreated(),
             indexShard.shardId(),
             fileOutputFactoryMap
         );

--- a/server/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
+++ b/server/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
@@ -39,7 +39,6 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collector;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -169,7 +168,6 @@ public class ProjectionToProjectorVisitor
     private final Function<RelationName, SysRowUpdater<?>> sysUpdaterGetter;
     private final Function<RelationName, StaticTableDefinition<?>> staticTableDefinitionGetter;
     private final CircuitBreakerService circuitBreakerService;
-    private final Version indexVersionCreated;
     @Nullable
     private final ShardId shardId;
     private final int numProcessors;
@@ -186,7 +184,6 @@ public class ProjectionToProjectorVisitor
                                         EvaluatingNormalizer normalizer,
                                         Function<RelationName, SysRowUpdater<?>> sysUpdaterGetter,
                                         Function<RelationName, StaticTableDefinition<?>> staticTableDefinitionGetter,
-                                        Version indexVersionCreated,
                                         @Nullable ShardId shardId,
                                         Map<String, FileOutputFactory> fileOutputFactoryMap) {
         this.clusterService = clusterService;
@@ -200,7 +197,6 @@ public class ProjectionToProjectorVisitor
         this.normalizer = normalizer;
         this.sysUpdaterGetter = sysUpdaterGetter;
         this.staticTableDefinitionGetter = staticTableDefinitionGetter;
-        this.indexVersionCreated = indexVersionCreated;
         this.shardId = shardId;
         this.numProcessors = EsExecutors.numberOfProcessors(settings);
         this.fileOutputFactoryMap = fileOutputFactoryMap;
@@ -228,7 +224,6 @@ public class ProjectionToProjectorVisitor
             normalizer,
             sysUpdaterGetter,
             staticTableDefinitionGetter,
-            Version.CURRENT,
             null,
             null
         );
@@ -339,8 +334,7 @@ public class ProjectionToProjectorVisitor
             ctx.aggregations().toArray(new AggregationContext[0]),
             context.ramAccounting,
             context.memoryManager,
-            clusterService.state().nodes().getMinNodeVersion(),
-            indexVersionCreated
+            clusterService.state().nodes().getMinNodeVersion()
         );
     }
 
@@ -359,8 +353,7 @@ public class ProjectionToProjectorVisitor
             ctx.aggregations().toArray(new AggregationContext[0]),
             context.ramAccounting,
             context.memoryManager,
-            clusterService.state().nodes().getMinNodeVersion(),
-            indexVersionCreated
+            clusterService.state().nodes().getMinNodeVersion()
         );
     }
 
@@ -722,7 +715,6 @@ public class ProjectionToProjectorVisitor
             context.ramAccounting,
             context.memoryManager,
             clusterService.state().nodes().getMinNodeVersion(),
-            indexVersionCreated,
             ThreadPools.numIdleThreads(searchThreadPool, numProcessors),
             searchThreadPool
         );

--- a/server/src/main/java/io/crate/execution/engine/window/AggregateToWindowFunctionAdapter.java
+++ b/server/src/main/java/io/crate/execution/engine/window/AggregateToWindowFunctionAdapter.java
@@ -49,7 +49,6 @@ public class AggregateToWindowFunctionAdapter implements WindowFunction {
     private final AggregationFunction aggregationFunction;
     private final ExpressionsInput<Row, Boolean> filter;
     private final RamAccounting ramAccounting;
-    private final Version indexVersionCreated;
     private final MemoryManager memoryManager;
     private final Version minNodeVersion;
     private Object accumulatedState;
@@ -60,19 +59,16 @@ public class AggregateToWindowFunctionAdapter implements WindowFunction {
 
     AggregateToWindowFunctionAdapter(AggregationFunction aggregationFunction,
                                      ExpressionsInput<Row, Boolean> filter,
-                                     Version indexVersionCreated,
                                      RamAccounting ramAccounting,
                                      MemoryManager memoryManager,
                                      Version minNodeVersion) {
         this.aggregationFunction = aggregationFunction.optimizeForExecutionAsWindowFunction();
         this.filter = filter;
         this.ramAccounting = ramAccounting;
-        this.indexVersionCreated = indexVersionCreated;
         this.memoryManager = memoryManager;
         this.minNodeVersion = minNodeVersion;
         this.accumulatedState = this.aggregationFunction.newState(
             this.ramAccounting,
-            indexVersionCreated,
             minNodeVersion,
             memoryManager
         );
@@ -148,7 +144,6 @@ public class AggregateToWindowFunctionAdapter implements WindowFunction {
                                    Input<?> ... args) {
         accumulatedState = aggregationFunction.newState(
             ramAccounting,
-            indexVersionCreated,
             minNodeVersion,
             memoryManager
         );

--- a/server/src/main/java/io/crate/execution/engine/window/WindowProjector.java
+++ b/server/src/main/java/io/crate/execution/engine/window/WindowProjector.java
@@ -69,7 +69,6 @@ public class WindowProjector {
                                            RamAccounting ramAccounting,
                                            MemoryManager memoryManager,
                                            Version minNodeVersion,
-                                           Version indexVersionCreated,
                                            IntSupplier numThreads,
                                            Executor executor) {
         var windowFunctionSymbols = projection.windowFunctions();
@@ -106,7 +105,6 @@ public class WindowProjector {
                     new AggregateToWindowFunctionAdapter(
                         (AggregationFunction) impl,
                         filter,
-                        indexVersionCreated,
                         ramAccounting,
                         memoryManager,
                         minNodeVersion

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/CollectSetAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/CollectSetAggregationTest.java
@@ -78,7 +78,7 @@ public class CollectSetAggregationTest extends AggregationTestCase {
                 null, "collect_set", List.of(Literal.of(DataTypes.LONG, null)),
             SearchPath.pathWithPGCatalogAndDoc());
 
-        Object state = impl.newState(RAM_ACCOUNTING, Version.CURRENT, Version.CURRENT, memoryManager);
+        Object state = impl.newState(RAM_ACCOUNTING, Version.CURRENT, memoryManager);
 
         BytesStreamOutput streamOutput = new BytesStreamOutput();
         impl.partialType().streamer().writeValueTo(streamOutput, state);
@@ -94,7 +94,7 @@ public class CollectSetAggregationTest extends AggregationTestCase {
             null, "collect_set", List.of(Literal.of(DataTypes.LONG, null)), SearchPath.pathWithPGCatalogAndDoc());
         var aggregationFunction = (AggregationFunction<Object, Object>) impl.optimizeForExecutionAsWindowFunction();
 
-        Object state = aggregationFunction.newState(RAM_ACCOUNTING, Version.CURRENT, Version.CURRENT, memoryManager);
+        Object state = aggregationFunction.newState(RAM_ACCOUNTING, Version.CURRENT, memoryManager);
         state = aggregationFunction.iterate(RAM_ACCOUNTING, memoryManager, state, Literal.of(10L));
         state = aggregationFunction.iterate(RAM_ACCOUNTING, memoryManager, state, Literal.of(10L));
 

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/PercentileAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/PercentileAggregationTest.java
@@ -254,7 +254,7 @@ public class PercentileAggregationTest extends AggregationTestCase {
         );
 
         RamAccounting ramAccounting = RamAccounting.NO_ACCOUNTING;
-        Object state = impl.newState(ramAccounting, Version.CURRENT, Version.CURRENT, memoryManager);
+        Object state = impl.newState(ramAccounting, Version.CURRENT, memoryManager);
         Literal<List<Double>> fractions = Literal.of(Collections.singletonList(0.95D), DataTypes.DOUBLE_ARRAY);
         impl.iterate(ramAccounting, memoryManager, state, Literal.of(10L), fractions);
         impl.iterate(ramAccounting, memoryManager, state, Literal.of(20L), fractions);
@@ -277,7 +277,7 @@ public class PercentileAggregationTest extends AggregationTestCase {
                 DataTypes.DOUBLE_ARRAY
         );
         RamAccounting ramAccounting = new PlainRamAccounting();
-        Object state = impl.newState(ramAccounting, Version.CURRENT, Version.CURRENT, memoryManager);
+        Object state = impl.newState(ramAccounting, Version.CURRENT, memoryManager);
         assertThat(ramAccounting.totalBytes()).isEqualTo(112L);
         Literal<List<Double>> fractions = Literal.of(Collections.singletonList(0.95D), DataTypes.DOUBLE_ARRAY);
         impl.iterate(ramAccounting, memoryManager, state, Literal.of(10L), fractions);

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/StringAggTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/StringAggTest.java
@@ -76,11 +76,11 @@ public class StringAggTest extends AggregationTestCase {
         var stringAgg = new StringAgg(
             StringAgg.SIGNATURE,
             BoundSignature.sameAsUnbound(StringAgg.SIGNATURE));
-        var state1 = stringAgg.newState(RAM_ACCOUNTING, Version.CURRENT, Version.CURRENT, memoryManager);
+        var state1 = stringAgg.newState(RAM_ACCOUNTING, Version.CURRENT, memoryManager);
         stringAgg.iterate(RAM_ACCOUNTING, memoryManager, state1, Literal.of("a"), Literal.of(","));
         stringAgg.iterate(RAM_ACCOUNTING, memoryManager, state1, Literal.of("b"), Literal.of(";"));
 
-        var state2 = stringAgg.newState(RAM_ACCOUNTING, Version.CURRENT, Version.CURRENT, memoryManager);
+        var state2 = stringAgg.newState(RAM_ACCOUNTING, Version.CURRENT, memoryManager);
         stringAgg.iterate(RAM_ACCOUNTING, memoryManager, state2, Literal.of("c"), Literal.of(","));
         stringAgg.iterate(RAM_ACCOUNTING, memoryManager, state2, Literal.of("d"), Literal.of(";"));
 

--- a/server/src/test/java/io/crate/execution/engine/pipeline/ProjectingRowConsumerTest.java
+++ b/server/src/test/java/io/crate/execution/engine/pipeline/ProjectingRowConsumerTest.java
@@ -34,7 +34,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
@@ -98,7 +97,6 @@ public class ProjectingRowConsumerTest extends CrateDummyClusterServiceUnitTest 
                 null),
             t -> null,
             t -> null,
-            Version.CURRENT,
             new ShardId("dummy", UUID.randomUUID().toString(), 0),
             Map.of(LocalFsFileOutputFactory.NAME, new LocalFsFileOutputFactory())
         );

--- a/server/src/test/java/io/crate/execution/engine/pipeline/ProjectorsTest.java
+++ b/server/src/test/java/io/crate/execution/engine/pipeline/ProjectorsTest.java
@@ -30,7 +30,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.UUID;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
@@ -81,7 +80,6 @@ public class ProjectorsTest extends CrateDummyClusterServiceUnitTest {
                 null),
             t -> null,
             t -> null,
-            Version.CURRENT,
             new ShardId("dummy", UUID.randomUUID().toString(), 0),
             null
         );

--- a/server/src/testFixtures/java/io/crate/execution/engine/window/AbstractWindowFunctionTest.java
+++ b/server/src/testFixtures/java/io/crate/execution/engine/window/AbstractWindowFunctionTest.java
@@ -149,7 +149,6 @@ public abstract class AbstractWindowFunctionTest extends CrateDummyClusterServic
             windowFunctionImpl = new AggregateToWindowFunctionAdapter(
                 (AggregationFunction) impl,
                 new ExpressionsInput<>(Literal.BOOLEAN_TRUE, List.of()),
-                Version.CURRENT,
                 RamAccounting.NO_ACCOUNTING,
                 memoryManager,
                 Version.CURRENT

--- a/server/src/testFixtures/java/io/crate/operation/aggregation/AggregationTestCase.java
+++ b/server/src/testFixtures/java/io/crate/operation/aggregation/AggregationTestCase.java
@@ -296,13 +296,13 @@ public abstract class AggregationTestCase extends ESTestCase {
         }
 
         ArrayList<Object> states = new ArrayList<>();
-        states.add(function.newState(RAM_ACCOUNTING, Version.CURRENT, minNodeVersion, memoryManager));
+        states.add(function.newState(RAM_ACCOUNTING, minNodeVersion, memoryManager));
         for (Row row : new ArrayBucket(data)) {
             for (RowCollectExpression input : inputs) {
                 input.setNextRow(row);
             }
             if (randomExtraStates && randomIntBetween(1, 4) == 1) {
-                states.add(function.newState(RAM_ACCOUNTING, Version.CURRENT, minNodeVersion, memoryManager));
+                states.add(function.newState(RAM_ACCOUNTING, minNodeVersion, memoryManager));
             }
             int idx = states.size() - 1;
             states.set(idx, function.iterate(RAM_ACCOUNTING, memoryManager, states.get(idx), inputs));


### PR DESCRIPTION
It was not used anywhere, instead the `minNodeVersion` arg is kept which is used in some cases for BWC purposes.
