### PR TITLE
Do not allow SWAP TABLE on LR published tables

### DIFF
--- a/docs/appendices/release-notes/5.10.11.rst
+++ b/docs/appendices/release-notes/5.10.11.rst
@@ -52,8 +52,8 @@ Fixes
   :ref:`cluster.routing.allocation.awareness.force.\*.values` to be shown under
   the ``settings`` column of the :ref:`sys-cluster` table.
 
-- Fixed an issue that allowed columns of tables create by
-  :ref`logical replication <administration-logical-replication>` subscriptions
+- Fixed an issue that wrongly allowed columns of tables created by
+  :ref:`logical replication <administration-logical-replication>` subscriptions
   to be renamed, dropped or added.
 
 - Fixed an issue that wrongly allowed tables created by

--- a/docs/appendices/release-notes/5.10.11.rst
+++ b/docs/appendices/release-notes/5.10.11.rst
@@ -56,6 +56,10 @@ Fixes
   :ref`logical replication <administration-logical-replication>` subscriptions
   to be renamed, dropped or added.
 
+- Fixed an issue that wrongly allowed tables created by
+  :ref:`logical replication <administration-logical-replication>` publications
+  to be :ref:`swapped<alter_cluster_swap_table>`.
+
 - Fixed an issue that could cause streaming errors, leading to shard failures
   and re-replication if using ``INSERT INTO`` statements with ``ON CONFLICT``
   clause combined with bulk requests if some operations ran into a conflict

--- a/server/src/main/java/io/crate/analyze/SwapTableAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/SwapTableAnalyzer.java
@@ -22,17 +22,20 @@
 package io.crate.analyze;
 
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 import io.crate.analyze.expressions.ExpressionAnalysisContext;
 import io.crate.analyze.expressions.ExpressionAnalyzer;
 import io.crate.analyze.relations.FieldProvider;
+import io.crate.exceptions.OperationOnInaccessibleRelationException;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Schemas;
 import io.crate.metadata.SearchPath;
+import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.table.Operation;
 import io.crate.role.Role;
 import io.crate.sql.tree.Expression;
@@ -68,10 +71,26 @@ public final class SwapTableAnalyzer {
         }
         SearchPath searchPath = txnCtx.sessionSettings().searchPath();
         Role user = txnCtx.sessionSettings().sessionUser();
-        return new AnalyzedSwapTable(
-            schemas.findRelation(swapTable.source(), Operation.ALTER, user, searchPath),
-            schemas.findRelation(swapTable.target(), Operation.ALTER, user, searchPath),
-            dropSource
-        );
+
+        var source = schemas.findRelation(swapTable.source(), Operation.ALTER_TABLE_RENAME, user, searchPath);
+        if (!(source instanceof DocTableInfo sourceRelation)) {
+            throw new OperationOnInaccessibleRelationException(
+                source.ident(),
+                String.format(
+                    Locale.ENGLISH, "The relation \"%s\" doesn't support or allow %s operations",
+                    source.ident().name(), Operation.ALTER_TABLE_RENAME
+                ));
+        }
+        var target = schemas.findRelation(swapTable.target(), Operation.ALTER_TABLE_RENAME, user, searchPath);
+        if (!(target instanceof DocTableInfo targetRelation)) {
+            throw new OperationOnInaccessibleRelationException(
+                target.ident(),
+                String.format(
+                    Locale.ENGLISH, "The relation \"%s\" doesn't support or allow %s operations",
+                    target.ident().name(), Operation.ALTER_TABLE_RENAME
+                ));
+        }
+
+        return new AnalyzedSwapTable(sourceRelation, targetRelation, dropSource);
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Fixes:

```
--publisher:
cr> create table doc.x (a int);
cr> create publication p for table doc.x;
cr> create table y (q int);
cr> alter cluster swap table x to y;  -- do not allow this to go through
ALTER OK, 1 row affected (2.892 sec)
```

Proposing `SWAP TABLE` to be an `Operation.ALTER_TABLE_RENAME` because it is equivalent to a series of `RENAME`.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
