### PR TITLE
Fix flaky AbstractAsyncTaskTests.testAutoRepeat

### DIFF
--- a/server/src/test/java/org/elasticsearch/common/util/concurrent/AbstractAsyncTaskTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/concurrent/AbstractAsyncTaskTests.java
@@ -53,7 +53,6 @@ public class AbstractAsyncTaskTests extends ESTestCase {
 
     @Test
     public void testAutoRepeat() throws Exception {
-
         boolean shouldRunThrowException = randomBoolean();
         final CyclicBarrier barrier1 = new CyclicBarrier(2); // 1 for runInternal plus 1 for the test sequence
         final CyclicBarrier barrier2 = new CyclicBarrier(2); // 1 for runInternal plus 1 for the test sequence
@@ -95,9 +94,9 @@ public class AbstractAsyncTaskTests extends ESTestCase {
         assertThat(task.isScheduled()).isTrue();
         barrier1.await();
         assertThat(task.isScheduled()).isTrue();
+        barrier1.reset();
         barrier2.await();
         assertThat(count.get()).isEqualTo(1);
-        barrier1.reset();
         barrier2.reset();
         barrier1.await();
         assertThat(task.isScheduled()).isTrue();


### PR DESCRIPTION
There was a race leading to:

    WARNING: Uncaught exception in thread: Thread[#46,cratedb[AbstractAsyncTaskTests][generic][T#2],5,TGRP-AbstractAsyncTaskTests]
    java.lang.AssertionError: interrupted
    	at __randomizedtesting.SeedInfo.seed([DCD8FFF276897349]:0)
    	at org.elasticsearch.common.util.concurrent.AbstractAsyncTaskTests$1.runInternal(AbstractAsyncTaskTests.java:74)
    	at org.elasticsearch.common.util.concurrent.AbstractAsyncTask.run(AbstractAsyncTask.java:143)
    	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1095)
    	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:619)
    	at java.base/java.lang.Thread.run(Thread.java:1447)

This could be reproduced adding a sleep after the
`assertThat(count.get()).isEqualTo(1);`. The problem was that the
`runInternal` could move to the `barrier1.await()` in the second
iteration before the `barrier1.reset()` call outside happened.
