### PR TITLE
Make RowConsumer optionally killable; short-circuit DistributingConsumer

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/InterceptingRowConsumer.java
+++ b/server/src/main/java/io/crate/execution/engine/InterceptingRowConsumer.java
@@ -97,6 +97,10 @@ class InterceptingRowConsumer implements RowConsumer {
         return consumer.completionFuture();
     }
 
+    @Override
+    public void kill(Throwable throwable) {
+        consumer.kill(throwable);
+    }
 
     @Override
     public String toString() {

--- a/server/src/main/java/io/crate/execution/engine/collect/CollectTask.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/CollectTask.java
@@ -157,10 +157,12 @@ public class CollectTask implements Task {
         if (started.compareAndSet(false, true)) {
             consumer.accept(null, throwable);
         } else {
-            batchIterator.whenComplete((it, err) -> {
-                if (err == null) {
+            batchIterator.whenComplete((it, _) -> {
+                consumer.kill(throwable);
+                if (it != null) {
                     it.kill(throwable);
-                } // else: Consumer must have received a failure already
+                }
+                // else: whenComplete handler defined in the CTOR takes care of the error case.
             });
         }
     }

--- a/server/src/main/java/io/crate/execution/engine/pipeline/ProjectingRowConsumer.java
+++ b/server/src/main/java/io/crate/execution/engine/pipeline/ProjectingRowConsumer.java
@@ -21,6 +21,13 @@
 
 package io.crate.execution.engine.pipeline;
 
+import java.util.Collection;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.jetbrains.annotations.Nullable;
+
 import io.crate.data.BatchIterator;
 import io.crate.data.Row;
 import io.crate.data.RowConsumer;
@@ -28,12 +35,6 @@ import io.crate.data.breaker.RamAccounting;
 import io.crate.execution.dsl.projection.Projection;
 import io.crate.memory.MemoryManager;
 import io.crate.metadata.TransactionContext;
-import org.elasticsearch.common.breaker.CircuitBreaker;
-
-import org.jetbrains.annotations.Nullable;
-import java.util.Collection;
-import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Consumer implementation which applies projections onto the BatchIterator received on accept,
@@ -119,6 +120,11 @@ public class ProjectingRowConsumer implements RowConsumer {
     @Override
     public CompletableFuture<?> completionFuture() {
         return consumer.completionFuture();
+    }
+
+    @Override
+    public void kill(Throwable throwable) {
+        consumer.kill(throwable);
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/DeclarePlan.java
+++ b/server/src/main/java/io/crate/planner/DeclarePlan.java
@@ -23,13 +23,10 @@ package io.crate.planner;
 
 import java.util.concurrent.CompletableFuture;
 
-import org.jetbrains.annotations.Nullable;
-
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.indices.breaker.HierarchyCircuitBreakerService;
+import org.jetbrains.annotations.Nullable;
 
-import io.crate.session.Cursor;
-import io.crate.session.Cursors;
 import io.crate.analyze.AnalyzedDeclare;
 import io.crate.data.BatchIterator;
 import io.crate.data.InMemoryBatchIterator;
@@ -38,6 +35,8 @@ import io.crate.data.RowConsumer;
 import io.crate.data.SentinelRow;
 import io.crate.planner.operators.SubQueryResults;
 import io.crate.protocols.postgres.TransactionState;
+import io.crate.session.Cursor;
+import io.crate.session.Cursors;
 import io.crate.sql.SqlFormatter;
 import io.crate.sql.tree.Declare;
 import io.crate.sql.tree.Declare.Hold;
@@ -109,6 +108,11 @@ public class DeclarePlan implements Plan {
         @Override
         public CompletableFuture<?> completionFuture() {
             return finalResult;
+        }
+
+        @Override
+        public void kill(Throwable throwable) {
+            consumer.kill(throwable);
         }
     }
 }


### PR DESCRIPTION
This is an alternative approach to https://github.com/crate/crate/pull/18166
It ensures we don't release searchers while they're still in use, but
also don't unnecessarily wait for downstream responses in the
`DistributingConsumer`


Opposed to https://github.com/crate/crate/pull/18172 it has the advantage that it also works if there are additional network hiccups. (E.g. network partition, allowing one node to send but not receive, which we also simulate in some tests via the network disruption)
Downside is that the downstream might still retry, but we have the recentlyFailed cache increase to account for that, and it is relatively harmless as it uses a scheduler - so not resource intensive.