### PR TITLE
Fix FORCE_MERGE thread pool usage, support parallelism per node

### DIFF
--- a/docs/appendices/release-notes/5.10.12.rst
+++ b/docs/appendices/release-notes/5.10.12.rst
@@ -79,3 +79,7 @@ Fixes
 
 - Fixed an issue that caused a ``NullPointerException`` when inserting ``NULL``
   to an object column with a non-deterministic sub-column.
+
+- Fixed the usage of the ``FORCE_MERGE`` thread pool to support parallel shard
+  operations per node when increasing the pools size. As the default size is
+  ``1``, this change does not affect existing installations.

--- a/docs/appendices/release-notes/6.0.1.rst
+++ b/docs/appendices/release-notes/6.0.1.rst
@@ -82,3 +82,7 @@ Fixes
 
 - Fixed an issue that caused a ``NullPointerException`` when inserting ``NULL``
   to an object column with a non-deterministic sub-column.
+
+- Fixed the usage of the ``FORCE_MERGE`` thread pool to support parallel shard
+  operations per node when increasing the pools size. As the default size is
+  ``1``, this change does not affect existing installations.

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/forcemerge/TransportForceMergeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/forcemerge/TransportForceMergeAction.java
@@ -44,20 +44,23 @@ import org.elasticsearch.transport.TransportService;
 public class TransportForceMergeAction extends TransportBroadcastByNodeAction<ForceMergeRequest, ForceMergeResponse, TransportBroadcastByNodeAction.EmptyResult> {
 
     private final IndicesService indicesService;
+    private final ThreadPool threadPool;
 
     @Inject
     public TransportForceMergeAction(ClusterService clusterService,
                                      TransportService transportService,
-                                     IndicesService indicesService) {
+                                     IndicesService indicesService,
+                                     ThreadPool threadPool) {
         super(
             ForceMergeAction.NAME,
             clusterService,
             transportService,
             ForceMergeRequest::new,
-            ThreadPool.Names.FORCE_MERGE,
+            ThreadPool.Names.SAME,
             true
         );
         this.indicesService = indicesService;
+        this.threadPool = threadPool;
     }
 
     @Override
@@ -77,10 +80,16 @@ public class TransportForceMergeAction extends TransportBroadcastByNodeAction<Fo
 
     @Override
     protected void shardOperation(ForceMergeRequest request, ShardRouting shardRouting, ActionListener<EmptyResult> listener) throws IOException {
-        IndexShard indexShard = indicesService.indexServiceSafe(shardRouting.shardId().getIndex()).getShard(shardRouting.shardId().id());
-        indexShard.flush(false);
-        indexShard.forceMerge(request);
-        listener.onResponse(EmptyResult.INSTANCE);
+        threadPool.executor(ThreadPool.Names.FORCE_MERGE).execute(() -> {
+            try {
+                IndexShard indexShard = indicesService.indexServiceSafe(shardRouting.shardId().getIndex()).getShard(shardRouting.shardId().id());
+                indexShard.flush(false);
+                indexShard.forceMerge(request);
+                listener.onResponse(EmptyResult.INSTANCE);
+            } catch (Exception e) {
+                listener.onFailure(e);
+            }
+        });
     }
 
     /**


### PR DESCRIPTION
The force merge transport action used the FORCE_MERGE pool only for receiving requests rather than for executing the actual shard operation, all shards were always processed sequentially. Thus, increasing this thread pool did not increase any parallelism on a node as the requests are node based.

This is fixed by using the thread pool for the real shard operation.