### PR TITLE
Fix seqNo=-3 indexing; insertItems mutations on upsert request retries

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
@@ -31,6 +31,7 @@ import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.TestingHelpers.printedTable;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static io.netty.handler.codec.http.HttpResponseStatus.CONFLICT;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.data.Offset.offset;
 
@@ -954,7 +955,7 @@ public class InsertIntoIntegrationTest extends IntegTestCase {
 
     @Test
     public void testBulkInsertWithMultiValue() throws Exception {
-        execute("create table t (x int)");
+        execute("create table t (x int) clustered into 1 shards");
         Object[][] bulkArgs = {
             new Object[]{10, 11},
             new Object[]{20, 21},


### PR DESCRIPTION
ShardUpsertRequests can be retried in a couple of error cases
(see `retryPrimaryException`).

If it is not the first item that is failing, it can be the case that:

- seqNo was changed to SequenceNumbers.SKIP_ON_REPLICA
- insertValues, pkValues and insertColumns were changed due to the
  update->insert conversion

The changed seqNo leads to indexing assertions triggering on the retry,
and the changed `insertValues` could cause value mixups when the
update->insert logic is run again with the already changed
`insertValues`.

To solve this without bigger streaming changes, this caches the original
values and resets the `item` instances before attempting a primary
retry.
