### PR TITLE
Remove wrong assertion when adding an IndexMetadata.Builder to the Metadata

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -720,8 +720,6 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata> {
             // we know its a new one, increment the version and store
             indexMetadataBuilder.version(indexMetadataBuilder.version() + 1);
             IndexMetadata indexMetadata = indexMetadataBuilder.build();
-            assert indices.containsKey(indexMetadata.getIndexUUID()) == false :
-                "An index with the same UUID already exists: [" + indexMetadata.getIndexUUID() + "]";
             indices.put(indexMetadata.getIndex().getName(), indexMetadata);
             return this;
         }


### PR DESCRIPTION
It is expected that an existing indexMetadata inside the Metadata's `indices` registry is overwritten by a new one with the same indexUUID. For example, when modifying some indexMetadata attribute, e.g. updating the replicas by calling `numberOfReplicas(newVal)`.

Additionally, the assertion never worked as expected as it uses the `indexUUID` as a key for checking existence in a map which uses the `indexName` as a key.

Follow up of 46af8aa528f8967799c278ba0406688f5269d132.