### PR TITLE
Fix a race condition swallowing pgwire messages

### DIFF
--- a/docs/appendices/release-notes/5.10.12.rst
+++ b/docs/appendices/release-notes/5.10.12.rst
@@ -47,6 +47,13 @@ See the :ref:`version_5.10.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed a race condition in the PostgreSQL wire protocol implementation that
+  could lead to it swallowing outbound messages. This led to undefined client
+  behavior and a memory leak on the server The JDBC client for example would
+  sometimes fail with::
+
+    Received resultset tuples, but no field structure for them
+
 - Fixed an issue that led to replication errors due to the ``seqNo`` and
   ``primaryTerm`` information missing when replicating new records written as
   part of ``INSERT INTO`` or ``COPY FROM`` statements from the primary to

--- a/docs/appendices/release-notes/6.0.1.rst
+++ b/docs/appendices/release-notes/6.0.1.rst
@@ -47,6 +47,13 @@ series.
 Fixes
 =====
 
+- Fixed a race condition in the PostgreSQL wire protocol implementation that
+  could lead to it swallowing outbound messages. This led to undefined client
+  behavior and a memory leak on the server The JDBC client for example would
+  sometimes fail with::
+
+    Received resultset tuples, but no field structure for them
+
 - Fixed an issue that led to replication errors due to the ``seqNo`` and
   ``primaryTerm`` information missing when replicating new records written as
   part of ``INSERT INTO`` or ``COPY FROM`` statements from the primary to

--- a/server/src/test/java/io/crate/protocols/postgres/DelayableWriteChannelTest.java
+++ b/server/src/test/java/io/crate/protocols/postgres/DelayableWriteChannelTest.java
@@ -23,13 +23,16 @@ package io.crate.protocols.postgres;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.elasticsearch.test.ESTestCase;
 import org.junit.Test;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 
-public class DelayableWriteChannelTest {
+public class DelayableWriteChannelTest extends ESTestCase {
 
     @Test
     public void test_delayed_writes_are_released_on_close() throws Exception {
@@ -39,5 +42,39 @@ public class DelayableWriteChannelTest {
         channel.write(buffer);
         channel.close();
         assertThat(buffer.refCnt()).isEqualTo(0);
+    }
+
+    @Test
+    public void test_can_add_and_unblock_from_different_threads() throws Exception {
+        AtomicInteger numMessages = new AtomicInteger(50);
+        EmbeddedChannel innerChannel = new EmbeddedChannel();
+        var channel = new DelayableWriteChannel(innerChannel);
+        try {
+            channel.delayWrites();
+            var thread1 = new Thread(() -> {
+                while (numMessages.decrementAndGet() >= 0) {
+                    ByteBuf msg = channel.alloc().buffer();
+                    msg.setInt(0, 1);
+                    channel.write(msg);
+                }
+            });
+            var thread2 = new Thread(() -> {
+                while (numMessages.get() > 0) {
+                    channel.writePendingMessages();
+                    channel.delayWrites();
+                }
+            });
+            thread1.start();
+            thread2.start();
+
+            thread1.join();
+            thread2.join();
+
+            channel.writePendingMessages();
+            channel.flush();
+            assertThat(innerChannel.outboundMessages()).hasSize(50);
+        } finally {
+            innerChannel.finishAndReleaseAll();
+        }
     }
 }


### PR DESCRIPTION
The `DelayableWriteChannel` had a race where:

- Thread1: Calls .write, channel is blocked and retrieves `delayedWrites`
- Thread2: Calls .writePendingMessages; unblocks and processes all delayed writes
- Thread1: Continues, adding the msg to the `delayedWrites` instance.

Given that there's no more reference to `delayedWrites`, the msg was
lost.

On the 5.10 branch this resulted in test failures like:

    Error:  Failures:
    Error:    PostgresITest>ESTestCase.after:331->ESTestCase.checkStaticState:438
    Expecting empty but was: ["LEAK: ByteBuf.release() was not called before it's garbage-collected. See https://netty.io/wiki/reference-counted-objects.html for more information.
    Recent access records:
    #1:
    	io.netty.buffer.AdvancedLeakAwareByteBuf.writeInt(AdvancedLeakAwareByteBuf.java:563)
    	io.crate.protocols.postgres.Messages.sendShortMsg(Messages.java:513)
    	io.crate.protocols.postgres.Messages.sendBindComplete(Messages.java:487)
    	io.crate.protocols.postgres.PostgresWireProtocol.handleBindMessage(PostgresWireProtocol.java:645)

On master I suspect it was responsible for:

    java.lang.AssertionError: Shouldn't throw an exception: Received resultset tuples, but no field structure for them
    at __randomizedtesting.SeedInfo.seed([6F84DB7A48589F86:8B9A58F08FB7751D]:0)
    at io.crate.integrationtests.PostgresJobsLogsITest.lambda$assertJobLogContains$0(PostgresJobsLogsITest.java:200)
    at org.elasticsearch.test.ESTestCase.assertBusy(ESTestCase.java:709)
    at org.elasticsearch.test.ESTestCase.assertBusy(ESTestCase.java:683)
    at io.crate.integrationtests.PostgresJobsLogsITest.assertJobLogContains(PostgresJobsLogsITest.java:186)
    at io.crate.integrationtests.PostgresJobsLogsITest.testBatchOperationStatsTableFailure(PostgresJobsLogsITest.java:176)



This might also explain errors I saw on wacklig recently (the service itself):

```
Sep 10 15:01:16 wacklig[433]: Unhandled exception of PGError: PGFATAL [XX000]: readerIndex(4) + length(4) exceeds writerIndex(4): PooledUnsafeDirectByteBuf(ridx: 4, widx: 4, cap: 2048)
Sep 11 10:58:58 wacklig[433]: Unhandled exception of PGError: PGFATAL [XX000]: readerIndex(4) + length(4) exceeds writerIndex(4): PooledUnsafeDirectByteBuf(ridx: 4, widx: 4, cap: 2048)
Sep 11 10:58:58 wacklig[433]: Unhandled exception of PGError: PGFATAL [XX000]: readerIndex(4) + length(4) exceeds writerIndex(4): PooledUnsafeDirectByteBuf(ridx: 4, widx: 4, cap: 2048)
```
