### PR TITLE
Add workaround for eclipse compile type inference regression

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/collect/sources/FileCollectSource.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/sources/FileCollectSource.java
@@ -35,11 +35,11 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.jetbrains.annotations.VisibleForTesting;
 
 import io.crate.analyze.AnalyzedCopyFrom;
 import io.crate.analyze.CopyFromParserProperties;
 import io.crate.analyze.SymbolEvaluator;
-import org.jetbrains.annotations.VisibleForTesting;
 import io.crate.data.BatchIterator;
 import io.crate.data.Row;
 import io.crate.data.SkippingBatchIterator;
@@ -52,6 +52,7 @@ import io.crate.execution.engine.collect.files.FileReadingIterator;
 import io.crate.execution.engine.collect.files.LineCollectorExpression;
 import io.crate.execution.engine.collect.files.LineProcessor;
 import io.crate.expression.InputFactory;
+import io.crate.expression.reference.ReferenceResolver;
 import io.crate.expression.reference.file.FileLineReferenceResolver;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.NodeContext;
@@ -91,8 +92,8 @@ public class FileCollectSource implements CollectSource {
                                                              CollectTask collectTask,
                                                              boolean supportMoveToStart) {
         FileUriCollectPhase fileUriCollectPhase = (FileUriCollectPhase) collectPhase;
-        InputFactory.Context<LineCollectorExpression<?>> ctx =
-            inputFactory.ctxForRefs(txnCtx, FileLineReferenceResolver::getImplementation);
+        ReferenceResolver<LineCollectorExpression<?>> referenceResolver = FileLineReferenceResolver::getImplementation;
+        InputFactory.Context<LineCollectorExpression<?>> ctx = inputFactory.ctxForRefs(txnCtx, referenceResolver);
         ctx.add(collectPhase.toCollect());
 
         Role user = requireNonNull(roles.findUser(txnCtx.sessionSettings().userName()), "User who invoked a statement must exist");

--- a/server/src/test/java/io/crate/execution/engine/collect/files/LineProcessorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/files/LineProcessorTest.java
@@ -36,6 +36,7 @@ import io.crate.execution.dsl.phases.FileUriCollectPhase.InputFormat;
 import io.crate.execution.engine.collect.files.FileReadingIterator.LineCursor;
 import io.crate.expression.InputFactory;
 import io.crate.expression.InputFactory.Context;
+import io.crate.expression.reference.ReferenceResolver;
 import io.crate.expression.reference.file.FileLineReferenceResolver;
 import io.crate.expression.reference.file.SourceParsingFailureExpression;
 import io.crate.metadata.CoordinatorTxnCtx;
@@ -48,6 +49,7 @@ public class LineProcessorTest {
 
     NodeContext nodeCtx = createNodeContext();
     InputFactory inputFactory = new InputFactory(nodeCtx);
+    ReferenceResolver<LineCollectorExpression<?>> referenceResolver = FileLineReferenceResolver::getImplementation;
 
     @Test
     public void test_line_processor_parses_json_input() throws Exception {
@@ -62,7 +64,7 @@ public class LineProcessorTest {
         );
         Context<LineCollectorExpression<?>> ctxForRefs = inputFactory.ctxForRefs(
             CoordinatorTxnCtx.systemTransactionContext(),
-            FileLineReferenceResolver::getImplementation
+            referenceResolver
         );
         ctxForRefs.add(List.of(
             TestingHelpers.createReference(SysColumns.RAW, DataTypes.STRING),
@@ -96,7 +98,7 @@ public class LineProcessorTest {
         );
         Context<LineCollectorExpression<?>> ctxForRefs = inputFactory.ctxForRefs(
             CoordinatorTxnCtx.systemTransactionContext(),
-            FileLineReferenceResolver::getImplementation
+            referenceResolver
         );
         ctxForRefs.add(List.of(
             TestingHelpers.createReference(SysColumns.RAW, DataTypes.STRING),
@@ -132,7 +134,7 @@ public class LineProcessorTest {
         );
         Context<LineCollectorExpression<?>> ctxForRefs = inputFactory.ctxForRefs(
             CoordinatorTxnCtx.systemTransactionContext(),
-            FileLineReferenceResolver::getImplementation
+            referenceResolver
         );
         ctxForRefs.add(List.of(
             TestingHelpers.createReference(SysColumns.RAW, DataTypes.STRING),
@@ -167,7 +169,7 @@ public class LineProcessorTest {
         );
         Context<LineCollectorExpression<?>> ctxForRefs = inputFactory.ctxForRefs(
             CoordinatorTxnCtx.systemTransactionContext(),
-            FileLineReferenceResolver::getImplementation
+            referenceResolver
         );
         ctxForRefs.add(List.of(
             TestingHelpers.createReference(SysColumns.RAW, DataTypes.STRING),


### PR DESCRIPTION
Latest version of jdtls has some kind of regression which prevents the
type inference for inputFactory/ReferenceResolver to work in some cases.

This introduces some typed locals to help it out.
