### PR TITLE
Ensure return value of `execute` methods in IntegTestCase is thread-safe

### DIFF
--- a/server/src/testFixtures/java/org/elasticsearch/test/IntegTestCase.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/IntegTestCase.java
@@ -1488,9 +1488,11 @@ public abstract class IntegTestCase extends ESTestCase {
     public SQLResponse systemExecute(String stmt, @Nullable String schema, String node) {
         Sessions sqlOperations = cluster().getInstance(Sessions.class, node);
         Roles roles = cluster().getInstance(Roles.class, node);
+        SQLResponse response;
         try (Session session = sqlOperations.newSession(
             new ConnectionProperties(null, null, Protocol.HTTP, null), schema, roles.getUser("crate"))) {
             response = sqlExecutor.exec(stmt, session);
+            this.response = response;
         }
         return response;
     }
@@ -1504,7 +1506,8 @@ public abstract class IntegTestCase extends ESTestCase {
      */
     public SQLResponse execute(String stmt, Object[] args) {
         try {
-            this.response = sqlExecutor.exec(testExecutionConfig(), stmt, args);
+            SQLResponse response = sqlExecutor.exec(testExecutionConfig(), stmt, args);
+            this.response = response;
             return response;
         } catch (ElasticsearchTimeoutException e) {
             LOGGER.error("Timeout on SQL statement: {} {}", stmt, e);
@@ -1523,7 +1526,8 @@ public abstract class IntegTestCase extends ESTestCase {
      */
     public SQLResponse execute(String stmt, Object[] args, TimeValue timeout) {
         try {
-            response = sqlExecutor.exec(testExecutionConfig(), stmt, args, timeout);
+            SQLResponse response = sqlExecutor.exec(testExecutionConfig(), stmt, args, timeout);
+            this.response = response;
             return response;
         } catch (ElasticsearchTimeoutException e) {
             LOGGER.error("Timeout on SQL statement: {} {}", stmt, e);
@@ -1688,7 +1692,8 @@ public abstract class IntegTestCase extends ESTestCase {
         Sessions sqlOperations = cluster().getInstance(Sessions.class, node);
         try (Session session = sqlOperations.newSession(
             new ConnectionProperties(null, null, Protocol.HTTP, null), sqlExecutor.getCurrentSchema(), Role.CRATE_USER)) {
-            this.response = sqlExecutor.exec(stmt, args, session, timeout);
+            SQLResponse response = sqlExecutor.exec(stmt, args, session, timeout);
+            this.response = response;
             return response;
         }
     }


### PR DESCRIPTION
In some test cases we use the `execute` methods in threads.
Using the global `response` property in such cases is problematic
because it can change between assignment/read due to threading.

This ensures the return value is always correct by introducing locals. -
the global is still kept for convenience for the non-threaded
test-cases.
