### PR TITLE
revert: Add retry handling to DistributingConsumer

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/distribution/DistributingConsumerFactory.java
+++ b/server/src/main/java/io/crate/execution/engine/distribution/DistributingConsumerFactory.java
@@ -112,8 +112,7 @@ public class DistributingConsumerFactory {
             bucketIdx,
             nodeOperation.downstreamNodes(),
             distributedResultAction,
-            pageSize,
-            threadPool
+            pageSize
         );
     }
 

--- a/server/src/test/java/io/crate/execution/engine/distribution/DistributingConsumerTest.java
+++ b/server/src/test/java/io/crate/execution/engine/distribution/DistributingConsumerTest.java
@@ -40,7 +40,6 @@ import java.util.concurrent.TimeUnit;
 
 import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.threadpool.ThreadPool;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -174,8 +173,7 @@ public class DistributingConsumerTest extends ESTestCase {
             0,
             Collections.singletonList("n1"),
             distributedResultAction::execute,
-            pageSize,
-            mock(ThreadPool.class)
+            pageSize
         );
     }
 


### PR DESCRIPTION
Partial revert of https://github.com/crate/crate/pull/17884
Although the retry handling has fixed
`testRetentionLeasesSyncOnRecovery` I suspect that it caused flakyness
with other tests.

This reverts the retry part, while keeping the structural change with
the `RequestHandler`.

---

I'll re-evaluate this soonish, for now I'd like to get this in to verify if the flakyness like the following disappears:

```
org.opentest4j.AssertionFailedError: 
[All incoming requests on node [node_s2] should have finished. Expected 0 but got 359; pending tasks [[]]] 
expected: 0L
 but was: 359L
	at __randomizedtesting.SeedInfo.seed([383156FB94483757:3BF6104EEE22163E]:0)
	at org.elasticsearch.test.TestCluster.lambda$assertRequestsFinished$1(TestCluster.java:2324)
	at org.elasticsearch.test.ESTestCase.assertBusy(ESTestCase.java:711)
	at org.elasticsearch.test.TestCluster.assertRequestsFinished(TestCluster.java:2318)
	at org.elasticsearch.test.TestCluster.assertAfterTest(TestCluster.java:2291)
	at org.elasticsearch.test.IntegTestCase.afterInternal(IntegTestCase.java:473)
```