### PR TITLE
docs: Sync 5.10.11 release notes

### DIFF
--- a/docs/appendices/release-notes/5.10.11.rst
+++ b/docs/appendices/release-notes/5.10.11.rst
@@ -47,6 +47,10 @@ See the :ref:`version_5.10.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an issue that allowed to :ref:`CREATE tables <ddl-create-table>` with
+  more columns than the limit defined by the
+  :ref:`sql-create-table-mapping-total-fields-limit` setting.
+
 - Fixed an issue that would prevent the
   :ref:`cluster.routing.allocation.awareness.attributes` and
   :ref:`cluster.routing.allocation.awareness.force.\*.values` to be shown under
@@ -69,6 +73,12 @@ Fixes
   wrongly reported as runtime errors, resulting in an error per batch instead of
   a single error for the whole batch operation. Both client interfaces,
   :ref:`HTTP<interface-http>` and :ref:`PG<interface-postgresql>`, are affected.
+
+- Fixed an issue which caused inserts of object arrays with columns having
+  mixed types to partially fail. It used the type of the first value seen, and
+  failed for the values with a different type.
+  The new behavior is that it will use the type with the higher precendence,
+  and cast the other values if possible.
 
 - Fixed incorrect JSON response formatting for bulk operations with a single
   argument that results in a runtime error. The response now follows the


### PR DESCRIPTION
A couple of fixes where merged directly to 5.10 branch, and the release notes of 5.10.11 were not reflected on `master`. Sync the release notes to avoid confusion.
