### PR TITLE
Remove development section from release note

### DIFF
--- a/docs/appendices/release-notes/5.10.8.rst
+++ b/docs/appendices/release-notes/5.10.8.rst
@@ -8,11 +8,6 @@ Released on 2025-06-10.
 
 .. NOTE::
 
-    In development. 5.10.8 isn't released yet. These are the release notes for
-    the upcoming release.
-
-.. NOTE::
-
     If you are upgrading a cluster, you must be running CrateDB 4.0.2 or higher
     before you upgrade to 5.10.8.
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
