### PR TITLE
Remove any nullable mark/handling of the `ReplicationRequest.shardId`

### DIFF
--- a/server/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
+++ b/server/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
@@ -131,7 +131,7 @@ public class TransportShardUpsertAction extends TransportShardAction<
                                                                                           ShardUpsertRequest request,
                                                                                           AtomicBoolean killed) {
         ShardResponse shardResponse = new ShardResponse(request.returnValues());
-        String indexName = request.index();
+        String indexName = request.shardId().getIndexName();
         DocTableInfo tableInfo = schemas.getTableInfo(RelationName.fromIndexName(indexName));
         TransactionContext txnCtx = TransactionContext.of(request.sessionSettings());
 
@@ -156,7 +156,7 @@ public class TransportShardUpsertAction extends TransportShardAction<
                 insertColumns
             );
             indexer = new Indexer(
-                request.index(),
+                request.shardId().getIndexName(),
                 tableInfo,
                 indexShard.getVersionCreated(),
                 txnCtx,
@@ -284,7 +284,7 @@ public class TransportShardUpsertAction extends TransportShardAction<
     protected WriteReplicaResult processRequestItemsOnReplica(IndexShard indexShard, UpsertReplicaRequest request) throws IOException {
         List<Reference> columns = request.columns();
         Translog.Location location = null;
-        String indexName = request.index();
+        String indexName = request.shardId().getIndexName();
         boolean traceEnabled = logger.isTraceEnabled();
         RelationName relationName = RelationName.fromIndexName(indexName);
         DocTableInfo tableInfo = schemas.getTableInfo(relationName);

--- a/server/src/main/java/io/crate/planner/operators/InsertFromValues.java
+++ b/server/src/main/java/io/crate/planner/operators/InsertFromValues.java
@@ -653,8 +653,8 @@ public class InsertFromValues implements LogicalPlan {
                     throwable = SQLExceptions.unwrap(throwable);
                     // we want to report duplicate key exceptions
                     if (!SQLExceptions.isDocumentAlreadyExistsException(throwable) &&
-                            (partitionWasDeleted(throwable, request.index())
-                                    || partitionClosed(throwable, request.index())
+                            (partitionWasDeleted(throwable, request.shardId().getIndexName())
+                                    || partitionClosed(throwable, request.shardId().getIndexName())
                                     || mixedArgumentTypesFailure(throwable))) {
                         result.complete(compressedResult);
                     } else {
@@ -672,7 +672,7 @@ public class InsertFromValues implements LogicalPlan {
                     .currentNodeId();
             } catch (IndexNotFoundException e) {
                 lastFailure.set(e);
-                if (!IndexName.isPartitioned(request.index())) {
+                if (!IndexName.isPartitioned(request.shardId().getIndexName())) {
                     synchronized (compressedResult) {
                         compressedResult.markAsFailed(request.items());
                     }
@@ -703,7 +703,7 @@ public class InsertFromValues implements LogicalPlan {
                 public void onFailure(Exception e) {
                     nodeLimit.onSample(startTime, true);
                     Throwable t = SQLExceptions.unwrap(e);
-                    if (!partitionWasDeleted(t, request.index())) {
+                    if (!partitionWasDeleted(t, request.shardId().getIndexName())) {
                         synchronized (compressedResult) {
                             compressedResult.markAsFailed(request.items());
                         }

--- a/server/src/main/java/org/elasticsearch/action/resync/ResyncReplicationRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/resync/ResyncReplicationRequest.java
@@ -19,15 +19,15 @@
 
 package org.elasticsearch.action.resync;
 
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Objects;
+
 import org.elasticsearch.action.support.replication.ReplicationRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.translog.Translog;
-
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.Objects;
 
 /**
  * Represents a batch of operations sent from the primary to its replicas during the primary-replica resync.
@@ -92,7 +92,6 @@ public final class ResyncReplicationRequest extends ReplicationRequest<ResyncRep
         return "TransportResyncReplicationAction.Request{" +
             "shardId=" + shardId +
             ", timeout=" + timeout +
-            ", index='" + index + '\'' +
             ", trimAboveSeqNo=" + trimAboveSeqNo +
             ", maxSeenAutoIdTimestampOnPrimary=" + maxSeenAutoIdTimestampOnPrimary +
             ", ops=" + operations.length +

--- a/server/src/main/java/org/elasticsearch/index/seqno/GlobalCheckpointSyncAction.java
+++ b/server/src/main/java/org/elasticsearch/index/seqno/GlobalCheckpointSyncAction.java
@@ -117,7 +117,6 @@ public class GlobalCheckpointSyncAction extends TransportReplicationAction<
             return "GlobalCheckpointSyncAction.Request{" +
                     "shardId=" + shardId +
                     ", timeout=" + timeout +
-                    ", index='" + index + '\'' +
                     ", waitForActiveShards=" + waitForActiveShards +
                     "}";
         }

--- a/server/src/main/java/org/elasticsearch/index/seqno/RetentionLeaseBackgroundSyncAction.java
+++ b/server/src/main/java/org/elasticsearch/index/seqno/RetentionLeaseBackgroundSyncAction.java
@@ -200,7 +200,6 @@ public class RetentionLeaseBackgroundSyncAction extends TransportReplicationActi
                     "retentionLeases=" + retentionLeases +
                     ", shardId=" + shardId +
                     ", timeout=" + timeout +
-                    ", index='" + index + '\'' +
                     ", waitForActiveShards=" + waitForActiveShards +
                     '}';
         }

--- a/server/src/main/java/org/elasticsearch/index/seqno/RetentionLeaseSyncAction.java
+++ b/server/src/main/java/org/elasticsearch/index/seqno/RetentionLeaseSyncAction.java
@@ -189,7 +189,6 @@ public class RetentionLeaseSyncAction extends
                     "retentionLeases=" + retentionLeases +
                     ", shardId=" + shardId +
                     ", timeout=" + timeout +
-                    ", index='" + index + '\'' +
                     ", waitForActiveShards=" + waitForActiveShards +
                     '}';
         }

--- a/server/src/test/java/io/crate/SerializationTests.java
+++ b/server/src/test/java/io/crate/SerializationTests.java
@@ -60,6 +60,6 @@ public class SerializationTests extends ESTestCase {
         assertThat(requestOut.isLast).isEqualTo(requestIn.isLast);
         assertThat(requestOut.content).isEqualTo(requestIn.content);
         assertThat(requestOut.transferId).isEqualTo(requestIn.transferId);
-        assertThat(requestOut.index()).isEqualTo(requestIn.index());
+        assertThat(requestOut.shardId()).isEqualTo(requestIn.shardId());
     }
 }

--- a/server/src/test/java/io/crate/blob/DeleteBlobRequestTest.java
+++ b/server/src/test/java/io/crate/blob/DeleteBlobRequestTest.java
@@ -46,7 +46,7 @@ public class DeleteBlobRequestTest extends ESTestCase {
 
         DeleteBlobRequest fromStream = new DeleteBlobRequest(out.bytes().streamInput());
 
-        assertThat(fromStream.index()).isEqualTo("foo");
+        assertThat(fromStream.shardId().getIndexName()).isEqualTo("foo");
         assertThat(fromStream.id()).isEqualTo(Hex.encodeHexString(digest));
     }
 }


### PR DESCRIPTION
The shardId of any ReplicationRequest is always set to a non-null value, such expecting it to be null is not needed.

This popped up by the work on using indexUUID's instead of the indexName as the shardId is always containing both and relying on it will help a lot for BWC (related to #18063).

The 2nd commit removes the `index` (name) property from the request as this is already streamed by the shardId.