### PR TITLE
Add NUMERIC support to AVG(DISTINCT <col>)

### DIFF
--- a/docs/appendices/release-notes/6.0.0.rst
+++ b/docs/appendices/release-notes/6.0.0.rst
@@ -271,6 +271,9 @@ Data Types
 Scalar and Aggregation Functions
 --------------------------------
 
+- Added support for :ref:`NUMERIC type<type-numeric>` to the
+  :ref:`aggregation-avg-distinct` function.
+
 - Added support for :ref:`NUMERIC type<type-numeric>` to the following
   arithmetic scalar functions: :ref:`POWER<scalar-power>`,
   :ref:`DEGREES<scalar-degrees>` and :ref:`RADIANS<scalar-radians>`.

--- a/docs/general/builtins/aggregation.rst
+++ b/docs/general/builtins/aggregation.rst
@@ -228,10 +228,9 @@ column to the ``numeric`` data type::
 ``avg(DISTINCT column)``
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-The ``avg`` aggregate function also supports the ``distinct`` keyword except for
-arguments of :ref:`NUMERIC type<type-numeric>`. This keyword changes the
-behaviour of the function so that it will only average the number of distinct
-values in this column that are not ``NULL``::
+The ``avg`` aggregate function also supports the ``distinct`` keyword. This
+keyword changes the behaviour of the function so that it will only average the
+number of distinct values in this column that are not ``NULL``::
 
     cr> select
     ...   avg(distinct position) AS avg_pos,

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/CollectSetAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/CollectSetAggregation.java
@@ -31,6 +31,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.jetbrains.annotations.Nullable;
 
+import io.crate.common.collections.Lists;
 import io.crate.data.Input;
 import io.crate.data.breaker.RamAccounting;
 import io.crate.execution.engine.aggregation.AggregationFunction;
