### PR TITLE
Load SrvPlugin as regular runtime plugin

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -119,12 +119,14 @@
       <artifactId>es-discovery-ec2</artifactId>
       <version>${project.version}</version>
     </dependency>
+
     <dependency>
       <groupId>io.crate</groupId>
       <artifactId>dns-discovery</artifactId>
       <version>${project.version}</version>
+      <scope>runtime</scope>
+      <optional>true</optional>
     </dependency>
-
     <dependency>
       <groupId>io.crate</groupId>
       <artifactId>crate-copy-s3</artifactId>

--- a/app/src/assembly/src.xml
+++ b/app/src/assembly/src.xml
@@ -104,6 +104,10 @@
       <source>../plugins/repository-gcs/src/main/resources/plugin-descriptor.properties</source>
       <outputDirectory>plugins/repository-gcs</outputDirectory>
     </file>
+    <file>
+      <source>../plugins/dns-discovery/src/main/resources/plugin-descriptor.properties</source>
+      <outputDirectory>plugins/dns-discovery</outputDirectory>
+    </file>
   </files>
   <dependencySets>
     <dependencySet>
@@ -130,6 +134,7 @@
         <exclude>io.crate:es-repository-azure</exclude>
         <exclude>com.microsoft.azure:*</exclude>
         <exclude>io.crate:repository-gcs</exclude>
+        <exclude>io.crate:dns-discovery</exclude>
       </excludes>
     </dependencySet>
   </dependencySets>
@@ -242,6 +247,20 @@
         <includeDependencies>true</includeDependencies>
         <unpack>false</unpack>
         <outputDirectory>plugins/repository-gcs</outputDirectory>
+      </binaries>
+    </moduleSet>
+    <moduleSet>
+      <useAllReactorProjects>true</useAllReactorProjects>
+      <includes>
+        <include>io.crate:dns-discovery</include>
+      </includes>
+      <binaries>
+        <includes>
+          <include>io.crate:dns-discovery</include>
+        </includes>
+        <includeDependencies>true</includeDependencies>
+        <unpack>false</unpack>
+        <outputDirectory>plugins/dns-discovery</outputDirectory>
       </binaries>
     </moduleSet>
     <moduleSet>

--- a/app/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
+++ b/app/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
@@ -62,14 +62,12 @@ import org.elasticsearch.repositories.s3.S3RepositoryPlugin;
 
 import io.crate.bootstrap.BootstrapException;
 import io.crate.ffi.Natives;
-import io.crate.plugin.SrvPlugin;
 
 public class Bootstrap {
 
     private static Bootstrap INSTANCE;
 
     private static final Collection<Class<? extends Plugin>> DEFAULT_PLUGINS = List.of(
-        SrvPlugin.class,
         URLRepositoryPlugin.class,
         S3RepositoryPlugin.class,
         Ec2DiscoveryPlugin.class

--- a/plugins/dns-discovery/src/main/resources/plugin-descriptor.properties
+++ b/plugins/dns-discovery/src/main/resources/plugin-descriptor.properties
@@ -1,0 +1,3 @@
+name=dns-discovery
+description="DNS Discovery"
+classname=io.crate.plugin.SrvPlugin


### PR DESCRIPTION
srv, url-repository, s3-repository and ec2-discovery are somehow special
in that they are statically integrated instead of dynamically like the
remaining plugins.

This is a step towards removing this distinction.