### PR TITLE
Complete IncrementalPageBucketReceiver's future when processingRows throws CBE

### DIFF
--- a/docs/appendices/release-notes/5.10.10.rst
+++ b/docs/appendices/release-notes/5.10.10.rst
@@ -57,3 +57,7 @@ Fixes
 - Fixed an issue that caused RAM under-accounting, potentially leading to an
   ``OutOfMemoryError`` when result sets contained numeric values with large
   digit counts. The issue affected ``HTTP`` requests only.
+
+- Fixed an issue that caused queries with aggregations to continue despite
+  ``CircuitBreakerException`` being thrown and return incorrect (partial)
+  results under memory pressure.

--- a/server/src/test/java/io/crate/execution/IncrementalPageBucketReceiverTest.java
+++ b/server/src/test/java/io/crate/execution/IncrementalPageBucketReceiverTest.java
@@ -23,7 +23,15 @@ package io.crate.execution;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
 
@@ -31,9 +39,12 @@ import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.junit.Test;
 
 import io.crate.Streamer;
+import io.crate.data.ArrayBucket;
 import io.crate.data.Bucket;
 import io.crate.data.Row;
 import io.crate.data.testing.TestingRowConsumer;
+import io.crate.execution.engine.distribution.DistributedResultResponse;
+import io.crate.execution.jobs.PageResultListener;
 
 public class IncrementalPageBucketReceiverTest {
 
@@ -53,5 +64,76 @@ public class IncrementalPageBucketReceiverTest {
         pageBucketReceiver.setBucket(0, Bucket.EMPTY, true, _ -> {});
         assertThat(pageBucketReceiver.completionFuture()).completesExceptionallyWithin(1, TimeUnit.SECONDS);
         assertThat(batchConsumer.completionFuture()).completesExceptionallyWithin(1, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void test_listener_doesnt_need_more_when_processRows_throws() {
+        TestingRowConsumer batchConsumer = new TestingRowConsumer();
+        Collector<Row, Object, Iterable<Row>> collector = new Collector<>() {
+            @Override
+            public Supplier<Object> supplier() {
+                return ArrayList::new;
+            }
+
+            @Override
+            public BiConsumer<Object, Row> accumulator() {
+                return (_, _) -> {
+                    throw new CircuitBreakingException("dummy");
+                };
+            }
+
+            @Override
+            public BinaryOperator<Object> combiner() {
+                return null;
+            }
+
+            @Override
+            public Function<Object, Iterable<Row>> finisher() {
+                return null;
+            }
+
+            @Override
+            public Set<Characteristics> characteristics() {
+                return Set.of();
+            }
+        };
+
+        var pageBucketReceiver = new IncrementalPageBucketReceiver<>(
+            collector,
+            batchConsumer,
+            Runnable::run,
+            new Streamer[1],
+            1
+        );
+
+        // First call goes to currentlyAccumulating == null, needMore must be true after the call
+        final CompletableFuture<DistributedResultResponse> result = new CompletableFuture<>();
+        PageResultListener listener = needMore -> result.complete(new DistributedResultResponse(needMore));
+        pageBucketReceiver.setBucket(0, Bucket.EMPTY, false, listener);
+        assertThat(result).isCompletedWithValueMatchingWithin(
+            distributedResultResponse -> distributedResultResponse.needMore() == true,
+            Duration.ofSeconds(1)
+        );
+
+        // Second call goes to currentlyAccumulating != null, use non-empty bucket to provoke CBE
+        Bucket bucket = new ArrayBucket(new Object[][]{
+            new Object[]{1},
+        });
+        final CompletableFuture<DistributedResultResponse> result2 = new CompletableFuture<>();
+        PageResultListener listener2 = needMore -> result2.complete(new DistributedResultResponse(needMore));
+        pageBucketReceiver.setBucket(0, bucket, false, listener2);
+        assertThat(result2).isCompletedWithValueMatchingWithin(
+            distributedResultResponse -> distributedResultResponse.needMore() == true,
+            Duration.ofSeconds(1)
+        );
+
+        // Call after failed processRows, listener must see that previous call was completed exceptionally
+        final CompletableFuture<DistributedResultResponse> result3 = new CompletableFuture<>();
+        PageResultListener listener3 = needMore -> result3.complete(new DistributedResultResponse(needMore));
+        pageBucketReceiver.setBucket(0, Bucket.EMPTY, false, listener3);
+        assertThat(result3).isCompletedWithValueMatchingWithin(
+            distributedResultResponse -> distributedResultResponse.needMore() == false,
+            Duration.ofSeconds(1)
+        );
     }
 }


### PR DESCRIPTION
`processRows` can throw CBE.

When it's thrown inside `currentlyAccumulating.whenComplete`, it leads to `currentlyAccumulating` being completed exceptionally but `processingFuture` is not completed directly.

 `processingFuture` still can be completed in the next `setBucket` call, but all scenarios a bit problematic:
 - when `isLast` is true and `remainingUpstreams` is zero - `consumerRows` used to check presence of a failure and sometimes completed `completeExceptionally`, see https://github.com/crate/crate/pull/9304/files#diff-0df62ae06ebf40e609df27af1893d900e40b19bae3436943ac54db3f65cfb508L133-L136, currently we always complete with finisher's state. 
 - `currentlyAccumulating.whenComplete` will see prev CBE as throwable in `whenComplete` and do `processingFuture.completeExceptionally(runtimeErr)`. However, initial check in the setBucket won't go into 
` if (processingFuture.isCompletedExceptionally())`  branch and  `pageResultListener.needMore(!isLast)` will be be true for non-last page even after CBE.

On failures: I think all failures with CBE are good, query trips with CBE as expected. However, there are failured assertions and queries return wrong results, see for example https://jenkins.crate.io/job/CrateDB/job/crate_on_pr/690/testReport/junit/io.crate.integrationtests/SubSelectIntegrationTest/testGlobalAggregateOnVirtualTableWithGroupBy/
 
