### PR TITLE
Don't reset translog location on errors during bulk delete

### DIFF
--- a/server/src/main/java/io/crate/execution/dml/delete/TransportShardDeleteAction.java
+++ b/server/src/main/java/io/crate/execution/dml/delete/TransportShardDeleteAction.java
@@ -106,12 +106,15 @@ public class TransportShardDeleteAction extends TransportShardAction<
                     item.seqNo(),
                     item.primaryTerm()
                 );
-                translogLocation = deleteResult.getTranslogLocation();
                 Exception failure = deleteResult.getFailure();
                 if (debugEnabled) {
                     logResult("primary", request.shardId(), item.id(), deleteResult);
                 }
                 if (failure == null) {
+                    Translog.Location newTranslogLocation = deleteResult.getTranslogLocation();
+                    if (newTranslogLocation != null) {
+                        translogLocation = newTranslogLocation;
+                    }
                     Item resultItem = new Item(
                         item.id(),
                         deleteResult.getSeqNo(),

--- a/server/src/main/java/org/elasticsearch/index/engine/Engine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/Engine.java
@@ -363,11 +363,13 @@ public abstract class Engine implements Closeable {
         }
 
         /** get the translog location after executing the operation */
+        @Nullable
         public Translog.Location getTranslogLocation() {
             return translogLocation;
         }
 
         /** get document failure while executing the operation {@code null} in case of no failure */
+        @Nullable
         public Exception getFailure() {
             return failure;
         }


### PR DESCRIPTION
During a bulk delete it can happen that one item succeeds and a
following item fails. The latter resetted the `translogLocation` to
`null`, which meant that the `pendingOps` wasn't incremented as
expected.

(Not entirely sure what/if there was a user facing impact for this. Hence no changes but I'd tend to backport this to at least 6.0?)
