### PR TITLE
Deduplicate CORS header logic

### DIFF
--- a/server/src/main/java/io/crate/protocols/http/HttpBlobHandler.java
+++ b/server/src/main/java/io/crate/protocols/http/HttpBlobHandler.java
@@ -36,8 +36,6 @@ import java.util.regex.Pattern;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
-import org.elasticsearch.http.netty4.cors.Netty4CorsConfig;
-import org.elasticsearch.http.netty4.cors.Netty4CorsHandler;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.jetbrains.annotations.Nullable;
 
@@ -90,7 +88,6 @@ public class HttpBlobHandler extends SimpleChannelInboundHandler<Object> {
 
     private final Matcher blobsMatcher = BLOBS_PATTERN.matcher("");
     private final BlobService blobService;
-    private final Netty4CorsConfig corsConfig;
     private HttpRequest currentMessage;
 
     private RemoteDigestBlob digestBlob;
@@ -98,10 +95,9 @@ public class HttpBlobHandler extends SimpleChannelInboundHandler<Object> {
     private String index;
     private String digest;
 
-    public HttpBlobHandler(BlobService blobService, Netty4CorsConfig corsConfig) {
+    public HttpBlobHandler(BlobService blobService) {
         super(false);
         this.blobService = blobService;
-        this.corsConfig = corsConfig;
     }
 
     private boolean possibleRedirect(HttpRequest request, String index, String digest) {
@@ -233,9 +229,6 @@ public class HttpBlobHandler extends SimpleChannelInboundHandler<Object> {
     }
 
     private void sendResponse(HttpRequest request, HttpResponse response) {
-        if (request != null) {
-            Netty4CorsHandler.setCorsResponseHeaders(request, response, corsConfig);
-        }
         ChannelFuture cf = ctx.channel().writeAndFlush(response);
         if (currentMessage != null && !HttpUtil.isKeepAlive(currentMessage)) {
             cf.addListener(ChannelFutureListener.CLOSE);
@@ -348,7 +341,6 @@ public class HttpBlobHandler extends SimpleChannelInboundHandler<Object> {
             DefaultHttpResponse response = new DefaultHttpResponse(HTTP_1_1, PARTIAL_CONTENT);
             maybeSetConnectionCloseHeader(response);
             HttpUtil.setContentLength(response, end - start + 1);
-            Netty4CorsHandler.setCorsResponseHeaders(request, response, corsConfig);
             response.headers().set(HttpHeaderNames.CONTENT_RANGE, "bytes " + start + "-" + end + "/" + raf.length());
             setDefaultGetHeaders(response);
 
@@ -371,7 +363,6 @@ public class HttpBlobHandler extends SimpleChannelInboundHandler<Object> {
     private void fullContentResponse(HttpRequest request, String index, final String digest) throws IOException {
         BlobShard blobShard = blobService.localBlobShard(index, digest);
         HttpResponse response = new DefaultHttpResponse(HTTP_1_1, HttpResponseStatus.OK);
-        Netty4CorsHandler.setCorsResponseHeaders(request, response, corsConfig);
         final RandomAccessFile raf = blobShard.blobContainer().getRandomAccessFile(digest);
         try {
             maybeSetConnectionCloseHeader(response);

--- a/server/src/main/java/io/crate/protocols/http/MainAndStaticFileHandler.java
+++ b/server/src/main/java/io/crate/protocols/http/MainAndStaticFileHandler.java
@@ -42,8 +42,6 @@ import org.elasticsearch.action.admin.cluster.state.TransportClusterState;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
-import org.elasticsearch.http.netty4.cors.Netty4CorsConfig;
-import org.elasticsearch.http.netty4.cors.Netty4CorsHandler;
 import org.elasticsearch.rest.RestStatus;
 import org.jetbrains.annotations.Nullable;
 
@@ -67,14 +65,12 @@ public class MainAndStaticFileHandler extends SimpleChannelInboundHandler<FullHt
 
     private final Path sitePath;
     private final NodeClient client;
-    private final Netty4CorsConfig corsConfig;
     private final String nodeName;
 
-    public MainAndStaticFileHandler(String nodeName, Path home, NodeClient client, Netty4CorsConfig corsConfig) {
+    public MainAndStaticFileHandler(String nodeName, Path home, NodeClient client) {
         this.nodeName = nodeName;
         this.sitePath = home.resolve("lib").resolve("site");
         this.client = client;
-        this.corsConfig = corsConfig;
     }
 
     @Override
@@ -104,7 +100,6 @@ public class MainAndStaticFileHandler extends SimpleChannelInboundHandler<FullHt
     }
 
     private void writeResponse(ChannelHandlerContext ctx, FullHttpRequest req, FullHttpResponse resp) {
-        Netty4CorsHandler.setCorsResponseHeaders(req, resp, corsConfig);
         ChannelPromise promise = ctx.newPromise();
         if (isCloseConnection(req)) {
             promise.addListener(ChannelFutureListener.CLOSE);

--- a/server/src/main/java/io/crate/rest/action/SqlHttpHandler.java
+++ b/server/src/main/java/io/crate/rest/action/SqlHttpHandler.java
@@ -45,8 +45,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.http.netty4.Netty4HttpServerTransport;
-import org.elasticsearch.http.netty4.cors.Netty4CorsConfig;
-import org.elasticsearch.http.netty4.cors.Netty4CorsHandler;
 import org.elasticsearch.indices.breaker.HierarchyCircuitBreakerService;
 import org.elasticsearch.transport.netty4.Netty4Utils;
 import org.jetbrains.annotations.Nullable;
@@ -92,7 +90,6 @@ public class SqlHttpHandler extends SimpleChannelInboundHandler<FullHttpRequest>
     private final Sessions sessions;
     private final Function<String, CircuitBreaker> circuitBreakerProvider;
     private final Roles roles;
-    private final Netty4CorsConfig corsConfig;
     private final boolean checkJwtProperties;
 
     private Session session;
@@ -100,14 +97,12 @@ public class SqlHttpHandler extends SimpleChannelInboundHandler<FullHttpRequest>
     public SqlHttpHandler(Settings settings,
                           Sessions sessions,
                           Function<String, CircuitBreaker> circuitBreakerProvider,
-                          Roles roles,
-                          Netty4CorsConfig corsConfig) {
+                          Roles roles) {
         super(false);
         this.settings = settings;
         this.sessions = sessions;
         this.circuitBreakerProvider = circuitBreakerProvider;
         this.roles = roles;
-        this.corsConfig = corsConfig;
         this.checkJwtProperties = settings.get(AUTH_HOST_BASED_JWT_ISS_SETTING.getKey()) == null;
     }
 
@@ -189,7 +184,6 @@ public class SqlHttpHandler extends SimpleChannelInboundHandler<FullHttpRequest>
             );
             resp.headers().add(HttpHeaderNames.CONTENT_TYPE, mediaType);
         }
-        Netty4CorsHandler.setCorsResponseHeaders(request, resp, corsConfig);
         resp.headers().add(HttpHeaderNames.CONTENT_LENGTH, String.valueOf(content.readableBytes()));
         boolean closeConnection = isCloseConnection(request);
         ChannelPromise promise = ctx.newPromise();

--- a/server/src/main/java/org/elasticsearch/http/netty4/Netty4HttpServerTransport.java
+++ b/server/src/main/java/org/elasticsearch/http/netty4/Netty4HttpServerTransport.java
@@ -600,7 +600,7 @@ public class Netty4HttpServerTransport extends AbstractLifecycleComponent implem
             aggregator.setMaxCumulationBufferComponents(transport.maxCompositeBufferComponents);
             pipeline.addLast("chunked", new ChunkedWriteHandler());
             pipeline.addLast("auth_handler", new HttpAuthUpstreamHandler(settings, authentication, roles));
-            pipeline.addLast("blob_handler", new HttpBlobHandler(blobService, transport.getCorsConfig()));
+            pipeline.addLast("blob_handler", new HttpBlobHandler(blobService));
             pipeline.addLast("aggregator", aggregator);
             if (transport.compression) {
                 pipeline.addLast("encoder_compress", new HttpContentCompressor(transport.compressionLevel));
@@ -609,14 +609,12 @@ public class Netty4HttpServerTransport extends AbstractLifecycleComponent implem
                 settings,
                 sessions,
                 breakerService::getBreaker,
-                roles,
-                transport.getCorsConfig()
+                roles
             ));
             pipeline.addLast("handler", new MainAndStaticFileHandler(
                 nodeName,
                 home,
-                nodeClient,
-                transport.getCorsConfig()
+                nodeClient
             ));
             if (SETTING_CORS_ENABLED.get(transport.settings())) {
                 pipeline.addAfter("encoder", "cors", new Netty4CorsHandler(transport.getCorsConfig()));

--- a/server/src/main/java/org/elasticsearch/http/netty4/cors/Netty4CorsConfig.java
+++ b/server/src/main/java/org/elasticsearch/http/netty4/cors/Netty4CorsConfig.java
@@ -19,11 +19,6 @@
 
 package org.elasticsearch.http.netty4.cors;
 
-import io.netty.handler.codec.http.DefaultHttpHeaders;
-import io.netty.handler.codec.http.EmptyHttpHeaders;
-import io.netty.handler.codec.http.HttpHeaders;
-import io.netty.handler.codec.http.HttpMethod;
-
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Map;
@@ -32,11 +27,15 @@ import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.regex.Pattern;
 
+import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.EmptyHttpHeaders;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.cors.CorsConfig;
+
 /**
  * Configuration for Cross-Origin Resource Sharing (CORS).
- *
- * This class was lifted from the Netty project:
- *  https://github.com/netty/netty
+ * Alternative to {@link CorsConfig} that supports patterns for the origin
  */
 public final class Netty4CorsConfig {
 

--- a/server/src/test/java/io/crate/integrationtests/BlobIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/BlobIntegrationTest.java
@@ -50,6 +50,7 @@ import org.junit.Test;
 
 import io.crate.blob.v2.BlobIndicesService;
 import io.crate.blob.v2.BlobShard;
+import io.netty.handler.codec.http.HttpHeaderNames;
 
 @IntegTestCase.ClusterScope(scope = IntegTestCase.Scope.SUITE, numDataNodes = 2)
 @WindowsIncompatible
@@ -87,7 +88,8 @@ public class BlobIntegrationTest extends BlobHttpIntegrationTest {
             .header("Origin", "Http://example.com")
             .build();
         var response = httpClient.send(request, BodyHandlers.discarding());
-        assertThat(response.headers().firstValue("Access-Control-Allow-Origin")).isPresent();
+        assertThat(response.headers().map())
+            .containsEntry(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString(), List.of("*"));
     }
 
     @Test

--- a/server/src/test/java/io/crate/rest/action/SqlHttpHandlerTest.java
+++ b/server/src/test/java/io/crate/rest/action/SqlHttpHandlerTest.java
@@ -34,17 +34,16 @@ import java.util.List;
 
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.http.netty4.cors.Netty4CorsConfigBuilder;
 import org.junit.Test;
 
-import io.crate.session.Session;
-import io.crate.session.Sessions;
 import io.crate.auth.AuthSettings;
 import io.crate.auth.Protocol;
 import io.crate.metadata.settings.CoordinatorSessionSettings;
 import io.crate.protocols.postgres.ConnectionProperties;
 import io.crate.role.Role;
 import io.crate.role.metadata.RolesHelper;
+import io.crate.session.Session;
+import io.crate.session.Sessions;
 import io.netty.handler.codec.http.DefaultHttpHeaders;
 import io.netty.handler.codec.http.FullHttpRequest;
 
@@ -56,8 +55,7 @@ public class SqlHttpHandlerTest {
             Settings.EMPTY,
             mock(Sessions.class),
             _ -> new NoopCircuitBreaker("dummy"),
-            () -> List.of(Role.CRATE_USER),
-            Netty4CorsConfigBuilder.forAnyOrigin().build()
+            () -> List.of(Role.CRATE_USER)
         );
 
         Role user = handler.userFromAuthHeader(null);
@@ -73,8 +71,7 @@ public class SqlHttpHandlerTest {
             settings,
             mock(Sessions.class),
             _ -> new NoopCircuitBreaker("dummy"),
-            () -> List.of(RolesHelper.userOf("trillian")),
-            Netty4CorsConfigBuilder.forAnyOrigin().build()
+            () -> List.of(RolesHelper.userOf("trillian"))
         );
 
         Role user = handler.userFromAuthHeader(null);
@@ -87,8 +84,7 @@ public class SqlHttpHandlerTest {
             Settings.EMPTY,
             mock(Sessions.class),
             _ -> new NoopCircuitBreaker("dummy"),
-            () -> List.of(RolesHelper.userOf("Aladdin")),
-            Netty4CorsConfigBuilder.forAnyOrigin().build()
+            () -> List.of(RolesHelper.userOf("Aladdin"))
         );
 
         Role user = handler.userFromAuthHeader("Basic QWxhZGRpbjpPcGVuU2VzYW1l");
@@ -115,8 +111,7 @@ public class SqlHttpHandlerTest {
             Settings.EMPTY,
             mockedSqlOperations,
             _ -> new NoopCircuitBreaker("dummy"),
-            () -> List.of(dummyUser),
-            Netty4CorsConfigBuilder.forAnyOrigin().build()
+            () -> List.of(dummyUser)
         );
 
         // 1st call to ensureSession creates a session instance bound to 'dummyUser'
@@ -142,8 +137,7 @@ public class SqlHttpHandlerTest {
             Settings.EMPTY,
             mock(Sessions.class),
             _ -> new NoopCircuitBreaker("dummy"),
-            () -> List.of(JWT_USER),
-            Netty4CorsConfigBuilder.forAnyOrigin().build()
+            () -> List.of(JWT_USER)
         );
 
         Role resolvedUser = handler.userFromAuthHeader("bearer " + JWT_TOKEN);


### PR DESCRIPTION
The `Netty4CorsHandler` is already a `ChannelDuplexHandler` so it can
take care of adding the CORS headers to outgoing HttpResponse objects
instead of doing that in each separate handler.

The upstream netty `CorsHandler` would do the same.
This also clarifies the class docs to explain why we don't use netty's
`CorsHandler` to begin with. The netty3 mention was outdated.
