### PR TITLE
TableStats Persistence with Arrow

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -346,6 +346,7 @@
     <versions.graalvm>24.2.1</versions.graalvm>
     <versions.jwt>4.5.0</versions.jwt>
     <versions.jwks-rsa>0.22.1</versions.jwks-rsa>
+    <versions.arrow>18.3.0</versions.arrow>
 
     <versions.google.gax>2.43.0</versions.google.gax>
     <versions.google.auth>1.23.0</versions.google.auth>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -412,5 +412,24 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.apache.arrow</groupId>
+      <artifactId>arrow-memory-core</artifactId>
+      <version>${versions.arrow}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.arrow</groupId>
+      <artifactId>arrow-vector</artifactId>
+      <version>${versions.arrow}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.arrow</groupId>
+      <artifactId>arrow-memory-unsafe</artifactId>
+      <version>${versions.arrow}</version>
+      <scope>runtime</scope>
+    </dependency>
+
   </dependencies>
 </project>

--- a/server/src/main/java/io/crate/statistics/ColumnStats.java
+++ b/server/src/main/java/io/crate/statistics/ColumnStats.java
@@ -108,6 +108,10 @@ public final class ColumnStats<T> implements Writeable {
         return histogram;
     }
 
+    public DataType<T> type() {
+        return type;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/server/src/main/java/io/crate/statistics/arrow/ArrowBufferAllocator.java
+++ b/server/src/main/java/io/crate/statistics/arrow/ArrowBufferAllocator.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.statistics.arrow;
+
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+
+public class ArrowBufferAllocator {
+
+    public static final BufferAllocator INSTANCE = new RootAllocator();
+
+    private ArrowBufferAllocator() {
+
+    }
+
+    public static void close() {
+        INSTANCE.close();
+    }
+
+}

--- a/server/src/main/java/io/crate/statistics/arrow/Statistics.java
+++ b/server/src/main/java/io/crate/statistics/arrow/Statistics.java
@@ -1,0 +1,209 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.statistics.arrow;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.channels.Channels;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.vector.BigIntVector;
+import org.apache.arrow.vector.VectorLoader;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.VectorUnloader;
+import org.apache.arrow.vector.complex.StructVector;
+import org.apache.arrow.vector.complex.impl.NullableStructReaderImpl;
+import org.apache.arrow.vector.complex.impl.NullableStructWriter;
+import org.apache.arrow.vector.ipc.ArrowStreamReader;
+import org.apache.arrow.vector.ipc.ArrowStreamWriter;
+import org.apache.arrow.vector.ipc.message.ArrowRecordBatch;
+import org.apache.arrow.vector.types.FloatingPointPrecision;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+
+import io.crate.metadata.ColumnIdent;
+import io.crate.statistics.ColumnStats;
+import io.crate.statistics.MostCommonValues;
+import io.crate.types.DataTypes;
+
+public class Statistics implements AutoCloseable {
+
+    private final VectorSchemaRoot root;
+
+    public Statistics(BufferAllocator bufferAllocator,
+                      long numDocs,
+                      long sizeInBytes,
+                      Map<ColumnIdent, ColumnStats<?>> statsByColumn) {
+        this.root = VectorSchemaRoot.create(schema(), bufferAllocator);
+
+        BigIntVector numDocsVector = (BigIntVector) root.getVector("numDocs");
+        numDocsVector.allocateNew(1);
+        numDocsVector.set(0, numDocs);
+        numDocsVector.setValueCount(1);
+
+        BigIntVector sizeInBytesVector = (BigIntVector) root.getVector("sizeInBytes");
+        sizeInBytesVector.allocateNew(1);
+        sizeInBytesVector.set(0, sizeInBytes);
+        sizeInBytesVector.setValueCount(1);
+
+        StructVector statsByColumnVector = (StructVector) root.getVector("statsByColumn");
+        statsByColumnVector.allocateNew();
+
+        NullableStructWriter structWriter = statsByColumnVector.getWriter();
+        structWriter.allocate();
+
+        for (Map.Entry<ColumnIdent, ColumnStats<?>> columnIdentColumnStatsEntry : statsByColumn.entrySet()) {
+            ColumnIdent columnIdent = columnIdentColumnStatsEntry.getKey();
+            ColumnStats<?> columnStats = columnIdentColumnStatsEntry.getValue();
+            structWriter.start();
+            structWriter.varChar("columnIdent").writeVarChar(columnIdent.fqn());
+            structWriter.float8("nullFraction").writeFloat8(columnStats.nullFraction());
+            structWriter.float8("averageSizeInBytes").writeFloat8(columnStats.averageSizeInBytes());
+            structWriter.float8("approxDistinct").writeFloat8(columnStats.approxDistinct());
+            structWriter.integer("type").writeInt(columnStats.type().id());
+            structWriter.end();
+        }
+
+        structWriter.setValueCount(statsByColumn.size());
+        statsByColumnVector.setValueCount(statsByColumn.size());
+    }
+
+    private Statistics(VectorSchemaRoot root) {
+        this.root = root;
+    }
+
+    public Statistics(BufferAllocator bufferAllocator, InputStream in) throws IOException {
+        try (ArrowStreamReader reader = new ArrowStreamReader(in, bufferAllocator)) {
+            reader.loadNextBatch();
+            try (VectorSchemaRoot source = reader.getVectorSchemaRoot()) {
+                VectorUnloader unloader = new VectorUnloader(source);
+                VectorSchemaRoot copy = VectorSchemaRoot.create(source.getSchema(), bufferAllocator);
+                VectorLoader loader = new VectorLoader(copy);
+                try (ArrowRecordBatch recordBatch = unloader.getRecordBatch()) {
+                    loader.load(recordBatch);
+                    this.root = copy;
+                }
+            }
+        }
+    }
+
+    public long numDocs() {
+        BigIntVector numDocsVector = (BigIntVector) root.getVector("numDocs");
+        return numDocsVector.get(0);
+    }
+
+    public long sizeInBytes() {
+        BigIntVector sizeInBytesVector = (BigIntVector) root.getVector("sizeInBytes");
+        return sizeInBytesVector.get(0);
+    }
+
+    public Map<ColumnIdent, ColumnStats<?>> statsByColumn() {
+        Map<ColumnIdent, ColumnStats<?>> result = new HashMap<>();
+        StructVector statsByColumn = (StructVector) root.getVector("statsByColumn");
+        NullableStructReaderImpl structReader = statsByColumn.getReader();
+        for (int i = 0; i < statsByColumn.getValueCount(); i++) {
+            structReader.setPosition(i);
+            ColumnIdent columnIdent = ColumnIdent.of(structReader.reader("columnIdent").readText().toString());
+
+            ColumnStats<?> columnStats = new ColumnStats<>(
+                structReader.reader("nullFraction").readDouble(),
+                structReader.reader("averageSizeInBytes").readDouble(),
+                structReader.reader("approxDistinct").readDouble(),
+                DataTypes.fromId(structReader.reader("type").readInteger()),
+                MostCommonValues.empty(),
+                List.of()
+            );
+            result.put(columnIdent, columnStats);
+        }
+        return result;
+    }
+
+    static Schema schema() {
+        List<Field> fields = new ArrayList<>();
+        fields.add(Field.notNullable("numDocs", new ArrowType.Int(64, true)));
+        fields.add(Field.notNullable("sizeInBytes", new ArrowType.Int(64, true)));
+
+        List<Field> columnStatsFields = new ArrayList<>();
+        columnStatsFields.add(Field.notNullable("columnIdent", new ArrowType.Utf8()));
+        columnStatsFields.add(Field.notNullable("nullFraction", new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE)));
+        columnStatsFields.add(Field.notNullable("averageSizeInBytes", new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE)));
+        columnStatsFields.add(Field.notNullable("approxDistinct", new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE)));
+        columnStatsFields.add(Field.notNullable("type", new ArrowType.Int(32, true)));
+
+        fields.add(new Field("statsByColumn", FieldType.notNullable(new ArrowType.Struct()), columnStatsFields));
+        return new Schema(fields);
+    }
+
+    public long averageSizePerRowInBytes() {
+        long numDocs = numDocs();
+        if (numDocs == -1) {
+            return -1;
+        } else if (numDocs == 0) {
+            return 0;
+        } else {
+            return sizeInBytes() / numDocs;
+        }
+    }
+
+    public void write(File file) throws IOException {
+        try (
+            FileOutputStream out = new FileOutputStream(file);
+            ArrowStreamWriter writer = new ArrowStreamWriter(this.root, null, out.getChannel());
+        ) {
+            writer.start();
+            writer.writeBatch();
+        }
+    }
+
+    public static Statistics read(BufferAllocator bufferAllocator, File file) throws IOException {
+        try (
+            FileInputStream fileInputStreamForStream = new FileInputStream(file);
+            ArrowStreamReader reader = new ArrowStreamReader(fileInputStreamForStream, bufferAllocator)
+        ) {
+            reader.loadNextBatch();
+            VectorSchemaRoot root = reader.getVectorSchemaRoot();
+            return new Statistics(root);
+        }
+    }
+
+    public void write(StreamOutput out) throws IOException {
+        try (ArrowStreamWriter writer = new ArrowStreamWriter(root, null, Channels.newChannel(out))) {
+            writer.start();
+            writer.writeBatch();
+        }
+    }
+
+    public void close() {
+        this.root.close();
+    }
+}

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -219,6 +219,7 @@ import io.crate.role.Roles;
 import io.crate.role.RolesService;
 import io.crate.session.Sessions;
 import io.crate.statistics.TableStats;
