### PR TITLE
Fix issue with Timestamp and columnstore=false

### DIFF
--- a/docs/appendices/release-notes/5.10.10.rst
+++ b/docs/appendices/release-notes/5.10.10.rst
@@ -47,6 +47,10 @@ See the :ref:`version_5.10.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an issue that would cause error to be thrown when selecting a column
+  of :ref:`type-timestamp-without-tz` or :ref:`type-timestamp-with-tz` for
+  which, the :ref:`ddl-storage-columnstore` is disabled.
+
 - Fixed a race condition that could lead to ``INSERT INTO`` statements with a
   ``ON CONFLICT`` clause to either take much longer than necessary or get stuck
   unless other activity caused cluster change events.

--- a/server/src/main/java/io/crate/types/TimestampType.java
+++ b/server/src/main/java/io/crate/types/TimestampType.java
@@ -69,6 +69,10 @@ public final class TimestampType extends DataType<Long>
         Precedence.TIMESTAMP);
 
     private static final StorageSupport<Long> STORAGE = new StorageSupport<>(true, true, new LongEqQuery()) {
+        @Override
+        public Long decode(long input) {
+            return input;
+        }
 
         @Override
         public ValueIndexer<Long> valueIndexer(RelationName table,

--- a/server/src/test/java/io/crate/integrationtests/StorageOptionsITest.java
+++ b/server/src/test/java/io/crate/integrationtests/StorageOptionsITest.java
@@ -101,4 +101,17 @@ public class StorageOptionsITest extends IntegTestCase {
                 "2",
                 "1");
     }
+
+    @Test
+    public void test_timestamp_with_columnstore_false() throws Exception {
+        execute("""
+            create table tbl (
+                ts timestamp without time zone storage with (columnstore=false),
+                tsz timestamp with time zone storage with (columnstore=false)
+            )""");
+        execute("insert into tbl (ts, tsz) values (?, ?)", new Object[]{"2025-06-27 11:22:33.987", "2025-06-27 11:22:33.987+02:00"});
+        execute("refresh table tbl");
+        execute("select ts, tsz from tbl limit 1");
+        assertThat(response).hasRows("1751023353987| 1751016153987");
+    }
 }


### PR DESCRIPTION
The `decode(long)` method was not implemented, so the parent one was called which throws an UnsupportedOperationException.

Fixes: #18070
