### PR TITLE
Fixed masked settings for Azure repos

### DIFF
--- a/docs/appendices/release-notes/5.10.8.rst
+++ b/docs/appendices/release-notes/5.10.8.rst
@@ -53,3 +53,7 @@ Fixes
   cluster before upgrading a publisher cluster to apply the fix correctly.
   This fix will only work if both, the publisher and subscriber clusters, are
   running with :ref:`version_5.10.8` or higher.
+
+- Fixed an issue where ``sas_token`` and ``key`` settings for
+  :ref:`azure repositories <sql-create-repo-azure>` were exposed as unmasked
+  settings in :ref:`sys.repositories <sys-repositories>` table.

--- a/plugins/es-repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureRepositoryPlugin.java
+++ b/plugins/es-repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureRepositoryPlugin.java
@@ -19,6 +19,10 @@
 
 package org.elasticsearch.repositories.azure;
 
+import static org.elasticsearch.repositories.azure.AzureRepository.Repository.ACCOUNT_SETTING;
+import static org.elasticsearch.repositories.azure.AzureRepository.Repository.KEY_SETTING;
+import static org.elasticsearch.repositories.azure.AzureRepository.Repository.SAS_TOKEN_SETTING;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -73,6 +77,6 @@ public class AzureRepositoryPlugin extends Plugin implements RepositoryPlugin {
 
     @Override
     public List<Setting<?>> getSettings() {
-        return List.of(AzureRepository.Repository.ACCOUNT_SETTING);
+        return List.of(ACCOUNT_SETTING, SAS_TOKEN_SETTING, KEY_SETTING);
     }
 }


### PR DESCRIPTION
Previsouly, `sas_token` and `key` where not registered through the `getSetting()` of the plugin, and therefore were not included in the `masked_settings` for the `SysRepositoriesTableInfo`.

Fixes: #17949

