### PR TITLE
Remove failure from ReplicaResult

### DIFF
--- a/server/src/main/java/io/crate/execution/dml/delete/TransportShardDeleteAction.java
+++ b/server/src/main/java/io/crate/execution/dml/delete/TransportShardDeleteAction.java
@@ -166,7 +166,7 @@ public class TransportShardDeleteAction extends TransportShardAction<ShardDelete
                 }
             }
         }
-        return new WriteReplicaResult(translogLocation, null, indexShard);
+        return new WriteReplicaResult(translogLocation, indexShard);
     }
 
     private Engine.DeleteResult shardDeleteOperationOnPrimary(ShardDeleteRequest.Item item, IndexShard indexShard) throws IOException {

--- a/server/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
+++ b/server/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
@@ -295,7 +295,7 @@ public class TransportShardUpsertAction extends TransportShardAction<ShardUpsert
             // this should mean that there are either no items to index, or that
             // all items on the primary errored out and so should be ignored.
             assert noItemsToIndexOnReplica(request);
-            return new WriteReplicaResult(null, null, indexShard);
+            return new WriteReplicaResult(null, indexShard);
         }
 
         Translog.Location location = null;
@@ -398,7 +398,7 @@ public class TransportShardUpsertAction extends TransportShardAction<ShardUpsert
             assert result.getSeqNo() == item.seqNo() : "Result of replica index operation must have item seqNo";
             location = locationToSync(location, result.getTranslogLocation());
         }
-        return new WriteReplicaResult(location, null, indexShard);
+        return new WriteReplicaResult(location, indexShard);
     }
 
     /**

--- a/server/src/main/java/io/crate/replication/logical/action/ReplayChangesAction.java
+++ b/server/src/main/java/io/crate/replication/logical/action/ReplayChangesAction.java
@@ -218,7 +218,7 @@ public class ReplayChangesAction extends ActionType<ReplicationResponse> {
         @Override
         protected WriteReplicaResult shardOperationOnReplica(Request request, IndexShard replica) throws Exception {
             Translog.Location location = performOnReplica(request, replica);
-            return new WriteReplicaResult(location, null, replica);
+            return new WriteReplicaResult(location, replica);
         }
 
         private Translog.Location performOnReplica(Request request, IndexShard replica) throws Exception {

--- a/server/src/main/java/org/elasticsearch/action/resync/TransportResyncReplicationAction.java
+++ b/server/src/main/java/org/elasticsearch/action/resync/TransportResyncReplicationAction.java
@@ -103,7 +103,7 @@ public class TransportResyncReplicationAction extends TransportWriteAction<Resyn
     protected WriteReplicaResult shardOperationOnReplica(ResyncReplicationRequest request,
                                                          IndexShard replica) throws Exception {
         Translog.Location location = performOnReplica(request, replica);
-        return new WriteReplicaResult(location, null, replica);
+        return new WriteReplicaResult(location, replica);
     }
 
     public static Translog.Location performOnReplica(ResyncReplicationRequest request, IndexShard replica) throws Exception {

--- a/server/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
@@ -450,22 +450,12 @@ public abstract class TransportReplicationAction<
     }
 
     public static class ReplicaResult {
-        final Exception finalFailure;
-
-        public ReplicaResult(@Nullable Exception finalFailure) {
-            this.finalFailure = finalFailure;
-        }
 
         public ReplicaResult() {
-            this(null);
         }
 
         public void runPostReplicaActions(ActionListener<Void> listener) {
-            if (finalFailure != null) {
-                listener.onFailure(finalFailure);
-            } else {
-                listener.onResponse(null);
-            }
+            listener.onResponse(null);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/action/support/replication/TransportWriteAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/TransportWriteAction.java
@@ -146,21 +146,14 @@ public abstract class TransportWriteAction<
         private final Location location;
         private final IndexShard replica;
 
-        public WriteReplicaResult(@Nullable Location location,
-                                  @Nullable Exception operationFailure,
-                                  IndexShard replica) {
-            super(operationFailure);
+        public WriteReplicaResult(@Nullable Location location, IndexShard replica) {
             this.location = location;
             this.replica = replica;
         }
 
         @Override
         public void runPostReplicaActions(ActionListener<Void> listener) {
-            if (finalFailure == null) {
-                new AsyncAfterWriteAction(replica, location, listener).run();
-            } else {
-                listener.onFailure(finalFailure);
-            }
+            new AsyncAfterWriteAction(replica, location, listener).run();
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/seqno/RetentionLeaseSyncAction.java
+++ b/server/src/main/java/org/elasticsearch/index/seqno/RetentionLeaseSyncAction.java
@@ -147,7 +147,7 @@ public class RetentionLeaseSyncAction extends
         Objects.requireNonNull(replica);
         replica.updateRetentionLeasesOnReplica(request.getRetentionLeases());
         replica.persistRetentionLeases();
-        return new WriteReplicaResult(null, null, replica);
+        return new WriteReplicaResult(null, replica);
     }
 
     @Override


### PR DESCRIPTION
Same change as https://github.com/crate/crate/pull/18024 but for the replica.
The errors get thrown instead of set on the `ReplicaResult`. All usages
passed `null`.
