### PR TITLE
Use NIOFSDirectory explicitly in TableStatsService

### DIFF
--- a/server/src/main/java/io/crate/statistics/TableStatsService.java
+++ b/server/src/main/java/io/crate/statistics/TableStatsService.java
@@ -283,7 +283,7 @@ public class TableStatsService implements Runnable, ClusterStateListener {
     }
 
     private IndexWriter createWriter() throws IOException {
-        Directory directory = NIOFSDirectory.open(dataPath);
+        Directory directory = new NIOFSDirectory(dataPath);
         boolean openExisting = DirectoryReader.indexExists(directory);
 
         IndexWriterConfig indexWriterConfig = new IndexWriterConfig(new KeywordAnalyzer());


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

`NIOFSDirectory.open()` can create various implementations of `FSDirectory` based on the platform. This makes sure always `NIOFSDirectory` is used.


## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
