### PR TITLE
Fix type guessing of objects/array-of-objects

### DIFF
--- a/docs/appendices/release-notes/5.10.11.rst
+++ b/docs/appendices/release-notes/5.10.11.rst
@@ -52,3 +52,8 @@ Fixes
   a single error for the whole batch operation. Both client interfaces,
   :ref:`HTTP<interface-http>` and :ref:`PG<interface-postgresql>`, are affected.
 
+- Fixed an issue which caused inserts of object arrays with columns having
+  mixed types to partially fail. It used the type of the first value seen, and
+  failed for the values with a different type.
+  The new behavior is that it will use the type with the higher precendence,
+  and cast the other values if possible.

--- a/server/src/main/java/io/crate/execution/dml/ArrayIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/ArrayIndexer.java
@@ -187,7 +187,7 @@ public class ArrayIndexer<T> implements ValueIndexer<List<T>> {
     private void handleNullArrayUpcast(List<?> values,
                                        Consumer<? super Reference> onDynamicColumn,
                                        Synthetics synthetics) throws IOException {
-        DataType<?> type = DataTypes.valueFromList(values, true);
+        DataType<?> type = DataTypes.typeFromList(values, true);
         if (DataTypes.isArrayOfNulls(type)) {
             return;
         }
@@ -200,8 +200,11 @@ public class ArrayIndexer<T> implements ValueIndexer<List<T>> {
         onDynamicColumn.accept(ref);
         StorageSupport<?> storageSupport = type.storageSupport();
         assert storageSupport != null;  // null storage will have thrown an exception in buildReference
+
+        // The reference resolver passed in to the new type must return `NULL` as the (child) columns are not present
+        // yet. They will be added later in the schema update process.
         ValueIndexer<Object> indexer
-            = (ValueIndexer<Object>) storageSupport.valueIndexer(ref.ident().tableIdent(), ref, _ -> ref);
+            = (ValueIndexer<Object>) storageSupport.valueIndexer(ref.ident().tableIdent(), ref, _ -> null);
         indexer.collectSchemaUpdates(values, onDynamicColumn, synthetics);
     }
 

--- a/server/src/main/java/io/crate/execution/dml/ObjectIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/ObjectIndexer.java
@@ -186,6 +186,8 @@ public class ObjectIndexer implements ValueIndexer<Map<String, Object>> {
                 var type = child.reference.valueType();
                 try {
                     innerValue = type.sanitizeValue(innerValue);
+                } catch (ConversionException e) {
+                    throw e;
                 } catch (ClassCastException | IllegalArgumentException e) {
                     throw new ConversionException(innerValue, type);
                 }

--- a/server/src/test/java/io/crate/DataTypeTest.java
+++ b/server/src/test/java/io/crate/DataTypeTest.java
@@ -89,7 +89,17 @@ public class DataTypeTest extends ESTestCase {
 
         List<Object> objects = List.of(objA, objB);
         DataType<?> dataType = DataTypes.guessType(objects);
-        assertThat(dataType).isEqualTo(new ArrayType<>(DataTypes.UNTYPED_OBJECT));
+        var expectedObjectType = ObjectType.of(ColumnPolicy.DYNAMIC)
+            .setInnerType("a", DataTypes.INTEGER)
+            .setInnerType(
+                "b",
+                ObjectType.of(ColumnPolicy.DYNAMIC)
+                    .setInnerType("bn1", DataTypes.INTEGER)
+                    .setInnerType("bn2", DataTypes.INTEGER)
+                    .build()
+            )
+            .build();
+        assertThat(dataType).isEqualTo(new ArrayType<>(expectedObjectType));
     }
 
     @Test
@@ -109,7 +119,7 @@ public class DataTypeTest extends ESTestCase {
 
     @Test
     public void testForValueMixedDataTypeInList() {
-        List<Object> objects = Arrays.<Object>asList("foo", 1);
+        List<Object> objects = Arrays.<Object>asList("foo", List.of(1));
         assertThatThrownBy(() -> DataTypes.guessType(objects))
             .isExactlyInstanceOf(IllegalArgumentException.class);
     }

--- a/server/src/test/java/io/crate/integrationtests/GeoShapeIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/GeoShapeIntegrationTest.java
@@ -40,18 +40,19 @@ import io.crate.types.JsonType;
 
 public class GeoShapeIntegrationTest extends IntegTestCase {
 
+
     private static final Map<String, Object> GEO_SHAPE1 = Map.of(
-        "coordinates", new double[][]{
-            {0, 0},
-            {1, 1}
-        },
+        "coordinates", List.of(
+            List.of(0.0, 0.0),
+            List.of(1.0, 1.0)
+        ),
         "type", "LineString"
     );
     private static final Map<String, Object> GEO_SHAPE2 = Map.of(
-        "coordinates", new double[][]{
-            {2, 2},
-            {3, 3}
-        },
+        "coordinates", List.of(
+            List.of(2.0, 2.0),
+            List.of(3.0, 3.0)
+        ),
         "type", "LineString"
     );
 

--- a/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
@@ -1293,15 +1293,13 @@ public class TransportSQLActionTest extends IntegTestCase {
         assertThat(response).hasRowCount(1L);
         execute("select * from t where within(p, ?)", $(Map.of(
             "type", "Polygon",
-            "coordinates", new double[][][]{
-                {
-                    {5.0, 5.0},
-                    {30.0, 5.0},
-                    {30.0, 30.0},
-                    {5.0, 30.0},
-                    {5.0, 5.0}
-                }
-            }
+            "coordinates", List.of(List.of(
+                List.of(5.0, 5.0),
+                List.of(30.0, 5.0),
+                List.of(30.0, 30.0),
+                List.of(5.0, 30.0),
+                List.of(5.0, 5.0)
+            ))
         )));
         assertThat(response).hasRowCount(1L);
 


### PR DESCRIPTION
Partly apply changes of #17139 about the type guessing of objects and array or objects.

Fixes #18073.

This change is already applied on master (issue isn't present there), thus this must only be fixed on 5.10.