### PR TITLE
Add tasks missing on kill to `recentlyFailed` cache

### DIFF
--- a/server/src/main/java/io/crate/execution/jobs/TasksService.java
+++ b/server/src/main/java/io/crate/execution/jobs/TasksService.java
@@ -234,13 +234,13 @@ public class TasksService extends AbstractLifecycleComponent implements Transpor
         for (UUID jobId : toKill) {
             RootTask ctx = activeTasks.get(jobId);
             if (ctx == null) {
+                recentlyFailed.put(jobId, failedSentinel);
                 // no kill but we need to count down
                 countDownFuture.onSuccess();
                 continue;
             }
             // superuser can always kill jobs; normal users only their own jobs
             if (isSuperUser || ctx.userName().equals(userName)) {
-                recentlyFailed.put(jobId, failedSentinel);
                 ctx.completionFuture().whenComplete(countDownFuture);
                 ctx.kill(reason);
                 numKilled++;


### PR DESCRIPTION
This speeds up query completion in the following distributed query
execution scenario:

- handler-node: mergeOnHandler starts
- handler-node: collect starts
- handler-node: collect finishes with a failure and:
  - forwards the failure to the participating downstreams
  - propagates the failure to sibling tasks to clean them up

- handler-node: Given that the local task failed, remote task
  initialization is skipped, instead it immediately sends out a kill to
  the other nodes

- remote node: kill received, but is a no-op, because context is missing
- remote node: receives the failure forwarded by the collect, but given
  that the task context is missing it retries.

To speed up the context cleanup in such a scenario, this changes the
TasksService to track the failed job within its `recentlyFailed` cache.

Relates to https://github.com/crate/crate/pull/17963 in that the
unlimited backoff policy helped uncover this.