### PR TITLE
Change datatype and return value of `columns.is_nullable`

### DIFF
--- a/docs/appendices/release-notes/6.1.0.rst
+++ b/docs/appendices/release-notes/6.1.0.rst
@@ -45,7 +45,10 @@ Version 6.1.0 - Unreleased
 Breaking Changes
 ================
 
-None
+- Changed the datatype and values returned from ``is_nullable`` column of
+  :ref:`information_schema.columns <information_schema_columns>` table.
+  Previously, it was returning ``BOOLEAN`` values, and now it returns ``'YES'``
+  or ``'NO'``, in order to be compatible with the SQL specification.
 
 Deprecations
 ============

--- a/docs/general/information-schema.rst
+++ b/docs/general/information-schema.rst
@@ -385,7 +385,7 @@ infinite recursion of your mind, beware!)::
     | interval_type            | text       |               30 |
     | is_generated             | text       |               31 |
     | is_identity              | boolean    |               32 |
-    | is_nullable              | boolean    |               33 |
+    | is_nullable              | text       |               33 |
     | numeric_precision        | integer    |               34 |
     | numeric_precision_radix  | integer    |               35 |
     | numeric_scale            | integer    |               36 |
@@ -420,7 +420,8 @@ infinite recursion of your mind, beware!)::
 | ``ordinal_position``          | The position of the column within the         | ``INTEGER``   |
 |                               | table                                         |               |
 +-------------------------------+-----------------------------------------------+---------------+
-| ``is_nullable``               | Whether the column is nullable                | ``BOOLEAN``   |
+| ``is_nullable``               | 'YES' if the column is nullable, 'NO'         | ``TEXT``      |
+|                               | if it's not nullable                          |               |
 +-------------------------------+-----------------------------------------------+---------------+
 | ``data_type``                 | The data type of the column                   | ``TEXT``      |
 |                               |                                               |               |

--- a/server/src/main/java/io/crate/metadata/information/InformationColumnsTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/information/InformationColumnsTableInfo.java
@@ -38,7 +38,7 @@ import io.crate.metadata.SystemTable;
 import io.crate.types.DataTypes;
 
 
-public class InformationColumnsTableInfo {
+public final class InformationColumnsTableInfo {
 
     public static final String NAME = "columns";
     public static final RelationName IDENT = new RelationName(InformationSchemaInfo.NAME, NAME);
@@ -47,6 +47,8 @@ public class InformationColumnsTableInfo {
     private static final String IS_GENERATED_ALWAYS = "ALWAYS";
     private static final Integer NUMERIC_PRECISION_RADIX = 2; // Binary
     private static final Integer DATETIME_PRECISION = 3; // Milliseconds
+
+    private InformationColumnsTableInfo() {}
 
     public static SystemTable<ColumnContext> INSTANCE = SystemTable.<ColumnContext>builder(IDENT)
         .addNonNull("table_schema", STRING, r -> r.ref().ident().tableIdent().schema())
@@ -61,10 +63,11 @@ public class InformationColumnsTableInfo {
             }
             return IS_GENERATED_NEVER;
         })
-        .addNonNull("is_nullable", BOOLEAN, r -> !r.relation().primaryKey().contains(r.ref().column()) && r.ref().isNullable())
+        .addNonNull("is_nullable", DataTypes.STRING, r ->
+            !r.relation().primaryKey().contains(r.ref().column()) && r.ref().isNullable() ? "YES" : "NO")
         .add("generation_expression", STRING, r -> {
-            if (r.ref() instanceof GeneratedReference) {
-                return ((GeneratedReference) r.ref()).formattedGeneratedExpression();
+            if (r.ref() instanceof GeneratedReference gr) {
+                return gr.formattedGeneratedExpression();
             }
             return null;
         })
@@ -127,5 +130,4 @@ public class InformationColumnsTableInfo {
             ColumnIdent.of("column_name")
         )
         .build();
-
 }

--- a/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -610,7 +610,7 @@ public class InformationSchemaTest extends IntegTestCase {
             "interval_type| text",
             "is_generated| text",
             "is_identity| boolean",
-            "is_nullable| boolean",
+            "is_nullable| text",
             "numeric_precision| integer",
             "numeric_precision_radix| integer",
             "numeric_scale| integer",
@@ -762,13 +762,13 @@ public class InformationSchemaTest extends IntegTestCase {
         assertThat(response.rows()[0][cols.get("identity_minimum")]).isEqualTo(null);
         assertThat(response.rows()[0][cols.get("identity_cycle")]).isEqualTo(null);
 
-        assertThat(response.rows()[0][cols.get("is_nullable")]).isEqualTo(false);
-        assertThat(response.rows()[2][cols.get("is_nullable")]).isEqualTo(false);
-        assertThat(response.rows()[3][cols.get("is_nullable")]).isEqualTo(true);
-        assertThat(response.rows()[7][cols.get("is_nullable")]).isEqualTo(false);
-        assertThat(response.rows()[8][cols.get("is_nullable")]).isEqualTo(false);
-        assertThat(response.rows()[9][cols.get("is_nullable")]).isEqualTo(false);
-        assertThat(response.rows()[10][cols.get("is_nullable")]).isEqualTo(true);
+        assertThat(response.rows()[0][cols.get("is_nullable")]).isEqualTo("NO");
+        assertThat(response.rows()[2][cols.get("is_nullable")]).isEqualTo("NO");
+        assertThat(response.rows()[3][cols.get("is_nullable")]).isEqualTo("YES");
+        assertThat(response.rows()[7][cols.get("is_nullable")]).isEqualTo("NO");
+        assertThat(response.rows()[8][cols.get("is_nullable")]).isEqualTo("NO");
+        assertThat(response.rows()[9][cols.get("is_nullable")]).isEqualTo("NO");
+        assertThat(response.rows()[10][cols.get("is_nullable")]).isEqualTo("YES");
 
         assertThat(response.rows()[1][cols.get("numeric_precision")]).isEqualTo(8);
         assertThat(response.rows()[6][cols.get("numeric_precision")]).isEqualTo(16);


### PR DESCRIPTION
To conform with the SQL spec regarding `information_schema.columns` table, change the datatype of `is_nullable` from `BOOLEAN` to `TEXT` and return `'YES'` or `'NO'` as strings.

Closes: #17979

