### PR TITLE
Fix issue with Blob tables

### DIFF
--- a/docs/appendices/release-notes/6.0.2.rst
+++ b/docs/appendices/release-notes/6.0.2.rst
@@ -47,4 +47,6 @@ series.
 Fixes
 =====
 
-None
+- Fixed a regression introduced in :ref:`version_6.0.0`. When upgrading
+  from a ``5.x`` cluster it changed metadata for blob tables in a way that
+  is not forward compatible with 6.1.

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataUpgradeServiceTest.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataUpgradeServiceTest.java
@@ -30,6 +30,7 @@ import java.util.Map;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.common.settings.IndexScopedSettings;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.TestCustomMetadata;
 import org.junit.Before;
 import org.junit.Test;
@@ -183,6 +184,21 @@ public class MetadataUpgradeServiceTest extends CrateDummyClusterServiceUnitTest
 
         IndexMetadata createdOnCurrentVersion = upgrade.index("created_on_current");
         assertThat(createdOnCurrentVersion).isEqualTo(indexMetadataCreatedOnCurrentVersion);
+    }
+
+    @Test
+    public void test_blob_table_is_added_to_RelationMetadata() {
+        var relationName = new RelationName("blob", "b1");
+        var metadataBuilder = Metadata.builder();
+        var indexMetadataBuilder = IndexMetadata.builder(relationName.indexNameOrAlias())
+            .settings(Settings.builder().put("index.version.created", Version.V_5_10_12))
+            .numberOfShards(1)
+            .numberOfReplicas(0);
+
+        metadataBuilder.put(indexMetadataBuilder);
+        var upgradedMetadata = metadataUpgradeService.upgradeMetadata(metadataBuilder.build());
+        assertThat((RelationMetadata) upgradedMetadata.getRelation(relationName))
+            .isExactlyInstanceOf(RelationMetadata.BlobTable.class);
     }
 
     private static class CustomMetadata extends TestCustomMetadata {


### PR DESCRIPTION
Blob tables were added as `RelationMetadata#Table` instead of `RelationMetadata#BlobTable`. This caused class cast exceptions on `6.1.x` since: https://github.com/crate/crate/pull/18337 landed.

Follows: #https://github.com/crate/crate/pull/17769
