### PR TITLE
Revert custom awareness settings in sandbox's crate.yml

### DIFF
--- a/sandbox/crate/config/crate.yml
+++ b/sandbox/crate/config/crate.yml
@@ -25,8 +25,3 @@ auth:
       99:
         method: password
 
-
-node.attr.zone: a
-cluster.routing.allocation.awareness.attributes: zone
-cluster.routing.allocation.awareness.force.zone.values: a,b,c
-cluster.routing.allocation.cluster_concurrent_rebalance: 99


### PR DESCRIPTION
They were only added for debugging purposes.

Follows: https://github.com/crate/crate/pull/18057
