### PR TITLE
Fix NullPointerException when casting values containing null to GEOPOINT

### DIFF
--- a/docs/appendices/release-notes/5.10.9.rst
+++ b/docs/appendices/release-notes/5.10.9.rst
@@ -55,3 +55,6 @@ Fixes
 
   The insert succeeded before, but now it will cause an
   ``IllegalArgumentException``.
+
+- Fixed ``NullPointerException`` thrown when casting an array containing
+  ``NULL`` to ``GEO_POINT``.

--- a/server/src/main/java/io/crate/types/GeoPointType.java
+++ b/server/src/main/java/io/crate/types/GeoPointType.java
@@ -106,10 +106,16 @@ public class GeoPointType extends DataType<Point> implements Streamer<Point>, Fi
             return point;
         } else if (value instanceof Double[] doubles) {
             checkLengthIs2(doubles.length);
+            if (doubles[0] == null || doubles[1] == null) {
+                return null;
+            }
             ensurePointsInRange(doubles[0], doubles[1]);
             return new PointImpl(doubles[0], doubles[1], JtsSpatialContext.GEO);
         } else if (value instanceof Object[] values) {
             checkLengthIs2(values.length);
+            if (values[0] == null || values[1] == null) {
+                return null;
+            }
             PointImpl point = new PointImpl(
                 ((Number) values[0]).doubleValue(),
                 ((Number) values[1]).doubleValue(),
@@ -120,6 +126,9 @@ public class GeoPointType extends DataType<Point> implements Streamer<Point>, Fi
             return pointFromString(str);
         } else if (value instanceof List<?> values) {
             checkLengthIs2(values.size());
+            if (values.getFirst() == null || values.getLast() == null) {
+                return null;
+            }
             PointImpl point = new PointImpl(
                 ((Number) values.get(0)).doubleValue(),
                 ((Number) values.get(1)).doubleValue(),
@@ -137,6 +146,9 @@ public class GeoPointType extends DataType<Point> implements Streamer<Point>, Fi
             return null;
         } else if (value instanceof List<?> values) {
             checkLengthIs2(values.size());
+            if (values.getFirst() == null || values.getLast() == null) {
+                return null;
+            }
             PointImpl point = new PointImpl(
                 ((Number) values.get(0)).doubleValue(),
                 ((Number) values.get(1)).doubleValue(),

--- a/server/src/test/java/io/crate/types/GeoPointTypeTest.java
+++ b/server/src/test/java/io/crate/types/GeoPointTypeTest.java
@@ -25,6 +25,7 @@ import static com.carrotsearch.randomizedtesting.RandomizedTest.assumeFalse;
 import static io.crate.testing.Asserts.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.Arrays;
 import java.util.List;
 
 import org.assertj.core.data.Offset;
@@ -102,6 +103,18 @@ public class GeoPointTypeTest extends DataTypeTestCase<Point> {
         Point value = DataTypes.GEO_POINT.implicitCast(new Integer[]{1, 2});
         assertThat(value.getX()).isEqualTo(1.0);
         assertThat(value.getY()).isEqualTo(2.0);
+    }
+
+    @Test
+    public void test_return_null_when_converting_values_containing_null_to_geo_point() {
+        Point value = DataTypes.GEO_POINT.implicitCast(new Integer[]{1, null});
+        assertThat(value).isNull();
+        value = DataTypes.GEO_POINT.implicitCast(Arrays.asList(null, 1));
+        assertThat(value).isNull();
+        value = DataTypes.GEO_POINT.implicitCast(new Double[]{null, 1.11});
+        assertThat(value).isNull();
+        value = DataTypes.GEO_POINT.sanitizeValue(Arrays.asList(null, 1));
+        assertThat(value).isNull();
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes https://github.com/crate/crate/issues/17998, after checking the len=2, we must also check if either is `null`.

BTW, `null` is still rejected when creating GEO_POINT from WKT string,
```
cr> INSERT INTO my_table_geo (
        id, pin
    ) VALUES (
        1, 'POINT (null 47.4108)'
    );
SQLParseException[Cannot cast `'POINT (null 47.4108)'` of type `text` to type `geo_point`]
```

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
