### PR TITLE
Fix geoshapes iso link

### DIFF
--- a/docs/general/dql/geo.rst
+++ b/docs/general/dql/geo.rst
@@ -291,4 +291,4 @@ query where scalar functions are allowed.
 
 .. _GeoJSON: https://geojson.org/
 .. _WKT: https://en.wikipedia.org/wiki/Well-known_text
-.. _ISO 19107: https://www.iso.org/standard/26012.html
+.. _ISO 19107: https://www.iso.org/standard/66175.html


### PR DESCRIPTION
There is a revised link to a 2019 standard which was accepted on 2025 and the older one has been withdrawn.
