### PR TITLE
Fix flaky TransportSQLActionTest.testSelectGroupByFailingSearchScript

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/ArithmeticIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ArithmeticIntegrationTest.java
@@ -30,6 +30,8 @@ import java.util.Locale;
 import org.elasticsearch.test.IntegTestCase;
 import org.junit.Test;
 
+import com.carrotsearch.randomizedtesting.annotations.Repeat;
+
 import io.crate.testing.Asserts;
 
 public class ArithmeticIntegrationTest extends IntegTestCase {
@@ -298,6 +300,7 @@ public class ArithmeticIntegrationTest extends IntegTestCase {
     }
 
     @Test
+    @Repeat(iterations = 200)
     public void testSelectFailingArithmeticScalar() throws Exception {
         execute("create table t (i integer, l long, d double) clustered into 1 shards with (number_of_replicas=0)");
         ensureYellow();

--- a/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
@@ -59,6 +59,7 @@ import org.junit.rules.TemporaryFolder;
 import org.locationtech.spatial4j.shape.Point;
 
 import com.carrotsearch.randomizedtesting.RandomizedContext;
+import com.carrotsearch.randomizedtesting.annotations.Repeat;
 import com.carrotsearch.randomizedtesting.generators.RandomPicks;
 
 import io.crate.analyze.validator.SemanticSortValidator;
@@ -1331,6 +1332,7 @@ public class TransportSQLActionTest extends IntegTestCase {
     }
 
     @Test
+    @Repeat(iterations = 200)
     public void testSelectFailingSearchScript() throws Exception {
         execute("create table t (i integer, l long, d double) clustered into 1 shards with (number_of_replicas=0)");
         ensureYellow();


### PR DESCRIPTION
Fixes flaky `TransportSQLActionTest.testSelectGroupByFailingSearchScript`

https://wacklig.pipifein.dev/github/crate/crate/f971bdda-74a7-466a-8b85-d462ef630fcc/3411f8a8-6f47-4dd8-93a8-5950e5ab2d51

And https://jenkins.crate.io/job/CrateDB/job/crate_on_pr/1654/testReport/junit/io.crate.integrationtests/ArithmeticIntegrationTest/testSelectGroupByFailingArithmeticScalar/



Follow up to https://github.com/crate/crate/pull/18248 and https://github.com/crate/crate/pull/18307



Overwriting failure logic could suffer from a race condition

