### PR TITLE
Fix NUMERIC precision loss

### DIFF
--- a/docs/appendices/release-notes/5.10.12.rst
+++ b/docs/appendices/release-notes/5.10.12.rst
@@ -53,3 +53,7 @@ Fixes
 
 - Fixed an issue that prevented users to change the value of the
   :ref:`indices.recovery.max_concurrent_file_chunks` setting.
+
+- Fixed an issue that caused a decimal literals to be converted to a ``DOUBLE``
+  when it cannot be contained exactly, causing precision loss. It is now
+  converted to a ``NUMERIC``.

--- a/docs/appendices/release-notes/6.0.1.rst
+++ b/docs/appendices/release-notes/6.0.1.rst
@@ -59,3 +59,7 @@ Fixes
 
 - Fixed an issue that prevented users to change the value of the
   :ref:`indices.recovery.max_concurrent_file_chunks` setting.
+
+- Fixed an issue that caused a decimal literals to be converted to a ``DOUBLE``
+  when it cannot be contained exactly, causing precision loss. It is now
+  converted to a ``NUMERIC``.

--- a/libs/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -2325,7 +2325,8 @@ class AstBuilder extends SqlBaseParserBaseVisitor<Node> {
     public Node visitDecimalLiteral(SqlBaseParser.DecimalLiteralContext context) {
         String text = context.getText().replace("_", "");
         BigDecimal bigDecimal = new BigDecimal(text);
-        if (bigDecimal.precision() <= 18 || bigDecimal.scale() < 0) {
+        // Must keep new BigDecimal(...) to preserve the precision, BigDecimal.of(...) will hide rounding errors
+        if (new BigDecimal(bigDecimal.doubleValue()).compareTo(bigDecimal) == 0) {
             return new DoubleLiteral(bigDecimal.doubleValue());
         }
         return new NumericLiteral(bigDecimal);

--- a/libs/sql-parser/src/test/java/io/crate/sql/parser/TestSqlParser.java
+++ b/libs/sql-parser/src/test/java/io/crate/sql/parser/TestSqlParser.java
@@ -31,6 +31,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.catchThrowableOfType;
 import static org.assertj.core.api.Fail.fail;
 
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -48,6 +49,7 @@ import io.crate.sql.tree.DoubleLiteral;
 import io.crate.sql.tree.Expression;
 import io.crate.sql.tree.FunctionCall;
 import io.crate.sql.tree.Node;
+import io.crate.sql.tree.NumericLiteral;
 import io.crate.sql.tree.ParameterExpression;
 import io.crate.sql.tree.QualifiedName;
 import io.crate.sql.tree.QualifiedNameReference;
@@ -132,7 +134,7 @@ public class TestSqlParser {
     }
 
     @Test
-    public void testDouble() {
+    public void test_decimal_literals() {
         assertExpression("123.", new DoubleLiteral(123));
         assertExpression("123.0", new DoubleLiteral(123));
         assertExpression(".5", new DoubleLiteral(.5));
@@ -142,15 +144,15 @@ public class TestSqlParser {
         assertExpression("123.E7", new DoubleLiteral(123E7));
         assertExpression("123.0E7", new DoubleLiteral(123E7));
         assertExpression("123E+7", new DoubleLiteral(123E7));
-        assertExpression("123E-7", new DoubleLiteral(123E-7));
+        assertExpression("123E-7", new NumericLiteral(new BigDecimal("123E-7")));
 
         assertExpression("123.456E7", new DoubleLiteral(123.456E7));
         assertExpression("123.456E+7", new DoubleLiteral(123.456E7));
-        assertExpression("123.456E-7", new DoubleLiteral(123.456E-7));
+        assertExpression("123.456E-7", new NumericLiteral(new BigDecimal("123.456E-7")));
 
-        assertExpression(".4E42", new DoubleLiteral(.4E42));
-        assertExpression(".4E+42", new DoubleLiteral(.4E42));
-        assertExpression(".4E-42", new DoubleLiteral(.4E-42));
+        assertExpression(".4E42", new NumericLiteral(new BigDecimal(".4E42")));
+        assertExpression(".4E+42", new NumericLiteral(new BigDecimal(".4E+42")));
+        assertExpression(".4E-42", new NumericLiteral(new BigDecimal(".4E-42")));
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes https://github.com/crate/crate/issues/18220.

Basically, the root cause was that `721330.4241866222` was converted to a `double` first which caused precision loss.
```
cr> select pg_typeof(721330.4241866222);
+------------------+
| pg_typeof        |
+------------------+
| double precision | -- double cannot represent this value with exact precision
+------------------+
SELECT 1 row in set (0.465 sec)
```
The PR will make sure that the decimal literal fits into a `double` before converting.

After the fix:
```
cr> select pg_typeof(721330.4241866222);
+-----------+
| pg_typeof |
+-----------+
| numeric   |
+-----------+
SELECT 1 row in set (0.002 sec)
```

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
