### PR TITLE
Fix handling of generated columns during INSERT

### DIFF
--- a/benchmarks/src/main/java/io/crate/execution/dml/IndexerBenchmark.java
+++ b/benchmarks/src/main/java/io/crate/execution/dml/IndexerBenchmark.java
@@ -49,6 +49,7 @@ import io.crate.execution.dml.IndexItem.StaticItem;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.NodeContext;
+import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.session.BaseResultReceiver;
@@ -89,17 +90,18 @@ public class IndexerBenchmark {
 
         NodeContext nodeContext = injector.getInstance(NodeContext.class);
         DocTableInfo table = nodeContext.schemas().getTableInfo(new RelationName("doc", "tbl"));
-
+        List<Reference> targetColumns = List.of(
+                table.getReference(ColumnIdent.of("x")),
+                table.getReference(ColumnIdent.of("y"))
+        );
         indexer = new Indexer(
             List.of(),
             table,
             table.versionCreated(),
             new CoordinatorTxnCtx(session.sessionSettings()),
             injector.getInstance(NodeContext.class),
-            List.of(
-                table.getReference(ColumnIdent.of("x")),
-                table.getReference(ColumnIdent.of("y"))
-            ),
+            targetColumns,
+            targetColumns,
             null
         );
         items = IntStream.range(1, 2000).mapToObj(x -> new IndexItem.StaticItem(

--- a/server/src/main/java/io/crate/execution/dml/Indexer.java
+++ b/server/src/main/java/io/crate/execution/dml/Indexer.java
@@ -934,12 +934,13 @@ public class Indexer {
 
         for (var synthetic : undeterministic) {
             ColumnIdent column = synthetic.ref.column();
+            Object value = synthetic.value();
             if (column.isRoot()) {
                 int idx = Reference.indexOf(columns, column);
                 if (idx == -1) {
-                    extendedValues.add(synthetic.value());
+                    extendedValues.add(value);
                 } else {
-                    extendedValues.set(idx, synthetic.value());
+                    extendedValues.set(idx, value);
                 }
             } else {
                 int valueIdx = Reference.indexOf(columns, column.getRoot());
@@ -953,7 +954,6 @@ public class Indexer {
                     root = (Map<String, Object>) insertValues[valueIdx];
                 }
                 ColumnIdent child = column.shiftRight();
-                Object value = synthetic.value();
                 // We don't override value if it exists.
                 // It's needed when:
                 // - users explicitly provide the whole object (including generated sub-column), then we take user provided value.

--- a/server/src/main/java/io/crate/execution/dml/RawIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/RawIndexer.java
@@ -105,6 +105,7 @@ public class RawIndexer {
                 txnCtx,
                 nodeCtx,
                 targetRefs,
+                targetRefs,
                 returnValues
             );
         });

--- a/server/src/main/java/io/crate/execution/dml/upsert/ShardUpsertRequest.java
+++ b/server/src/main/java/io/crate/execution/dml/upsert/ShardUpsertRequest.java
@@ -284,13 +284,13 @@ public final class ShardUpsertRequest extends ShardRequest<ShardUpsertRequest, S
          * List of symbols used on update if document exist
          */
         @Nullable
-        private Symbol[] updateAssignments;
+        private final Symbol[] updateAssignments;
 
         /**
          * List of objects used on insert
          */
         @Nullable
-        private Object[] insertValues;
+        private final Object[] insertValues;
 
         /**
          * Values that make up the primary key.
@@ -403,10 +403,6 @@ public final class ShardUpsertRequest extends ShardRequest<ShardUpsertRequest, S
             return insertValues;
         }
 
-        public void insertValues(Object[] insertValues) {
-            this.insertValues = insertValues;
-        }
-
         public List<String> pkValues() {
             return pkValues;
         }
@@ -431,6 +427,8 @@ public final class ShardUpsertRequest extends ShardRequest<ShardUpsertRequest, S
                 for (int i = 0; i < assignmentsSize; i++) {
                     updateAssignments[i] = Symbol.fromStream(in);
                 }
+            } else {
+                updateAssignments = null;
             }
 
             int missingAssignmentsSize = in.readVInt();
@@ -440,6 +438,8 @@ public final class ShardUpsertRequest extends ShardRequest<ShardUpsertRequest, S
                 for (int i = 0; i < missingAssignmentsSize; i++) {
                     insertValues[i] = insertValueStreamers[i].readValueFrom(in);
                 }
+            } else {
+                insertValues = null;
             }
             if (in.getVersion().before(Version.V_5_8_0)) {
                 if (in.readBoolean()) {

--- a/server/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
+++ b/server/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
@@ -170,6 +170,7 @@ public class TransportShardUpsertAction extends TransportShardAction<
                 txnCtx,
                 nodeCtx,
                 updateToInsert.columns(),
+                insertColumns,
                 request.returnValues()
             );
             firstColumnIdent = indexer.columns().getFirst().column();
@@ -180,6 +181,7 @@ public class TransportShardUpsertAction extends TransportShardAction<
                 indexShard.getVersionCreated(),
                 txnCtx,
                 nodeCtx,
+                insertColumns,
                 insertColumns,
                 request.returnValues()
             );
@@ -342,6 +344,7 @@ public class TransportShardUpsertAction extends TransportShardAction<
                 indexShard.getVersionCreated(),
                 txnCtx,
                 nodeCtx,
+                targetColumns,
                 targetColumns,
                 null
             );

--- a/server/src/main/java/io/crate/execution/dml/upsert/package-info.java
+++ b/server/src/main/java/io/crate/execution/dml/upsert/package-info.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+/// There are four types of write operations from a user perspective:
+///
+/// 1. INSERT INTO
+/// 2. INSERT INTO with ON CONFLICT
+/// 3. COPY TO
+/// 4. UPDATE
+///
+/// Internally all four use [io.crate.execution.dml.upsert.ShardUpsertRequest]
+/// With either:
+///
+/// - Only `insertColumns` set (INSERT INTO or COPY TO, both pure insert)
+/// - Only `updateColumns` set (pure update)
+/// - Both `insertColumns` and `updateColumns` set (INSERT with ON CONFLICT)
+///
+/// Given that Lucene is append-only, update operations are executed with a read
+/// followed by a write using:
+///
+/// - [io.crate.execution.engine.collect.PKLookupOperation] for the read
+/// - [io.crate.execution.dml.upsert.UpdateToInsert] to convert the read data into a structure for the insert
+/// - [io.crate.execution.dml.Indexer] to create the Lucene index fields
+///
+/// The read and update->insert conversion always happens on the primary shard.
+/// For the replica, the operation always looks like a pure insert.
+/// Pure inserts use [io.crate.execution.dml.Indexer] directly.
+///
+/// ON CONFLICT are internally either like an insert or an update.
+/// This means that with bulk operations there can be a mix of inserts and updates within the same statement.
+///
+/// For the replica request the `insertColumns` will be the superset of the
+/// insert and update cases.
+/// The values on item level can have different lengths to cover either the
+/// insert (fewer values) or update (more values).
+///
+/// Given a table like:
+///
+/// ```sql
+/// CREATE TABLE tbl (
+///     id int primary key,
+///     x int,
+///     y int,
+///     z int default 0,
+///     write_ts as current_timestamp
+/// )
+/// ```
+///
+/// And a statement like:
+///
+/// ```sql
+/// INSERT INTO tbl (id, x) VALUES (?, ?)
+///     ON CONFLICT (id) DO UPDATE SET y = 10
+/// ```
+///
+/// We could have:
+///
+/// - INSERT [id, x, write_ts]       with VALUES [?, ?, write_ts generated]
+/// - UPDATE [id, x, write_ts, z, y] with VALUES [?, ?, write_ts generated, z, y]
+///
+/// The column order for the replica is always:
+///
+/// - Insert target columns
+/// - Undeterministic generated columns (always added to write the same value on the replica)
+/// - All remaining table columns (for update or on conflict)
+///
+package io.crate.execution.dml.upsert;

--- a/server/src/main/java/io/crate/execution/engine/collect/sources/FileCollectSource.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/sources/FileCollectSource.java
@@ -35,11 +35,11 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.jetbrains.annotations.VisibleForTesting;
 
 import io.crate.analyze.AnalyzedCopyFrom;
 import io.crate.analyze.CopyFromParserProperties;
 import io.crate.analyze.SymbolEvaluator;
-import org.jetbrains.annotations.VisibleForTesting;
 import io.crate.data.BatchIterator;
 import io.crate.data.Row;
 import io.crate.data.SkippingBatchIterator;
@@ -52,6 +52,7 @@ import io.crate.execution.engine.collect.files.FileReadingIterator;
 import io.crate.execution.engine.collect.files.LineCollectorExpression;
 import io.crate.execution.engine.collect.files.LineProcessor;
 import io.crate.expression.InputFactory;
+import io.crate.expression.reference.ReferenceResolver;
 import io.crate.expression.reference.file.FileLineReferenceResolver;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.NodeContext;
@@ -91,8 +92,8 @@ public class FileCollectSource implements CollectSource {
                                                              CollectTask collectTask,
                                                              boolean supportMoveToStart) {
         FileUriCollectPhase fileUriCollectPhase = (FileUriCollectPhase) collectPhase;
-        InputFactory.Context<LineCollectorExpression<?>> ctx =
-            inputFactory.ctxForRefs(txnCtx, FileLineReferenceResolver::getImplementation);
+        ReferenceResolver<LineCollectorExpression<?>> referenceResolver = FileLineReferenceResolver::getImplementation;
+        InputFactory.Context<LineCollectorExpression<?>> ctx = inputFactory.ctxForRefs(txnCtx, referenceResolver);
         ctx.add(collectPhase.toCollect());
 
         Role user = requireNonNull(roles.findUser(txnCtx.sessionSettings().userName()), "User who invoked a statement must exist");

--- a/server/src/test/java/io/crate/execution/dml/IndexerTest.java
+++ b/server/src/test/java/io/crate/execution/dml/IndexerTest.java
@@ -108,15 +108,17 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
                                      String tableName,
                                      String ... columns) {
         DocTableInfo table = e.resolveTableInfo(tableName);
+        List<Reference> targetColumns = Stream.of(columns)
+            .map(x -> table.resolveColumn(x, true, false))
+            .toList();
         return new Indexer(
             List.of(),
             table,
             table.versionCreated(),
             new CoordinatorTxnCtx(e.getSessionSettings()),
             e.nodeCtx,
-            Stream.of(columns)
-                .map(x -> table.resolveColumn(x, true, false))
-                .toList(),
+            targetColumns,
+            targetColumns,
             null
         );
     }
@@ -159,6 +161,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
             new CoordinatorTxnCtx(executor.getSessionSettings()),
             executor.nodeCtx,
             List.of(o),
+            List.of(o),
             null
         );
 
@@ -198,6 +201,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
             Version.CURRENT,
             new CoordinatorTxnCtx(executor.getSessionSettings()),
             executor.nodeCtx,
+            List.of(o),
             List.of(o),
             null
         );
@@ -263,6 +267,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
             new CoordinatorTxnCtx(executor.getSessionSettings()),
             executor.nodeCtx,
             List.of(o),
+            List.of(o),
             null
         );
 
@@ -306,6 +311,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
             txnCtx,
             executor.nodeCtx,
             List.of(y),
+            List.of(y),
             null
         );
         var parsedDoc = indexer.index(item(new Object[] { null }));
@@ -321,6 +327,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
             Version.CURRENT,
             txnCtx,
             executor.nodeCtx,
+            List.of(x),
             List.of(x),
             null
         );
@@ -345,6 +352,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
             new CoordinatorTxnCtx(executor.getSessionSettings()),
             executor.nodeCtx,
             List.of(x),
+            List.of(x),
             null
         );
         var parsedDoc = indexer.index(item(1));
@@ -365,6 +373,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
             Version.CURRENT,
             new CoordinatorTxnCtx(executor.getSessionSettings()),
             executor.nodeCtx,
+            List.of(x),
             List.of(x),
             null
         );
@@ -409,6 +418,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
             new CoordinatorTxnCtx(executor.getSessionSettings()),
             executor.nodeCtx,
             List.of(x),
+            List.of(x),
             null
         );
         var parsedDoc = indexer.index(item(1));
@@ -429,6 +439,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
             Version.CURRENT,
             new CoordinatorTxnCtx(executor.getSessionSettings()),
             executor.nodeCtx,
+            List.of(o),
             List.of(o),
             null
         );
@@ -461,6 +472,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
             new CoordinatorTxnCtx(executor.getSessionSettings()),
             executor.nodeCtx,
             List.of(x),
+            List.of(x),
             null
         );
         var parsedDoc = indexer.index(item(42));
@@ -489,6 +501,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
             new CoordinatorTxnCtx(executor.getSessionSettings()),
             executor.nodeCtx,
             List.of(x, y),
+            List.of(x, y),
             null
         );
         assertThatThrownBy(() -> indexer1.index(item(1, 2)))
@@ -501,6 +514,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
             new CoordinatorTxnCtx(executor.getSessionSettings()),
             executor.nodeCtx,
             List.of(x, o),
+            List.of(x, o),
             null
         );
         assertThatThrownBy(() -> indexer2.index(item(1, Map.of("z", 10))))
@@ -512,15 +526,17 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
         SQLExecutor executor = SQLExecutor.of(clusterService)
             .addTable("create table tbl (x int not null, y int default 0 NOT NULL)");
         DocTableInfo table = executor.resolveTableInfo("tbl");
+        List<Reference> targetColumns = List.of(
+            table.getReference(ColumnIdent.of("x"))
+        );
         Indexer indexer = new Indexer(
             List.of(),
             table,
             Version.CURRENT,
             new CoordinatorTxnCtx(executor.getSessionSettings()),
             executor.nodeCtx,
-            List.of(
-                table.getReference(ColumnIdent.of("x"))
-            ),
+            targetColumns,
+            targetColumns,
             null
         );
         assertThatThrownBy(() -> indexer.index(item(new Object[] { null })))
@@ -543,16 +559,18 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
                 )
                 """);
         DocTableInfo table = executor.resolveTableInfo("tbl");
+        List<Reference> targetColumns = List.of(
+            table.getReference(ColumnIdent.of("x")),
+            table.getReference(ColumnIdent.of("z"))
+        );
         Indexer indexer = new Indexer(
             List.of(),
             table,
             Version.CURRENT,
             new CoordinatorTxnCtx(executor.getSessionSettings()),
             executor.nodeCtx,
-            List.of(
-                table.getReference(ColumnIdent.of("x")),
-                table.getReference(ColumnIdent.of("z"))
-            ),
+            targetColumns,
+            targetColumns,
             null
         );
         assertThatThrownBy(() -> indexer.index(item(8, 10)))
@@ -575,15 +593,17 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
                 )
                 """);
         DocTableInfo table = executor.resolveTableInfo("tbl");
+        List<Reference> targetColumns = List.of(
+            table.getReference(ColumnIdent.of("o"))
+        );
         Indexer indexer = new Indexer(
             List.of(),
             table,
             Version.CURRENT,
             new CoordinatorTxnCtx(executor.getSessionSettings()),
             executor.nodeCtx,
-            List.of(
-                table.getReference(ColumnIdent.of("o"))
-            ),
+            targetColumns,
+            targetColumns,
             null
         );
         assertThatThrownBy(() -> indexer.collectSchemaUpdates(item(Map.of("x", 10, "y", 20))))
@@ -601,15 +621,17 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
                 )
                 """);
         DocTableInfo table = executor.resolveTableInfo("tbl");
+        List<Reference> targetColumns = List.of(
+            table.getReference(ColumnIdent.of("o"))
+        );
         Indexer indexer = new Indexer(
             List.of(),
             table,
             Version.CURRENT,
             new CoordinatorTxnCtx(executor.getSessionSettings()),
             executor.nodeCtx,
-            List.of(
-                table.getReference(ColumnIdent.of("o"))
-            ),
+            targetColumns,
+            targetColumns,
             null
         );
         List<Reference> newColumns = indexer.collectSchemaUpdates(item(Map.of("x", 10, "y", 20)));
@@ -626,15 +648,17 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
             .addTable("create table tbl (x int, y int default 20)");
 
         DocTableInfo table = e.resolveTableInfo("tbl");
+        List<Reference> targetColumns = List.of(
+            table.getReference(ColumnIdent.of("x"))
+        );
         Indexer indexer = new Indexer(
             List.of(),
             table,
             Version.CURRENT,
             new CoordinatorTxnCtx(e.getSessionSettings()),
             e.nodeCtx,
-            List.of(
-                table.getReference(ColumnIdent.of("x"))
-            ),
+            targetColumns,
+            targetColumns,
             new Symbol[] {
                 table.getReference(ColumnIdent.of("_id")),
                 table.getReference(ColumnIdent.of("x")),
@@ -652,16 +676,18 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
             .addTable("create table tbl (x int, o object as (y int))");
 
         DocTableInfo table = e.resolveTableInfo("tbl");
+        List<Reference> targetColumns = List.of(
+            table.getReference(ColumnIdent.of("x")),
+            table.getReference(ColumnIdent.of("o"))
+        );
         Indexer indexer = new Indexer(
             List.of(),
             table,
             Version.CURRENT,
             new CoordinatorTxnCtx(e.getSessionSettings()),
             e.nodeCtx,
-            List.of(
-                table.getReference(ColumnIdent.of("x")),
-                table.getReference(ColumnIdent.of("o"))
-            ),
+            targetColumns,
+            targetColumns,
             null
         );
 
@@ -788,13 +814,15 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
                 table,
                 clusterService.state(), Version.CURRENT)) {
 
+            List<Reference> targetColumns = Lists.map(columns, c -> table.getReference(c));
             Indexer indexer = new Indexer(
                 List.of(),
                 table,
                 Version.CURRENT,
                 new CoordinatorTxnCtx(e.getSessionSettings()),
                 e.nodeCtx,
-                Lists.map(columns, c -> table.getReference(c)),
+                targetColumns,
+                targetColumns,
                 null
             );
             ParsedDocument doc = indexer.index(item(values.toArray()));
@@ -818,17 +846,19 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
             .addTable("create table tbl (x int) with (column_policy = 'dynamic')");
 
         DocTableInfo table = e.resolveTableInfo("tbl");
+        List<Reference> targetColumns = List.of(
+            table.getReference(ColumnIdent.of("x")),
+            table.getDynamic(ColumnIdent.of("y"), true, false),
+            table.getDynamic(ColumnIdent.of("z"), true, false)
+        );
         Indexer indexer = new Indexer(
             List.of(),
             table,
             Version.CURRENT,
             new CoordinatorTxnCtx(e.getSessionSettings()),
             e.nodeCtx,
-            List.of(
-                table.getReference(ColumnIdent.of("x")),
-                table.getDynamic(ColumnIdent.of("y"), true, false),
-                table.getDynamic(ColumnIdent.of("z"), true, false)
-            ),
+            targetColumns,
+            targetColumns,
             null
         );
         IndexItem item = item(42, "Hello", 21);
@@ -861,6 +891,13 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
         SQLExecutor e = SQLExecutor.of(clusterService)
             .addTable("create table tbl (x int)");
         DocTableInfo table = e.resolveTableInfo("tbl");
+        List<Reference> targetColumns = List.<Reference>of(
+            new DynamicReference(
+                new ReferenceIdent(table.ident(), "y"),
+                RowGranularity.DOC,
+                -1
+            )
+        );
         assertThatThrownBy(() -> {
             new Indexer(
                 List.of(),
@@ -868,13 +905,8 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
                 Version.CURRENT,
                 new CoordinatorTxnCtx(e.getSessionSettings()),
                 e.nodeCtx,
-                List.<Reference>of(
-                    new DynamicReference(
-                        new ReferenceIdent(table.ident(), "y"),
-                        RowGranularity.DOC,
-                        -1
-                    )
-                ),
+                targetColumns,
+                targetColumns,
                 null
             );
         }).isExactlyInstanceOf(IllegalArgumentException.class)
@@ -1138,15 +1170,17 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
         DocTableInfo newTable = addColumns(e, table, newColumns);
         Reference oRef = newTable.getReference(ColumnIdent.of("o"));
         assertThat(((ObjectType) oRef.valueType()).innerTypes().keySet()).containsExactlyElementsOf(keys);
+        List<Reference> targetColumns = List.of("x", "o", "y").stream()
+            .map(x -> newTable.getReference(ColumnIdent.of(x)))
+            .toList();
         indexer = new Indexer(
             List.of(),
             newTable,
             Version.CURRENT,
             new CoordinatorTxnCtx(e.getSessionSettings()),
             e.nodeCtx,
-            List.of("x", "o", "y").stream()
-                .map(x -> newTable.getReference(ColumnIdent.of(x)))
-                .toList(),
+            targetColumns,
+            targetColumns,
             null
         );
         Map<String, Integer> o = new LinkedHashMap<>();
@@ -1238,6 +1272,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
             new CoordinatorTxnCtx(executor.getSessionSettings()),
             executor.nodeCtx,
             List.of(x, y),
+            List.of(x, y),
             null
         );
         IndexItem item = item(10, List.of(List.of(1, 2), List.of(3, 4)));
@@ -1267,17 +1302,19 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
              """
             );
         DocTableInfo table = executor.resolveTableInfo("t");
+        List<Reference> targetColumns = List.of(
+            table.getReference(ColumnIdent.of("a"))
+            // 'Parted' is not in targets to imitate insert-from-subquery behavior
+            //  which excludes partitioned columns from targets
+        );
         Indexer indexer = new Indexer(
             List.of("2"),
             table,
             Version.CURRENT,
             new CoordinatorTxnCtx(executor.getSessionSettings()),
             executor.nodeCtx,
-            List.of(
-                table.getReference(ColumnIdent.of("a"))
-                // 'Parted' is not in targets to imitate insert-from-subquery behavior
-                //  which excludes partitioned columns from targets
-            ),
+            targetColumns,
+            targetColumns,
             null
         );
 
@@ -1306,6 +1343,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
             Version.CURRENT,
             new CoordinatorTxnCtx(executor.getSessionSettings()),
             executor.nodeCtx,
+            List.of(x),
             List.of(x),
             null
         );

--- a/server/src/test/java/io/crate/execution/engine/collect/files/LineProcessorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/files/LineProcessorTest.java
@@ -36,6 +36,7 @@ import io.crate.execution.dsl.phases.FileUriCollectPhase.InputFormat;
 import io.crate.execution.engine.collect.files.FileReadingIterator.LineCursor;
 import io.crate.expression.InputFactory;
 import io.crate.expression.InputFactory.Context;
+import io.crate.expression.reference.ReferenceResolver;
 import io.crate.expression.reference.file.FileLineReferenceResolver;
 import io.crate.expression.reference.file.SourceParsingFailureExpression;
 import io.crate.metadata.CoordinatorTxnCtx;
@@ -48,6 +49,7 @@ public class LineProcessorTest {
 
     NodeContext nodeCtx = createNodeContext();
     InputFactory inputFactory = new InputFactory(nodeCtx);
+    ReferenceResolver<LineCollectorExpression<?>> referenceResolver = FileLineReferenceResolver::getImplementation;
 
     @Test
     public void test_line_processor_parses_json_input() throws Exception {
@@ -62,7 +64,7 @@ public class LineProcessorTest {
         );
         Context<LineCollectorExpression<?>> ctxForRefs = inputFactory.ctxForRefs(
             CoordinatorTxnCtx.systemTransactionContext(),
-            FileLineReferenceResolver::getImplementation
+            referenceResolver
         );
         ctxForRefs.add(List.of(
             TestingHelpers.createReference(SysColumns.RAW, DataTypes.STRING),
@@ -96,7 +98,7 @@ public class LineProcessorTest {
         );
         Context<LineCollectorExpression<?>> ctxForRefs = inputFactory.ctxForRefs(
             CoordinatorTxnCtx.systemTransactionContext(),
-            FileLineReferenceResolver::getImplementation
+            referenceResolver
         );
         ctxForRefs.add(List.of(
             TestingHelpers.createReference(SysColumns.RAW, DataTypes.STRING),
@@ -132,7 +134,7 @@ public class LineProcessorTest {
         );
         Context<LineCollectorExpression<?>> ctxForRefs = inputFactory.ctxForRefs(
             CoordinatorTxnCtx.systemTransactionContext(),
-            FileLineReferenceResolver::getImplementation
+            referenceResolver
         );
         ctxForRefs.add(List.of(
             TestingHelpers.createReference(SysColumns.RAW, DataTypes.STRING),
@@ -167,7 +169,7 @@ public class LineProcessorTest {
         );
         Context<LineCollectorExpression<?>> ctxForRefs = inputFactory.ctxForRefs(
             CoordinatorTxnCtx.systemTransactionContext(),
-            FileLineReferenceResolver::getImplementation
+            referenceResolver
         );
         ctxForRefs.add(List.of(
             TestingHelpers.createReference(SysColumns.RAW, DataTypes.STRING),

--- a/server/src/testFixtures/java/io/crate/operation/aggregation/AggregationTestCase.java
+++ b/server/src/testFixtures/java/io/crate/operation/aggregation/AggregationTestCase.java
@@ -406,6 +406,7 @@ public abstract class AggregationTestCase extends ESTestCase {
             CoordinatorTxnCtx.systemTransactionContext(),
             nodeCtx,
             targetColumns,
+            targetColumns,
             null
         );
 

--- a/server/src/testFixtures/java/io/crate/testing/QueryTester.java
+++ b/server/src/testFixtures/java/io/crate/testing/QueryTester.java
@@ -61,6 +61,7 @@ import io.crate.lucene.LuceneQueryBuilder;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.PartitionName;
+import io.crate.metadata.Reference;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.planner.PlannerContext;
 import io.crate.planner.optimizer.symbol.Optimizer;
@@ -138,13 +139,15 @@ public final class QueryTester implements AutoCloseable {
 
         public Builder indexValue(String column, Object value) throws IOException {
             IndexMetadata indexMetadata = plannerContext.clusterState().metadata().getIndex(table.ident(), List.of(), true, im -> im);
+            List<Reference> targetColumns = List.of(table.getReference(ColumnIdent.fromPath(column)));
             Indexer indexer = new Indexer(
                 indexMetadata.partitionValues(),
                 table,
                 indexVersion,
                 plannerContext.transactionContext(),
                 plannerContext.nodeContext(),
-                List.of(table.getReference(ColumnIdent.fromPath(column))),
+                targetColumns,
+                targetColumns,
                 null
             );
             var item = new IndexItem.StaticItem("dummy-id", List.of(), new Object[] { value }, -1L, -1L);
@@ -155,13 +158,15 @@ public final class QueryTester implements AutoCloseable {
 
         public Builder indexValues(List<String> columns, Object ... values) throws IOException {
             IndexMetadata indexMetadata = plannerContext.clusterState().metadata().getIndex(table.ident(), List.of(), true, im -> im);
+            List<Reference> targetColumns = Lists.map(columns, c -> table.getReference(ColumnIdent.fromPath(c)));
             Indexer indexer = new Indexer(
                 indexMetadata.partitionValues(),
                 table,
                 indexVersion,
                 plannerContext.transactionContext(),
                 plannerContext.nodeContext(),
-                Lists.map(columns, c -> table.getReference(ColumnIdent.fromPath(c))),
+                targetColumns,
+                targetColumns,
                 null
             );
             var item = new IndexItem.StaticItem("dummy-id", List.of(), values, -1L, -1L);


### PR DESCRIPTION
Fixes https://github.com/crate/crate/issues/18219

Regression was introduced in https://github.com/crate/crate/pull/18087
Due to `UpdateToInsert` extending the column list to include the
undeterministic generated columns, the `Indexer` thought that they were
provided in the statement, and didn't generate values for it.

Solution:

- Provide both the final target columns, and the provided columns to the
  Indexer so it knowns if it needs to generate the value or not.
- Adapt `Indexer.addGeneratedValues` to add the generated value at the
  right position.


Alternative to https://github.com/crate/crate/pull/18238

## TODO

- [ ] default handling
