### PR TITLE
Avoid some .toList() copies during create snapshot

### DIFF
--- a/server/src/main/java/org/elasticsearch/repositories/RepositoryData.java
+++ b/server/src/main/java/org/elasticsearch/repositories/RepositoryData.java
@@ -444,7 +444,7 @@ public final class RepositoryData {
      * @param indicesToResolve names of indices to resolve
      * @param inFlightIds      name to index mapping for currently in-flight snapshots not yet in the repository data to fall back to
      */
-    public List<IndexId> resolveNewIndices(List<Index> indicesToResolve, Map<String, IndexId> inFlightIds) {
+    public List<IndexId> resolveNewIndices(Iterable<Index> indicesToResolve, Map<String, IndexId> inFlightIds) {
         List<IndexId> snapshotIndices = new ArrayList<>();
         for (Index index : indicesToResolve) {
             IndexId indexId = indices.get(index.getName());


### PR DESCRIPTION
Indices and relationMetadata are only iterated over once - no need to create
a full copy
