### PR TITLE
Optimize sync check in IndexShard.maybeSyncGlobalCheckpoint

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/seqno/ReplicationTracker.java
+++ b/server/src/main/java/org/elasticsearch/index/seqno/ReplicationTracker.java
@@ -966,6 +966,15 @@ public class ReplicationTracker extends AbstractIndexShardComponent implements L
         return globalCheckpoint;
     }
 
+    public boolean globalNeedsSync() {
+        for (var checkpointState : checkpoints.values()) {
+            if (checkpointState.inSync && checkpointState.globalCheckpoint < globalCheckpoint) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     @Override
     public long getAsLong() {
         return globalCheckpoint;


### PR DESCRIPTION
Minor optimization to avoid the copy operations from `getInSyncGlobalCheckpoints`

During debugging of https://github.com/crate/crate/pull/18274 I added
logging for the variable which ended up causing GC warnings in the logs.
