### PR TITLE
RowConsumerToResultReceiver must be closed and finished if there was an attempt to close it

### DIFF
--- a/docs/appendices/release-notes/5.10.12.rst
+++ b/docs/appendices/release-notes/5.10.12.rst
@@ -47,4 +47,5 @@ See the :ref:`version_5.10.0` release notes for a full list of changes in the
 Fixes
 =====
 
-None
+- Fixed an issue that caused having stuck ``sys.jobs`` entries when using PG
+  protocol and prepared statements.

--- a/server/src/main/java/io/crate/protocols/postgres/Portal.java
+++ b/server/src/main/java/io/crate/protocols/postgres/Portal.java
@@ -34,6 +34,7 @@ public final class Portal {
     private String portalName;
     private final PreparedStmt preparedStmt;
     private final List<Object> params;
+    private boolean closeAttemptIgnored = false;
 
     @Nullable
     private final FormatCodes.FormatCode[] resultFormatCodes;
@@ -72,7 +73,11 @@ public final class Portal {
     }
 
     public void setActiveConsumer(RowConsumerToResultReceiver consumer) {
+        if (closeAttemptIgnored) {
+            consumer.markToBeClosed();
+        }
         this.consumer = consumer;
+
     }
 
     @Nullable
@@ -83,6 +88,8 @@ public final class Portal {
     public void closeActiveConsumer() {
         if (consumer != null) {
             consumer.closeAndFinishIfSuspended();
+        } else {
+            closeAttemptIgnored = true;
         }
     }
 

--- a/server/src/main/java/io/crate/session/RowConsumerToResultReceiver.java
+++ b/server/src/main/java/io/crate/session/RowConsumerToResultReceiver.java
@@ -156,8 +156,12 @@ public class RowConsumerToResultReceiver implements RowConsumer {
             // can arrive before batch is processed.
             // We mark "failed" close attempt so that it's done again
             // when portal is back to the suspended state after finishing a batch.
-            closeAttemptIgnored = true;
+            markToBeClosed();
         }
+    }
+
+    public void markToBeClosed() {
+        closeAttemptIgnored = true;
     }
 
     public boolean suspended() {


### PR DESCRIPTION
Relates to https://github.com/crate/support/issues/603


https://www.postgresql.org/docs/current/protocol-flow.html#PROTOCOL-FLOW-PIPELINING

A BIND message can arrive amid previous execution (happening in a different thread) when a batch hasn't finished yet and consumer is not suspended. `closeAndFinishIfSuspended` won't have effect in this case. Also, consumer can be not assigned yet and  `portal.closeActiveConsumer` won't have effect as well.

We finish consumer again once batch is completed and if we already (unsuccessfully) attempted to close it. 
This way we ensure that we don't leak sys.jobs

------
Reproduction (on 5.10.11) UPD: Managed to reproduce with an itest, see last commit


<details>

<summary>Flink job</summary>

```
public class App {

    public static void main( String[] args ) {
        try {
            StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
            env.setParallelism(1);
            DataStream<Integer> source = env.fromSequence(1, 3).map(Long::intValue);
            source.addSink(
                    JdbcSink.sink(
                            "SELECT ?",
                            (ps, value) -> ps.setInt(1, value),
                            JdbcExecutionOptions.builder()
                                    .withMaxRetries(0)
                                    .build(),
                            new JdbcConnectionOptions.JdbcConnectionOptionsBuilder()
                                    .withDriverName("io.crate.client.jdbc.CrateDriver")
                                    .withUrl("jdbc:crate://localhost:5432/")
                                    // .withDriverName("org.postgresql.Driver")
                                    // .withUrl("jdbc:postgresql://localhost:5432/crate")
                                    .withUsername("crate")
                                    .withPassword("")
                                    .build()
                    )
            );
            env.execute("crate-repro");
        } catch (Exception ex) {
        }
    }
}
```

</details>

<details>


<summary>pom.xml</summary>

```
<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
  <modelVersion>4.0.0</modelVersion>

  <groupId>org.test</groupId>
  <artifactId>flink-repro</artifactId>
  <version>1.0-SNAPSHOT</version>
  <packaging>jar</packaging>

  <name>flink-repro</name>
  <url>http://maven.apache.org</url>

  <properties>
    <maven.compiler.source>11</maven.compiler.source>
    <maven.compiler.target>11</maven.compiler.target>
    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
    <flink.version>1.20.0</flink.version>
  </properties>

  <dependencies>

    <dependency>
      <groupId>org.apache.flink</groupId>
      <artifactId>flink-streaming-java</artifactId>
      <version>${flink.version}</version>
    </dependency>

    <dependency>
      <groupId>org.apache.flink</groupId>
      <artifactId>flink-clients</artifactId>
      <version>${flink.version}</version>
    </dependency>


    <dependency>
      <groupId>org.apache.flink</groupId>
      <artifactId>flink-core</artifactId>
      <version>${flink.version}</version>
    </dependency>

    <dependency>
      <groupId>io.crate</groupId>
      <artifactId>crate-jdbc</artifactId>
      <version>2.7.0</version>
    </dependency>

<!--    <dependency>-->
<!--      <groupId>org.postgresql</groupId>-->
<!--      <artifactId>postgresql</artifactId>-->
<!--      <version>42.7.5</version>-->
<!--    </dependency>-->

    <dependency>
      <groupId>org.apache.flink</groupId>
      <artifactId>flink-connector-jdbc</artifactId>
      <version>3.3.0-1.20</version>
    </dependency>

  </dependencies>
</project>
```

</details>

-----


