### PR TITLE
Fix rejected execution handling in DistributingConsumer retries

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/PriorityRunnable.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/PriorityRunnable.java
@@ -66,6 +66,11 @@ public class PriorityRunnable {
         public Runnable unwrap() {
             return runnable;
         }
+
+        @Override
+        public String toString() {
+            return "[" + source + "/" + priority() + "=" + runnable + "]";
+        }
     }
 
     public static class SimplePriorityRunnable extends PrioritizedRunnable implements WrappedRunnable {
@@ -85,6 +90,11 @@ public class PriorityRunnable {
         @Override
         public Runnable unwrap() {
             return runnable;
+        }
+
+        @Override
+        public String toString() {
+            return "[" + source + "/" + priority() + "=" + runnable + "]";
         }
     }
 }


### PR DESCRIPTION
Follow up to https://github.com/crate/crate/pull/18025
Caused "uncaught exception" errors in the logs. Noticed this while
looking into ThreadPoolsExhaustedIntegrationTest failures.
