### PR TITLE
Increase cache for recently killed jobs

### DIFF
--- a/server/src/main/java/io/crate/execution/jobs/TasksService.java
+++ b/server/src/main/java/io/crate/execution/jobs/TasksService.java
@@ -75,7 +75,7 @@ public class TasksService extends AbstractLifecycleComponent implements Transpor
     private final Object failedSentinel = new Object();
     private final Cache<UUID, Object> recentlyFailed = Caffeine.newBuilder()
         .executor(Runnable::run)
-        .maximumSize(200L)
+        .maximumSize(1000L)
         .expireAfterWrite(30, TimeUnit.SECONDS)
         .build();
 


### PR DESCRIPTION
Lower risk change that should help fix the test flakyness as outlined in
https://github.com/crate/crate/pull/18166
