### PR TITLE
tests: Temp ignore testCoreHeadersAreSet()

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/BlobIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/BlobIntegrationTest.java
@@ -47,6 +47,7 @@ import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.shard.ShardNotFoundException;
 import org.elasticsearch.test.IntegTestCase;
 import org.jetbrains.annotations.Nullable;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import io.crate.blob.v2.BlobIndicesService;
@@ -83,6 +84,7 @@ public class BlobIntegrationTest extends BlobHttpIntegrationTest {
     }
 
     @Test
+    @Ignore("Flakiness introduced with JDK 24.0.2")
     public void testCorsHeadersAreSet() throws Exception {
         String digest = uploadTinyBlob();
         HttpRequest request = HttpRequest.newBuilder(blobUri(digest))


### PR DESCRIPTION
The test is flaky with jdk 24.0.2 which is currently pickedup by github actions workflows:

```
Expecting Optional to contain a value but it was empty.
	at __randomizedtesting.SeedInfo.seed([6A82062249493589:2FE7027B240934DD]:0)
	at io.crate.integrationtests.BlobIntegrationTest.testCorsHeadersAreSet(BlobIntegrationTest.java:92)
	at java.base/java.lang.reflect.Method.invoke(Method.java:565)
	at com.carrotsearch.randomizedtesting.RandomizedRunner.invoke(RandomizedRunner.java:1763)
	at com.carrotsearch.randomizedtesting.RandomizedRunner$8.evaluate(RandomizedRunner.java:946)
	at com.carrotsearch.randomizedtesting.RandomizedRunner$9.evaluate(RandomizedRunner.java:982)
	at com.carrotsearch.randomizedtesting.RandomizedRunner$10.evaluate(RandomizedRunner.java:996)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:328)
	at java.base/java.lang.Thread.run(Thread.java:1447)
```

