### PR TITLE
Avoid indexName decoding to get open indices for routing in DocTableInfo

### DIFF
--- a/server/src/main/java/io/crate/analyze/WhereClause.java
+++ b/server/src/main/java/io/crate/analyze/WhereClause.java
@@ -34,6 +34,7 @@ import io.crate.exceptions.VersioningValidationException;
 import io.crate.expression.operator.AndOperator;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.PartitionName;
 import io.crate.metadata.doc.SysColumns;
 
 public class WhereClause {
@@ -66,7 +67,7 @@ public class WhereClause {
     @Nullable
     private final Symbol query;
     private final Set<Symbol> clusteredBy;
-    private final List<String> partitions;
+    private final List<PartitionName> partitions;
 
     public WhereClause(@Nullable Symbol query) {
         this.query = query;
@@ -75,7 +76,7 @@ public class WhereClause {
     }
 
     public WhereClause(@Nullable Symbol normalizedQuery,
-                       @Nullable List<String> partitions,
+                       @Nullable List<PartitionName> partitions,
                        Set<Symbol> clusteredBy) {
         this.clusteredBy = clusteredBy;
         this.partitions = Objects.requireNonNullElse(partitions, List.of());
@@ -143,7 +144,7 @@ public class WhereClause {
      * <p>
      * Note that the NO_MATCH case has to be tested separately.
      */
-    public List<String> partitions() {
+    public List<PartitionName> partitions() {
         return partitions;
     }
 

--- a/server/src/main/java/io/crate/metadata/doc/DocTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocTableInfo.java
@@ -484,13 +484,13 @@ public class DocTableInfo implements TableInfo, ShardedTable, StoredTable {
             .toArray(String[]::new);
     }
 
-    public String[] concreteOpenIndices(Metadata metadata, List<String> partitions) {
+    public String[] concreteOpenIndices(Metadata metadata, List<PartitionName> partitions) {
         if (partitions.isEmpty()) {
             return new String[0];
         }
         String[] uuids = new String[partitions.size()];
         for (int i = 0; i < partitions.size(); i++) {
-            List<String> partitionValues = PartitionName.fromIndexOrTemplate(partitions.get(i)).values();
+            List<String> partitionValues = partitions.get(i).values();
             List<String> indexUUIDS = metadata.getIndices(
                 ident,
                 partitionValues,

--- a/server/src/main/java/io/crate/planner/WhereClauseOptimizer.java
+++ b/server/src/main/java/io/crate/planner/WhereClauseOptimizer.java
@@ -129,8 +129,8 @@ public final class WhereClauseOptimizer {
                 WhereClauseAnalyzer.PartitionResult partitionResult =
                     WhereClauseAnalyzer.resolvePartitions(boundQuery, table, txnCtx, nodeCtx, metadata);
                 return new WhereClause(
-                    partitionResult.query,
-                    partitionResult.partitions,
+                    partitionResult.query(),
+                    partitionResult.partitions(),
                     clusteredBy
                 );
             } else {

--- a/server/src/main/java/io/crate/planner/statement/CopyToPlan.java
+++ b/server/src/main/java/io/crate/planner/statement/CopyToPlan.java
@@ -213,7 +213,7 @@ public final class CopyToPlan implements Plan {
         );
         DocTableInfo table = (DocTableInfo) copyTo.tableInfo();
 
-        List<String> partitions = resolvePartitions(
+        List<PartitionName> partitions = resolvePartitions(
             Lists.map(copyTo.table().partitionProperties(), x -> x.map(eval)),
             table,
             metadata);
@@ -268,13 +268,13 @@ public final class CopyToPlan implements Plan {
             settings);
     }
 
-    private static List<String> resolvePartitions(List<Assignment<Object>> partitionProperties,
-                                                  DocTableInfo table,
-                                                  Metadata metadata) {
+    private static List<PartitionName> resolvePartitions(List<Assignment<Object>> partitionProperties,
+                                                         DocTableInfo table,
+                                                         Metadata metadata) {
         if (partitionProperties.isEmpty()) {
             return Collections.emptyList();
         }
         var partitionName = PartitionName.ofAssignments(table, partitionProperties, metadata);
-        return List.of(partitionName.asIndexName());
+        return List.of(partitionName);
     }
 }

--- a/server/src/main/java/io/crate/planner/statement/DeletePlanner.java
+++ b/server/src/main/java/io/crate/planner/statement/DeletePlanner.java
@@ -51,7 +51,6 @@ import io.crate.expression.eval.EvaluatingNormalizer;
 import io.crate.expression.symbol.InputColumn;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
-import io.crate.metadata.IndexName;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.Reference;
 import io.crate.metadata.Routing;
@@ -144,14 +143,13 @@ public final class DeletePlanner {
             if (!where.partitions().isEmpty()
                 && (!where.hasQuery() || Literal.BOOLEAN_TRUE.equals(where.query()))) {
                 List<PartitionName> partitionValues = new ArrayList<>(where.partitions().size());
-                for (String partition : where.partitions()) {
-                    partitionValues.add(new PartitionName(
-                        table.relationName(), IndexName.decode(partition).partitionIdent()));
+                for (PartitionName partition : where.partitions()) {
+                    partitionValues.add(partition);
                 }
                 dependencies.client().execute(
                     TransportDropPartitionsAction.ACTION,
                     new DropPartitionsRequest(table.relationName(), partitionValues)
-                ).whenComplete(new OneRowActionListener<>(consumer, ignoredResponse -> Row1.ROW_COUNT_UNKNOWN));
+                ).whenComplete(new OneRowActionListener<>(consumer, _ -> Row1.ROW_COUNT_UNKNOWN));
                 return;
             }
 

--- a/server/src/test/java/io/crate/analyze/CopyAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/CopyAnalyzerTest.java
@@ -265,18 +265,18 @@ public class CopyAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     public void testCopyToFileWithPartitionClause() throws Exception {
         BoundCopyTo analysis = analyze(
             "COPY parted PARTITION (date=1395874800000) TO DIRECTORY '/blah'");
-        String parted = new PartitionName(
-            new RelationName("doc", "parted"), Collections.singletonList("1395874800000")).asIndexName();
-        assertThat(analysis.whereClause().partitions()).containsExactly(parted);
+        var partitionName = new PartitionName(
+            new RelationName("doc", "parted"), Collections.singletonList("1395874800000"));
+        assertThat(analysis.whereClause().partitions()).containsExactly(partitionName);
     }
 
     @Test
     public void testCopyToDirectoryWithPartitionClause() throws Exception {
         BoundCopyTo analysis = analyze(
             "COPY parted PARTITION (date=1395874800000) TO DIRECTORY '/tmp'");
-        String parted = new PartitionName(
-            new RelationName("doc", "parted"), Collections.singletonList("1395874800000")).asIndexName();
-        assertThat(analysis.whereClause().partitions()).containsExactly(parted);
+        var partitionName = new PartitionName(
+            new RelationName("doc", "parted"), Collections.singletonList("1395874800000"));
+        assertThat(analysis.whereClause().partitions()).containsExactly(partitionName);
         assertThat(analysis.overwrites()).isEmpty();
     }
 
@@ -298,19 +298,19 @@ public class CopyAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     public void testCopyToWithPartitionIdentAndPartitionInWhereClause() throws Exception {
         BoundCopyTo analysis = analyze(
             "COPY parted PARTITION (date=1395874800000) WHERE date = 1395874800000 TO DIRECTORY '/tmp/foo'");
-        String parted = new PartitionName(
-            new RelationName("doc", "parted"), Collections.singletonList("1395874800000")).asIndexName();
-        assertThat(analysis.whereClause().partitions()).containsExactly(parted);
+        var partitionName = new PartitionName(
+            new RelationName("doc", "parted"), Collections.singletonList("1395874800000"));
+        assertThat(analysis.whereClause().partitions()).containsExactly(partitionName);
     }
 
     @Test
     public void testCopyToWithPartitionIdentAndWhereClause() throws Exception {
         BoundCopyTo analysis = analyze(
             "COPY parted PARTITION (date=1395874800000) WHERE id = 1 TO DIRECTORY '/tmp/foo'");
-        String parted = new PartitionName(
-            new RelationName("doc", "parted"), Collections.singletonList("1395874800000")).asIndexName();
+        var partitionName = new PartitionName(
+            new RelationName("doc", "parted"), Collections.singletonList("1395874800000"));
         WhereClause where = analysis.whereClause();
-        assertThat(where.partitions()).containsExactly(parted);
+        assertThat(where.partitions()).containsExactly(partitionName);
         assertThat(where.query()).isFunction("op_=");
     }
 


### PR DESCRIPTION
To avoid issues with table swap no longer updating the indexName on
index/shard level

As a bonus it also avoids a few `PartitionName -> String -> PartitionName`
transformations
