### PR TITLE
Include items with delete failure in replica request

### DIFF
--- a/server/src/main/java/io/crate/execution/dml/delete/TransportShardDeleteAction.java
+++ b/server/src/main/java/io/crate/execution/dml/delete/TransportShardDeleteAction.java
@@ -112,15 +112,15 @@ public class TransportShardDeleteAction extends TransportShardAction<
                     logResult("primary", request.shardId(), item.id(), deleteResult);
                 }
                 if (failure == null) {
+                    Item resultItem = new Item(
+                        item.id(),
+                        deleteResult.getSeqNo(),
+                        deleteResult.getTerm(),
+                        deleteResult.getVersion()
+                    );
+                    replicaRequest.add(location, resultItem);
                     if (deleteResult.isFound()) {
                         shardResponse.add(location);
-                        Item resultItem = new Item(
-                            item.id(),
-                            deleteResult.getSeqNo(),
-                            deleteResult.getTerm(),
-                            deleteResult.getVersion()
-                        );
-                        replicaRequest.add(location, resultItem);
                     } else {
                         var ex = new DocumentMissingException(indexShard.shardId(), item.id());
                         shardResponse.add(location, item.id(), ex, false);

--- a/server/src/main/java/org/elasticsearch/index/engine/Engine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/Engine.java
@@ -433,13 +433,6 @@ public abstract class Engine implements Closeable {
             this.found = found;
         }
 
-        /**
-         * use in case of the delete operation failed before getting to internal engine
-         **/
-        public DeleteResult(Exception failure, long version, long term) {
-            this(failure, version, term, SequenceNumbers.UNASSIGNED_SEQ_NO, false);
-        }
-
         public DeleteResult(Exception failure, long version, long term, long seqNo, boolean found) {
             super(failure, version, term, seqNo);
             this.found = found;


### PR DESCRIPTION
Regression introduced by https://github.com/crate/crate/pull/18087
Caused flaky test failures with errors like:

    java.lang.AssertionError:
    shard [insert_test/-PvTnzheRtuup9kF8777XA][0] on node [node_sd3] has pending operations:
     --> 0 marking VbGKCMhdSDi9SAU9NFt30g as in sync
    	at org.elasticsearch.index.shard.IndexShardOperationPermits.acquire(IndexShardOperationPermits.java:242)
    	at org.elasticsearch.index.shard.IndexShard.acquirePrimaryOperationPermit(IndexShard.java:2692)
    	at org.elasticsearch.index.shard.IndexShard.acquirePrimaryOperationPermit(IndexShard.java:2684)
    	at org.elasticsearch.indices.recovery.RecoverySourceHandler.lambda$runUnderPrimaryPermit$0(RecoverySourceHandler.java:405)
    	at org.elasticsearch.common.util.CancellableThreads.execute(CancellableThreads.java:97)
    	at org.elasticsearch.indices.recovery.RecoverySourceHandler.runUnderPrimaryPermit(RecoverySourceHandler.java:390)
    	at org.elasticsearch.indices.recovery.RecoverySourceHandler.finalizeRecovery(RecoverySourceHandler.java:873)
    	at org.elasticsearch.indices.recovery.RecoverySourceHandler.lambda$recoverToTarget$15(RecoverySourceHandler.java:361)

No new changes because https://github.com/crate/crate/pull/18236 sort of covers it too
