### PR TITLE
Sync 6.0.2 release notes

### DIFF
--- a/docs/appendices/release-notes/6.0.2.rst
+++ b/docs/appendices/release-notes/6.0.2.rst
@@ -47,4 +47,6 @@ series.
 Fixes
 =====
 
-None
+- Fixed a regression introduced in :ref:`version_6.0.0`. When upgrading
+  from a ``5.x`` cluster it changed metadata for blob tables in a way that
+  is not forward compatible with 6.1.


### PR DESCRIPTION
https://github.com/crate/crate/pull/18394 needs to be applied only on 6.0 branch.

