### PR TITLE
Update netty to 4.1.124

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -324,7 +324,7 @@
     <versions.antlr>4.13.2</versions.antlr>
     <versions.quickcheck>1.0</versions.quickcheck>
     <versions.hppc>0.8.2</versions.hppc>
-    <versions.netty>4.1.116.Final</versions.netty>
+    <versions.netty>4.1.124.Final</versions.netty>
     <versions.lucene>9.12.0</versions.lucene>
     <versions.spatial4j>0.8</versions.spatial4j>
     <versions.jts>1.20.0</versions.jts>


### PR DESCRIPTION
Includes a bunch of fixes:

- https://netty.io/news/2025/01/14/4-1-117-Final.html
- https://netty.io/news/2025/02/10/4-1-118-Final.html
- https://netty.io/news/2025/02/26/4-1-119-Final.html
- https://netty.io/news/2025/04/23/4-1-120-Final.html
- https://netty.io/news/2025/04/24/4-1-121-Final.html
- https://netty.io/news/2025/06/03/4-1-122-Final.html
- https://netty.io/news/2025/07/16/4-1-123-Final.html
- https://netty.io/news/2025/08/13/4-1-124-Final.html

Among them:

https://github.com/netty/netty/security/advisories/GHSA-prj3-ccx8-p6x4

But the motivation was that running tests for
https://github.com/crate/crate/pull/18310 failed locally with ByteBuf
leak errors.

Updating netty got rid of them. Although that might have been
coincidence.