+import io.crate.statistics.arrow.ArrowBufferAllocator;
 import io.crate.types.DataTypes;
 import io.crate.udc.service.UDCService;
 
@@ -1253,7 +1254,7 @@ public class Node implements Closeable {
         // awaitClose if the node doesn't finish closing within the specified time.
         toClose.add(() -> stopWatch.stop());
 
-
+        ArrowBufferAllocator.close();
 
         if (logger.isTraceEnabled()) {
             logger.trace("Close times for each service:\n{}", stopWatch.prettyPrint());

--- a/server/src/test/java/io/crate/statistics/arrow/StatisticsTest.java
+++ b/server/src/test/java/io/crate/statistics/arrow/StatisticsTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.statistics.arrow;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.test.ESTestCase;
+import org.junit.Test;
+
+import io.crate.metadata.ColumnIdent;
+import io.crate.statistics.ColumnStats;
+import io.crate.statistics.MostCommonValues;
+import io.crate.types.DataTypes;
+
+public class StatisticsTest extends ESTestCase {
+
+    final Map<ColumnIdent, ColumnStats<?>> columnStats = Map.of(
+        ColumnIdent.of("a"), new ColumnStats<>(1.0D, 2.0D, 3.0D, DataTypes.INTEGER, MostCommonValues.empty(), List.of()),
+        ColumnIdent.of("b"), new ColumnStats<>(3.0D, 4.0D, 5.0D, DataTypes.INTEGER, MostCommonValues.empty(), List.of()),
+        ColumnIdent.of("c"), new ColumnStats<>(6.0D, 7.0D, 8.0D, DataTypes.INTEGER, MostCommonValues.empty(), List.of())
+    );
+
+    @Test
+    public void test_basic() {
+        Map<ColumnIdent, ColumnStats<?>> statsByColumn = columnStats;
+        try (BufferAllocator bufferAllocator = new RootAllocator()) {
+            Statistics statistics = new Statistics(bufferAllocator, 1L, 200L, statsByColumn);
+            assertThat(statistics.numDocs()).isEqualTo(1);
+            assertThat(statistics.sizeInBytes()).isEqualTo(200L);
+            var result = statistics.statsByColumn();
+            assertThat(result).isEqualTo(statsByColumn);
+            statistics.close();
+        }
+    }
+
+    @Test
+    public void test_streaming() throws IOException {
+        try (BufferAllocator bufferAllocator = new RootAllocator();
+            BytesStreamOutput out = new BytesStreamOutput()) {
+            Statistics statistics = new Statistics(bufferAllocator, 1L, 200L, columnStats);
+            statistics.write(out);
+            Statistics fromStream = new Statistics(bufferAllocator, out.bytes().streamInput());
+            assertThat(statistics.numDocs()).isEqualTo(fromStream.numDocs());
+            assertThat(statistics.sizeInBytes()).isEqualTo(fromStream.sizeInBytes());
+            assertThat(statistics.statsByColumn()).isEqualTo(fromStream.statsByColumn());
+            fromStream.close();
+            statistics.close();
+        }
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This is a POC modelling the TableStats with Apache Arrow. We said we wanted to have the ability to serialize Stats on a per-table basis, therefore one Stats class is modelled with Apache Arrow vectors. In this way we can persist Stats for each table individually. 

@mfussenegger could you provide some early feedback on this ?


## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
