### PR TITLE
Re-add default limit to exponentialBackoff

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/bulk/BackoffPolicy.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BackoffPolicy.java
@@ -76,8 +76,7 @@ public final class BackoffPolicy {
      * iterator created from it should only be used by a single thread.
      */
     public static Iterable<TimeValue> exponentialBackoff() {
-        return () -> exponential(TimeValue.timeValueMillis(50))
-            .iterator();
+        return exponentialBackoff(TimeValue.timeValueMillis(50), 8);
     }
 
     /**

--- a/server/src/test/java/io/crate/action/LimitedBackoffPolicyTest.java
+++ b/server/src/test/java/io/crate/action/LimitedBackoffPolicyTest.java
@@ -57,6 +57,20 @@ public class LimitedBackoffPolicyTest extends ESTestCase {
     }
 
     @Test
+    public void test_exp_backoff_defaults_to_8_retries() throws Exception {
+        assertThat(BackoffPolicy.exponentialBackoff()).containsExactly(
+            TimeValue.timeValueMillis(60),
+            TimeValue.timeValueMillis(80),
+            TimeValue.timeValueMillis(150),
+            TimeValue.timeValueMillis(280),
+            TimeValue.timeValueMillis(580),
+            TimeValue.timeValueMillis(1250),
+            TimeValue.timeValueMillis(2740),
+            TimeValue.timeValueMillis(6050)
+        );
+    }
+
+    @Test
     public void testLimit() throws Exception {
         int maxDelay = 1000;
         Iterable<TimeValue> policy = BackoffPolicy.exponentialBackoff(0, 1000, maxDelay);


### PR DESCRIPTION
Follow up to https://github.com/crate/crate/pull/17943 which
accidentally removed the 8 max retries from the `exponentialBackoff`
variant.

This variant is used in `TransportDistributedResultAction` and unlimited
retries meant that tests got flaky with context leak errors.
