### PR TITLE
Improve RamAccounting for stddev_pop/samp on NUMERIC for doc values

### DIFF
--- a/extensions/functions/src/main/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregation.java
+++ b/extensions/functions/src/main/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregation.java
@@ -200,7 +200,7 @@ public class HyperLogLogDistinctAggregation extends AggregationFunction<HyperLog
                         var state = new HllState(dataType, minNodeVersion.onOrAfter(Version.V_4_1_0));
                         return initIfNeeded(state, memoryManager, precision);
                     },
-                    (values, state) -> {
+                    (_, values, state) -> {
                         var hash = BitMixer.mix64(values.nextValue());
                         state.addHash(hash);
                     }
@@ -212,7 +212,7 @@ public class HyperLogLogDistinctAggregation extends AggregationFunction<HyperLog
                         var state = new HllState(dataType, minNodeVersion.onOrAfter(Version.V_4_1_0));
                         return initIfNeeded(state, memoryManager, precision);
                     },
-                    (values, state) -> {
+                    (_, values, state) -> {
                         // Murmur3Hash.Double in regular aggregation calls mix64 of doubleToLongBits(double value).
                         // Equivalent of that in context of double DocValue is
                         // mix64(doubleToLongBits(decoded))
@@ -230,7 +230,7 @@ public class HyperLogLogDistinctAggregation extends AggregationFunction<HyperLog
                         var state = new HllState(dataType, minNodeVersion.onOrAfter(Version.V_4_1_0));
                         return initIfNeeded(state, memoryManager, precision);
                     },
-                    (values, state) -> {
+                    (_, values, state) -> {
                         // Murmur3Hash.Float in regular aggregation calls mix64 of doubleToLongBits(double value).
                         // Equivalent of that in context of float DocValue is
                         // mix64(doubleToLongBits(decoded))

--- a/libs/shared/src/main/java/io/crate/common/CheckedTriConsumer.java
+++ b/libs/shared/src/main/java/io/crate/common/CheckedTriConsumer.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.common;
+
+/**
+ * A {@link TriConsumer}-like interface which allows throwing checked exceptions.
+ */
+public interface CheckedTriConsumer<K, V, S, E extends Exception> {
+    void accept(K k, V v, S s) throws E;
+}

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/CountAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/CountAggregation.java
@@ -259,38 +259,27 @@ public class CountAggregation extends AggregationFunction<MutableLong, Long> {
         if (!ref.hasDocValues()) {
             return null;
         }
-        switch (ref.valueType().id()) {
-            case ByteType.ID:
-            case ShortType.ID:
-            case IntegerType.ID:
-            case LongType.ID:
-            case TimestampType.ID_WITH_TZ:
-            case TimestampType.ID_WITHOUT_TZ:
-            case FloatType.ID:
-            case DoubleType.ID:
-            case GeoPointType.ID:
-                return new SortedNumericDocValueAggregator<>(
+        return switch (ref.valueType().id()) {
+            case ByteType.ID, ShortType.ID, IntegerType.ID, LongType.ID, TimestampType.ID_WITH_TZ,
+                 TimestampType.ID_WITHOUT_TZ, FloatType.ID, DoubleType.ID, GeoPointType.ID ->
+                new SortedNumericDocValueAggregator<>(
                     ref.storageIdent(),
                     (ramAccounting, _, _) -> {
                         ramAccounting.addBytes(LongStateType.INSTANCE.fixedSize());
                         return new MutableLong(0L);
                     },
-                    (_, state) -> state.add(1L)
+                    (_, _, state) -> state.add(1L)
                 );
-            case IpType.ID:
-            case StringType.ID:
-            case BitStringType.ID:
-                return new BinaryDocValueAggregator<>(
-                    ref.storageIdent(),
-                    (ramAccounting, _, _) -> {
-                        ramAccounting.addBytes(LongStateType.INSTANCE.fixedSize());
-                        return new MutableLong(0L);
-                    },
-                    (_, state) -> state.add(1L)
-                );
-            default:
-                return null;
-        }
+            case IpType.ID, StringType.ID, BitStringType.ID -> new BinaryDocValueAggregator<>(
+                ref.storageIdent(),
+                (ramAccounting, _, _) -> {
+                    ramAccounting.addBytes(LongStateType.INSTANCE.fixedSize());
+                    return new MutableLong(0L);
+                },
+                (_, _, state) -> state.add(1L)
+            );
+            default -> null;
+        };
     }
 
     @Nullable

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/GeometricMeanAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/GeometricMeanAggregation.java
@@ -327,7 +327,7 @@ public class GeometricMeanAggregation extends AggregationFunction<GeometricMeanA
                         ramAccounting.addBytes(GeometricMeanStateType.INSTANCE.fixedSize());
                         return new GeometricMeanState();
                     },
-                    (values, state) -> state.addValue(values.nextValue())
+                    (_, values, state) -> state.addValue(values.nextValue())
                 );
             case FloatType.ID:
                 return new SortedNumericDocValueAggregator<>(
@@ -336,7 +336,7 @@ public class GeometricMeanAggregation extends AggregationFunction<GeometricMeanA
                         ramAccounting.addBytes(GeometricMeanStateType.INSTANCE.fixedSize());
                         return new GeometricMeanState();
                     },
-                    (values, state) -> {
+                    (_, values, state) -> {
                         var value = NumericUtils.sortableIntToFloat((int) values.nextValue());
                         state.addValue(value);
                     }
@@ -348,7 +348,7 @@ public class GeometricMeanAggregation extends AggregationFunction<GeometricMeanA
                         ramAccounting.addBytes(GeometricMeanStateType.INSTANCE.fixedSize());
                         return new GeometricMeanState();
                     },
-                    (values, state) -> {
+                    (_, values, state) -> {
                         var value = NumericUtils.sortableLongToDouble((values.nextValue()));
                         state.addValue(value);
                     }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/NumericStandardDeviationAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/NumericStandardDeviationAggregation.java
@@ -188,9 +188,12 @@ public abstract class NumericStandardDeviationAggregation<V extends NumericVaria
                     reference.storageIdent(),
                     (ramAccounting, memoryManager, version) ->
                         newState(ramAccounting, version, memoryManager),
-                    (values, state) -> {
+                    (ramAccounting, values, state) -> {
                         long docValue = values.nextValue();
+                        long sizeBefore = state.size();
                         state.increment(BigDecimal.valueOf(docValue, scale));
+                        long sizeAfter = state.size();
+                        ramAccounting.addBytes(sizeBefore - sizeAfter);
                     }
             );
         } else {
@@ -198,10 +201,13 @@ public abstract class NumericStandardDeviationAggregation<V extends NumericVaria
                     reference.storageIdent(),
                     (ramAccounting, memoryManager, version) ->
                         newState(ramAccounting, version, memoryManager),
-                    (values, state) -> {
+                    (ramAccounting, values, state) -> {
                         BytesRef bytesRef = values.lookupOrd(values.nextOrd());
                         BigInteger bigInteger = NumericUtils.sortableBytesToBigInt(bytesRef.bytes, bytesRef.offset, bytesRef.length);
+                        long sizeBefore = state.size();
                         state.increment(new BigDecimal(bigInteger, scale));
+                        long sizeAfter = state.size();
+                        ramAccounting.addBytes(sizeBefore - sizeAfter);
                     }
             );
         }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/StandardDeviationAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/StandardDeviationAggregation.java
@@ -184,7 +184,7 @@ public abstract class StandardDeviationAggregation<V extends Variance> extends A
                          ramAccounting.addBytes(V.fixedSize());
                          return newState(ramAccounting, version, memoryManager);
                      },
-                     (values, state) -> state.increment(values.nextValue())
+                     (_, values, state) -> state.increment(values.nextValue())
             );
             case FloatType.ID -> new SortedNumericDocValueAggregator<>(
                 reference.storageIdent(),
@@ -192,7 +192,7 @@ public abstract class StandardDeviationAggregation<V extends Variance> extends A
                     ramAccounting.addBytes(V.fixedSize());
                     return newState(ramAccounting, version, memoryManager);
                 },
