### PR TITLE
Fix flaky ThreadPoolsExhaustedIntegrationTest; eager release searchers on CollectTask.kill

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/collect/CollectTask.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/CollectTask.java
@@ -118,7 +118,7 @@ public class CollectTask implements Task {
                 consumer.accept(null, err);
             }
         });
-        this.consumerCompleted = consumer.completionFuture().handle((res, err) -> {
+        this.consumerCompleted = consumer.completionFuture().handle((_, err) -> {
             totalBytes = ramAccounting.totalBytes();
             releaseResources();
             if (err != null) {
@@ -130,19 +130,18 @@ public class CollectTask implements Task {
 
     private void releaseResources() {
         synchronized (searchers) {
-            if (releasedResources == false) {
-                releasedResources = true;
-                for (var cursor : searchers.values()) {
-                    cursor.value.close();
-                }
-                searchers.clear();
-                for (var memoryManager : memoryManagers) {
-                    memoryManager.close();
-                }
-                memoryManagers.clear();
-            } else {
-                throw new AssertionError("Double release must not happen");
+            if (releasedResources) {
+                return;
             }
+            releasedResources = true;
+            for (var cursor : searchers.values()) {
+                cursor.value.close();
+            }
+            searchers.clear();
+            for (var memoryManager : memoryManagers) {
+                memoryManager.close();
+            }
+            memoryManagers.clear();
         }
     }
 
@@ -154,6 +153,7 @@ public class CollectTask implements Task {
     @Override
     public void kill(Throwable throwable) {
         killed = throwable;
+        releaseResources();
         if (started.compareAndSet(false, true)) {
             consumer.accept(null, throwable);
         } else {
@@ -212,8 +212,12 @@ public class CollectTask implements Task {
                 }
             } else {
                 searcher.close();
-                // addSearcher call after resource-release should only happen in error case
-                // the join call should trigger the original failure
+                // addSearcher call after resource-release should only happen
+                // in error case or explicit kill.
+                if (killed != null) {
+                    throw Exceptions.toRuntimeException(killed);
+                }
+                // if not killed, then the join call should trigger the original failure
                 try {
                     consumerCompleted.join();
                 } catch (CompletionException e) {
@@ -285,7 +289,7 @@ public class CollectTask implements Task {
 
     public MemoryManager memoryManager() {
         MemoryManager memoryManager = memoryManagerFactory.apply(ramAccounting);
-        // an atomicBoolean call would not be enough, because without syncronization
+        // an atomicBoolean call would not be enough, because without synchronization
         // the `memoryManagers.add` could be called just right *after* another thread triggered `releaseResources`
         synchronized (searchers) {
             if (releasedResources == false) {
@@ -293,7 +297,7 @@ public class CollectTask implements Task {
                 return memoryManager;
             } else {
                 memoryManager.close();
-                // memoryManager acess after resource-release should only happen in error case
+                // memoryManager access after resource-release should only happen in error case
                 // the join call should trigger the original failure
                 try {
                     consumerCompleted.join();


### PR DESCRIPTION
`testDistributedPushSelectWithFewAvailableThreadsShouldNeverGetStuck`
could fail with:

    [ERROR]   ThreadPoolsExhaustedIntegrationTest>CrateLuceneTestCase.closeAfterSuite:415 » ResourceDisposal Resource in scope SUITE failed to close. Resource was registered from thread Thread[id=96, name=cratedb[node_t1][write][T#1], state=RUNNABLE, group=TGRP-ThreadPoolsExhaustedIntegrationTest], registration stack trace below.
    [...]
    Suppressed: java.lang.RuntimeException: Unreleased Searcher, source [fetch-task: node=OjveEGQ1QtygXTrHyFCLfQ, 45918f94-526e-ce83-4a06-e2804a42caa2-2-fetchPhase]
        at org.elasticsearch.test.engine.MockEngineSupport$InFlightSearchers.add(MockEngineSupport.java:231)
        at org.elasticsearch.test.engine.MockEngineSupport$SearcherCloseable.<init>(MockEngineSupport.java:258)
        at org.elasticsearch.test.engine.MockEngineSupport.wrapSearcher(MockEngineSupport.java:193)
        at org.elasticsearch.test.engine.MockInternalEngine.acquireSearcher(MockInternalEngine.java:82)
        at org.elasticsearch.index.shard.IndexShard.acquireSearcher(IndexShard.java:1259)
        at org.elasticsearch.index.shard.IndexShard.acquireSearcher(IndexShard.java:1249)
        at io.crate.execution.jobs.SharedShardContext.lambda$new$0(SharedShardContext.java:53)
        at io.crate.common.collections.RefCountedItem.markAcquired(RefCountedItem.java:60)
        at io.crate.execution.jobs.SharedShardContext.acquireSearcher(SharedShardContext.java:59)
        at io.crate.execution.engine.fetch.FetchTask.setupSearchers(FetchTask.java:314)
        at io.crate.execution.engine.fetch.FetchTask.lambda$start$1(FetchTask.java:263)
        at java.base/java.util.concurrent.CompletableFuture.uniApplyNow(CompletableFuture.java:730)
        at java.base/java.util.concurrent.CompletableFuture.uniApplyStage(CompletableFuture.java:708)
        at java.base/java.util.concurrent.CompletableFuture.thenApply(CompletableFuture.java:2252)
        at io.crate.execution.engine.fetch.FetchTask.start(FetchTask.java:260)
        at io.crate.execution.jobs.RootTask.start(RootTask.java:209)
        at io.crate.execution.jobs.RootTask.start(RootTask.java:194)
        at io.crate.execution.jobs.transport.TransportJobAction.nodeOperation(TransportJobAction.java:109)

This happened if the test teardown ran while the kill processing was still
asynchronously continuing. Consider the following scenario:

1. node0: Collect runs into rejected execution, starts kill propagation
2. node0: DistResultRXTask is removed due to ^
3. node1: the DistributingConsumer sends a result to node0
4. node1: While waiting for a response, the CollectTask is killed.
   BatchIterator.kill gets called, but it is passive - waiting for the
   consumer to observe it. The consumer is waiting for a response from
   the downstreams
5. node0: Receives the result from node1, but the context is missing and `recentlyFailed` overflowed and is missing the jobId entry due to the concurrency in the test. It starts retrying as it thinks that the result is for a job it hasn't received yet
6. Test teardown happens during the retries. Searchers are still active due to ^ running


To fix the issue this changed the CollectTask.kill to release the searchers eagerly. Anything depending on them should fail anyway due to the kill. (And observe the kill first).

No release notes because this was mostly a timing issue. The searcher would eventually get released once the retries expire. It only failed because in the tests that can take too long.

(The `FetchTask` allocation source from the stackTrace is misleading,
that's only because the fetch task allocates searchers first, the close
was missing from the `CollectTask`)
