### PR TITLE
Fix incorrect response formatting when single-arg bulk operation fails

### DIFF
--- a/docs/appendices/release-notes/5.10.11.rst
+++ b/docs/appendices/release-notes/5.10.11.rst
@@ -47,4 +47,6 @@ See the :ref:`version_5.10.0` release notes for a full list of changes in the
 Fixes
 =====
 
-None
+- Fixed incorrect JSON response formatting for bulk operations with a single
+  argument that results in a runtime error. The response now follows the
+  structure specified in :ref:`bulk-errors <http-bulk-errors>`.

--- a/server/src/main/java/io/crate/rest/action/SqlHttpHandler.java
+++ b/server/src/main/java/io/crate/rest/action/SqlHttpHandler.java
@@ -292,7 +292,7 @@ public class SqlHttpHandler extends SimpleChannelInboundHandler<FullHttpRequest>
         var sessionSettings = session.sessionSettings();
         AccessControl accessControl = roles.getAccessControl(sessionSettings.authenticatedUser(), sessionSettings.sessionUser());
         return session.sync()
-            .thenApply(ignored -> {
+            .handle((_, _) -> {
                 try {
                     return ResultToXContentBuilder.builder(JsonXContent.builder())
                         .cols(emptyList())

--- a/server/src/test/java/io/crate/integrationtests/RestSQLActionIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/RestSQLActionIntegrationTest.java
@@ -227,4 +227,23 @@ public class RestSQLActionIntegrationTest extends SQLHttpIntegrationTest {
         // The last error message must not be available in the response
         assertThat(response.body()).contains("{\"rowcount\":-2}");
     }
+
+    /**
+     * https://github.com/crate/crate/issues/18066
+     */
+    @Test
+    public void test_response_formatting_when_single_arg_bulk_operation_threw_runtime_error() throws Exception {
+        execute("CREATE TABLE doc.insert_test (id INT PRIMARY KEY) CLUSTERED INTO 1 SHARDS");
+        var body = """
+            {
+              "stmt": "INSERT INTO doc.insert_test(id) VALUES(?)",
+              "bulk_args": [[1]]
+            }
+            """;
+        post(body);
+        var response = post(body);
+        assertThat(response.statusCode()).isEqualTo(200);
+        assertThat(response.body()).contains(
+            "\"results\":[{\"rowcount\":0,\"error\":{\"code\":4091,\"message\":\"DuplicateKeyException[A document with the same primary key exists already]\"}}]}");
+    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes https://github.com/crate/crate/issues/18066.

A single arg bulk operation does return `results` array as expected, so the issue is only for the single arg operations that fail, see https://github.com/crate/crate/issues/18066#issuecomment-3020338785.

Before fix:
```json
{
  "error": {
    "message": "DuplicateKeyException[A document with the same primary key exists already]",
    "code": 4091
  }
}
```
After:
```json
{
  "cols": [],
  "duration": 18250.764,
  "results": [
    {
      "rowcount": 0,
      "error": {
        "code": 4091,
        "message": "DuplicateKeyException[A document with the same primary key exists already]"
      }
    }
  ]
}

```

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
