### PR TITLE
Add persistence for table stats

### DIFF
--- a/docs/appendices/release-notes/6.1.0.rst
+++ b/docs/appendices/release-notes/6.1.0.rst
@@ -87,7 +87,9 @@ None
 Administration and Operations
 -----------------------------
 
-None
+- Added persistence for the :ref:`pg_catalog.pg_stats <pg_stats>` table. After
+  running ``ANALYZE``, table statistics are now written to disk and remain
+  available after a cluster restart.
 
 Client interfaces
 -----------------

--- a/libs/shared/src/main/java/io/crate/common/collections/Iterables.java
+++ b/libs/shared/src/main/java/io/crate/common/collections/Iterables.java
@@ -21,6 +21,8 @@
 
 package io.crate.common.collections;
 
+import static java.util.stream.StreamSupport.stream;
+
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
@@ -268,6 +270,10 @@ public final class Iterables {
             return addTo.addAll(c);
         }
         return Iterators.addAll(addTo, Objects.requireNonNull(elementsToAdd).iterator());
+    }
+
+    public static <T> Stream<T> sequentialStream(Iterable<T> iterable) {
+        return stream(iterable.spliterator(), false);
     }
 
     abstract static class FluentIterable<E> implements Iterable<E> {

--- a/server/src/main/java/io/crate/execution/engine/collect/sources/InformationSchemaIterables.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/sources/InformationSchemaIterables.java
@@ -21,6 +21,7 @@
 
 package io.crate.execution.engine.collect.sources;
 
+import static io.crate.common.collections.Iterables.sequentialStream;
 import static java.util.Collections.emptyList;
 import static java.util.stream.Stream.concat;
 import static java.util.stream.StreamSupport.stream;
@@ -267,10 +268,6 @@ public class InformationSchemaIterables {
     public static Stream<TableInfo> tablesStream(Schemas schemas) {
         return sequentialStream(schemas)
             .flatMap(s -> sequentialStream(s.getTables()));
-    }
-
-    private static <T> Stream<T> sequentialStream(Iterable<T> iterable) {
-        return stream(iterable.spliterator(), false);
     }
 
     public Iterable<SchemaInfo> schemas() {

--- a/server/src/main/java/io/crate/module/CrateCommonModule.java
+++ b/server/src/main/java/io/crate/module/CrateCommonModule.java
@@ -29,7 +29,6 @@ import io.crate.metadata.FulltextAnalyzerResolver;
 import io.crate.protocols.postgres.PostgresNetty;
 import io.crate.replication.logical.ShardReplicationService;
 import io.crate.replication.logical.repository.PublisherRestoreService;
-import io.crate.statistics.TableStatsService;
 
 public class CrateCommonModule extends AbstractModule {
 
@@ -37,7 +36,6 @@ public class CrateCommonModule extends AbstractModule {
     protected void configure() {
         bind(FulltextAnalyzerResolver.class).asEagerSingleton();
         bind(PostgresNetty.class).asEagerSingleton();
-        bind(TableStatsService.class).asEagerSingleton();
         bind(MemoryManagerFactory.class).asEagerSingleton();
         bind(DanglingArtifactsService.class).asEagerSingleton();
         bind(PublisherRestoreService.class).asEagerSingleton();

--- a/server/src/main/java/io/crate/planner/Planner.java
+++ b/server/src/main/java/io/crate/planner/Planner.java
@@ -168,7 +168,6 @@ import io.crate.role.RoleManager;
 import io.crate.session.Cursors;
 import io.crate.session.Session;
 import io.crate.sql.tree.SetSessionAuthorizationStatement;
-import io.crate.statistics.TableStats;
 
 @Singleton
 public class Planner extends AnalyzedStatementVisitor<PlannerContext, Plan> {
@@ -176,7 +175,6 @@ public class Planner extends AnalyzedStatementVisitor<PlannerContext, Plan> {
     private static final Logger LOGGER = LogManager.getLogger(Planner.class);
 
     private final ClusterService clusterService;
-    private final TableStats tableStats;
     private final LogicalPlanner logicalPlanner;
     private final NumberOfShards numberOfShards;
     private final CreateTableClient tableCreator;
@@ -191,7 +189,6 @@ public class Planner extends AnalyzedStatementVisitor<PlannerContext, Plan> {
     public Planner(Settings settings,
                    ClusterService clusterService,
                    NodeContext nodeCtx,
-                   TableStats tableStats,
                    NumberOfShards numberOfShards,
                    CreateTableClient tableCreator,
                    RoleManager roleManager,
@@ -199,7 +196,6 @@ public class Planner extends AnalyzedStatementVisitor<PlannerContext, Plan> {
                    SessionSettingRegistry sessionSettingRegistry) {
         this.clusterService = clusterService;
         this.nodeCtx = nodeCtx;
-        this.tableStats = tableStats;
         this.logicalPlanner = new LogicalPlanner(
             nodeCtx,
             foreignDataWrappers,
@@ -231,7 +227,7 @@ public class Planner extends AnalyzedStatementVisitor<PlannerContext, Plan> {
             params,
             cursors,
             transactionState,
-            new PlanStats(nodeCtx, txnCtx, tableStats),
+            new PlanStats(nodeCtx, txnCtx, nodeCtx.tableStats()),
             this.logicalPlanner::optimize,
             timeoutToken
         );

--- a/server/src/main/java/io/crate/statistics/PublishTableStatsRequest.java
+++ b/server/src/main/java/io/crate/statistics/PublishTableStatsRequest.java
@@ -43,7 +43,7 @@ public final class PublishTableStatsRequest extends TransportRequest {
         int numRelations = in.readVInt();
         statsByRelation = HashMap.newHashMap(numRelations);
         for (int i = 0; i < numRelations; i++) {
-            statsByRelation.put(new RelationName(in), new Stats(in));
+            statsByRelation.put(new RelationName(in), Stats.readFrom(in));
         }
     }
 

--- a/server/src/main/java/io/crate/statistics/TransportAnalyzeAction.java
+++ b/server/src/main/java/io/crate/statistics/TransportAnalyzeAction.java
@@ -72,7 +72,7 @@ public final class TransportAnalyzeAction {
                                   ReservoirSampler reservoirSampler,
                                   NodeContext nodeContext,
                                   ClusterService clusterService,
-                                  TableStats tableStats,
+                                  TableStatsService tableStatsService,
                                   ThreadPool threadPool) {
         this.transportService = transportService;
         this.schemas = nodeContext.schemas();
@@ -115,7 +115,7 @@ public final class TransportAnalyzeAction {
             // Explicit generic is required for eclipse JDT, otherwise it won't compile
             new NodeActionRequestHandler<PublishTableStatsRequest, AcknowledgedResponse>(
                 req -> {
-                    tableStats.updateTableStats(req.tableStats());
+                    tableStatsService.update(req.tableStats());
                     return completedFuture(new AcknowledgedResponse(true));
                 }
             )

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -217,6 +217,7 @@ import io.crate.role.Roles;
 import io.crate.role.RolesService;
 import io.crate.session.Sessions;
 import io.crate.statistics.TableStats;
+import io.crate.statistics.TableStatsService;
 import io.crate.types.DataTypes;
 import io.crate.udc.service.UDCService;
 
@@ -706,7 +707,6 @@ public class Node implements Closeable {
                 settings,
                 clusterService,
                 nodeContext,
-                tableStats,
                 new NumberOfShards(clusterService),
                 new CreateTableClient(client),
                 rolesManager,
@@ -754,9 +754,20 @@ public class Node implements Closeable {
                 client
             );
 
+            TableStatsService tableStatsService = new TableStatsService(
+                settings,
+                threadPool,
+                clusterService,
+                sessions,
+                nodeEnvironment.nodeDataPaths()[0]
+            );
+
+            tableStats.updateTableStats(tableStatsService::get);
+
             modules.add(b -> {
                     b.bind(Node.class).toInstance(this);
                     b.bind(NodeContext.class).toInstance(nodeContext);
+                    b.bind(TableStatsService.class).toInstance(tableStatsService);
                     b.bind(TableStats.class).toInstance(tableStats);
                     b.bind(Analyzer.class).toInstance(analyzer);
                     b.bind(Sessions.class).toInstance(sessions);

--- a/server/src/test/java/io/crate/integrationtests/SubSelectIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SubSelectIntegrationTest.java
@@ -375,7 +375,7 @@ public class SubSelectIntegrationTest extends IntegTestCase {
             newStats.put(
                 new RelationName(sqlExecutor.getCurrentSchema(), "t"),
                 new Stats(100, 64, Map.of()));
-            tableStats.updateTableStats(newStats);
+            tableStats.updateTableStats(newStats::get);
         }
 
         // Left table is expected to be one row, due to the single row subselect in the where clause.

--- a/server/src/test/java/io/crate/planner/UnionPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/UnionPlannerTest.java
@@ -224,7 +224,7 @@ public class UnionPlannerTest extends CrateDummyClusterServiceUnitTest {
         Map<RelationName, Stats> rowCountByTable = new HashMap<>();
         rowCountByTable.put(USER_TABLE_IDENT, new Stats(-1, 0, Map.of()));
         rowCountByTable.put(TEST_DOC_LOCATIONS_TABLE_IDENT, new Stats(1, 0, Map.of()));
-        tableStats.updateTableStats(rowCountByTable);
+        tableStats.updateTableStats(rowCountByTable::get);
 
         var context = e.getPlannerContext();
         var logicalPlanner = new LogicalPlanner(
@@ -237,7 +237,7 @@ public class UnionPlannerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(e.getStats(union).numDocs()).isEqualTo(-1L);
         rowCountByTable.put(USER_TABLE_IDENT, new Stats(1, 0, Map.of()));
         rowCountByTable.put(TEST_DOC_LOCATIONS_TABLE_IDENT, new Stats(-1, 0, Map.of()));
-        tableStats.updateTableStats(rowCountByTable);
+        tableStats.updateTableStats(rowCountByTable::get);
         plan = logicalPlanner.plan(e.analyze(stmt), context);
         union = (Union) plan.sources().get(0);
         assertThat(e.getStats(union).numDocs()).isEqualTo(-1L);

--- a/server/src/test/java/io/crate/planner/operators/GroupHashAggregateTest.java
+++ b/server/src/test/java/io/crate/planner/operators/GroupHashAggregateTest.java
@@ -66,7 +66,7 @@ public class GroupHashAggregateTest extends CrateDummyClusterServiceUnitTest {
             )
         );
         tableStats = new TableStats();
-        tableStats.updateTableStats(Map.of(new RelationName("doc", "t1"), stats));
+        tableStats.updateTableStats(Map.of(new RelationName("doc", "t1"), stats)::get);
         expressions = new SqlExpressions(T3.sources(clusterService));
     }
 

--- a/server/src/test/java/io/crate/planner/operators/JoinTest.java
+++ b/server/src/test/java/io/crate/planner/operators/JoinTest.java
@@ -406,7 +406,7 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
         Map<RelationName, Stats> stats = new HashMap<>();
         stats.put(T3.T1, new Stats(23, 64, Map.of()));
         stats.put(T3.T4, new Stats(42, 64, Map.of()));
-        tableStats.updateTableStats(stats);
+        tableStats.updateTableStats(stats::get);
 
         // rebuild executor + cluster state with 1 node
         resetClusterService();

--- a/server/src/test/java/io/crate/planner/optimizer/costs/PlanStatsTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/costs/PlanStatsTest.java
@@ -77,7 +77,7 @@ public class PlanStatsTest extends CrateDummyClusterServiceUnitTest {
                                  WhereClause.MATCH_ALL);
 
         TableStats tableStats = new TableStats();
-        tableStats.updateTableStats(Map.of(a.ident(), new Stats(1, DataTypes.INTEGER.fixedSize(), Map.of())));
+        tableStats.updateTableStats(Map.of(a.ident(), new Stats(1, DataTypes.INTEGER.fixedSize(), Map.of()))::get);
 
         var memo = new Memo(source);
         PlanStats planStats = new PlanStats(nodeContext, txnCtx, tableStats, memo);
@@ -98,7 +98,7 @@ public class PlanStatsTest extends CrateDummyClusterServiceUnitTest {
         var groupReference = new GroupReference(1, source.outputs(), Set.of());
 
         TableStats tableStats = new TableStats();
-        tableStats.updateTableStats(Map.of(a.ident(), new Stats(1, DataTypes.INTEGER.fixedSize(), Map.of())));
+        tableStats.updateTableStats(Map.of(a.ident(), new Stats(1, DataTypes.INTEGER.fixedSize(), Map.of()))::get);
 
         var memo = new Memo(source);
         PlanStats planStats = new PlanStats(nodeContext, txnCtx, tableStats, memo);
@@ -118,7 +118,7 @@ public class PlanStatsTest extends CrateDummyClusterServiceUnitTest {
         var source = new Collect(new DocTableRelation(a), List.of(x), WhereClause.MATCH_ALL);
 
         TableStats tableStats = new TableStats();
-        tableStats.updateTableStats(Map.of(a.ident(), new Stats(10L, 1, Map.of())));
+        tableStats.updateTableStats(Map.of(a.ident(), new Stats(10L, 1, Map.of()))::get);
 
         var limit = new Limit(source, Literal.of(5), Literal.of(0));
 
@@ -130,7 +130,7 @@ public class PlanStatsTest extends CrateDummyClusterServiceUnitTest {
                                                                 "  └ Collect[doc.a | [x] | true] (rows=10)");
 
         // now the source is smaller than the limit
-        tableStats.updateTableStats(Map.of(a.ident(), new Stats(3L, 1, Map.of())));
+        tableStats.updateTableStats(Map.of(a.ident(), new Stats(3L, 1, Map.of()))::get);
 
         result = planStats.get(limit);
         assertThat(result.numDocs()).isEqualTo(3L);
@@ -159,7 +159,7 @@ public class PlanStatsTest extends CrateDummyClusterServiceUnitTest {
             Map.of(
                 aDoc.ident(), new Stats(9L, 9 * DataTypes.INTEGER.fixedSize(), Map.of()),
                 bDoc.ident(), new Stats(1L, 1 * DataTypes.INTEGER.fixedSize(), Map.of())
-            )
+            )::get
         );
 
         var union = new Union(lhs, rhs, List.of());
@@ -212,7 +212,7 @@ public class PlanStatsTest extends CrateDummyClusterServiceUnitTest {
             Map.of(
                 aDoc.ident(), new Stats(9L, 9 * DataTypes.INTEGER.fixedSize(), columnStats),
                 bDoc.ident(), new Stats(1L, 1 * DataTypes.INTEGER.fixedSize(), columnStats)
-            )
+            )::get
         );
 
         var hashjoin = new HashJoin(lhs, rhs, joinCondition, JoinType.INNER);
@@ -247,7 +247,7 @@ public class PlanStatsTest extends CrateDummyClusterServiceUnitTest {
             Map.of(
                 aDoc.ident(), new Stats(9L, 9 * DataTypes.INTEGER.fixedSize(), Map.of(ColumnIdent.of("x"), xStats)),
                 bDoc.ident(), new Stats(2L, 2 * DataTypes.INTEGER.fixedSize(), Map.of(ColumnIdent.of("y"), yStats))
-            )
+            )::get
         );
 
         var nestedLoopJoin = new NestedLoopJoin(lhs, rhs, JoinType.INNER, Literal.BOOLEAN_TRUE, false, false, false, AbstractJoinPlan.LookUpJoin.NONE);
@@ -298,7 +298,7 @@ public class PlanStatsTest extends CrateDummyClusterServiceUnitTest {
         tableStats.updateTableStats(Map.of(
             tbl.ident(),
             new Stats(5_000, 5_000 * DataTypes.INTEGER.fixedSize(), columnStats)
-        ));
+        )::get);
 
         PlanStats planStats = new PlanStats(nodeContext, txnCtx, tableStats, null);
         Stats stats = planStats.get(filter);

--- a/server/src/test/java/io/crate/statistics/TableStatsTest.java
+++ b/server/src/test/java/io/crate/statistics/TableStatsTest.java
@@ -76,7 +76,7 @@ public class TableStatsTest extends ESTestCase {
     @Test
     public void test_estimating_row_size_with_with_stats() {
         TableStats tableStats = new TableStats();
-        tableStats.updateTableStats(Map.of(docTableInfo.ident(), new Stats(1L, 1000L, Map.of())));
+        tableStats.updateTableStats(Map.of(docTableInfo.ident(), new Stats(1L, 1000L, Map.of()))::get);
         long sizeEstimate = tableStats.estimatedSizePerRow(docTableInfo.ident());
         assertThat(sizeEstimate).isEqualTo(1000L);
     }

--- a/server/src/test/java/io/crate/statistics/TransportAnalyzeActionTest.java
+++ b/server/src/test/java/io/crate/statistics/TransportAnalyzeActionTest.java
@@ -62,6 +62,6 @@ public class TransportAnalyzeActionTest extends ESTestCase {
                 null)
         );
         var stats = samples.createTableStats(references);
-        assertThat(stats.numDocs).isEqualTo(2L);
+        assertThat(stats.numDocs()).isEqualTo(2L);
     }
 }

--- a/server/src/testFixtures/java/io/crate/testing/SQLExecutor.java
+++ b/server/src/testFixtures/java/io/crate/testing/SQLExecutor.java
@@ -397,7 +397,6 @@ public class SQLExecutor {
                         settings,
                         clusterService,
                         nodeCtx,
-                        tableStats,
                         null,
                         null,
                         roleManager,
@@ -654,7 +653,7 @@ public class SQLExecutor {
     }
 
     public void updateTableStats(Map<RelationName, Stats> stats) {
-        tableStats.updateTableStats(stats);
+        tableStats.updateTableStats(stats::get);
     }
 
     public PlanStats planStats() {

--- a/server/src/testFixtures/java/org/elasticsearch/test/IntegTestCase.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/IntegTestCase.java
@@ -191,6 +191,8 @@ import io.crate.session.Session;
 import io.crate.session.Sessions;
 import io.crate.sql.Identifiers;
 import io.crate.sql.parser.SqlParser;
+import io.crate.statistics.TableStats;
+import io.crate.statistics.TableStatsService;
 import io.crate.test.integration.SystemPropsTestLoggingListener;
 import io.crate.testing.SQLResponse;
 import io.crate.testing.SQLTransportExecutor;
@@ -1344,6 +1346,13 @@ public abstract class IntegTestCase extends ESTestCase {
     @After
     public void resetPageSize() {
         Paging.PAGE_SIZE = ORIGINAL_PAGE_SIZE;
+    }
+
+    @After
+    private void resetTableStats() {
+        for (TableStatsService tableStats : cluster().getInstances(TableStatsService.class)) {
+            tableStats.clear();
+        }
     }
 
     public IntegTestCase(SQLTransportExecutor sqlExecutor) {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This adds persistence for tablestats storing the data as binary in a lucene index under `data/nodes/0/_stats`.  Stats are now stored on disk, and loaded on demand into memory with caching.

Resolves https://github.com/crate/crate/issues/15059

This is the read/write performance for the table stats for the uservisits dataset:

| Writing to disk with index creation | Reading from disk (cold)|
| ------------- | ------------- |
| 30 ms  | 9 ms  |

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
