### PR TITLE
Fix intermittent subscription loss in logical replication during rolling upgrades

### DIFF
--- a/docs/appendices/release-notes/6.0.1.rst
+++ b/docs/appendices/release-notes/6.0.1.rst
@@ -47,4 +47,5 @@ series.
 Fixes
 =====
 
-None
+- Fix intermittent subscription loss in logical replication during rolling
+  upgrades.


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Intermittent subscription loss in LR during rolling upgrades identified when adding https://github.com/crate/crate-qa/pull/354.

`PublicationsStateAction.Response` instances may be passed between publisher nodes before being forwarded to subscriber node. During rolling upgrades, this forwarding behaviour leads to a chain of cross-version conversions of the `Response` instance: 5.10 -> 6.0 -> 5.10. The final `Response` sent to the subscriber node is missing `relationsInPublications`, resulting in subscription loss.

Relates to #17960.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
