### PR TITLE
Ensure assertions triggered in ActionListener.wrap's onResponse trigger onFailure

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/ActionListener.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionListener.java
@@ -91,25 +91,13 @@ public interface ActionListener<Response> extends BiConsumer<Response, Throwable
         }
 
         @Override
-        public void accept(T response, Throwable throwable) {
-            if (throwable == null) {
-                try {
-                    onResponse.accept(response);
-                    return;
-                } catch (Throwable t) {
-                    throwable = t;
-                }
-            }
-            onFailure.accept(Exceptions.toException(SQLExceptions.unwrap(throwable)));
-        }
-
-
-        @Override
         public void onResponse(T response) {
             try {
                 onResponse.accept(response);
             } catch (Exception e) {
-                onFailure(e);
+                onFailure.accept(e);
+            } catch (Throwable t) {
+                onFailure.accept(Exceptions.toException(t));
             }
         }
 

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -1788,7 +1788,7 @@ public class IndexShardTests extends IndexShardTestCase {
                         ThreadPool.Names.WRITE,
                         ""
                     ))
-                .isExactlyInstanceOf(AssertionError.class)
+                .hasCauseExactlyInstanceOf(AssertionError.class)
                 .hasMessageContaining("in primary mode cannot be a replication target");
         }
 


### PR DESCRIPTION
Similar to https://github.com/crate/crate/pull/18124
Motivated by flaky tests:

    [All incoming requests on node [node_s1] should have finished. in_flight_requests-bytesUsed=358, pendingTasks=[], responseHandlers=ResponseHandlers{{274=ResponseContext{action=indices:admin/seq_no/retention_lease_sync[p], connection=org.elasticsearch.transport.TransportService$2@4a244a1}}}]
    expected: 0L
     but was: 358L

Current suspect is that assertions are triggering, preventing the
listener from triggering and causing the request handler to leak
