### PR TITLE
Fix false omission of NULL-assigned sub-columns during replica recovery

### DIFF
--- a/docs/appendices/release-notes/5.10.13.rst
+++ b/docs/appendices/release-notes/5.10.13.rst
@@ -59,3 +59,6 @@ Fixes
 - Fixed an issue that caused ``ArrayIndexOutOfBoundsExeption`` when executing
   ``COPY FROM`` on a table containing non-deterministic generated or default
   columns.
+
+- Fixed an issue where null-valued sub-columns of objects were omitted when
+  queried.

--- a/docs/appendices/release-notes/6.0.3.rst
+++ b/docs/appendices/release-notes/6.0.3.rst
@@ -58,3 +58,6 @@ Fixes
 - Fixed an issue that caused ``ArrayIndexOutOfBoundsExeption`` when executing
   ``COPY FROM`` on a table containing non-deterministic generated or default
   columns.
+
+- Fixed an issue where null-valued sub-columns of objects were omitted when
+  queried.

--- a/server/src/main/java/io/crate/execution/dml/IndexDocumentBuilder.java
+++ b/server/src/main/java/io/crate/execution/dml/IndexDocumentBuilder.java
@@ -106,12 +106,8 @@ public class IndexDocumentBuilder {
         return translogWriter;
     }
 
-    /**
-     * @return a generated value for the given column if one exists, otherwise null
-     */
-    public Object getSyntheticValue(ColumnIdent columnIdent) {
-        Input<Object> input = synthetics.get(columnIdent);
-        return input == null ? null : input.value();
+    public Input<Object> getSynthetic(ColumnIdent columnIdent) {
+        return synthetics.get(columnIdent);
     }
 
     /**

--- a/server/src/test/java/io/crate/execution/dml/IndexerTest.java
+++ b/server/src/test/java/io/crate/execution/dml/IndexerTest.java
@@ -650,33 +650,6 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
     }
 
     @Test
-    public void test_fields_are_omitted_in_source_for_null_values() throws Exception {
-        SQLExecutor e = SQLExecutor.of(clusterService)
-            .addTable("create table tbl (x int, o object as (y int))");
-
-        DocTableInfo table = e.resolveTableInfo("tbl");
-        Indexer indexer = new Indexer(
-            List.of(),
-            table,
-            Version.CURRENT,
-            new CoordinatorTxnCtx(e.getSessionSettings()),
-            e.nodeCtx,
-            List.of(
-                table.getReference(ColumnIdent.of("x")),
-                table.getReference(ColumnIdent.of("o"))
-            ),
-            null, null
-        );
-
-        HashMap<String, Object> o = new HashMap<>();
-        o.put("y", null);
-        ParsedDocument doc = indexer.index(item(null, o));
-        assertThat(source(doc, table)).isEqualTo(
-            "{\"o\":{}}"
-        );
-    }
-
-    @Test
     public void test_indexing_float_results_in_float_field() throws Exception {
         SQLExecutor e = SQLExecutor.of(clusterService)
             .addTable("create table tbl (x float)");
@@ -1582,6 +1555,41 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
         );
         var item = new IndexItem.StaticItem("0", List.of(), new Object[]{-1, 0}, 0L, 0L);
         indexer.collectSchemaUpdates(item); // checks that it does not throw any IndexOutOfBoundsExceptions
+    }
+
+    @Test
+    public void test_null_valued_sub_columns_are_stored() throws Exception {
+        SQLExecutor executor = SQLExecutor.of(clusterService)
+            .addTable("""
+                create table t (
+                    o object as (a int, b int as o['a']+1, c int)
+                )
+                """
+            );
+        DocTableInfo table = executor.resolveTableInfo("t");
+
+        Indexer indexer = new Indexer(
+            List.of(),
+            table,
+            Version.CURRENT,
+            new CoordinatorTxnCtx(executor.getSessionSettings()),
+            executor.nodeCtx,
+            new ArrayList<>(List.of(table.getReference(ColumnIdent.of("o")))),
+            null, null
+        );
+        // update t set o['a']=null, o['c']=1
+        ParsedDocument parsedDocument = indexer.index(item(MapBuilder.newMapBuilder().put("a", null).put("c", 1).map()));
+        assertThat(source(parsedDocument, table)).isEqualTo("{\"o\":{\"a\":null,\"b\":null,\"c\":1}}");
+
+        // notice null valued sub-columns and non-null sub-columns are persisted differently
+        Map<String, Object> storedValue = new HashMap<>();
+        storedValue.put("a", null);
+        storedValue.put("b", null);
+        assertThat(parsedDocument.doc().getField("1").binaryValue()) // "1" is the oid for 'o'
+            .isEqualTo(ObjectIndexer.toBytes(storedValue, Version.CURRENT).toBytesRef());
+        assertThat(parsedDocument.doc().getField("4").numericValue()).isEqualTo(1); // "4" is the oid for 'c'
+
+        assertTranslogParses(parsedDocument, table);
     }
 
     public static void assertTranslogParses(ParsedDocument doc, DocTableInfo info) {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes a bug discovered by a flaky test:

```
test_insert_on_conflict_can_assign_null_to_default_columns

execute("""
    create table t (
        a int default -1,
        b int default round(random() * 10),
        i int,
        o object as (
            a int default -1,
            b int default round(random() * 10),
            i int,
            o object as (
                a int default -1,
                b int default round(random() * 10),
                i int
            )
        ),
        c int primary key
    )
    """);
execute("""
    insert into t values (null, null, null, {a=null, b=null, i=null, o={a=null, b=null, i=null}}, 1)
    on conflict (c) do update set a=1, b=2, i=3, o['a']=4, o['b']=5, o['i']=6, o['o']['a']=7, o['o']['b']=8, o['o']['i']=9
    """);
execute("refresh table t");
execute("select * from t");
assertThat(response).hasRows("NULL| NULL| NULL| {a=NULL, b=NULL, i=NULL, o={a=NULL, b=NULL, i=NULL}}| 1");
```
```
Expected :[NULL| NULL| NULL| {a=NULL, b=NULL, i=NULL, o={a=NULL, b=NULL, i=NULL}}| 1]
Actual   :[NULL| NULL| NULL| {o={}}| 1]
```

The row was missing the expected null values (e.g. `{o={}}`) because, during translog recovery on the replica, the translog entry did not include child columns that had been assigned null.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
