### PR TITLE
Ensure that job log is cleared when bulk execution completes with an error

### DIFF
--- a/docs/appendices/release-notes/5.10.8.rst
+++ b/docs/appendices/release-notes/5.10.8.rst
@@ -63,3 +63,6 @@ Fixes
 
 - Fixed an issue that caused queries to not complete and return if a 
   ``CircuitBreakerException`` was thrown while constructing the result set.
+
+- Fixed an issue that caused an interrupted bulk operation to not be cleared
+  from the :ref:`sys.jobs <sys-jobs>` table.


### PR DESCRIPTION
Ensure that job log is cleared when bulk execution completes with an error

This is needed only in 5.10 as in 6.0 such handling was added in https://github.com/crate/crate/pull/17689

Relates to https://github.com/crate/support/issues/603

Bulk execution doesn't clean up sys.jobs when bulk operation's future was not completed successfully.

------
Scenarios I didn't mention in the change entry because I don't have tests for them:

In general:
Anything that makes `plan.executeBulk` return `CompleteFuture<BulkResponse>` that is completed exceptionally.

More specific:

Bulk `UpdateById`, bulk `DeleteById` - `BulkShardResponseListener` hitting `onFailure` or `onResponse` hitting internal catch block.

`InsertFromValues` afaik can have failed CompleteFuture<BulkResponse> on `IndexNotFoundException`

Bulk UPDATE/DELETE - `JobLauncher.executeBulk` failed on `setupTasks`. 

