### PR TITLE
Raise IndexNotFound instead of RelationUnknown in TransportShardUpsertAction

### DIFF
--- a/server/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
+++ b/server/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
@@ -40,6 +40,7 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
 import org.elasticsearch.common.lucene.uid.Versions;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.VersionType;
 import org.elasticsearch.index.engine.DocumentMissingException;
 import org.elasticsearch.index.engine.Engine;
@@ -63,7 +64,6 @@ import com.carrotsearch.hppc.IntArrayList;
 
 import io.crate.common.collections.Lists;
 import io.crate.common.exceptions.Exceptions;
-import io.crate.exceptions.RelationUnknown;
 import io.crate.execution.ddl.tables.AddColumnRequest;
 import io.crate.execution.ddl.tables.TransportAddColumn;
 import io.crate.execution.dml.IndexItem;
@@ -138,7 +138,7 @@ public class TransportShardUpsertAction extends TransportShardAction<
         Metadata metadata = clusterService.state().metadata();
         RelationMetadata relationMetadata = metadata.getRelation(indexUUID);
         if (relationMetadata == null) {
-            throw new RelationUnknown("RelationMetadata for index '" + indexUUID + "' not found in cluster state");
+            throw new IndexNotFoundException(indexShard.shardId().getIndex());
         }
         DocTableInfo tableInfo = schemas.getTableInfo(relationMetadata.name());
         IndexMetadata indexMetadata = metadata.index(indexUUID);
@@ -303,7 +303,7 @@ public class TransportShardUpsertAction extends TransportShardAction<
         Metadata metadata = clusterService.state().metadata();
         RelationMetadata relationMetadata = metadata.getRelation(indexUUID);
         if (relationMetadata == null) {
-            throw new IllegalStateException("RelationMetadata for index " + indexUUID + " not found in cluster state");
+            throw new IndexNotFoundException(indexShard.shardId().getIndex());
         }
         DocTableInfo tableInfo = schemas.getTableInfo(relationMetadata.name());
         IndexMetadata indexMetadata = metadata.index(indexUUID);


### PR DESCRIPTION
Follow up to the indexName->indexUUID change.

The retry detection of the underlying `ReplicationOperationAction`
doesn't recognize `RelationUnknown` as a retryable error.

I suspect this caused `test_stress_partition_deletion_and_creation`
failures like:

    io.crate.exceptions.RelationUnknown: Relation 'RelationMetadata for index '09WDOt2dT2C64Gwd86-y-w' not found in cluster state' unknown
    	at __randomizedtesting.SeedInfo.seed([FEAF173AC8E3FE02]:0)
    	at io.crate.execution.dml.upsert.TransportShardUpsertAction.processRequestItems(TransportShardUpsertAction.java:141)
    	at io.crate.execution.dml.upsert.TransportShardUpsertAction.processRequestItems(TransportShardUpsertAction.java:90)
    	at io.crate.execution.dml.TransportShardAction$1.call(TransportShardAction.java:116)
    	at io.crate.execution.dml.TransportShardAction$1.call(TransportShardAction.java:112)
    	at io.crate.execution.dml.TransportShardAction.withActiveOperation(TransportShardAction.java:147)
    	at io.crate.execution.dml.TransportShardAction.shardOperationOnPrimary(TransportShardAction.java:119)
    	at io.crate.execution.dml.TransportShardAction.shardOperationOnPrimary(TransportShardAction.java:57)
    	at org.elasticsearch.action.support.replication.TransportReplicationAction$PrimaryShardReference.perform(TransportReplicationAction.java:887)
    	at org.elasticsearch.action.support.replication.ReplicationOperation.execute(ReplicationOperation.java:124)
    	at org.elasticsearch.action.support.replication.TransportReplicationAction$AsyncPrimaryAction.runWithPrimaryShardReference(TransportReplicationAction.java:400)
