### PR TITLE
Ensure row consumer waiting for netty write is not cancelled

### DIFF
--- a/server/src/main/java/io/crate/session/RowConsumerToResultReceiver.java
+++ b/server/src/main/java/io/crate/session/RowConsumerToResultReceiver.java
@@ -27,6 +27,7 @@ import java.util.function.Consumer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.VisibleForTesting;
 
 import io.crate.data.BatchIterator;
 import io.crate.data.Row;
@@ -46,6 +47,7 @@ public class RowConsumerToResultReceiver implements RowConsumer {
      */
     private int rowCount = 0;
     private CompletableFuture<BatchIterator<Row>> suspendedIt = new CompletableFuture<>();
+    private boolean waitingForWrite = false;
 
     public RowConsumerToResultReceiver(ResultReceiver<?> resultReceiver, int maxRows, Consumer<Throwable> onCompletion) {
         this.resultReceiver = resultReceiver;
@@ -86,10 +88,10 @@ public class RowConsumerToResultReceiver implements RowConsumer {
                     CompletableFuture<Void> writeFuture = resultReceiver.setNextRow(iterator.currentElement());
                     if (writeFuture != null) {
                         LOGGER.trace("Suspended execution after {} rows as the receiver is not writable anymore", rowCount);
-                        suspendedIt.complete(iterator);
+                        waitingForWrite = true;
                         writeFuture.thenRun(() -> {
                             LOGGER.trace("Resume execution after {} rows", rowCount);
-                            suspendedIt = new CompletableFuture<>();
+                            waitingForWrite = false;
                             rowCount = 0;
                             consumeIt(iterator);
                         });
@@ -147,6 +149,11 @@ public class RowConsumerToResultReceiver implements RowConsumer {
 
     public boolean suspended() {
         return suspendedIt.isDone();
+    }
+
+    @VisibleForTesting
+    public boolean waitingForWrite() {
+        return waitingForWrite;
     }
 
     public void replaceResultReceiver(ResultReceiver<?> resultReceiver, int maxRows) {


### PR DESCRIPTION
Follow up to https://github.com/crate/crate/pull/18235

If we receive a bind during active execution we must only close the
portal/consumer if it is suspended due to a maxRows, not if it is
waiting for the `.write` on a netty channel to proceed.
