### PR TITLE
Ensure retention lease sync action doesn't get stuck on assertion errors

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/seqno/RetentionLeaseSyncAction.java
+++ b/server/src/main/java/org/elasticsearch/index/seqno/RetentionLeaseSyncAction.java
@@ -136,8 +136,8 @@ public class RetentionLeaseSyncAction extends
             Objects.requireNonNull(primary);
             primary.persistRetentionLeases();
             listener.onResponse(new WritePrimaryResult<>(request, new ReplicationResponse(), null, primary));
-        } catch (Exception ex) {
-            listener.onFailure(ex);
+        } catch (Throwable ex) {
+            listener.onFailure(Exceptions.toException(ex));
         }
     }
 


### PR DESCRIPTION
Motivated by flaky failures:

    [All incoming requests on node [node_s1] should have finished. in_flight_requests-bytesUsed=358, pendingTasks=[], responseHandlers=ResponseHandlers{{274=ResponseContext{action=indices:admin/seq_no/retention_lease_sync[p], connection=org.elasticsearch.transport.TransportService$2@4a244a1}}}]
    expected: 0L
     but was: 358L


Can't reproduce the issue so this is mostly a wild guess. Worst case it
doesn't change anything, best case it either solves it or we get at
least more info.
