### PR TITLE
Fix issue with concurrent call to TableStatsService#update()

### DIFF
--- a/server/src/main/java/io/crate/statistics/TableStatsService.java
+++ b/server/src/main/java/io/crate/statistics/TableStatsService.java
@@ -28,6 +28,7 @@ import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -37,7 +38,6 @@ import org.apache.lucene.document.Field;
 import org.apache.lucene.document.StoredField;
 import org.apache.lucene.document.StringField;
 import org.apache.lucene.index.DirectoryReader;
-import org.apache.lucene.index.IndexNotFoundException;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
@@ -77,12 +77,12 @@ import org.jetbrains.annotations.VisibleForTesting;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 
+import io.crate.common.unit.TimeValue;
+import io.crate.data.Row;
 import io.crate.metadata.RelationName;
 import io.crate.session.BaseResultReceiver;
 import io.crate.session.Session;
 import io.crate.session.Sessions;
-import io.crate.common.unit.TimeValue;
-import io.crate.data.Row;
 
 /**
  * Handles persistence for {@link TableStats} and periodically refreshes {@link TableStats}
@@ -112,6 +112,7 @@ public class TableStatsService implements Runnable, ClusterStateListener {
 
     @VisibleForTesting
     volatile Scheduler.ScheduledCancellable scheduledRefresh;
+    private AtomicBoolean refreshingStats = new AtomicBoolean(false);
 
     private static final String STATS = "_stats";
     private static final String DATA_FIELD = "data";
@@ -167,10 +168,10 @@ public class TableStatsService implements Runnable, ClusterStateListener {
         }
         try {
             BaseResultReceiver resultReceiver = new BaseResultReceiver();
-            resultReceiver.completionFuture().whenComplete((res, err) -> {
+            resultReceiver.completionFuture().whenComplete((_, err) -> {
                 scheduledRefresh = scheduleNextRefresh(refreshInterval);
                 if (err != null) {
-                    LOGGER.error("Error running periodic " + STMT + "", err);
+                    LOGGER.error("Error running periodic " + STMT, err);
                 }
             });
             if (session == null) {
@@ -212,11 +213,9 @@ public class TableStatsService implements Runnable, ClusterStateListener {
         if (!Files.exists(dataPath)) {
             return;
         }
-        try {
-            try (var writer = createWriter()) {
-                writer.deleteDocuments(relTerm(relationName));
-                writer.commit();
-            }
+        try (var writer = createWriter()) {
+            writer.deleteDocuments(relTerm(relationName));
+            writer.commit();
             cache.invalidate(relationName);
         } catch (IOException e) {
             throw new UncheckedIOException("Can't delete TableStats from disk", e);
@@ -228,11 +227,9 @@ public class TableStatsService implements Runnable, ClusterStateListener {
         if (!Files.exists(dataPath)) {
             return;
         }
-        try {
-            try (var writer = createWriter()) {
-                writer.deleteAll();
-                writer.commit();
-            }
+        try (var writer = createWriter()) {
+            writer.deleteAll();
+            writer.commit();
             cache.invalidateAll();
         } catch (IOException e) {
             throw new UncheckedIOException("Can't delete TableStats from disk", e);
@@ -246,14 +243,7 @@ public class TableStatsService implements Runnable, ClusterStateListener {
         if (!Files.exists(dataPath)) {
             return null;
         }
-        try (Directory dir = new NIOFSDirectory(dataPath)) {
-            DirectoryReader reader;
-            try {
-                reader = DirectoryReader.open(dir);
-            } catch (IndexNotFoundException e) {
-                LOGGER.warn("Failed to load Stats from {} {}", dataPath.toString(), e.getMessage());
-                return null;
-            }
+        try (Directory dir = new NIOFSDirectory(dataPath); DirectoryReader reader = DirectoryReader.open(dir)) {
             IndexSearcher indexSearcher = new IndexSearcher(reader);
             indexSearcher.setQueryCache(null);
             Query query = new TermQuery(relTerm(relationName));
@@ -277,36 +267,39 @@ public class TableStatsService implements Runnable, ClusterStateListener {
                 }
             }
         } catch (IOException e) {
+            LOGGER.warn("Failed to load Stats from {} {}", dataPath, e.getMessage());
             throw new UncheckedIOException(e);
         }
         return null;
     }
 
-    private IndexWriter createWriter() throws IOException {
+    private TableStatsIndexWriter createWriter() throws IOException {
         Directory directory = new NIOFSDirectory(dataPath);
-        boolean openExisting = DirectoryReader.indexExists(directory);
-
         IndexWriterConfig indexWriterConfig = new IndexWriterConfig(new KeywordAnalyzer());
-        indexWriterConfig.setOpenMode(openExisting ? IndexWriterConfig.OpenMode.APPEND : IndexWriterConfig.OpenMode.CREATE);
+        indexWriterConfig.setOpenMode(IndexWriterConfig.OpenMode.CREATE_OR_APPEND);
         indexWriterConfig.setMergeScheduler(new SerialMergeScheduler());
 
-        return new IndexWriter(directory, indexWriterConfig);
+        return new TableStatsIndexWriter(directory, indexWriterConfig);
     }
 
     public void update(Map<RelationName, Stats> stats) {
-        try {
-            try (var writer = createWriter()) {
-                for (Map.Entry<RelationName, Stats> entry : stats.entrySet()) {
-                    RelationName relationName = entry.getKey();
-                    Document doc = makeDocument(relationName, entry.getValue());
-                    writer.updateDocument(relTerm(relationName), doc);
-                }
-                writer.prepareCommit();
-                writer.commit();
+        if (refreshingStats.getAndSet(true)) {
+            LOGGER.error("Already refreshing stats");
+            return;
+        }
+        try (var writer = createWriter()) {
+            for (Map.Entry<RelationName, Stats> entry : stats.entrySet()) {
+                RelationName relationName = entry.getKey();
+                Document doc = makeDocument(relationName, entry.getValue());
+                writer.updateDocument(relTerm(relationName), doc);
             }
+            writer.prepareCommit();
+            writer.commit();
             cache.invalidateAll(stats.keySet());
         } catch (IOException e) {
-            throw new UncheckedIOException("Can't load TableStats from disk", e);
+            throw new UncheckedIOException("Can't write TableStats to disk", e);
+        } finally {
+            refreshingStats.set(false);
         }
     }
 
@@ -337,6 +330,18 @@ public class TableStatsService implements Runnable, ClusterStateListener {
             if (!newMetadata.contains(name)) {
                 remove(name);
             }
+        }
+    }
+
+    private static class TableStatsIndexWriter extends IndexWriter {
+        public TableStatsIndexWriter(Directory d, IndexWriterConfig conf) throws IOException {
+            super(d, conf);
+        }
+
+        @Override
+        public void close() throws IOException {
+            super.close();
+            getDirectory().close();
         }
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/TableStatsServiceIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TableStatsServiceIntegrationTest.java
@@ -30,17 +30,18 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.carrotsearch.randomizedtesting.annotations.Seed;
+
 import io.crate.metadata.RelationName;
 import io.crate.statistics.Stats;
 import io.crate.statistics.TableStats;
-
 
 @IntegTestCase.ClusterScope(supportsDedicatedMasters = false, numDataNodes = 2, numClientNodes = 0)
 public class TableStatsServiceIntegrationTest extends IntegTestCase {
 
     @Before
     public void setRefreshInterval() {
-        execute("set global transient stats.service.interval='50ms'");
+        execute("set global transient stats.service.interval='100ms'");
     }
 
     @After
@@ -49,6 +50,7 @@ public class TableStatsServiceIntegrationTest extends IntegTestCase {
     }
 
     @Test
+    @Seed("35E3B4A35CA4C33B")
     public void test_stats_updated_and_deleted() throws Exception {
         execute("create table t1(a int) with (number_of_replicas = 1)");
         ensureGreen();
@@ -70,6 +72,7 @@ public class TableStatsServiceIntegrationTest extends IntegTestCase {
         }, 5, TimeUnit.SECONDS);
     }
 
+    @Seed("35E3B4A35CA4C33B")
     public void test_delete_table_stats_when_partitioned_table_is_dropped() throws Exception {
         execute("create table t1 (id integer, timestamp timestamp with time zone) " +
             "partitioned by(timestamp) with (number_of_replicas=0)");
@@ -94,6 +97,5 @@ public class TableStatsServiceIntegrationTest extends IntegTestCase {
             Stats stats = tableStats.getStats(new RelationName(sqlExecutor.getCurrentSchema(), "t1"));
             assertThat(stats).isEqualTo(Stats.EMPTY);
         }, 5, TimeUnit.SECONDS);
-
     }
 }

--- a/server/src/testFixtures/java/org/elasticsearch/test/IntegTestCase.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/IntegTestCase.java
@@ -191,7 +191,6 @@ import io.crate.session.Session;
 import io.crate.session.Sessions;
 import io.crate.sql.Identifiers;
 import io.crate.sql.parser.SqlParser;
-import io.crate.statistics.TableStats;
 import io.crate.statistics.TableStatsService;
 import io.crate.test.integration.SystemPropsTestLoggingListener;
 import io.crate.testing.SQLResponse;
@@ -1349,7 +1348,7 @@ public abstract class IntegTestCase extends ESTestCase {
     }
 
     @After
-    private void resetTableStats() {
+    public void resetTableStats() {
         for (TableStatsService tableStats : cluster().getInstances(TableStatsService.class)) {
             tableStats.clear();
         }


### PR DESCRIPTION
- The issue is revealed because of the short (`50ms`) refresh interval set in `TableStatsServiceIntegrationTest`. Add and `AtomicBoolean` as synchronization point to reject concurrent calls to `update`.

- Some minor code cleanup.
- Use a custom IndexWriter class to also close the NIO Directory

Follows: https://github.com/crate/crate/pull/18071

Example failures:
```
java.io.UncheckedIOException: Can't delete TableStats from disk
	at __randomizedtesting.SeedInfo.seed([35E3B4A35CA4C33B:62F673901921B036]:0)
	at io.crate.statistics.TableStatsService.clear(TableStatsService.java:238)
	at org.elasticsearch.test.IntegTestCase.resetTableStats(IntegTestCase.java:1354)
	at java.base/java.lang.reflect.Method.invoke(Method.java:565)
	at com.carrotsearch.randomizedtesting.RandomizedRunner.invoke(RandomizedRunner.java:1763)
	at com.carrotsearch.randomizedtesting.RandomizedRunner$10.evaluate(RandomizedRunner.java:1004)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:328)
	at java.base/java.lang.Thread.run(Thread.java:1447)
Caused by: org.apache.lucene.store.LockObtainFailedException: Lock held by this virtual machine: /tmp/io.crate.integrationtests.TableStatsServiceIntegrationTest_35E3B4A35CA4C33B-001/tempDir-002/node_s0/d0/nodes/0/_stats/write.lock
	at org.apache.lucene.store.NativeFSLockFactory.obtainFSLock(NativeFSLockFactory.java:126)
	at org.apache.lucene.store.FSLockFactory.obtainLock(FSLockFactory.java:43)
	at org.apache.lucene.store.BaseDirectory.obtainLock(BaseDirectory.java:44)
	at org.apache.lucene.index.IndexWriter.<init>(IndexWriter.java:956)
	at io.crate.statistics.TableStatsService.createWriter(TableStatsService.java:293)
	at io.crate.statistics.TableStatsService.clear(TableStatsService.java:232)

REPRODUCE WITH: ./mvnw -pl server test -Dtest=io.crate.integrationtests.TableStatsServiceIntegrationTest -Dtests.method=test_stats_updated_and_deleted -Dtests.seed=35E3B4A35CA4C33B -Dtests.locale=fr-Latn-FR -Dtests.timezone=America/Indiana/Indianapolis
```

```
Caused by: org.elasticsearch.transport.RemoteTransportException: [node_s0][127.0.0.1:37813][internal:crate:sql/analyze/receive_stats]
Caused by: java.io.UncheckedIOException: Can't load TableStats from disk
	at io.crate.statistics.TableStatsService.update(TableStatsService.java:309)
	at io.crate.statistics.TransportAnalyzeAction.lambda$new$3(TransportAnalyzeAction.java:118)
	at io.crate.execution.support.NodeActionRequestHandler.messageReceived(NodeActionRequestHandler.java:48)
	at org.elasticsearch.transport.RequestHandlerRegistry.processMessageReceived(RequestHandlerRegistry.java:59)
	at org.elasticsearch.transport.InboundHandler.handleRequest(InboundHandler.java:224)
	at org.elasticsearch.transport.InboundHandler.messageReceived(InboundHandler.java:107)
	at org.elasticsearch.transport.InboundHandler.inboundMessage(InboundHandler.java:96)
	at org.elasticsearch.transport.TcpTransport.inboundMessage(TcpTransport.java:682)
	at org.elasticsearch.transport.InboundPipeline.forwardFragments(InboundPipeline.java:133)
	at org.elasticsearch.transport.InboundPipeline.doHandleBytes(InboundPipeline.java:108)
	at org.elasticsearch.transport.InboundPipeline.handleBytes(InboundPipeline.java:73)
	at org.elasticsearch.transport.netty4.Netty4MessageChannelHandler.channelRead(Netty4MessageChannelHandler.java:71)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:354)
	at io.netty.handler.logging.LoggingHandler.channelRead(LoggingHandler.java:280)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:354)
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1429)
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:918)
	at io.netty.channel.epoll.AbstractEpollStreamChannel$EpollStreamUnsafe.epollInReady(AbstractEpollStreamChannel.java:793)
	at io.netty.channel.epoll.AbstractEpollChannel$AbstractEpollUnsafe.handle(AbstractEpollChannel.java:482)
	at io.netty.channel.epoll.EpollIoHandler$DefaultEpollIoRegistration.handle(EpollIoHandler.java:307)
	at io.netty.channel.epoll.EpollIoHandler.processReady(EpollIoHandler.java:489)
	at io.netty.channel.epoll.EpollIoHandler.run(EpollIoHandler.java:444)
	at io.netty.channel.SingleThreadIoEventLoop.runIo(SingleThreadIoEventLoop.java:207)
	at io.netty.channel.SingleThreadIoEventLoop.run(SingleThreadIoEventLoop.java:178)
	at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:1073)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at java.lang.Thread.run(Thread.java:1447)
Caused by: org.apache.lucene.store.LockObtainFailedException: Lock held by this virtual machine: /tmp/io.crate.integrationtests.TableStatsServiceIntegrationTest_35E3B4A35CA4C33B-001/tempDir-002/node_s0/d0/nodes/0/_stats/write.lock
	at org.apache.lucene.store.NativeFSLockFactory.obtainFSLock(NativeFSLockFactory.java:126)
	at org.apache.lucene.store.FSLockFactory.obtainLock(FSLockFactory.java:43)
	at org.apache.lucene.store.BaseDirectory.obtainLock(BaseDirectory.java:44)
	at org.apache.lucene.index.IndexWriter.<init>(IndexWriter.java:956)
	at io.crate.statistics.TableStatsService.createWriter(TableStatsService.java:293)
	at io.crate.statistics.TableStatsService.update(TableStatsService.java:298)

REPRODUCE WITH: ./mvnw -pl server test -Dtest=io.crate.integrationtests.TableStatsServiceIntegrationTest -Dtests.method=test_delete_table_stats_when_partitioned_table_is_dropped -Dtests.seed=35E3B4A35CA4C33B -Dtests.locale=fr-Latn-FR -Dtests.timezone=America/Indiana/Indianapolis
```