### PR TITLE
Ping JDK to 24.0.1 for github action jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Maven Java
         uses: actions/setup-java@v4
         with:
-          java-version: "24"
+          java-version: "24.0.1"
           distribution: "temurin"
           cache: maven
 
@@ -55,7 +55,7 @@ jobs:
       - name: Setup Maven Java
         uses: actions/setup-java@v4
         with:
-          java-version: "24"
+          java-version: "24.0.1"
           distribution: "temurin"
           cache: maven
       - name: Run forbiddenapis:check

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Maven Java
         uses: actions/setup-java@v4
         with:
-          java-version: "24"
+          java-version: "24.0.1"
           distribution: "temurin"
           cache: maven
 


### PR DESCRIPTION
24.0.2 results in flakiness for
`BlobIntegrationTest.testCorsHeadersAreSet` test

