### PR TITLE
Fix timeouts in testSeqNoCASLinearizability

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
@@ -222,7 +222,7 @@ public class PgCatalogITest extends IntegTestCase {
     @UseJdbc(0)
     @UseRandomizedSchema(random = false)
     @UseHashJoins(0)
-    public void testPgSettingsTable() {
+    public void testPgSettingsTable() throws Exception {
         // The default timeout is set via system property and is different between local/jenkins and GHA
         // -> Use a fixed timeout to have deterministic output
         TimeValue timeout = TimeValue.timeValueSeconds(10);

--- a/server/src/testFixtures/java/org/elasticsearch/test/IntegTestCase.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/IntegTestCase.java
@@ -44,6 +44,7 @@ import java.lang.reflect.Method;
 import java.net.InetSocketAddress;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -1524,7 +1525,7 @@ public abstract class IntegTestCase extends ESTestCase {
      * @param timeout internal timeout of the statement
      * @return the SQLResponse
      */
-    public SQLResponse execute(String stmt, Object[] args, TimeValue timeout) {
+    public SQLResponse execute(String stmt, Object[] args, TimeValue timeout) throws SQLException {
         try {
             SQLResponse response = sqlExecutor.exec(testExecutionConfig(), stmt, args, timeout);
             this.response = response;


### PR DESCRIPTION
It appears as if the PostgreSQL JDBC driver is ignoring the interrupt
from the `CASUpdateThread.terminate()`, leading to timeout errors

To solve this, this wraps the execution in a virtual thread.