### PR TITLE
Fix the table AST parsing of group table settings to strip index prefix

### DIFF
--- a/docs/appendices/release-notes/5.10.10.rst
+++ b/docs/appendices/release-notes/5.10.10.rst
@@ -65,3 +65,7 @@ Fixes
 - Fixed an issue that caused queries with aggregations to continue despite
   ``CircuitBreakerException`` being thrown and return incorrect (partial)
   results under memory pressure.
+
+- Fixed the table parameter namings of the :ref:`ref-show-create-table`
+  statement output, some parameters were wrongly prefixed with
+  ``index.``.

--- a/server/src/main/java/io/crate/analyze/TableInfoToAST.java
+++ b/server/src/main/java/io/crate/analyze/TableInfoToAST.java
@@ -22,6 +22,8 @@
 package io.crate.analyze;
 
 
+import static io.crate.analyze.TableParameters.stripIndexPrefix;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -305,7 +307,7 @@ public class TableInfoToAST {
     private GenericProperties<Expression> extractTableProperties() {
         // WITH ( key = value, ... )
         Map<String, Expression> properties = new HashMap<>();
-        String numberOfReplicasKey = TableParameters.stripIndexPrefix(NumberOfReplicas.SETTING.getKey());
+        String numberOfReplicasKey = stripIndexPrefix(NumberOfReplicas.SETTING.getKey());
         if (tableInfo instanceof DocTableInfo docTable) {
             Expression numReplicas = new StringLiteral(docTable.numberOfReplicas());
             properties.put(numberOfReplicasKey, numReplicas);
@@ -326,7 +328,7 @@ public class TableInfoToAST {
                 for (String namespace : namespaces) {
                     String key = prefix + namespace;
                     Object value = affixSetting.getConcreteSetting(key).get(parameters);
-                    properties.put(key, literalOfSettingValue(value));
+                    properties.put(stripIndexPrefix(key), literalOfSettingValue(value));
                 }
             } else if (parameters.hasValue(setting.getKey())) {
                 Object value = setting.get(parameters);

--- a/server/src/test/java/io/crate/analyze/TableInfoToASTTest.java
+++ b/server/src/test/java/io/crate/analyze/TableInfoToASTTest.java
@@ -391,4 +391,29 @@ public class TableInfoToASTTest extends CrateDummyClusterServiceUnitTest {
         assertThat(geoRef.precision()).isEqualTo("1m");
         assertThat(geoRef.distanceErrorPct()).isEqualTo(0.25);
     }
+
+    /**
+     * Ensures that the index prefix for table parameters, including group settings, is stripped
+     * when printing the table definition.
+     */
+    @Test
+    public void test_table_parameters_index_prefix_stripped() throws Exception {
+        SQLExecutor e = SQLExecutor.of(clusterService)
+            .addTable("CREATE TABLE t1 (id int) CLUSTERED INTO 1 SHARDS " +
+                "WITH (\"blocks.read_only_allow_delete\" = true, \"routing.allocation.exclude._name\" = 'node-1')");
+        DocTableInfo table = e.resolveTableInfo("t1");
+        var node = new TableInfoToAST(table).toStatement();
+        assertThat(SqlFormatter.formatSql(node)).isEqualTo("""
+              CREATE TABLE IF NOT EXISTS "doc"."t1" (
+                 "id" INTEGER
+              )
+              CLUSTERED INTO 1 SHARDS
+              WITH (
+                 "blocks.read_only_allow_delete" = true,
+                 column_policy = 'strict',
+                 number_of_replicas = '0-1',
+                 "routing.allocation.exclude._name" = 'node-1'
+              )""");
+
+    }
 }


### PR DESCRIPTION
The `index.` prefix was not stripped for group settings like e.g. `index.routing.allocation.exclude.`.

Fixes #18072.