### PR TITLE
Replace ClusterApplyListener with ActionListener

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/service/ClusterApplier.java
+++ b/server/src/main/java/org/elasticsearch/cluster/service/ClusterApplier.java
@@ -19,9 +19,10 @@
 
 package org.elasticsearch.cluster.service;
 
-import org.elasticsearch.cluster.ClusterState;
-
 import java.util.function.Supplier;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.cluster.ClusterState;
 
 public interface ClusterApplier {
     /**
@@ -37,24 +38,5 @@ public interface ClusterApplier {
      * @param clusterStateSupplier the cluster state supplier which provides the latest cluster state to apply
      * @param listener callback that is invoked after cluster state is applied
      */
-    void onNewClusterState(String source, Supplier<ClusterState> clusterStateSupplier, ClusterApplyListener listener);
-
-    /**
-     * Listener for results of cluster state application
-     */
-    interface ClusterApplyListener {
-        /**
-         * Called on successful cluster state application
-         * @param source information where the cluster state came from
-         */
-        default void onSuccess(String source) {
-        }
-
-        /**
-         * Called on failure during cluster state application
-         * @param source information where the cluster state came from
-         * @param e exception that occurred
-         */
-        void onFailure(String source, Exception e);
-    }
+    void onNewClusterState(String source, Supplier<ClusterState> clusterStateSupplier, ActionListener<Void> listener);
 }

--- a/server/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -59,6 +59,7 @@ import org.apache.lucene.util.CollectionUtil;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ResourceAlreadyExistsException;
 import org.elasticsearch.Version;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.bulk.BackoffPolicy;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
@@ -569,7 +570,10 @@ public class IndicesService extends AbstractLifecycleComponent
                             backoffIt
                         );
                     },
-                    (_, e1) -> result.completeExceptionally(e1),
+                    ActionListener.wrap(
+                        _ -> {},
+                        e1 -> result.completeExceptionally(e1)
+                    ),
                     Priority.NORMAL
                 );
             };

--- a/server/src/main/java/org/elasticsearch/indices/store/IndicesStore.java
+++ b/server/src/main/java/org/elasticsearch/indices/store/IndicesStore.java
@@ -33,6 +33,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
@@ -300,7 +301,9 @@ public class IndicesStore implements ClusterStateListener, Closeable {
                         LOGGER.debug(() -> new ParameterizedMessage("{} failed to delete unallocated shard, ignoring", shardId), ex);
                     }
                 },
-                (source, e) -> LOGGER.error(() -> new ParameterizedMessage("{} unexpected error during deletion of unallocated shard", shardId), e)
+                ActionListener.wrap(
+                    _ -> {},
+                    err -> LOGGER.error(() -> new ParameterizedMessage("{} unexpected error during deletion of unallocated shard", shardId), err))
             );
         }
 

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/NoOpClusterApplier.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/NoOpClusterApplier.java
@@ -20,6 +20,7 @@ package org.elasticsearch.cluster.coordination;
 
 import java.util.function.Supplier;
 
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.service.ClusterApplier;
 
@@ -30,7 +31,7 @@ public class NoOpClusterApplier implements ClusterApplier {
     }
 
     @Override
-    public void onNewClusterState(String source, Supplier<ClusterState> clusterStateSupplier, ClusterApplyListener listener) {
-        listener.onSuccess(source);
+    public void onNewClusterState(String source, Supplier<ClusterState> clusterStateSupplier, ActionListener<Void> listener) {
+        listener.onResponse(null);
     }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/routing/BatchedRerouteServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/BatchedRerouteServiceTests.java
@@ -38,6 +38,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.coordination.FailedToCommitClusterStateException;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.node.DiscoveryNodes.Builder;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.Randomness;
@@ -216,11 +217,18 @@ public class BatchedRerouteServiceTests extends ESTestCase {
             }
 
             if (rarely()) {
-                clusterService.getClusterApplierService().onNewClusterState("simulated", () -> {
-                    ClusterState state = clusterService.state();
-                    return ClusterState.builder(state).nodes(DiscoveryNodes.builder(state.nodes())
-                        .masterNodeId(randomBoolean() ? null : state.nodes().getLocalNodeId())).build();
-                }, (source, e) -> { });
+                clusterService.getClusterApplierService().onNewClusterState(
+                    "simulated",
+                    () -> {
+                        ClusterState state = clusterService.state();
+                        Builder nodesBuilder = DiscoveryNodes.builder(state.nodes())
+                            .masterNodeId(randomBoolean() ? null : state.nodes().getLocalNodeId());
+                        return ClusterState.builder(state)
+                            .nodes(nodesBuilder)
+                            .build();
+                    },
+                    ActionListener.wrap(() -> {})
+                );
             }
         }
 

--- a/server/src/test/java/org/elasticsearch/snapshots/InternalSnapshotsInfoServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/InternalSnapshotsInfoServiceTests.java
@@ -58,7 +58,6 @@ import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
-import org.elasticsearch.cluster.service.ClusterApplier;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
@@ -374,18 +373,8 @@ public class InternalSnapshotsInfoServiceTests extends ESTestCase {
     private void applyClusterState(final String reason, final UnaryOperator<ClusterState> applier) {
         TestFutureUtils.get(future -> clusterService.getClusterApplierService().onNewClusterState(reason,
             () -> applier.apply(clusterService.state()),
-            new ClusterApplier.ClusterApplyListener() {
-                @Override
-                public void onSuccess(String source) {
-                    future.onResponse(source);
-                }
-
-                @Override
-                public void onFailure(String source, Exception e) {
-                    future.onFailure(e);
-                }
-            })
-        );
+            future.map(_ -> (Void) null)
+        ));
     }
 
     private void waitForMaxActiveGenericThreads(final int nbActive) throws Exception {


### PR DESCRIPTION
The signature of `ClusterApplyListener` matched `ActionListener` pretty
closely, we can easily unify the two.
