### PR TITLE
Try fix flaky testRecentPrimaryInformation

### DIFF
--- a/server/src/test/java/org/elasticsearch/gateway/ReplicaShardAllocatorIT.java
+++ b/server/src/test/java/org/elasticsearch/gateway/ReplicaShardAllocatorIT.java
@@ -205,10 +205,15 @@ public class ReplicaShardAllocatorIT extends IntegTestCase {
                 }
             });
             // AllocationService only calls GatewayAllocator if there are unassigned shards
+            // Excluding the new node for allocation to avoid rebalance of the `doc.test` table.
             execute("""
                 create table doc.dummy (x int)
-                with ("number_of_replicas" = 1, "write.wait_for_active_shards" = 0)
-            """);
+                with (
+                    "number_of_replicas" = 1,
+                    "write.wait_for_active_shards" = 0,
+                    "routing.allocation.exclude._name" = ?
+                )
+            """, new Object[] { newNode });
             cluster().startDataOnlyNode(nodeWithReplicaSettings);
 
             // need to wait for events to ensure the reroute has happened since we perform it async when a new node joins.


### PR DESCRIPTION
The test is flaky on CI:

    java.lang.AssertionError:
    Expecting HashSet:
      ["node_td3", "node_t0"]
    to contain:
      ["node_td2"]
    but could not find the following element(s):
      ["node_td2"]
    	at __randomizedtesting.SeedInfo.seed([5EFC65AF64A542A:3AD2C08D0B0C82F2]:0)
    	at org.elasticsearch.gateway.ReplicaShardAllocatorIT.lambda$testRecentPrimaryInformation$3(ReplicaShardAllocatorIT.java:230)
    	at org.elasticsearch.test.ESTestCase.assertBusy(ESTestCase.java:709)
    	at org.elasticsearch.test.ESTestCase.assertBusy(ESTestCase.java:683)
    	at org.elasticsearch.gateway.ReplicaShardAllocatorIT.testRecentPrimaryInformation(ReplicaShardAllocatorIT.java:227)

Couldn't reproduce the failure locally. This is a wild guess that the
`doc.dummy` table gets allocated on the new node and a rebalance moves
the `doc.test` table away.

To avoid that, this adds a routing allocation exclude setting for the
`doc.dummy` table.
