### PR TITLE
Remove unused finalFailure from PrimaryResult

### DIFF
--- a/server/src/main/java/io/crate/execution/dml/delete/TransportShardDeleteAction.java
+++ b/server/src/main/java/io/crate/execution/dml/delete/TransportShardDeleteAction.java
@@ -136,7 +136,7 @@ public class TransportShardDeleteAction extends TransportShardAction<ShardDelete
             }
         }
 
-        return new WritePrimaryResult<>(request, shardResponse, translogLocation, null, indexShard);
+        return new WritePrimaryResult<>(request, shardResponse, translogLocation, indexShard);
     }
 
     @Override

--- a/server/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
+++ b/server/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
@@ -273,7 +273,7 @@ public class TransportShardUpsertAction extends TransportShardAction<ShardUpsert
                 break;
             }
         }
-        return new WritePrimaryResult<>(request, shardResponse, translogLocation, null, indexShard);
+        return new WritePrimaryResult<>(request, shardResponse, translogLocation, indexShard);
     }
 
     private static boolean noItemsToIndexOnReplica(ShardUpsertRequest req) {

--- a/server/src/main/java/io/crate/replication/logical/action/ReplayChangesAction.java
+++ b/server/src/main/java/io/crate/replication/logical/action/ReplayChangesAction.java
@@ -129,7 +129,6 @@ public class ReplayChangesAction extends ActionType<ReplicationResponse> {
                     new Request(primary.shardId(), replicaOps, request.maxSeqNoOfUpdatesOrDeletes()),
                     new ReplicationResponse(),
                     location,
-                    null,
                     primary)
                 );
             }, listener::onFailure);

--- a/server/src/main/java/org/elasticsearch/action/resync/TransportResyncReplicationAction.java
+++ b/server/src/main/java/org/elasticsearch/action/resync/TransportResyncReplicationAction.java
@@ -93,7 +93,7 @@ public class TransportResyncReplicationAction extends TransportWriteAction<Resyn
                                            IndexShard primary,
                                            ActionListener<PrimaryResult<ResyncReplicationRequest, ReplicationResponse>> listener) {
         try {
-            listener.onResponse(new WritePrimaryResult<>(performOnPrimary(request), new ReplicationResponse(), null, null, primary));
+            listener.onResponse(new WritePrimaryResult<>(performOnPrimary(request), new ReplicationResponse(), null, primary));
         } catch (Exception ex) {
             listener.onFailure(ex);
         }

--- a/server/src/main/java/org/elasticsearch/action/resync/TransportResyncReplicationAction.java
+++ b/server/src/main/java/org/elasticsearch/action/resync/TransportResyncReplicationAction.java
@@ -93,14 +93,10 @@ public class TransportResyncReplicationAction extends TransportWriteAction<Resyn
                                            IndexShard primary,
                                            ActionListener<PrimaryResult<ResyncReplicationRequest, ReplicationResponse>> listener) {
         try {
-            listener.onResponse(new WritePrimaryResult<>(performOnPrimary(request), new ReplicationResponse(), null, primary));
+            listener.onResponse(new WritePrimaryResult<>(request, new ReplicationResponse(), null, primary));
         } catch (Exception ex) {
             listener.onFailure(ex);
         }
-    }
-
-    public static ResyncReplicationRequest performOnPrimary(ResyncReplicationRequest request) {
-        return request;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
@@ -27,7 +27,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.lucene.store.AlreadyClosedException;
-import org.elasticsearch.Assertions;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionListenerResponseHandler;
@@ -387,11 +386,19 @@ public abstract class TransportReplicationAction<
                         onCompletionListener.onResponse(response);
                     }, e -> handleException(primaryShardReference, e));
 
