### PR TITLE
Remove logging only params from ChannelActionListener

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/support/ChannelActionListener.java
+++ b/server/src/main/java/org/elasticsearch/action/support/ChannelActionListener.java
@@ -21,24 +21,17 @@ package org.elasticsearch.action.support;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.transport.TransportChannel;
-import org.elasticsearch.transport.TransportRequest;
 import org.elasticsearch.transport.TransportResponse;
 
-public final class ChannelActionListener<
-    Response extends TransportResponse, Request extends TransportRequest> implements ActionListener<Response> {
+public final class ChannelActionListener<Response extends TransportResponse> implements ActionListener<Response> {
 
     private static final Logger LOGGER = LogManager.getLogger(ChannelActionListener.class);
     private final TransportChannel channel;
-    private final Request request;
-    private final String actionName;
 
-    public ChannelActionListener(TransportChannel channel, String actionName, Request request) {
+    public ChannelActionListener(TransportChannel channel) {
         this.channel = channel;
-        this.request = request;
-        this.actionName = actionName;
     }
 
     @Override
@@ -56,8 +49,7 @@ public final class ChannelActionListener<
             channel.sendResponse(e);
         } catch (Exception e1) {
             e1.addSuppressed(e);
-            LOGGER.warn(() -> new ParameterizedMessage(
-                "Failed to send error response for action [{}] and request [{}]", actionName, request), e1);
+            LOGGER.warn("Failed to send error response on channel={} err={}", channel, e1);
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/support/HandledTransportAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/HandledTransportAction.java
@@ -61,7 +61,7 @@ public abstract class HandledTransportAction<Request extends TransportRequest, R
     class TransportHandler implements TransportRequestHandler<Request> {
         @Override
         public final void messageReceived(final Request request, final TransportChannel channel) throws Exception {
-            execute(request).whenComplete(new ChannelActionListener<>(channel, actionName, request));
+            execute(request).whenComplete(new ChannelActionListener<>(channel));
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
@@ -278,12 +278,11 @@ public abstract class TransportReplicationAction<
     }
 
     protected void handleOperationRequest(final Request request, final TransportChannel channel) {
-        execute(request).whenComplete(new ChannelActionListener<>(channel, actionName, request));
+        execute(request).whenComplete(new ChannelActionListener<>(channel));
     }
 
     protected void handlePrimaryRequest(final ConcreteShardRequest<Request> request, final TransportChannel channel) {
-        new AsyncPrimaryAction(
-            request, new ChannelActionListener<>(channel, transportPrimaryAction, request)).run();
+        new AsyncPrimaryAction(request, new ChannelActionListener<>(channel)).run();
     }
 
     class AsyncPrimaryAction implements RejectableRunnable {
@@ -478,8 +477,7 @@ public abstract class TransportReplicationAction<
 
     protected void handleReplicaRequest(final ConcreteReplicaRequest<ReplicaRequest> replicaRequest,
                                         final TransportChannel channel) {
-        new AsyncReplicaAction(
-            replicaRequest, new ChannelActionListener<>(channel, transportReplicaAction, replicaRequest)).run();
+        new AsyncReplicaAction(replicaRequest, new ChannelActionListener<>(channel)).run();
     }
 
     public static class RetryOnReplicaException extends ElasticsearchException {

--- a/server/src/main/java/org/elasticsearch/action/support/single/shard/TransportSingleShardAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/single/shard/TransportSingleShardAction.java
@@ -270,7 +270,7 @@ public abstract class TransportSingleShardAction<Request extends SingleShardRequ
         @Override
         public void messageReceived(Request request, final TransportChannel channel) throws Exception {
             // if we have a local operation, execute it on a thread since we don't spawn
-            execute(request).whenComplete(new ChannelActionListener<>(channel, actionName, request));
+            execute(request).whenComplete(new ChannelActionListener<>(channel));
         }
     }
 
@@ -281,9 +281,7 @@ public abstract class TransportSingleShardAction<Request extends SingleShardRequ
             if (logger.isTraceEnabled()) {
                 logger.trace("executing [{}] on shard [{}]", request, request.internalShardId);
             }
-            asyncShardOperation(request,
-                                request.internalShardId,
-                                new ChannelActionListener<>(channel, transportShardAction, request));
+            asyncShardOperation(request, request.internalShardId, new ChannelActionListener<>(channel));
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoverySourceService.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoverySourceService.java
@@ -180,14 +180,14 @@ public class PeerRecoverySourceService extends AbstractLifecycleComponent implem
 
         @Override
         public void messageReceived(final StartRecoveryRequest request, final TransportChannel channel) throws Exception {
-            recover(request, new ChannelActionListener<>(channel, Actions.START_RECOVERY, request));
+            recover(request, new ChannelActionListener<>(channel));
         }
     }
 
     class ReestablishRecoveryTransportRequestHandler implements TransportRequestHandler<ReestablishRecoveryRequest> {
         @Override
         public void messageReceived(ReestablishRecoveryRequest request, TransportChannel channel) throws Exception {
-            reestablish(request, new ChannelActionListener<>(channel, Actions.REESTABLISH_RECOVERY, request));
+            reestablish(request, new ChannelActionListener<>(channel));
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetService.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetService.java
@@ -366,7 +366,7 @@ public class PeerRecoveryTargetService implements IndexEventListener {
             boolean success = false;
             try {
                 recoveryRef.target().handoffPrimaryContext(request.primaryContext(),
-                    ActionListener.runBefore(new ChannelActionListener<>(channel, Actions.HANDOFF_PRIMARY_CONTEXT, request)
+                    ActionListener.runBefore(new ChannelActionListener<>(channel)
                         .map(v -> TransportResponse.Empty.INSTANCE), recoveryRef::close));
                 success = true;
             } finally {
@@ -532,7 +532,7 @@ public class PeerRecoveryTargetService implements IndexEventListener {
                                                         final String action, final RecoveryTransportRequest request,
                                                         final CheckedFunction<Void, TransportResponse, Exception> responseFn) {
         final RecoveryTarget recoveryTarget = recoveryRef.target();
-        final ActionListener<TransportResponse> channelListener = new ChannelActionListener<>(channel, action, request);
+        final ActionListener<TransportResponse> channelListener = new ChannelActionListener<>(channel);
         final ActionListener<Void> voidListener = channelListener.map(responseFn);
 
         final long requestSeqNo = request.requestSeqNo();

--- a/server/src/main/java/org/elasticsearch/transport/InboundHandler.java
+++ b/server/src/main/java/org/elasticsearch/transport/InboundHandler.java
@@ -156,7 +156,9 @@ public class InboundHandler {
         }
     }
 
-    private <T extends TransportRequest> void handleRequest(CloseableChannel channel, Header header, InboundMessage message) throws IOException {
+    private <T extends TransportRequest> void handleRequest(CloseableChannel channel,
+                                                            Header header,
+                                                            InboundMessage message) throws IOException {
         final String action = header.getActionName();
         final long requestId = header.getRequestId();
         final Version version = header.getVersion();
@@ -189,8 +191,16 @@ public class InboundHandler {
                 }
             }
         } else {
-            final TransportChannel transportChannel = new TcpTransportChannel(outboundHandler, channel, action, requestId, version,
-                header.isCompressed(), header.isHandshake(), message.takeBreakerReleaseControl());
+            final TransportChannel transportChannel = new TcpTransportChannel(
+                outboundHandler,
+                channel,
+                action,
+                requestId,
+                version,
+                header.isCompressed(),
+                header.isHandshake(),
+                message.takeBreakerReleaseControl()
+            );
             try {
                 messageListener.onRequestReceived(requestId, action);
                 if (message.isShortCircuit()) {

--- a/server/src/main/java/org/elasticsearch/transport/TcpTransportChannel.java
+++ b/server/src/main/java/org/elasticsearch/transport/TcpTransportChannel.java
@@ -100,5 +100,10 @@ public final class TcpTransportChannel implements TransportChannel {
     public CloseableChannel getChannel() {
         return channel;
     }
+
+    @Override
+    public String toString() {
+        return "TcpTransportChannel{action=" + action + ", channel=" + channel + "}";
+    }
 }
 


### PR DESCRIPTION
This insteads adds a `toString()` implementation to the
`TcpTransportChannel` to still log the action name.
