### PR TITLE
tests: Add a CREATE integ test to test `mapping.total_fields.limit`

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/CreateTableIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/CreateTableIntegrationTest.java
@@ -22,6 +22,7 @@
 package io.crate.integrationtests;
 
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
+import static io.crate.testing.Asserts.assertSQLError;
 import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.TestingHelpers.printedTable;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
@@ -33,8 +34,6 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.elasticsearch.test.IntegTestCase;
 import org.junit.Test;
-
-import io.crate.testing.Asserts;
 
 public class CreateTableIntegrationTest extends IntegTestCase {
 
@@ -154,7 +153,7 @@ public class CreateTableIntegrationTest extends IntegTestCase {
 
     @Test
     public void test_enforce_soft_deletes() {
-        Asserts.assertSQLError(
+        assertSQLError(
             () -> execute("create table test(t timestamp) with (\"soft_deletes.enabled\" = false)"))
             .hasPGError(INTERNAL_ERROR)
             .hasHTTPError(BAD_REQUEST, 4000)
@@ -171,7 +170,7 @@ public class CreateTableIntegrationTest extends IntegTestCase {
                     col2 INT GENERATED ALWAYS AS col1*2 CONSTRAINT gt_zero CHECK (col2 > 0)
                 )
                 """);
-        Asserts.assertSQLError(
+        assertSQLError(
             () -> execute("INSERT INTO test(col1) VALUES(0)"))
             .hasPGError(INTERNAL_ERROR)
             .hasHTTPError(BAD_REQUEST, 4000)

--- a/server/src/test/java/io/crate/integrationtests/TableSettingsTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TableSettingsTest.java
@@ -22,6 +22,7 @@
 package io.crate.integrationtests;
 
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
+import static io.crate.testing.Asserts.assertSQLError;
 import static io.crate.testing.TestingHelpers.printedTable;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -119,6 +120,19 @@ public class TableSettingsTest extends IntegTestCase {
         execute("select * from information_schema.tables " +
                 "where settings['routing']['allocation']['total_shards_per_node'] >= 10");
         assertThat(response.rowCount()).isEqualTo(1);
+    }
+
+    @Test
+    public void testCreateTableWithTotalFieldsLimit() {
+        var msg = String.format(Locale.ENGLISH,
+            "Limit of total columns [2] in table [%s.test] exceeded", sqlExecutor.getCurrentSchema());
+
+        assertSQLError(() -> execute(
+            "CREATE TABLE test (a int, b long, c string) " +
+                "with (\"mapping.total_fields.limit\"=2)"))
+            .hasPGError(INTERNAL_ERROR)
+            .hasHTTPError(BAD_REQUEST, 4000)
+            .hasMessageContaining(msg);
     }
 
     @Test


### PR DESCRIPTION
Since the limit is checked in execution path, is not caught by Analyzer/Planner unit tests.
