### PR TITLE
Only build index metadata aliases for old (<6.0.0) indices

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -1024,6 +1024,12 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata> {
             SortedMap<String, AliasOrIndex> aliasAndIndexLookup = new TreeMap<>();
             for (ObjectCursor<IndexMetadata> cursor : indices.values()) {
                 IndexMetadata indexMetadata = cursor.value;
+                if (indexMetadata.getCreationVersion().onOrAfter(Version.V_6_0_0)) {
+                    // aliases are deprecated and only needed to be built for old indices, aliases will be removed once
+                    // the metadata is fully migrated/upgraded to schemas/relations.
+                    continue;
+                }
+
                 AliasOrIndex existing = aliasAndIndexLookup.put(indexMetadata.getIndex().getName(), new AliasOrIndex.Index(indexMetadata));
                 assert existing == null : "duplicate for " + indexMetadata.getIndex();
 

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataUpgradeService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataUpgradeService.java
@@ -277,10 +277,11 @@ public class MetadataUpgradeService {
 
 
     /**
-     * Checks if the index was already opened by this version of Elasticsearch and doesn't require any additional checks.
+     * Checks if the index was already opened by this version of CrateDB and doesn't require any additional checks.
      */
     private boolean isUpgraded(IndexMetadata indexMetadata) {
-        return indexMetadata.getUpgradedVersion().onOrAfter(Version.CURRENT);
+        return indexMetadata.getCreationVersion().onOrAfter(Version.CURRENT)
+            || indexMetadata.getUpgradedVersion().onOrAfter(Version.CURRENT);
     }
 
     /**


### PR DESCRIPTION
Once the indices metadatas are upgraded, the aliases aren't used anymore and are removed.
On tables >= 6.0.0, partition resolving is done using the new relations entities instead of aliases and templates.

Extracted from #18063, but should be merged to master directly.