-                    new ReplicationOperation<>(primaryRequest.getRequest(), primaryShardReference,
+                    var replicationOperation = new ReplicationOperation<>(
+                        primaryRequest.getRequest(),
+                        primaryShardReference,
                         responseListener.map(result -> result.finalResponseIfSuccessful),
-                        newReplicasProxy(), logger, threadPool, actionName, primaryRequest.getPrimaryTerm(), initialRetryBackoffBound,
-                        retryTimeout)
-                        .execute();
+                        newReplicasProxy(),
+                        logger,
+                        threadPool,
+                        actionName,
+                        primaryRequest.getPrimaryTerm(),
+                        initialRetryBackoffBound,
+                        retryTimeout
+                    );
+                    replicationOperation.execute();
                 }
             } catch (Exception e) {
                 Releasables.closeIgnoringException(primaryShardReference); // release shard operation lock before responding to caller
@@ -415,23 +422,14 @@ public abstract class TransportReplicationAction<
             implements ReplicationOperation.PrimaryResult<ReplicaRequest> {
         protected final ReplicaRequest replicaRequest;
         public final Response finalResponseIfSuccessful;
-        public final Exception finalFailure;
 
         /**
          * Result of executing a primary operation
          * expects <code>finalResponseIfSuccessful</code> or <code>finalFailure</code> to be not-null
          */
-        public PrimaryResult(ReplicaRequest replicaRequest, Response finalResponseIfSuccessful, Exception finalFailure) {
-            assert finalFailure != null ^ finalResponseIfSuccessful != null
-                    : "either a response or a failure has to be not null, " +
-                    "found [" + finalFailure + "] failure and [" + finalResponseIfSuccessful + "] response";
+        public PrimaryResult(ReplicaRequest replicaRequest, Response finalResponseIfSuccessful) {
             this.replicaRequest = replicaRequest;
             this.finalResponseIfSuccessful = finalResponseIfSuccessful;
-            this.finalFailure = finalFailure;
-        }
-
-        public PrimaryResult(ReplicaRequest replicaRequest, Response replicationResponse) {
-            this(replicaRequest, replicationResponse, null);
         }
 
         @Override
@@ -448,11 +446,7 @@ public abstract class TransportReplicationAction<
 
         @Override
         public void runPostReplicationActions(ActionListener<Void> listener) {
-            if (finalFailure != null) {
-                listener.onFailure(finalFailure);
-            } else {
-                listener.onResponse(null);
-            }
+            listener.onResponse(null);
         }
     }
 
@@ -879,13 +873,6 @@ public abstract class TransportReplicationAction<
 
         @Override
         public void perform(Request request, ActionListener<PrimaryResult<ReplicaRequest, Response>> listener) {
-            if (Assertions.ENABLED) {
-                listener = listener.map(result -> {
-                    assert result.replicaRequest() == null || result.finalFailure == null : "a replica request [" + result.replicaRequest()
-                        + "] with a primary failure [" + result.finalFailure + "]";
-                    return result;
-                });
-            }
             assert indexShard.getActiveOperationsCount() != 0 : "must perform shard operation under a permit";
             shardOperationOnPrimary(request, indexShard, listener);
         }

--- a/server/src/main/java/org/elasticsearch/action/support/replication/TransportWriteAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/TransportWriteAction.java
@@ -121,29 +121,21 @@ public abstract class TransportWriteAction<
         public final IndexShard primary;
 
         public WritePrimaryResult(ReplicaRequest request,
-                                  @Nullable Response finalResponse,
+                                  Response finalResponse,
                                   @Nullable Location location,
-                                  @Nullable Exception operationFailure,
                                   IndexShard primary) {
-            super(request, finalResponse, operationFailure);
+            super(request, finalResponse);
             this.location = location;
             this.primary = primary;
-            assert location == null || operationFailure == null
-                    : "expected either failure to be null or translog location to be null, " +
-                    "but found: [" + location + "] translog location and [" + operationFailure + "] failure";
         }
 
         @Override
         public void runPostReplicationActions(ActionListener<Void> listener) {
-            if (finalFailure != null) {
-                listener.onFailure(finalFailure);
-            } else {
-                /*
-                 * We call this after replication because this might wait for a refresh and that can take a while.
-                 * This way we wait for the refresh in parallel on the primary and on the replica.
-                 */
-                new AsyncAfterWriteAction(primary, location, listener).run();
-            }
+            /*
+                * We call this after replication because this might wait for a refresh and that can take a while.
+                * This way we wait for the refresh in parallel on the primary and on the replica.
+                */
+            new AsyncAfterWriteAction(primary, location, listener).run();
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/seqno/RetentionLeaseSyncAction.java
+++ b/server/src/main/java/org/elasticsearch/index/seqno/RetentionLeaseSyncAction.java
@@ -135,7 +135,7 @@ public class RetentionLeaseSyncAction extends
             Objects.requireNonNull(request);
             Objects.requireNonNull(primary);
             primary.persistRetentionLeases();
-            listener.onResponse(new WritePrimaryResult<>(request, new ReplicationResponse(), null, null, primary));
+            listener.onResponse(new WritePrimaryResult<>(request, new ReplicationResponse(), null, primary));
         } catch (Exception ex) {
             listener.onFailure(ex);
         }


### PR DESCRIPTION
All usages always passed `null`.
Errors are thrown/handled via listener.onFailure, instead of setting
them on the result.