-                (values, state) -> {
+                (_, values, state) -> {
                     var value = NumericUtils.sortableIntToFloat((int) values.nextValue());
                     state.increment(value);
                 }
@@ -203,7 +203,7 @@ public abstract class StandardDeviationAggregation<V extends Variance> extends A
                     ramAccounting.addBytes(V.fixedSize());
                     return newState(ramAccounting, version, memoryManager);
                 },
-                (values, state) -> {
+                (_, values, state) -> {
                     var value = NumericUtils.sortableLongToDouble((values.nextValue()));
                     state.increment(value);
                 }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/TopKAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/TopKAggregation.java
@@ -268,12 +268,12 @@ public class TopKAggregation extends AggregationFunction<TopKAggregation.State, 
             return new SortedNumericDocValueAggregator<>(
                 ref.storageIdent(),
                 (ramAccounting, _, _) -> topKLongState(ramAccounting, limit, capacity),
-                (values, state) -> state.update(values.nextValue(), type));
+                (_, values, state) -> state.update(values.nextValue(), type));
         } else if (type.id() == StringType.ID) {
             return new BinaryDocValueAggregator<>(
                 ref.storageIdent(),
                 (ramAccounting, _, _) -> topKState(ramAccounting, limit, capacity),
-                (values, state) -> {
+                (_, values, state) -> {
                     long ord = values.nextOrd();
                     BytesRef value = values.lookupOrd(ord);
                     state.update(value.utf8ToString(), type);
@@ -282,7 +282,7 @@ public class TopKAggregation extends AggregationFunction<TopKAggregation.State, 
             return new BinaryDocValueAggregator<>(
                 ref.storageIdent(),
                 (ramAccounting, _, _) -> topKState(ramAccounting, limit, capacity),
-                (values, state) -> {
+                (_, values, state) -> {
                     long ord = values.nextOrd();
                     BytesRef value = values.lookupOrd(ord);
                     state.update(NetworkUtils.formatIPBytes(value), type);

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/VarianceAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/VarianceAggregation.java
@@ -249,7 +249,7 @@ public class VarianceAggregation extends AggregationFunction<Variance, Double> {
                         ramAccounting.addBytes(VarianceStateType.INSTANCE.fixedSize());
                         return new Variance();
                     },
-                    (values, state) -> state.increment(values.nextValue())
+                    (_, values, state) -> state.increment(values.nextValue())
                 );
             case FloatType.ID:
                 return new SortedNumericDocValueAggregator<>(
@@ -258,7 +258,7 @@ public class VarianceAggregation extends AggregationFunction<Variance, Double> {
                         ramAccounting.addBytes(VarianceStateType.INSTANCE.fixedSize());
                         return new Variance();
                     },
-                    (values, state) -> {
+                    (_, values, state) -> {
                         var value = NumericUtils.sortableIntToFloat((int) values.nextValue());
                         state.increment(value);
                     }
@@ -270,7 +270,7 @@ public class VarianceAggregation extends AggregationFunction<Variance, Double> {
                         ramAccounting.addBytes(VarianceStateType.INSTANCE.fixedSize());
                         return new Variance();
                     },
-                    (values, state) -> {
+                    (_, values, state) -> {
                         var value = NumericUtils.sortableLongToDouble((values.nextValue()));
                         state.increment(value);
                     }


### PR DESCRIPTION
Use `RamAccounting` in the consumer used in DocValueAggregators to calculate ram usage depending on changes in state's size where needed. Current usage is only for `NumericStandardDeviationAggregation`.
