### PR TITLE
Make SysClusterHealth/TableHealth.compute synchronous

### DIFF
--- a/server/src/main/java/io/crate/metadata/sys/SysTableDefinitions.java
+++ b/server/src/main/java/io/crate/metadata/sys/SysTableDefinitions.java
@@ -35,7 +35,6 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.repositories.RepositoriesService;
 
-import io.crate.session.Sessions;
 import io.crate.execution.engine.collect.files.SummitsIterable;
 import io.crate.execution.engine.collect.stats.JobsLogs;
 import io.crate.expression.reference.StaticTableDefinition;
@@ -54,6 +53,7 @@ import io.crate.role.Securable;
 import io.crate.role.metadata.SysPrivilegesTableInfo;
 import io.crate.role.metadata.SysRolesTableInfo;
 import io.crate.role.metadata.SysUsersTableInfo;
+import io.crate.session.Sessions;
 
 public class SysTableDefinitions {
 
@@ -204,7 +204,7 @@ public class SysTableDefinitions {
             Map.entry(
                 SysHealth.IDENT,
                 new StaticTableDefinition<>(
-                    () -> TableHealth.compute(clusterService.state()),
+                    () -> completedFuture(TableHealth.compute(clusterService.state())),
                     SysHealth.INSTANCE.expressions(),
                     (user, tableHealth) -> roles.hasAnyPrivilege(user, Securable.TABLE, tableHealth.fqn()),
                     true
@@ -213,7 +213,7 @@ public class SysTableDefinitions {
             Map.entry(
                 SysClusterHealth.IDENT,
                 new StaticTableDefinition<>(
-                    () -> SysClusterHealth.compute(clusterService.state(), clusterService.getMasterService().numberOfPendingTasks()),
+                    () -> completedFuture(SysClusterHealth.compute(clusterService.state(), clusterService.getMasterService().numberOfPendingTasks())),
                     SysClusterHealth.INSTANCE.expressions(),
                     false
                 )

--- a/server/src/main/java/io/crate/metadata/sys/TableHealth.java
+++ b/server/src/main/java/io/crate/metadata/sys/TableHealth.java
@@ -21,9 +21,6 @@
 
 package io.crate.metadata.sys;
 
-import static java.util.concurrent.CompletableFuture.completedFuture;
-
-import java.util.concurrent.CompletableFuture;
 import java.util.stream.StreamSupport;
 
 import org.elasticsearch.cluster.ClusterState;
@@ -45,13 +42,11 @@ class TableHealth {
         }
     }
 
-    public static CompletableFuture<Iterable<TableHealth>> compute(ClusterState clusterState) {
+    public static Iterable<TableHealth> compute(ClusterState clusterState) {
         var clusterHealth = new ClusterStateHealth(clusterState);
-        return completedFuture(
-            StreamSupport.stream(clusterHealth.spliterator(), false)
-                .filter(i -> IndexName.isDangling(i.getIndex()) == false)
-                .map(TableHealth::map)::iterator
-        );
+        return StreamSupport.stream(clusterHealth.spliterator(), false)
+            .filter(i -> IndexName.isDangling(i.getIndex()) == false)
+            .map(TableHealth::map)::iterator;
     }
 
     private static TableHealth map(ClusterIndexHealth indexHealth) {

--- a/server/src/test/java/io/crate/metadata/sys/SysClusterHealthTest.java
+++ b/server/src/test/java/io/crate/metadata/sys/SysClusterHealthTest.java
@@ -42,7 +42,7 @@ public class SysClusterHealthTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void test_green_no_tables() {
-        var healths = SysClusterHealth.compute(clusterService.state(), 0).join();
+        var healths = SysClusterHealth.compute(clusterService.state(), 0);
         var expected = new SysClusterHealth.ClusterHealth(
             TableHealth.Health.GREEN,
             "",
@@ -59,7 +59,7 @@ public class SysClusterHealthTest extends CrateDummyClusterServiceUnitTest {
             .addTable("create table doc.t1 (id int) with (number_of_replicas = 0)");
         executor.startShards("doc.t1");
 
-        var healths = SysClusterHealth.compute(clusterService.state(), 0).join();
+        var healths = SysClusterHealth.compute(clusterService.state(), 0);
         var expected = new SysClusterHealth.ClusterHealth(
             TableHealth.Health.GREEN,
             "",
@@ -85,7 +85,7 @@ public class SysClusterHealthTest extends CrateDummyClusterServiceUnitTest {
         var newState = ClusterState.builder(clusterService.state())
             .blocks(ClusterBlocks.builder().addGlobalBlock(globalBlock))
             .build();
-        var healths = SysClusterHealth.compute(newState, 0).join();
+        var healths = SysClusterHealth.compute(newState, 0);
         var expected = new SysClusterHealth.ClusterHealth(
             TableHealth.Health.YELLOW,
             "cannot write metadata",
@@ -101,7 +101,7 @@ public class SysClusterHealthTest extends CrateDummyClusterServiceUnitTest {
         SQLExecutor executor = SQLExecutor.builder(clusterService).build()
             .addTable("create table doc.t1 (id int) with (number_of_replicas = 1)");
 
-        var healths = SysClusterHealth.compute(clusterService.state(), 0).join();
+        var healths = SysClusterHealth.compute(clusterService.state(), 0);
         var expected = new SysClusterHealth.ClusterHealth(
             TableHealth.Health.YELLOW,
             "One or more tables are missing shards",
@@ -113,7 +113,7 @@ public class SysClusterHealthTest extends CrateDummyClusterServiceUnitTest {
 
         executor.startShards("doc.t1");
 
-        healths = SysClusterHealth.compute(clusterService.state(), 0).join();
+        healths = SysClusterHealth.compute(clusterService.state(), 0);
         expected = new SysClusterHealth.ClusterHealth(
             TableHealth.Health.YELLOW,
             "One or more tables have underreplicated shards",
@@ -143,7 +143,7 @@ public class SysClusterHealthTest extends CrateDummyClusterServiceUnitTest {
         var newState = ClusterState.builder(clusterService.state())
             .blocks(ClusterBlocks.builder().addGlobalBlock(globalBlock))
             .build();
-        var healths = SysClusterHealth.compute(newState, 0).join();
+        var healths = SysClusterHealth.compute(newState, 0);
         var expected = new SysClusterHealth.ClusterHealth(
             TableHealth.Health.YELLOW,
             "Cannot write metadata",    // cluster level message takes precedence
@@ -172,7 +172,7 @@ public class SysClusterHealthTest extends CrateDummyClusterServiceUnitTest {
         var newState = ClusterState.builder(clusterService.state())
                 .blocks(ClusterBlocks.builder().addGlobalBlock(globalBlock))
                 .build();
-        var healths = SysClusterHealth.compute(newState, 0).join();
+        var healths = SysClusterHealth.compute(newState, 0);
         var expected = new SysClusterHealth.ClusterHealth(
             TableHealth.Health.RED,
             "recovering",   // cluster level message takes precedence
@@ -190,7 +190,7 @@ public class SysClusterHealthTest extends CrateDummyClusterServiceUnitTest {
         executor.startShards("doc.t1");
         executor.failShards("doc.t1");
 
-        var healths = SysClusterHealth.compute(clusterService.state(), 0).join();
+        var healths = SysClusterHealth.compute(clusterService.state(), 0);
         var expected = new SysClusterHealth.ClusterHealth(
             TableHealth.Health.RED,
             "One or more tables are missing shards",
@@ -203,7 +203,7 @@ public class SysClusterHealthTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void test_pending_tasks() throws Exception {
-        var healths = SysClusterHealth.compute(clusterService.state(), 1).join();
+        var healths = SysClusterHealth.compute(clusterService.state(), 1);
         assertThat(healths).containsExactly(new SysClusterHealth.ClusterHealth(
             TableHealth.Health.GREEN,
             "",
@@ -212,7 +212,7 @@ public class SysClusterHealthTest extends CrateDummyClusterServiceUnitTest {
             1
         ));
 
-        healths = SysClusterHealth.compute(clusterService.state(), 0).join();
+        healths = SysClusterHealth.compute(clusterService.state(), 0);
         assertThat(healths).containsExactly(new SysClusterHealth.ClusterHealth(
             TableHealth.Health.GREEN,
             "",


### PR DESCRIPTION
Having the methods return futures gives the impression that they do
something asynchronous, but they don't. There is no disk or network IO
involved.
