### PR TITLE
Fix aggregation on PARTITION BY cols

### DIFF
--- a/docs/appendices/release-notes/5.10.9.rst
+++ b/docs/appendices/release-notes/5.10.9.rst
@@ -58,3 +58,7 @@ Fixes
 
 - Fixed ``NullPointerException`` thrown when casting an array containing
   ``NULL`` to ``GEO_POINT``.
+
+- Fixed an issue that would cause :ref:`aggregation functions <aggregation>` on
+  columns used in the ``PARTITION BY()`` clause of a
+  :ref:`partitioned table <partitioned-tables>` to always return ``NULL``.

--- a/server/src/main/java/io/crate/execution/engine/aggregation/AggregationFunction.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/AggregationFunction.java
@@ -41,6 +41,7 @@ import io.crate.expression.symbol.Literal;
 import io.crate.memory.MemoryManager;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.Reference;
+import io.crate.metadata.RowGranularity;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.types.DataType;
 import io.crate.types.NumericStorage;
@@ -145,15 +146,26 @@ public abstract class AggregationFunction<TPartial, TFinal> implements FunctionI
         return null;
     }
 
+    protected Reference getAggReference(List<Reference> aggregationReferences) {
+        if (aggregationReferences.isEmpty()) {
+            return null;
+        }
+        Reference reference = aggregationReferences.getFirst();
+        if (reference == null) {
+            return null;
+        }
+        if (!reference.hasDocValues() || reference.granularity() != RowGranularity.DOC) {
+            return null;
+        }
+        return reference;
+    }
+
     protected DocValueAggregator<?> getNumericDocValueAggregator(
         List<Reference> aggregationReferences,
         TriConsumer<RamAccounting, TPartial, BigDecimal> applyToState) {
 
-        Reference reference = aggregationReferences.get(0);
+        Reference reference = getAggReference(aggregationReferences);
         if (reference == null) {
-            return null;
-        }
-        if (!reference.hasDocValues()) {
             return null;
         }
 

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/ArbitraryAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/ArbitraryAggregation.java
@@ -160,14 +160,11 @@ public class ArbitraryAggregation extends AggregationFunction<Object, Object> {
                                                        DocTableInfo table,
                                                        Version shardCreatedVersion,
                                                        List<Literal<?>> optionalParams) {
-        Reference arg = aggregationReferences.get(0);
-        if (arg == null) {
+        Reference reference = getAggReference(aggregationReferences);
+        if (reference == null) {
             return null;
         }
-        if (!arg.hasDocValues()) {
-            return null;
-        }
-        var dataType = arg.valueType();
+        var dataType = reference.valueType();
         switch (dataType.id()) {
             case ByteType.ID:
             case ShortType.ID:
@@ -176,18 +173,18 @@ public class ArbitraryAggregation extends AggregationFunction<Object, Object> {
             case TimestampType.ID_WITH_TZ:
             case TimestampType.ID_WITHOUT_TZ:
                 return new LongArbitraryDocValueAggregator<>(
-                    arg.storageIdent(),
+                    reference.storageIdent(),
                     dataType
                 );
             case FloatType.ID:
-                return new FloatArbitraryDocValueAggregator(arg.storageIdent());
+                return new FloatArbitraryDocValueAggregator(reference.storageIdent());
             case DoubleType.ID:
-                return new DoubleArbitraryDocValueAggregator(arg.storageIdent());
+                return new DoubleArbitraryDocValueAggregator(reference.storageIdent());
             case IpType.ID:
-                return new ArbitraryIPDocValueAggregator(arg.storageIdent());
+                return new ArbitraryIPDocValueAggregator(reference.storageIdent());
             case StringType.ID:
                 return new ArbitraryBinaryDocValueAggregator<>(
-                    arg.storageIdent(),
+                    reference.storageIdent(),
                     dataType
                 );
             default:

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/CmpByAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/CmpByAggregation.java
@@ -47,6 +47,7 @@ import io.crate.memory.MemoryManager;
 import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
+import io.crate.metadata.RowGranularity;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.functions.BoundSignature;
@@ -164,7 +165,7 @@ public final class CmpByAggregation extends AggregationFunction<CmpByAggregation
         if (searchField == null) {
             return null;
         }
-        if (!searchField.hasDocValues()) {
+        if (!searchField.hasDocValues() || searchField.granularity() != RowGranularity.DOC) {
             return null;
         }
 

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/CountAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/CountAggregation.java
@@ -48,6 +48,7 @@ import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
+import io.crate.metadata.RowGranularity;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.doc.DocTableInfo;
@@ -256,7 +257,7 @@ public class CountAggregation extends AggregationFunction<MutableLong, Long> {
     }
 
     private DocValueAggregator<?> getDocValueAggregator(Reference ref) {
-        if (!ref.hasDocValues()) {
+        if (!ref.hasDocValues() || ref.granularity() != RowGranularity.DOC) {
             return null;
         }
         return switch (ref.valueType().id()) {
@@ -292,17 +293,16 @@ public class CountAggregation extends AggregationFunction<MutableLong, Long> {
         if (aggregationReferences.size() != 1) {
             return null;
         }
-        Reference reference = aggregationReferences.get(0);
+        Reference reference = aggregationReferences.getFirst();
         if (reference == null) {
             return null;
         }
         if (reference.valueType().id() == ObjectType.ID) {
             // Count on object would require loading the source just to check if there is a value.
             // Try to count on a non-null sub-column to be able to utilize doc-values.
-            var aggregationRef = aggregationReferences.get(0);
             for (var notNullCol : table.notNullColumns()) {
                 // the first seen not-null sub-column will be used
-                if (notNullCol.isChildOf(aggregationRef.column())) {
+                if (notNullCol.isChildOf(reference.column())) {
                     var notNullColRef = table.getReference(notNullCol);
                     if (notNullColRef == null) {
                         continue;
@@ -313,9 +313,6 @@ public class CountAggregation extends AggregationFunction<MutableLong, Long> {
                     }
                 }
             }
-        }
-        if (!reference.hasDocValues()) {
-            return null;
         }
         return getDocValueAggregator(reference);
     }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/GeometricMeanAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/GeometricMeanAggregation.java
@@ -307,7 +307,7 @@ public class GeometricMeanAggregation extends AggregationFunction<GeometricMeanA
                                                        DocTableInfo table,
                                                        Version shardCreatedVersion,
                                                        List<Literal<?>> optionalParams) {
-        Reference reference = aggregationReferences.get(0);
+        Reference reference = getAggReference(aggregationReferences);
         if (reference == null) {
             return null;
         }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/MaximumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/MaximumAggregation.java
@@ -228,24 +228,19 @@ public abstract class MaximumAggregation extends AggregationFunction<Object, Obj
                                                            DocTableInfo table,
                                                            Version shardCreatedVersion,
                                                            List<Literal<?>> optionalParams) {
-            Reference reference = aggregationReferences.get(0);
-
+            Reference reference = getAggReference(aggregationReferences);
             if (reference == null) {
                 return null;
             }
-
-            if (!reference.hasDocValues()) {
-                return null;
-            }
-            DataType<?> arg = reference.valueType();
-            switch (arg.id()) {
+            DataType<?> valueType = reference.valueType();
+            switch (valueType.id()) {
                 case ByteType.ID:
                 case ShortType.ID:
                 case IntegerType.ID:
                 case LongType.ID:
                 case TimestampType.ID_WITH_TZ:
                 case TimestampType.ID_WITHOUT_TZ:
-                    return new LongMax(reference.storageIdent(), arg);
+                    return new LongMax(reference.storageIdent(), valueType);
 
                 case FloatType.ID:
                     return new FloatMax(reference.storageIdent());

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/MinimumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/MinimumAggregation.java
@@ -261,22 +261,19 @@ public abstract class MinimumAggregation extends AggregationFunction<Object, Obj
                                                            DocTableInfo table,
                                                            Version shardCreatedVersion,
                                                            List<Literal<?>> optionalParams) {
-            Reference reference = aggregationReferences.get(0);
+            Reference reference = getAggReference(aggregationReferences);
             if (reference == null) {
                 return null;
             }
-            if (!reference.hasDocValues()) {
-                return null;
-            }
-            DataType<?> arg = reference.valueType();
-            switch (arg.id()) {
+            DataType<?> valueType = reference.valueType();
+            switch (valueType.id()) {
                 case ByteType.ID:
                 case ShortType.ID:
                 case IntegerType.ID:
                 case LongType.ID:
                 case TimestampType.ID_WITH_TZ:
                 case TimestampType.ID_WITHOUT_TZ:
-                    return new LongMin(reference.storageIdent(), arg);
+                    return new LongMin(reference.storageIdent(), valueType);
 
                 case FloatType.ID:
                     return new FloatMin(reference.storageIdent());

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/NumericSumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/NumericSumAggregation.java
@@ -182,11 +182,8 @@ public class NumericSumAggregation extends AggregationFunction<BigDecimal, BigDe
                                                        DocTableInfo table,
                                                        Version shardCreatedVersion,
                                                        List<Literal<?>> optionalParams) {
-        Reference reference = aggregationReferences.get(0);
+        Reference reference = getAggReference(aggregationReferences);
         if (reference == null) {
-            return null;
-        }
-        if (!reference.hasDocValues()) {
             return null;
         }
         return switch (reference.valueType().id()) {

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/StandardDeviationAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/StandardDeviationAggregation.java
@@ -169,11 +169,8 @@ public abstract class StandardDeviationAggregation<V extends Variance> extends A
                                                        DocTableInfo table,
                                                        Version shardCreatedVersion,
                                                        List<Literal<?>> optionalParams) {
-        Reference reference = aggregationReferences.get(0);
+        Reference reference = getAggReference(aggregationReferences);
         if (reference == null) {
-            return null;
-        }
-        if (!reference.hasDocValues()) {
             return null;
         }
         return switch (reference.valueType().id()) {

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/SumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/SumAggregation.java
@@ -195,13 +195,8 @@ public class SumAggregation<T extends Number> extends AggregationFunction<T, T> 
                                                        DocTableInfo table,
                                                        Version shardCreatedVersion,
                                                        List<Literal<?>> optionalParams) {
-        Reference reference = aggregationReferences.get(0);
-
+        Reference reference = getAggReference(aggregationReferences);
         if (reference == null) {
-            return null;
-        }
-
-        if (!reference.hasDocValues()) {
             return null;
         }
 

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/TopKAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/TopKAggregation.java
@@ -221,16 +221,8 @@ public class TopKAggregation extends AggregationFunction<TopKAggregation.State, 
                                                        DocTableInfo table,
                                                        Version shardCreatedVersion,
                                                        List<Literal<?>> optionalParams) {
-        if (aggregationReferences.isEmpty()) {
-            return null;
-        }
-
-        Reference reference = aggregationReferences.getFirst();
+        Reference reference = getAggReference(aggregationReferences);
         if (reference == null) {
-            return null;
-        }
-
-        if (!reference.hasDocValues()) {
             return null;
         }
 

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/VarianceAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/VarianceAggregation.java
@@ -229,13 +229,11 @@ public class VarianceAggregation extends AggregationFunction<Variance, Double> {
                                                        DocTableInfo table,
                                                        Version shardCreatedVersion,
                                                        List<Literal<?>> optionalParams) {
-        Reference reference = aggregationReferences.get(0);
+        Reference reference = getAggReference(aggregationReferences);
         if (reference == null) {
             return null;
         }
-        if (!reference.hasDocValues()) {
-            return null;
-        }
+
         switch (reference.valueType().id()) {
             case ByteType.ID:
             case ShortType.ID:

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/average/AverageAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/average/AverageAggregation.java
@@ -311,11 +311,8 @@ public class AverageAggregation extends AggregationFunction<AverageAggregation.A
                                                        DocTableInfo table,
                                                        Version shardCreatedVersion,
                                                        List<Literal<?>> optionalParams) {
-        Reference reference = aggregationReferences.get(0);
+        Reference reference = getAggReference(aggregationReferences);
         if (reference == null) {
-            return null;
-        }
-        if (!reference.hasDocValues()) {
             return null;
         }
         return switch (reference.valueType().id()) {


### PR DESCRIPTION
When a column is the PARTITION BY clause of a table we cannot use doc values aggregators, otherwise the agg function will always return `NULL` since no values are collected for those columns. Add checks to `getDocValueAggregator()` to return `null` if the column has `PARTITION` granularity.

Fixes: #17980

