### PR TITLE
Remove duplicate partitionValues generation in MetadataUpgradeService

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataUpgradeService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataUpgradeService.java
@@ -260,7 +260,6 @@ public class MetadataUpgradeService {
         }
 
         for (IndexMetadata indexMetadata : metadata) {
-            indexMetadata = upgradeIndexMetadata(indexMetadata, null, Version.V_5_0_0, null);
             DocTableInfo docTable = tableFactory.create(indexMetadata);
             String indexName = indexMetadata.getIndex().getName();
             IndexParts indexParts = IndexName.decode(indexName);

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataUpgradeService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataUpgradeService.java
@@ -21,8 +21,8 @@ package org.elasticsearch.cluster.metadata;
 
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_VERSION_CREATED;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_VERSION_UPGRADED;
-import static org.elasticsearch.cluster.metadata.Metadata.Builder.NO_OID_COLUMN_OID_SUPPLIER;
 import static org.elasticsearch.cluster.metadata.Metadata.COLUMN_OID_UNASSIGNED;
+import static org.elasticsearch.cluster.metadata.Metadata.Builder.NO_OID_COLUMN_OID_SUPPLIER;
 
 import java.util.HashMap;
 import java.util.List;
@@ -292,12 +292,6 @@ public class MetadataUpgradeService {
                 if (table.indexUUIDs().contains(indexMetadata.getIndexUUID())) {
                     // already added
                     continue;
-                }
-                if (indexParts.isPartitioned()) {
-                    indexMetadata = IndexMetadata.builder(indexMetadata)
-                        .partitionValues(PartitionName.decodeIdent(indexParts.partitionIdent()))
-                        .build();
-                    newMetadata.put(indexMetadata, false);
                 }
                 newMetadata.addIndexUUIDs(table, List.of(indexMetadata.getIndexUUID()));
             }


### PR DESCRIPTION
The partitionValues are already added in:

https://github.com/crate/crate/blob/d60205fe50488de8e302c38b81cb38d8ed838bdc/server/src/main/java/io/crate/metadata/upgrade/MetadataIndexUpgrader.java?plain=1#L246-L258

Which is called as part of the `upgradeIndexMetdata` call in:

https://github.com/crate/crate/blob/d60205fe50488de8e302c38b81cb38d8ed838bdc/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataUpgradeService.java?plain=1#L263-L263