@@ -56,7 +57,7 @@ public class CollectSetAggregation extends AggregationFunction<Map<Object, Objec
     public static final String NAME = "collect_set";
 
     public static void register(Functions.Builder builder) {
-        for (DataType<?> supportedType : DataTypes.PRIMITIVE_TYPES) {
+        for (DataType<?> supportedType : Lists.concat(DataTypes.PRIMITIVE_TYPES, DataTypes.NUMERIC)) {
             var returnType = new ArrayType<>(supportedType);
             builder.add(
                     Signature.builder(NAME, FunctionType.AGGREGATE)

--- a/server/src/main/java/io/crate/expression/scalar/NumericCollectionAverageFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/NumericCollectionAverageFunction.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.expression.scalar;
+
+import java.math.BigDecimal;
+import java.math.MathContext;
+import java.util.List;
+
+import io.crate.data.Input;
+import io.crate.metadata.FunctionType;
+import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.Scalar;
+import io.crate.metadata.TransactionContext;
+import io.crate.metadata.functions.BoundSignature;
+import io.crate.metadata.functions.Signature;
+import io.crate.types.ArrayType;
+import io.crate.types.DataTypes;
+
+public class NumericCollectionAverageFunction extends Scalar<BigDecimal, List<BigDecimal>> {
+
+    public static final String NAME = "collection_avg";
+
+    public static void register(Functions.Builder builder) {
+        builder.add(
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(new ArrayType<>(DataTypes.NUMERIC).getTypeSignature())
+                .returnType(DataTypes.NUMERIC.getTypeSignature())
+                .features(Feature.DETERMINISTIC, Feature.STRICTNULL)
+                .build(),
+            NumericCollectionAverageFunction::new
+        );
+    }
+
+    private NumericCollectionAverageFunction(Signature signature, BoundSignature boundSignature) {
+        super(signature, boundSignature);
+    }
+
+    @Override
+    public BigDecimal evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<List<BigDecimal>>... args) {
+        List<BigDecimal> values = args[0].value();
+        if (values == null) {
+            return null;
+        }
+        BigDecimal sum = new BigDecimal(0);
+        long count = 0;
+        for (BigDecimal value : values) {
+            sum = sum.add(value) ;
+            count++;
+        }
+        if (count > 0) {
+            return sum.divide(new BigDecimal(count), MathContext.DECIMAL128);
+        } else {
+            return null;
+        }
+    }
+}

--- a/server/src/main/java/io/crate/expression/scalar/ScalarFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/ScalarFunctions.java
@@ -118,6 +118,7 @@ public class ScalarFunctions implements FunctionsProvider {
         NegateFunctions.register(builder);
         CollectionCountFunction.register(builder);
         CollectionAverageFunction.register(builder);
+        NumericCollectionAverageFunction.register(builder);
         FormatFunction.register(builder);
         SubstrFunction.register(builder);
         RegexpReplaceFunction.register(builder);

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/CollectSetAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/CollectSetAggregationTest.java
@@ -23,6 +23,7 @@ package io.crate.execution.engine.aggregation.impl;
 
 import static io.crate.testing.Asserts.assertThat;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 import org.elasticsearch.Version;
@@ -41,6 +42,7 @@ import io.crate.operation.aggregation.AggregationTestCase;
 import io.crate.types.ArrayType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
+import io.crate.types.NumericType;
 
 public class CollectSetAggregationTest extends AggregationTestCase {
 
@@ -61,6 +63,18 @@ public class CollectSetAggregationTest extends AggregationTestCase {
         FunctionImplementation collectSet = nodeCtx.functions().get(
             null, "collect_set", List.of(Literal.of(DataTypes.INTEGER, null)), SearchPath.pathWithPGCatalogAndDoc());
         assertThat(collectSet.boundSignature().returnType()).isEqualTo(new ArrayType<>(DataTypes.INTEGER));
+        collectSet = nodeCtx.functions().get(
+            null, "collect_set", List.of(Literal.of(DataTypes.NUMERIC, null)), SearchPath.pathWithPGCatalogAndDoc());
+        assertThat(collectSet.boundSignature().returnType()).isEqualTo(new ArrayType<>(DataTypes.NUMERIC));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testNumeric() throws Exception {
+        assertThat(
+            (List<BigDecimal>) executeAggregation(new NumericType(4, 3), new Object[][]{{
+                new BigDecimal("0.713")}, {new BigDecimal("0.312")}, {new BigDecimal("0.713")}}))
+            .containsExactlyInAnyOrder(new BigDecimal("0.312"), new BigDecimal("0.713"));
     }
 
     @SuppressWarnings("unchecked")

--- a/server/src/test/java/io/crate/expression/scalar/CollectionAvgFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/CollectionAvgFunctionTest.java
@@ -21,6 +21,7 @@
 
 package io.crate.expression.scalar;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 import org.junit.Test;
@@ -28,6 +29,7 @@ import org.junit.Test;
 import io.crate.expression.symbol.Literal;
 import io.crate.types.ArrayType;
 import io.crate.types.LongType;
+import io.crate.types.NumericType;
 
 public class CollectionAvgFunctionTest extends ScalarTestCase {
 
@@ -40,4 +42,14 @@ public class CollectionAvgFunctionTest extends ScalarTestCase {
         );
     }
 
+    @Test
+    public void test_evaluate_numeric() throws Exception {
+        assertEvaluate(
+            "collection_avg(numeric_array)",
+            new BigDecimal("2.440"),
+            Literal.of(
+                List.of(new BigDecimal("1.325"), new BigDecimal("2.345"), new BigDecimal("3.65")),
+                new ArrayType<>(new NumericType(5, 3)))
+        );
+    }
 }

--- a/server/src/testFixtures/java/io/crate/expression/scalar/ScalarTestCase.java
+++ b/server/src/testFixtures/java/io/crate/expression/scalar/ScalarTestCase.java
@@ -96,6 +96,7 @@ public abstract class ScalarTestCase extends CrateDummyClusterServiceUnitTest {
             "  int_array array(int)," +
             "  short_array array(short)," +
             "  double_array array(double precision)," +
+            "  numeric_array array(numeric)," +
             "  regex_pattern text," +
             "  geoshape geo_shape," +
             "  geopoint geo_point," +


### PR DESCRIPTION
Add support for NUMERIC to `CollectSetAggregation` which was missing, and add a special class and signature for `CollectionAverageFunction` which supports numeric.
