### PR TITLE
Change stddev to link to stddev_samp instead of stddev_pop

### DIFF
--- a/docs/appendices/release-notes/6.0.0.rst
+++ b/docs/appendices/release-notes/6.0.0.rst
@@ -219,6 +219,11 @@ Breaking Changes
         | TRUE          |
         +---------------+
 
+ - :ref:`aggregation-stddev` changed and is now an alias for
+   :ref:`aggregation-stddev-samp`, to match PostgreSQL behavior. In order to
+   calculate the population standard deviation, :ref:`aggregation-stddev-pop`
+   must be used.
+
 Deprecations
 ============
 

--- a/docs/general/builtins/aggregation.rst
+++ b/docs/general/builtins/aggregation.rst
@@ -597,7 +597,7 @@ An Example::
 ``stddev(column)``
 ------------------
 
-``stddev`` is an alias for :ref:`aggregation-stddev-pop`.
+``stddev`` is an alias for :ref:`aggregation-stddev-samp`.
 
 
 .. _aggregation-stddev-pop:

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/StandardDeviationPopAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/StandardDeviationPopAggregation.java
@@ -42,7 +42,7 @@ import io.crate.types.DataTypes;
 
 public class StandardDeviationPopAggregation extends StandardDeviationAggregation<StandardDeviationPop> {
 
-    public static final List<String> NAMES = List.of("stddev", "stddev_pop");
+    public static final String NAME = "stddev_pop";
 
     static {
         DataTypes.register(StdDevPopStateType.ID, _ -> StdDevPopStateType.INSTANCE);
@@ -52,17 +52,15 @@ public class StandardDeviationPopAggregation extends StandardDeviationAggregatio
         DataTypes.NUMERIC_PRIMITIVE_TYPES, DataTypes.TIMESTAMPZ);
 
     public static void register(Functions.Builder builder) {
-        for (var name: NAMES) {
-            for (var supportedType : SUPPORTED_TYPES) {
-                builder.add(
-                    Signature.builder(name, FunctionType.AGGREGATE)
-                        .argumentTypes(supportedType.getTypeSignature())
-                        .returnType(DataTypes.DOUBLE.getTypeSignature())
-                        .features(Scalar.Feature.DETERMINISTIC)
-                        .build(),
-                     StandardDeviationPopAggregation::new
-                );
-            }
+        for (var supportedType : SUPPORTED_TYPES) {
+            builder.add(
+                Signature.builder(NAME, FunctionType.AGGREGATE)
+                    .argumentTypes(supportedType.getTypeSignature())
+                    .returnType(DataTypes.DOUBLE.getTypeSignature())
+                    .features(Scalar.Feature.DETERMINISTIC)
+                    .build(),
+                 StandardDeviationPopAggregation::new
+            );
         }
     }
 

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/StandardDeviationSampAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/StandardDeviationSampAggregation.java
@@ -42,7 +42,7 @@ import io.crate.types.DataTypes;
 
 public class StandardDeviationSampAggregation extends StandardDeviationAggregation<StandardDeviationSamp> {
 
-    public static final String NAME = "stddev_samp";
+    public static final List<String> NAMES = List.of("stddev_samp", "stddev");
 
     static {
         DataTypes.register(StdDevSampStateType.ID, _ -> StdDevSampStateType.INSTANCE);
@@ -52,15 +52,17 @@ public class StandardDeviationSampAggregation extends StandardDeviationAggregati
         DataTypes.NUMERIC_PRIMITIVE_TYPES, DataTypes.TIMESTAMPZ);
 
     public static void register(Functions.Builder builder) {
-        for (var supportedType : SUPPORTED_TYPES) {
-            builder.add(
-                Signature.builder(NAME, FunctionType.AGGREGATE)
-                    .argumentTypes(supportedType.getTypeSignature())
-                    .returnType(DataTypes.DOUBLE.getTypeSignature())
-                    .features(Scalar.Feature.DETERMINISTIC)
-                    .build(),
-                 StandardDeviationSampAggregation::new
-            );
+        for (var name: NAMES) {
+            for (var supportedType : SUPPORTED_TYPES) {
+                builder.add(
+                    Signature.builder(name, FunctionType.AGGREGATE)
+                        .argumentTypes(supportedType.getTypeSignature())
+                        .returnType(DataTypes.DOUBLE.getTypeSignature())
+                        .features(Scalar.Feature.DETERMINISTIC)
+                        .build(),
+                    StandardDeviationSampAggregation::new
+                );
+            }
         }
     }
 

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/StdDevPopAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/StdDevPopAggregationTest.java
@@ -57,7 +57,7 @@ public class StdDevPopAggregationTest extends AggregationTestCase {
     }
 
     @Test
-    public void test_functions_return_type_is_always_double_for_any_argument_type() {
+    public void test_functions_return_type_is_always_double_for_any_argument_type_except_numeric() {
         for (DataType<?> type : Stream.concat(
             DataTypes.NUMERIC_PRIMITIVE_TYPES.stream(),
             Stream.of(DataTypes.TIMESTAMPZ)).toList()) {
@@ -70,6 +70,17 @@ public class StdDevPopAggregationTest extends AggregationTestCase {
             );
             assertThat(stddev.boundSignature().returnType()).isEqualTo(DataTypes.DOUBLE);
         }
+    }
+
+    @Test
+    public void test_numeric_return_type() {
+        FunctionImplementation stddev = nodeCtx.functions().get(
+            null,
+            StandardDeviationPopAggregation.NAME,
+            List.of(Literal.of(DataTypes.NUMERIC, null)),
+            SearchPath.pathWithPGCatalogAndDoc());
+
+        assertThat(stddev.boundSignature().returnType()).isEqualTo(DataTypes.NUMERIC);
     }
 
     @Test

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/StdDevPopAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/StdDevPopAggregationTest.java
@@ -58,19 +58,17 @@ public class StdDevPopAggregationTest extends AggregationTestCase {
 
     @Test
     public void test_functions_return_type_is_always_double_for_any_argument_type() {
-        for (var name: StandardDeviationPopAggregation.NAMES) {
-            for (DataType<?> type : Stream.concat(
-                DataTypes.NUMERIC_PRIMITIVE_TYPES.stream(),
-                Stream.of(DataTypes.TIMESTAMPZ)).toList()) {
+        for (DataType<?> type : Stream.concat(
+            DataTypes.NUMERIC_PRIMITIVE_TYPES.stream(),
+            Stream.of(DataTypes.TIMESTAMPZ)).toList()) {
 
-                FunctionImplementation stddev = nodeCtx.functions().get(
-                    null,
-                    name,
-                    List.of(Literal.of(type, null)),
-                    SearchPath.pathWithPGCatalogAndDoc()
-                );
-                assertThat(stddev.boundSignature().returnType()).isEqualTo(DataTypes.DOUBLE);
-            }
+            FunctionImplementation stddev = nodeCtx.functions().get(
+                null,
+                StandardDeviationPopAggregation.NAME,
+                List.of(Literal.of(type, null)),
+                SearchPath.pathWithPGCatalogAndDoc()
+            );
+            assertThat(stddev.boundSignature().returnType()).isEqualTo(DataTypes.DOUBLE);
         }
     }
 

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/StdDevSampAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/StdDevSampAggregationTest.java
@@ -46,7 +46,7 @@ public class StdDevSampAggregationTest extends AggregationTestCase {
 
     private Object executeAggregation(DataType<?> argumentType, Object[][] data) throws Exception {
         return executeAggregation(
-                Signature.builder("stddev_samp", FunctionType.AGGREGATE)
+                Signature.builder(randomFrom("stddev_samp", "stddev"), FunctionType.AGGREGATE)
                         .argumentTypes(argumentType.getTypeSignature())
                         .returnType(argumentType.getTypeSignature())
                         .features(Scalar.Feature.DETERMINISTIC)
@@ -58,17 +58,19 @@ public class StdDevSampAggregationTest extends AggregationTestCase {
 
     @Test
     public void test_functions_return_type_is_always_double_for_any_argument_type() {
-        for (DataType<?> type : Stream.concat(
-            DataTypes.NUMERIC_PRIMITIVE_TYPES.stream(),
-            Stream.of(DataTypes.TIMESTAMPZ)).toList()) {
+        for (var name: StandardDeviationSampAggregation.NAMES) {
+            for (DataType<?> type : Stream.concat(
+                DataTypes.NUMERIC_PRIMITIVE_TYPES.stream(),
+                Stream.of(DataTypes.TIMESTAMPZ)).toList()) {
 
-            FunctionImplementation stddev = nodeCtx.functions().get(
-                null,
-                StandardDeviationSampAggregation.NAME,
-                List.of(Literal.of(type, null)),
-                SearchPath.pathWithPGCatalogAndDoc()
-            );
-            assertThat(stddev.boundSignature().returnType()).isEqualTo(DataTypes.DOUBLE);
+                FunctionImplementation stddev = nodeCtx.functions().get(
+                    null,
+                    name,
+                    List.of(Literal.of(type, null)),
+                    SearchPath.pathWithPGCatalogAndDoc()
+                );
+                assertThat(stddev.boundSignature().returnType()).isEqualTo(DataTypes.DOUBLE);
+            }
         }
     }
 
@@ -141,6 +143,6 @@ public class StdDevSampAggregationTest extends AggregationTestCase {
     public void testUnsupportedType() {
         assertThatThrownBy(() -> executeAggregation(DataTypes.GEO_POINT, new Object[][]{}))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessageStartingWith("Invalid arguments in: stddev_samp(INPUT(0)) with (geo_point). Valid types: ");
+            .hasMessageStartingWith("Invalid arguments in: stddev");
     }
 }

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/StdDevSampAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/StdDevSampAggregationTest.java
@@ -57,7 +57,7 @@ public class StdDevSampAggregationTest extends AggregationTestCase {
     }
 
     @Test
-    public void test_functions_return_type_is_always_double_for_any_argument_type() {
+    public void test_functions_return_type_is_always_double_for_any_argument_type_except_numeric() {
         for (var name: StandardDeviationSampAggregation.NAMES) {
             for (DataType<?> type : Stream.concat(
                 DataTypes.NUMERIC_PRIMITIVE_TYPES.stream(),
@@ -71,6 +71,19 @@ public class StdDevSampAggregationTest extends AggregationTestCase {
                 );
                 assertThat(stddev.boundSignature().returnType()).isEqualTo(DataTypes.DOUBLE);
             }
+        }
+    }
+
+    @Test
+    public void test_numeric_return_type() {
+        for (var name: StandardDeviationSampAggregation.NAMES) {
+            FunctionImplementation stddev = nodeCtx.functions().get(
+                null,
+                name,
+                List.of(Literal.of(DataTypes.NUMERIC, null)),
+                SearchPath.pathWithPGCatalogAndDoc());
+
+            assertThat(stddev.boundSignature().returnType()).isEqualTo(DataTypes.NUMERIC);
         }
     }
 

--- a/server/src/test/java/io/crate/execution/engine/window/AggregationWindowFunctionsTest.java
+++ b/server/src/test/java/io/crate/execution/engine/window/AggregationWindowFunctionsTest.java
@@ -102,10 +102,10 @@ public class AggregationWindowFunctionsTest extends AbstractWindowFunctionTest {
     }
 
     @Test
-    public void testStdDevOverUnboundedFollowingFrames() throws Throwable {
+    public void testStdDevPopOverUnboundedFollowingFrames() throws Throwable {
         Object[] expected = new Object[]{0.47140452079103146, 0.0, 0.0, 0.816496580927726, 0.5, 0.0, null};
         assertEvaluate(
-            "stddev(x) OVER(" +
+            "stddev_pop(x) OVER(" +
             "   PARTITION BY x>2 ORDER BY x RANGE BETWEEN CURRENT ROW and UNBOUNDED FOLLOWING" +
             ")",
             expected,

--- a/server/src/test/java/io/crate/integrationtests/GroupByAggregateTest.java
+++ b/server/src/test/java/io/crate/integrationtests/GroupByAggregateTest.java
@@ -1073,10 +1073,10 @@ public class GroupByAggregateTest extends IntegTestCase {
     }
 
     @Test
-    public void groupByAggregateStdDevByte() throws Exception {
+    public void groupByAggregateStdDevPopByte() throws Exception {
         this.setup.groupBySetup("byte");
 
-        execute("select stddev(age), gender from characters group by gender order by gender");
+        execute("select stddev_pop(age), gender from characters group by gender order by gender");
         assertThat(response.rowCount()).isEqualTo(2L);
         assertThat(response.rows()[0][0]).isEqualTo(5.5d);
         assertThat(response.rows()[1][0]).isEqualTo(39.0d);
@@ -1093,10 +1093,10 @@ public class GroupByAggregateTest extends IntegTestCase {
     }
 
     @Test
-    public void groupByAggregateStdDevDouble() throws Exception {
+    public void groupByAggregateStdDevPopDouble() throws Exception {
         this.setup.groupBySetup("double");
 
-        execute("select stddev(age), gender from characters group by gender order by gender");
+        execute("select stddev_pop(age), gender from characters group by gender order by gender");
         assertThat(response.rowCount()).isEqualTo(2L);
         assertThat(response.rows()[0][0]).isEqualTo(5.5d);
         assertThat(response.rows()[1][0]).isEqualTo(39.0d);
@@ -1113,7 +1113,7 @@ public class GroupByAggregateTest extends IntegTestCase {
         assertThat((double) row[2]).isCloseTo(47.84415001097868d, Percentage.withPercentage(0.01));
         assertThat(row[3]).isEqualTo((short) 112);
         assertThat(row[4]).isEqualTo(1090.6875d);
-        assertThat(row[5]).isEqualTo(33.025558284456d);
+        assertThat(row[5]).isEqualTo(38.13462993133669d);
     }
 
     @Test


### PR DESCRIPTION
Follows: #17543
Follows: #17910
Relates: #15638

- Additionally, improve data type tests for the functions.
