### PR TITLE
Reflect release 5.10.11

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,4 +1,7 @@
 ---
+merge_queue:
+  max_parallel_checks: 1
+
 queue_rules:
   - name: default
     queue_conditions:

--- a/docs/appendices/release-notes/5.10.11.rst
+++ b/docs/appendices/release-notes/5.10.11.rst
@@ -1,17 +1,10 @@
 .. _version_5.10.11:
 
-============================
-Version 5.10.11 - Unreleased
-============================
+===============
+Version 5.10.11
+===============
 
-
-.. comment 1. Remove the " - Unreleased" from the header above and adjust the ==
-.. comment 2. Remove the NOTE below and replace with: "Released on 20XX-XX-XX."
-.. comment    (without a NOTE entry, simply starting from col 1 of the line)
-.. NOTE::
-
-    In development. 5.10.11 isn't released yet. These are the release notes for
-    the upcoming release.
+Released on 2025-07-14.
 
 .. NOTE::
 

--- a/docs/appendices/release-notes/5.10.12.rst
+++ b/docs/appendices/release-notes/5.10.12.rst
@@ -1,0 +1,50 @@
+.. _version_5.10.12:
+
+============================
+Version 5.10.12 - Unreleased
+============================
+
+
+.. comment 1. Remove the " - Unreleased" from the header above and adjust the ==
+.. comment 2. Remove the NOTE below and replace with: "Released on 20XX-XX-XX."
+.. comment    (without a NOTE entry, simply starting from col 1 of the line)
+.. NOTE::
+
+    In development. 5.10.12 isn't released yet. These are the release notes for
+    the upcoming release.
+
+.. NOTE::
+
+    If you are upgrading a cluster, you must be running CrateDB 4.0.2 or higher
+    before you upgrade to 5.10.12.
+
+    We recommend that you upgrade to the latest 5.9 release before moving to
+    5.10.12.
+
+    A rolling upgrade from 5.9.x to 5.10.12 is supported.
+    Before upgrading, you should `back up your data`_.
+
+.. WARNING::
+
+    Tables that were created before CrateDB 4.x will not function with 5.x
+    and must be recreated before moving to 5.x.x.
+
+    You can recreate tables using ``COPY TO`` and ``COPY FROM`` or by
+    `inserting the data into a new table`_.
+
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
+.. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
+
+.. rubric:: Table of contents
+
+.. contents::
+   :local:
+
+
+See the :ref:`version_5.10.0` release notes for a full list of changes in the
+5.10 series.
+
+Fixes
+=====
+
+None

--- a/docs/appendices/release-notes/index.rst
+++ b/docs/appendices/release-notes/index.rst
@@ -37,6 +37,7 @@ Versions
 .. toctree::
     :maxdepth: 1
 
+    5.10.12
     5.10.11
     5.10.10
     5.10.9

--- a/server/src/main/java/org/elasticsearch/Version.java
+++ b/server/src/main/java/org/elasticsearch/Version.java
@@ -197,6 +197,7 @@ public class Version implements Comparable<Version> {
     public static final Version V_5_10_8 = new Version(8_10_08_99, false, org.apache.lucene.util.Version.LUCENE_9_12_0);
     public static final Version V_5_10_9 = new Version(8_10_09_99, false, org.apache.lucene.util.Version.LUCENE_9_12_0);
     public static final Version V_5_10_10 = new Version(8_10_10_99, false, org.apache.lucene.util.Version.LUCENE_9_12_0);
+    public static final Version V_5_10_11 = new Version(8_10_11_99, false, org.apache.lucene.util.Version.LUCENE_9_12_0);
 
     public static final Version V_6_0_0 = new Version(9_00_00_99, true, org.apache.lucene.util.Version.LUCENE_10_2_2);
 


### PR DESCRIPTION
Also set `max_parallel_checks` to `1`, to prevent mergify to open additional PRs to run checks for multiple PRs in parallel.