### PR TITLE
Add support for relative paths for `path.repo`

### DIFF
--- a/docs/appendices/release-notes/6.1.0.rst
+++ b/docs/appendices/release-notes/6.1.0.rst
@@ -50,6 +50,13 @@ Breaking Changes
   Previously, it was returning ``BOOLEAN`` values, and now it returns ``'YES'``
   or ``'NO'``, in order to be compatible with the SQL specification.
 
+- Changed behavior of relative paths defined for :ref:`path.conf <path.conf>`,
+  :ref:`path.data <path.data>`, :ref:`path.repo <path.repo>` and
+  :ref:`path.logs <path.logs>`, to use the value of
+  :ref:`CRATE_HOME <conf-env-crate-home>` as the basis directory, against which
+  the relative paths are resolved, thus conforming to the behavior already
+  described in the :ref:`documentation <conf-node-settings_paths>`.
+
 Deprecations
 ============
 

--- a/docs/config/node.rst
+++ b/docs/config/node.rst
@@ -330,6 +330,8 @@ Transport settings
   feature, because TCP keep-alives apply to all kinds of long-lived connections
   and not just to transport connections.
 
+.. _conf-node-settings_paths:
+
 Paths
 =====
 

--- a/sandbox/crate/config/crate.yml
+++ b/sandbox/crate/config/crate.yml
@@ -9,7 +9,7 @@ ssl.keystore_filepath: ../server/src/test/resources/keystore.pcks12 # working di
 ssl.keystore_password: keystorePassword
 ssl.keystore_key_password: keystorePassword
 
-path.repo: ../sandbox/crate/repo # working dir is ${PROJEC_DIR}/app
+path.repo: repo # working dir is ${PROJEC_DIR}/app
 
 http.cors.enabled: true
 http.cors.allow-origin: "*"

--- a/server/src/main/java/org/elasticsearch/env/Environment.java
+++ b/server/src/main/java/org/elasticsearch/env/Environment.java
@@ -87,8 +87,7 @@ public class Environment {
         this(settings, configPath, PathUtils.get(System.getProperty("java.io.tmpdir")));
     }
 
-    // Should only be called directly by this class's unit tests
-    Environment(final Settings settings, final Path configPath, final Path tmpPath) {
+    private Environment(final Settings settings, final Path configPath, final Path tmpPath) {
         final Path homeFile;
         if (PATH_HOME_SETTING.exists(settings)) {
             homeFile = PathUtils.get(PATH_HOME_SETTING.get(settings)).normalize();
@@ -97,7 +96,7 @@ public class Environment {
         }
 
         if (configPath != null) {
-            configFile = configPath.normalize();
+            configFile = homeFile.resolve(configPath.toString()).normalize().toAbsolutePath();
         } else {
             configFile = homeFile.resolve("config");
         }
@@ -111,7 +110,7 @@ public class Environment {
             if (dataPaths.isEmpty() == false) {
                 dataFiles = new Path[dataPaths.size()];
                 for (int i = 0; i < dataPaths.size(); i++) {
-                    dataFiles[i] = PathUtils.get(dataPaths.get(i));
+                    dataFiles[i] = homeFile.resolve(dataPaths.get(i)).normalize().toAbsolutePath();
                 }
             } else {
                 dataFiles = new Path[]{homeFile.resolve("data")};
@@ -135,13 +134,13 @@ public class Environment {
         } else {
             repoFiles = new Path[repoPaths.size()];
             for (int i = 0; i < repoPaths.size(); i++) {
-                repoFiles[i] = PathUtils.get(repoPaths.get(i));
+                repoFiles[i] = homeFile.resolve(repoPaths.get(i)).normalize().toAbsolutePath();
             }
         }
 
         // this is trappy, Setting#get(Settings) will get a fallback setting yet return false for Settings#exists(Settings)
         if (PATH_LOGS_SETTING.exists(settings)) {
-            logsFile = PathUtils.get(PATH_LOGS_SETTING.get(settings)).normalize();
+            logsFile = homeFile.resolve(PATH_LOGS_SETTING.get(settings)).normalize().toAbsolutePath();
         } else {
             logsFile = homeFile.resolve("logs");
         }

--- a/server/src/test/java/org/elasticsearch/env/EnvironmentTests.java
+++ b/server/src/test/java/org/elasticsearch/env/EnvironmentTests.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.env;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.ESTestCase;
+import org.junit.Test;
+
+public class EnvironmentTests extends ESTestCase {
+
+    @Test
+    public void testRelativePaths() {
+        Path cwd = Paths.get(System.getProperty("user.dir"));
+        String home = "home/";
+        Path config = Paths.get("./config");
+        String[] data = new String[] {"../data1", "/data2"};
+        String logs = "../../logs";
+        String repo = "../repo/";
+        Settings settings = Settings.builder()
+            .put(Environment.PATH_HOME_SETTING.getKey(), home)
+            .putList(Environment.PATH_DATA_SETTING.getKey(), data)
+            .put(Environment.PATH_LOGS_SETTING.getKey(), logs)
+            .put(Environment.PATH_REPO_SETTING.getKey(), repo)
+            .build();
+
+        Environment env = new Environment(settings, config);
+        assertThat(env.configFile()).hasToString(Paths.get(cwd.toString(), "home/config").toString());
+        assertThat(env.logsFile()).hasToString(Paths.get(cwd.toString(), "../logs").toString());
+        assertThat(env.dataFiles()).satisfiesExactly(
+            d -> assertThat(d).hasToString(Paths.get(cwd.toString(), "data1").toString()),
+            d -> assertThat(d).hasToString(Paths.get("/data2").toString())
+        );
+        assertThat(env.repoFiles()).satisfiesExactly(
+            r -> assertThat(r).hasToString(Paths.get(cwd.toString(), "repo").toString())
+        );
+    }
+}


### PR DESCRIPTION
Add `toAbsolutePath()` to be able to define relative repo paths like we currently do in `sandbox/crate/confg/crate.yml`
