### PR TITLE
Fix: Don't register CURRENT_CATALOG also as a normal function with `()`

### DIFF
--- a/docs/appendices/release-notes/6.0.0.rst
+++ b/docs/appendices/release-notes/6.0.0.rst
@@ -225,8 +225,8 @@ Breaking Changes
    must be used.
 
 - ``current_catalog`` has been added to the list of reserved keywords, because
-  of the addition of :ref:`scalar-current_catalog` function which works also as
-  a keyword without the ``()``. The whole list of keywords can be found
+  of the addition of :ref:`scalar-current_catalog` function which is called as a
+  keyword without the ``()``. The whole list of keywords can be found
   :ref:`here <sql_lexical_keywords_identifiers>`.
 
 Deprecations

--- a/docs/general/builtins/scalar-functions.rst
+++ b/docs/general/builtins/scalar-functions.rst
@@ -4305,25 +4305,19 @@ Returns the server start time as ``timestamp with time zone``.
 
 .. _scalar-current_catalog:
 
-``current_catalog()``
+``current_catalog``
 ----------------------
 
 The ``current_catalog`` function returns the name of the current catalog, which
 in CrateDB will always be ``crate``::
 
-    cr> select current_catalog() AS db;
+    cr> select current_catalog AS db;
     +-------+
     | db    |
     +-------+
     | crate |
     +-------+
     SELECT 1 row in set (... sec)
-
-.. NOTE::
-
-    The ``CURRENT_CATALOG`` function has a special SQL syntax, meaning that it
-    must be called without trailing parenthesis (``()``). However, CrateDB also
-    supports the optional parenthesis.
 
 .. _scalar-current_database:
 

--- a/libs/sql-parser/src/main/antlr/io/crate/sql/parser/antlr/SqlBaseParser.g4
+++ b/libs/sql-parser/src/main/antlr/io/crate/sql/parser/antlr/SqlBaseParser.g4
@@ -913,7 +913,6 @@ nonReserved
     | CONNECTION
     | COPY
     | CURRENT
-    | CURRENT_CATALOG
     | CURRENT_DATE
     | CURRENT_SCHEMA
     | CURRENT_TIME

--- a/libs/sql-parser/src/test/java/io/crate/sql/parser/TestSqlParser.java
+++ b/libs/sql-parser/src/test/java/io/crate/sql/parser/TestSqlParser.java
@@ -425,8 +425,7 @@ public class TestSqlParser {
     @Test
     public void testCurrentCatalogFunction() {
         assertInstanceOf("CURRENT_CATALOG", FunctionCall.class);
-        assertInstanceOf("CURRENT_CATALOG()", FunctionCall.class);
-        var stmt = SqlParser.createStatement("SELECT CURRENT_CATALOG AS CURRENT_CATALOG");
+        var stmt = SqlParser.createStatement("SELECT CURRENT_CATALOG AS \"current_catalog\"");
         assertThat(((QuerySpecification)((Query) stmt).getQueryBody()).getSelect().getSelectItems()).satisfiesExactly(
             s -> assertThat(((SingleColumn) s).getAlias()).isEqualTo("current_catalog")
         );

--- a/libs/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/libs/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -1246,13 +1246,10 @@ public class TestStatementBuilder {
         printStatement("select * from information_schema.tables where table_schema = current_schema()");
         printStatement("select * from information_schema.tables where table_schema = pg_catalog.current_schema()");
 
-        printStatement("select current_catalog");
-        printStatement("select current_catalog()");
-        printStatement("select pg_catalog.current_catalog()");
-
         printStatement("select current_database()");
         printStatement("select pg_catalog.current_database()");
 
+        printStatement("select current_catalog");
         printStatement("select current_user");
         printStatement("select current_role");
         printStatement("select user");

--- a/server/src/main/java/io/crate/expression/symbol/Function.java
+++ b/server/src/main/java/io/crate/expression/symbol/Function.java
@@ -322,6 +322,10 @@ public class Function implements Symbol, Cloneable {
                 builder.append(arguments.get(0).toString(style));
                 break;
 
+            case "current_catalog":
+                builder.append("CURRENT_CATALOG");
+                break;
+
             case "current_user":
                 builder.append("CURRENT_USER");
                 break;

--- a/server/src/test/java/io/crate/expression/scalar/CurrentDatabaseFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/CurrentDatabaseFunctionTest.java
@@ -21,7 +21,11 @@
 
 package io.crate.expression.scalar;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.junit.Test;
+
+import io.crate.expression.symbol.Symbol;
 
 public class CurrentDatabaseFunctionTest extends ScalarTestCase {
 
@@ -31,8 +35,7 @@ public class CurrentDatabaseFunctionTest extends ScalarTestCase {
     }
 
     @Test
-    public void testCurrenCatalogReturnsTheDefaultDBName() {
-        assertEvaluate("current_catalog()", "crate");
+    public void testCurrentCatalogReturnsTheDefaultDBName() {
         assertEvaluate("current_catalog", "crate");
     }
 
@@ -42,7 +45,9 @@ public class CurrentDatabaseFunctionTest extends ScalarTestCase {
     }
 
     @Test
-    public void testCurrentCatalogWithFQNFunctionName() {
-        assertEvaluate("pg_catalog.current_catalog()", "crate");
+    public void test_format_current_catalog() {
+        sqlExpressions.context().allowEagerNormalize(false);
+        Symbol f = sqlExpressions.asSymbol("current_catalog");
+        assertThat(f).hasToString("CURRENT_CATALOG");
     }
 }


### PR DESCRIPTION
PostgreSQL only registers it as a keyword and cannot be called with `()`. For CrateDB, it's also confusing to have it as `reserved` keyword and also be registered as a function call `()`, since it requires to be in the `nonReserved` list in the ANTLR4 grammar. Therefore, don't register it as a normal function call with `()` but only as a keyword.

Follows: https://github.com/crate/crate/pull/17972

