### PR TITLE
Fix func name output when using subselects

### DIFF
--- a/server/src/main/java/io/crate/analyze/relations/AliasedAnalyzedRelation.java
+++ b/server/src/main/java/io/crate/analyze/relations/AliasedAnalyzedRelation.java
@@ -65,7 +65,9 @@ public class AliasedAnalyzedRelation implements AnalyzedRelation, FieldResolver 
         for (int i = 0; i < relation.outputs().size(); i++) {
             Symbol childOutput = relation.outputs().get(i);
             ColumnIdent childColumn = childOutput.toColumn();
-            ColumnIdent columnAlias = childColumn;
+            ColumnIdent columnAlias = relation.outputNames() != null
+                ? ColumnIdent.of(relation.outputNames().get(i))
+                : childColumn;
             if (i < columnAliases.size()) {
                 columnAlias = ColumnIdent.of(columnAliases.get(i));
             }

--- a/server/src/main/java/io/crate/analyze/relations/select/SelectAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/relations/select/SelectAnalyzer.java
@@ -119,11 +119,13 @@ public final class SelectAnalyzer {
         }
 
         private static void addAllFieldsFromRelation(SelectAnalysis context, AnalyzedRelation relation) {
+            int i = 0;
             for (Symbol field : relation.outputs()) {
                 var columnIdent = field.toColumn();
                 if (!columnIdent.isSystemColumn()) {
-                    context.add(field.toColumn(), field, null);
+                    context.add(field.toColumn(), field, relation.outputNames() != null ? relation.outputNames().get(i) : null);
                 }
+                i++;
             }
         }
     }

--- a/server/src/test/java/io/crate/integrationtests/ScalarIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ScalarIntegrationTest.java
@@ -28,13 +28,14 @@ import org.elasticsearch.test.IntegTestCase;
 import org.junit.Test;
 
 import io.crate.exceptions.ColumnUnknownException;
+import io.crate.testing.Asserts;
 import io.crate.testing.TestingHelpers;
 import io.crate.testing.UseJdbc;
 import io.crate.types.DataTypes;
 
-@UseJdbc(0) // data types needed
 public class ScalarIntegrationTest extends IntegTestCase {
 
+    @UseJdbc(0) // data types needed
     @Test
     public void testExtractFunctionReturnTypes() {
         execute("SELECT EXTRACT(DAY FROM CURRENT_TIMESTAMP)");
@@ -70,5 +71,13 @@ public class ScalarIntegrationTest extends IntegTestCase {
                                             session2);
             assertThat(TestingHelpers.printedTable(response.rows())).isEqualTo("[1]\n[NULL]\n");
         }
+    }
+
+    @Test
+    public void testCurrentDatabase() {
+        execute("select * FROM (SELECT current_database()) as vt");
+        Asserts.assertThat(response)
+            .hasColumns("current_database")
+            .hasRows("crate");
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/TableFunctionITest.java
+++ b/server/src/test/java/io/crate/integrationtests/TableFunctionITest.java
@@ -23,7 +23,6 @@ package io.crate.integrationtests;
 
 import static com.carrotsearch.randomizedtesting.RandomizedTest.$;
 import static io.crate.testing.Asserts.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
 import java.util.Comparator;

--- a/server/src/test/java/io/crate/planner/operators/PushDownTest.java
+++ b/server/src/test/java/io/crate/planner/operators/PushDownTest.java
@@ -346,7 +346,7 @@ public class PushDownTest extends CrateDummyClusterServiceUnitTest {
         );
         var expectedPlan =
             """
-            Rename[x, "pg_catalog.generate_series(1, x)"] AS tt
+            Rename[x, generate_series] AS tt
               └ Eval[x, pg_catalog.generate_series(1, x)]
                 └ ProjectSet[pg_catalog.generate_series(1, x), x]
                   └ Collect[doc.t1 | [x] | (x > 1)]
@@ -433,7 +433,7 @@ public class PushDownTest extends CrateDummyClusterServiceUnitTest {
         );
         var expectedPlan =
             """
-            Rename[x, "sum(x) OVER (PARTITION BY x)"] AS sums
+            Rename[x, sum] AS sums
               └ WindowAgg[x] | [sum(x) OVER (PARTITION BY x)]
                 └ Collect[doc.t1 | [x] | (x = 10)]
             """;


### PR DESCRIPTION
Change `AliasedAnalyzedRelation` to return the outputNames() from its
underlining `relation` to keep any aliases set there. On top,
when handling such `AlisedAnalyzedRelation`s use the `outputNames()` to
retrieve a name if the list is not null and add special handling to
`TableFunctionRelation` to return a null list  or not depending on if there is 
an alias defined or not.

Follows: #17858
