### PR TITLE
Write pending messages in ready-for-query callback to avoid msg ordering mixup

### DIFF
--- a/server/src/main/java/io/crate/protocols/postgres/DelayableWriteChannel.java
+++ b/server/src/main/java/io/crate/protocols/postgres/DelayableWriteChannel.java
@@ -298,13 +298,6 @@ public class DelayableWriteChannel implements Channel {
         }
     }
 
-    public synchronized void writePendingMessages(DelayedWrites delayedWrites) {
-        if (delay == delayedWrites) {
-            delay = null;
-        }
-        delayedWrites.writeDelayed();
-    }
-
     public synchronized void writePendingMessages() {
         if (delay == null) {
             return;

--- a/server/src/main/java/io/crate/protocols/postgres/RowCountReceiver.java
+++ b/server/src/main/java/io/crate/protocols/postgres/RowCountReceiver.java
@@ -26,10 +26,9 @@ import java.util.concurrent.CompletableFuture;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import io.crate.session.BaseResultReceiver;
 import io.crate.auth.AccessControl;
 import io.crate.data.Row;
-import io.crate.protocols.postgres.DelayableWriteChannel.DelayedWrites;
+import io.crate.session.BaseResultReceiver;
 import io.netty.channel.ChannelFuture;
 
 class RowCountReceiver extends BaseResultReceiver {
@@ -37,16 +36,13 @@ class RowCountReceiver extends BaseResultReceiver {
     private final DelayableWriteChannel channel;
     private final String query;
     private final AccessControl accessControl;
-    private final DelayedWrites delayedWrites;
     private long rowCount;
 
     RowCountReceiver(String query,
                      DelayableWriteChannel channel,
-                     DelayedWrites delayedWrites,
                      AccessControl accessControl) {
         this.query = query;
         this.channel = channel;
-        this.delayedWrites = delayedWrites;
         this.accessControl = accessControl;
     }
 
@@ -67,16 +63,14 @@ class RowCountReceiver extends BaseResultReceiver {
     @Override
     public void allFinished() {
         ChannelFuture sendCommandComplete = Messages.sendCommandComplete(channel.bypassDelay(), query, rowCount);
-        channel.writePendingMessages(delayedWrites);
         channel.flush();
-        sendCommandComplete.addListener(f -> super.allFinished());
+        sendCommandComplete.addListener(_ -> super.allFinished());
     }
 
     @Override
     public void fail(@NotNull Throwable throwable) {
         ChannelFuture sendErrorResponse = Messages.sendErrorResponse(channel.bypassDelay(), accessControl, throwable);
-        channel.writePendingMessages(delayedWrites);
         channel.flush();
-        sendErrorResponse.addListener(f -> super.fail(throwable));
+        sendErrorResponse.addListener(_ -> super.fail(throwable));
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/PostgresITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PostgresITest.java
@@ -50,6 +50,7 @@ import java.util.function.Function;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.IntegTestCase;
+import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -59,6 +60,8 @@ import org.postgresql.jdbc.PreferQueryMode;
 import org.postgresql.util.PGobject;
 import org.postgresql.util.PSQLException;
 import org.postgresql.util.PSQLState;
+
+import com.carrotsearch.randomizedtesting.annotations.Seed;
 
 import io.crate.execution.engine.collect.stats.JobsLogService;
 import io.crate.execution.engine.collect.stats.JobsLogs;
@@ -70,6 +73,7 @@ import io.crate.testing.UseJdbc;
 import io.crate.types.DataTypes;
 
 @IntegTestCase.ClusterScope(numDataNodes = 2, numClientNodes = 0, supportsDedicatedMasters = false)
+@Seed("8775A19D72F9F7EC:205C1045F52D8DBB")
 public class PostgresITest extends IntegTestCase {
 
     private static final String NO_IPV6 = "CRATE_TESTS_NO_IPV6";
@@ -478,6 +482,7 @@ public class PostgresITest extends IntegTestCase {
     }
 
     @Test
+    @TestLogging("io.crate.session.Sessions:TRACE,io.crate.protocols.postgres.Messages:TRACE,io.crate.protocols.postgres.PostgresWireProtocol:TRACE")
     public void testFetchSize() throws Exception {
         try (Connection conn = DriverManager.getConnection(url(RW), properties)) {
             conn.createStatement().executeUpdate("create table t (x int) with (number_of_replicas = 0)");
@@ -502,6 +507,9 @@ public class PostgresITest extends IntegTestCase {
                     Collections.sort(result);
                     assertThat(result).containsExactly(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19);
                     assertThat(resultSet.next()).isFalse();
+                } catch (Throwable t) {
+                    logger.error(t);
+                    throw t;
                 }
             }
         }

--- a/server/src/test/java/io/crate/protocols/postgres/ResultSetReceiverTest.java
+++ b/server/src/test/java/io/crate/protocols/postgres/ResultSetReceiverTest.java
@@ -35,7 +35,6 @@ import org.mockito.Answers;
 
 import io.crate.auth.AccessControl;
 import io.crate.data.Row1;
-import io.crate.protocols.postgres.DelayableWriteChannel.DelayedWrites;
 import io.crate.protocols.postgres.types.PGTypes;
 import io.crate.types.DataTypes;
 import io.netty.buffer.ByteBuf;
@@ -52,11 +51,9 @@ public class ResultSetReceiverTest {
         Channel channel = mock(Channel.class, Answers.RETURNS_DEEP_STUBS);
         when(channel.isWritable()).thenReturn(true);
         DelayableWriteChannel delayableWriteChannel = new DelayableWriteChannel(channel);
-        DelayedWrites delayWrites = delayableWriteChannel.delayWrites();
         ResultSetReceiver resultSetReceiver = new ResultSetReceiver(
             "select * from t",
             delayableWriteChannel,
-            delayWrites,
             AccessControl.DISABLED,
             Collections.singletonList(PGTypes.get(DataTypes.INTEGER)),
             null
@@ -72,11 +69,9 @@ public class ResultSetReceiverTest {
     public void test_channel_is_flushed_if_not_writable_anymore() {
         Channel channel = mock(Channel.class, Answers.RETURNS_DEEP_STUBS);
         DelayableWriteChannel delayableWriteChannel = new DelayableWriteChannel(channel);
-        DelayedWrites delayWrites = delayableWriteChannel.delayWrites();
         ResultSetReceiver resultSetReceiver = new ResultSetReceiver(
             "select * from t",
             delayableWriteChannel,
-            delayWrites,
             AccessControl.DISABLED,
             Collections.singletonList(PGTypes.get(DataTypes.INTEGER)),
             null
@@ -108,11 +103,9 @@ public class ResultSetReceiverTest {
             }
         };
         DelayableWriteChannel delayableWriteChannel = new DelayableWriteChannel(channel);
-        DelayedWrites delayWrites = delayableWriteChannel.delayWrites();
         ResultSetReceiver resultSetReceiver = new ResultSetReceiver(
             "select * from t",
             delayableWriteChannel,
-            delayWrites,
             AccessControl.DISABLED,
             Collections.singletonList(PGTypes.get(DataTypes.INTEGER)),
             null


### PR DESCRIPTION
ResultReceivers can run in either netty-worker threads or other pools
like write and search.

As long as all of them ran in the same category of thread pool things work
okay, but if mixed it could happen that the messages sent out via
`.writePendingMessages` on the `DelayableWriteChannel` were lagging
behind.

To solve this order mixup, this defers the write of pending messages to
the `ReadyForQuery` callback which is usually triggered when the `sync`
future completes - at that point it is ensured that all operations
relevant for the current work-cycle are done.

## TODO

- [ ] run all crate-qa client tests against this to ensure it doesn't break any
