### PR TITLE
Enforce that non-partitioned RelationMetadata has exactly 1 indexUUID

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
@@ -1434,4 +1434,10 @@ public class IndexMetadata implements Diffable<IndexMetadata> {
             && VERIFIED_BEFORE_CLOSE_SETTING.exists(indexMetadata.getSettings())
             && VERIFIED_BEFORE_CLOSE_SETTING.get(indexMetadata.getSettings());
     }
+
+
+    @Override
+    public String toString() {
+        return "IndexMetadata{" + index + "}";
+    }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
@@ -585,14 +585,15 @@ public class MetadataCreateIndexService {
             indexName = partitionName.asIndexName();
         }
 
-        List<IndexMetadata> existingIndices = currentState.metadata().getIndices(tableName, partitionValues, true, im -> im);
+        Metadata metadata = currentState.metadata();
+        List<IndexMetadata> existingIndices = metadata.getIndices(tableName, partitionValues, false, im -> im);
         if (!existingIndices.isEmpty()) {
             throw new ResourceAlreadyExistsException(existingIndices.getFirst().getIndex().getName());
         }
 
         validateIndexSettings(indexName, concreteIndexSettings, true);
 
-        Metadata.Builder metadataBuilder = Metadata.builder(currentState.metadata());
+        Metadata.Builder metadataBuilder = Metadata.builder(metadata);
         final MappingMetadata mapping = new MappingMetadata(Map.of("default", MappingUtil.createMapping(
             MappingUtil.AllocPosition.forNewTable(),
             table.pkConstraintName(),

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/RelationMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/RelationMetadata.java
@@ -123,6 +123,12 @@ public sealed interface RelationMetadata extends Writeable permits
                  List<String> indexUUIDs,
                  long tableVersion) implements RelationMetadata {
 
+        public Table {
+            assert (partitionedBy.isEmpty() && indexUUIDs.size() == 1) || !partitionedBy.isEmpty()
+                : "Non-Partitioned table " + name + " must have exactly one indexUUID: " + indexUUIDs;
+        }
+
+
         private static final short ORD = 1;
 
         @Override

--- a/server/src/test/java/io/crate/metadata/doc/DocTableInfoFactoryTest.java
+++ b/server/src/test/java/io/crate/metadata/doc/DocTableInfoFactoryTest.java
@@ -120,12 +120,21 @@ public class DocTableInfoFactoryTest extends ESTestCase {
         String mapping = """
             {
                 "default": {
+                    "_meta" : {
+                        "partitioned_by" : [ [ "p", "integer"] ]
+                    },
                     "properties": {
                         "id": {
                             "type": "integer",
                             "position": 1,
                             "index": "not_analyzed",
                             "oid": 1
+                        },
+                        "p": {
+                            "type": "integer",
+                            "position": 2,
+                            "index": "not_analyzed",
+                            "oid": 2
                         }
                     }
                 }
@@ -167,8 +176,16 @@ public class DocTableInfoFactoryTest extends ESTestCase {
         String mapping = """
             {
                 "default": {
+                    "_meta": {
+                        "partitioned_by": [["p", "integer"]]
+                    },
                     "properties": {
                         "id": {
+                            "type": "integer",
+                            "position": 2,
+                            "index": "not_analyzed"
+                        },
+                        "p": {
                             "type": "integer",
                             "position": 1,
                             "index": "not_analyzed"


### PR DESCRIPTION
Should help ensure that we always have sound RelationMetadata 