### PR TITLE
Fix stuck SELECT via pg if maxRows=numRows using batch execution

### DIFF
--- a/docs/appendices/release-notes/5.10.12.rst
+++ b/docs/appendices/release-notes/5.10.12.rst
@@ -47,5 +47,9 @@ See the :ref:`version_5.10.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an issue that could cause ``SELECT`` statements to get stuck if executed
+  via a PostgreSQL client that set the ``maxRow`` option as part of an
+  ``EXECUTE`` message and it matched the number of result rows exactly.
+
 - Fixed an issue that prevented users to change the value of the
   :ref:`indices.recovery.max_concurrent_file_chunks` setting.

--- a/docs/appendices/release-notes/6.0.1.rst
+++ b/docs/appendices/release-notes/6.0.1.rst
@@ -47,6 +47,10 @@ series.
 Fixes
 =====
 
+- Fixed an issue that could cause ``SELECT`` statements to get stuck if executed
+  via a PostgreSQL client that set the ``maxRow`` option as part of an
+  ``EXECUTE`` message and it matched the number of result rows exactly.
+
 - Fixed a regression introduced in 6.0.0 that could cause ``INSERT INTO``
   statements to get stuck during a network partition.
 

--- a/server/src/main/java/io/crate/protocols/postgres/Portal.java
+++ b/server/src/main/java/io/crate/protocols/postgres/Portal.java
@@ -25,9 +25,9 @@ import java.util.List;
 
 import org.jetbrains.annotations.Nullable;
 
+import io.crate.analyze.AnalyzedStatement;
 import io.crate.session.PreparedStmt;
 import io.crate.session.RowConsumerToResultReceiver;
-import io.crate.analyze.AnalyzedStatement;
 
 public final class Portal {
 
@@ -91,6 +91,7 @@ public final class Portal {
         return "Portal{" +
                "portalName=" + portalName +
                ", preparedStmt=" + preparedStmt.rawStatement() +
+               ", consumer=" + consumer +
                '}';
     }
 }

--- a/server/src/main/java/io/crate/session/RowConsumerToResultReceiver.java
+++ b/server/src/main/java/io/crate/session/RowConsumerToResultReceiver.java
@@ -45,12 +45,12 @@ public class RowConsumerToResultReceiver implements RowConsumer {
      * Reset per suspend/execute
      */
     private int rowCount = 0;
-    private BatchIterator<Row> activeIt;
+    private CompletableFuture<BatchIterator<Row>> suspendedIt = new CompletableFuture<>();
 
     public RowConsumerToResultReceiver(ResultReceiver<?> resultReceiver, int maxRows, Consumer<Throwable> onCompletion) {
         this.resultReceiver = resultReceiver;
         this.maxRows = maxRows;
-        completionFuture.whenComplete((res, err) -> {
+        completionFuture.whenComplete((_, err) -> {
             onCompletion.accept(err);
         });
     }
@@ -77,22 +77,23 @@ public class RowConsumerToResultReceiver implements RowConsumer {
         while (true) {
             try {
                 while (iterator.moveNext()) {
+                    if (rowCount > 0 && maxRows > 0 && rowCount % maxRows == 0) {
+                        suspendedIt.complete(iterator);
+                        resultReceiver.batchFinished();
+                        return; // resumed via postgres protocol, close is done later
+                    }
                     rowCount++;
                     CompletableFuture<Void> writeFuture = resultReceiver.setNextRow(iterator.currentElement());
                     if (writeFuture != null) {
                         LOGGER.trace("Suspended execution after {} rows as the receiver is not writable anymore", rowCount);
-                        activeIt = iterator;
+                        suspendedIt.complete(iterator);
                         writeFuture.thenRun(() -> {
                             LOGGER.trace("Resume execution after {} rows", rowCount);
-                            resume();
+                            suspendedIt = new CompletableFuture<>();
+                            rowCount = 0;
+                            consumeIt(iterator);
                         });
                         return;
-                    }
-
-                    if (maxRows > 0 && rowCount % maxRows == 0) {
-                        activeIt = iterator;
-                        resultReceiver.batchFinished();
-                        return; // resumed via postgres protocol, close is done later
                     }
                 }
                 if (iterator.allLoaded()) {
@@ -109,7 +110,7 @@ public class RowConsumerToResultReceiver implements RowConsumer {
                         }
                         continue;
                     }
-                    nextBatch.whenComplete((r, f) -> {
+                    nextBatch.whenComplete((_, f) -> {
                         if (f == null) {
                             consumeIt(iterator);
                         } else {
@@ -135,17 +136,17 @@ public class RowConsumerToResultReceiver implements RowConsumer {
      * and finish the ResultReceiver
      */
     public void closeAndFinishIfSuspended() {
-        if (activeIt != null) {
-            activeIt.close();
+        suspendedIt.whenComplete((it, _) -> {
+            it.close();
             completionFuture.complete(null);
             // resultReceiver is left untouched:
             // - A previous .batchCompleted() call already flushed out pending messages
             // - Calling failure/allFinished would lead to extra messages, including  sentCommandComplete, to the client, which can lead to issues on the client.
-        }
+        });
     }
 
     public boolean suspended() {
-        return activeIt != null;
+        return suspendedIt.isDone();
     }
 
     public void replaceResultReceiver(ResultReceiver<?> resultReceiver, int maxRows) {
@@ -159,10 +160,20 @@ public class RowConsumerToResultReceiver implements RowConsumer {
     }
 
     public void resume() {
-        assert activeIt != null : "resume must only be called if suspended() returned true and activeIt is not null";
-        BatchIterator<Row> iterator = this.activeIt;
-        this.activeIt = null;
-        consumeIt(iterator);
+        assert suspended() : "resume must only be called if suspended() returned true";
+        BatchIterator<Row> it = null;
+        try {
+            it = suspendedIt.join();
+            suspendedIt = new CompletableFuture<>();
+            resultReceiver.setNextRow(it.currentElement());
+            consumeIt(it);
+        } catch (Throwable t) {
+            if (it != null) {
+                it.close();
+            }
+            completionFuture.completeExceptionally(t);
+            resultReceiver.fail(t);
+        }
     }
 
     @Override
@@ -171,7 +182,7 @@ public class RowConsumerToResultReceiver implements RowConsumer {
                "resultReceiver=" + resultReceiver +
                ", maxRows=" + maxRows +
                ", rowCount=" + rowCount +
-               ", activeIt=" + activeIt +
+               ", activeIt=" + suspendedIt +
                '}';
     }
 }

--- a/server/src/main/java/io/crate/session/Session.java
+++ b/server/src/main/java/io/crate/session/Session.java
@@ -630,6 +630,7 @@ public class Session implements AutoCloseable {
         if (activeExecution == null) {
             return triggerDeferredExecutions(forceBulk);
         } else {
+            LOGGER.debug("method=sync activeExecution={}", activeExecution);
             var result = activeExecution;
             activeExecution = null;
             return result;
@@ -679,9 +680,10 @@ public class Session implements AutoCloseable {
     }
 
     private CompletableFuture<?> triggerDeferredExecutions(boolean forceBulk) {
-        switch (deferredExecutionsByStmt.size()) {
+        int numDeferred = deferredExecutionsByStmt.size();
+        LOGGER.debug("method=sync deferredExecutions={}", numDeferred);
+        switch (numDeferred) {
             case 0:
-                LOGGER.debug("method=sync deferredExecutions=0");
                 return CompletableFuture.completedFuture(null);
             case 1: {
                 var deferredExecutions = deferredExecutionsByStmt.values().iterator().next();
@@ -689,7 +691,7 @@ public class Session implements AutoCloseable {
                 return exec(deferredExecutions, forceBulk);
             }
             default: {
-                // Mix of different defered execution is PG specific.
+                // Mix of different deferred execution is PG specific.
                 // HTTP sync-s at the end of both single/bulk requests, and it's always one statement.
                 // sequentiallize execution to ensure client receives row counts in correct order
                 CompletableFuture<?> allCompleted = null;

--- a/server/src/test/java/io/crate/integrationtests/PostgresITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PostgresITest.java
@@ -970,6 +970,22 @@ public class PostgresITest extends IntegTestCase {
     }
 
     @Test
+    public void testExecuteBatchDoesNotLeakSysJobsLog() throws Exception {
+        try (Connection conn = DriverManager.getConnection(url(RW), properties)) {
+            PreparedStatement stmt = conn.prepareStatement("SELECT ?");
+            for (int i = 1; i <= 3; i++) {
+                stmt.setInt(1, i);
+                stmt.addBatch();
+            }
+            stmt.executeBatch();
+        }
+        for (JobsLogService jobsLogService : cluster().getDataNodeInstances(JobsLogService.class)) {
+            assertBusy(() -> assertThat(jobsLogService.get().activeJobs()).isEmpty());
+        }
+    }
+
+
+    @Test
     public void test_insert_with_on_conflict_do_nothing_batch_error_resp_is_0_for_conflicting_items() throws Exception {
         try (Connection conn = DriverManager.getConnection(url(RW), properties)) {
             conn.prepareStatement("create table t (id int primary key) clustered into 1 shards").execute();


### PR DESCRIPTION
A portal got suspended if `maxRows` set by the client matched the number
of rows returned.

This resulted in a `portalSuspended` message that a client might ignore,
moving onto executing the next statement and leaving the portal in
suspended state.

Two issues here:

- The portal should complete instead of suspend it is on the last row.
- Suspended portals should get cleaned up if the client doesn't continue
  using them.
