### PR TITLE
Store table column stats separately per column

### DIFF
--- a/server/src/main/java/io/crate/planner/operators/GroupHashAggregate.java
+++ b/server/src/main/java/io/crate/planner/operators/GroupHashAggregate.java
@@ -77,10 +77,10 @@ public class GroupHashAggregate extends ForwardingLogicalPlan {
         for (Symbol groupKey : groupKeys) {
             ColumnStats<?> columnStats = null;
             if (groupKey instanceof Reference ref) {
-                columnStats = stats.statsByColumn().get(ref.column());
+                columnStats = stats.getColumnStats(ref.column());
                 numKeysWithStats++;
             } else if (groupKey instanceof ScopedSymbol scopedSymbol) {
-                columnStats = stats.statsByColumn().get(scopedSymbol.column());
+                columnStats = stats.getColumnStats(scopedSymbol.column());
                 numKeysWithStats++;
             }
 

--- a/server/src/main/java/io/crate/planner/selectivity/SelectivityFunctions.java
+++ b/server/src/main/java/io/crate/planner/selectivity/SelectivityFunctions.java
@@ -208,7 +208,7 @@ public class SelectivityFunctions {
         if (column == null) {
             return MAGIC_SEL;
         }
-        var columnStats = stats.statsByColumn().get(column);
+        var columnStats = stats.getColumnStats(column);
         if (columnStats == null) {
             return MAGIC_SEL;
         }
@@ -223,7 +223,7 @@ public class SelectivityFunctions {
         if (lhsColumn == null) {
             return DEFAULT_EQ_SEL;
         }
-        var lhsStats = stats.statsByColumn().get(lhsColumn);
+        var lhsStats = stats.getColumnStats(lhsColumn);
         if (lhsStats == null) {
             return DEFAULT_EQ_SEL;
         }
@@ -240,7 +240,7 @@ public class SelectivityFunctions {
             if (rhsColumn == null) {
                 return 1.0 / lhsStats.approxDistinct();
             }
-            var rhsStats = stats.statsByColumn().get(rhsColumn);
+            var rhsStats = stats.getColumnStats(rhsColumn);
             if (rhsStats == null) {
                 return 1.0 / lhsStats.approxDistinct();
             }

--- a/server/src/main/java/io/crate/statistics/ColStats.java
+++ b/server/src/main/java/io/crate/statistics/ColStats.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.statistics;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.jetbrains.annotations.Nullable;
+
+import io.crate.common.collections.Maps;
+import io.crate.expression.symbol.AliasSymbol;
+import io.crate.expression.symbol.ScopedSymbol;
+import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.Reference;
+import io.crate.types.FixedWidthType;
+
+public record ColStats(Map<ColumnIdent, ColumnStats<?>> statsByColumn) implements Writeable {
+
+    public static final ColStats EMPTY = new ColStats(Map.of());
+
+    public static ColStats readFrom(StreamInput in) throws IOException {
+        int numColumnStats = in.readVInt();
+        Map<ColumnIdent, ColumnStats<?>> statsByColumn = HashMap.newHashMap(numColumnStats);
+        for (int i = 0; i < numColumnStats; i++) {
+            statsByColumn.put(ColumnIdent.of(in), new ColumnStats<>(in));
+        }
+        return new ColStats(statsByColumn);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeVInt(statsByColumn.size());
+        for (var entry : statsByColumn.entrySet()) {
+            entry.getKey().writeTo(out);
+            entry.getValue().writeTo(out);
+        }
+    }
+
+    public boolean isEmpty() {
+        return statsByColumn.isEmpty();
+    }
+
+    public ColStats add(ColStats other) {
+        return new ColStats(Maps.concat(statsByColumn, other.statsByColumn));
+    }
+
+    public Map<ColumnIdent, ColumnStats<?>> statsByColumn() {
+        return statsByColumn;
+    }
+
+    @Nullable
+    public ColumnStats<?> getColumnStats(ColumnIdent column) {
+        return statsByColumn.get(column);
+    }
+
+    public long estimateSizeForColumns(Iterable<? extends Symbol> toCollect) {
+        long sum = 0L;
+        for (Symbol symbol : toCollect) {
+            ColumnStats<?> columnStats = null;
+            while (symbol instanceof AliasSymbol alias) {
+                symbol = alias.symbol();
+            }
+            if (symbol instanceof Reference ref) {
+                columnStats = statsByColumn.get(ref.column());
+            } else if (symbol instanceof ScopedSymbol scopedSymbol) {
+                columnStats = statsByColumn.get(scopedSymbol.column());
+            }
+            if (columnStats == null) {
+                if (symbol.valueType() instanceof FixedWidthType fixedWidthType) {
+                    sum += fixedWidthType.fixedSize();
+                } else {
+                    sum += RamUsageEstimator.UNKNOWN_DEFAULT_RAM_BYTES_USED;
+                }
+            } else {
+                sum += (long) columnStats.averageSizeInBytes();
+            }
+        }
+        return sum;
+    }
+}

--- a/server/src/main/java/io/crate/statistics/StatsLookup.java
+++ b/server/src/main/java/io/crate/statistics/StatsLookup.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.statistics;
+
+import io.crate.metadata.RelationName;
+
+public interface StatsLookup {
+
+    Stats getStats(RelationName relationName);
+
+    /**
+     * Returns the number of docs a table has.
+     * <p>
+     * <p>
+     * The returned number isn't an accurate real-time value but a cached value that is periodically updated
+     * </p>
+     * Returns -1 if the table isn't in the cache
+     */
+    long numDocs(RelationName relationName);
+
+}

--- a/server/src/main/java/io/crate/statistics/TableStatsService.java
+++ b/server/src/main/java/io/crate/statistics/TableStatsService.java
@@ -26,6 +26,9 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.logging.log4j.LogManager;
@@ -79,6 +82,7 @@ import com.github.benmanes.caffeine.cache.LoadingCache;
 import io.crate.common.io.IOUtils;
 import io.crate.common.unit.TimeValue;
 import io.crate.data.Row;
+import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.RelationName;
 import io.crate.session.BaseResultReceiver;
 import io.crate.session.Session;
@@ -100,16 +104,22 @@ public class TableStatsService extends AbstractLifecycleComponent implements Run
         "stats.service.max_bytes_per_sec", new ByteSizeValue(40, ByteSizeUnit.MB), Property.NodeScope, Property.Dynamic, Property.Exposed);
 
     static final String STMT = "ANALYZE";
-    private static final String STATS = "_stats";
+    private static final String TABLES_STATS = "_stats_tables";
+    private static final String COLS_STATS = "_stats_cols";
     private static final String DATA_FIELD = "data";
     private static final String RELATION_NAME_FIELD = "relationName";
+    private static final String COLUMN_NAME_FIELD = "columnName";
+    private static final String COLUMN_NAMES_FIELD = "columnNames";
 
     private final ClusterService clusterService;
     private final ThreadPool threadPool;
     private final Sessions sessions;
-    private final Directory directory;
-    private final IndexWriter writer;
-    private final SearcherManager searcherManager;
+    private final Directory tablesDirectory;
+    private final Directory colsDirectory;
+    private final IndexWriter tablesWriter;
+    private final IndexWriter colsWriter;
+    private final SearcherManager tablesSearcherManager;
+    private final SearcherManager colsSearcherManager;
     private final LoadingCache<RelationName, Stats> cache;
 
     private Session session;
@@ -143,12 +153,18 @@ public class TableStatsService extends AbstractLifecycleComponent implements Run
             .build(this::loadFromDisk);
 
         try {
-            this.directory = new NIOFSDirectory(dataPath.resolve(STATS));
-            IndexWriterConfig indexWriterConfig = new IndexWriterConfig(new KeywordAnalyzer());
-            indexWriterConfig.setOpenMode(IndexWriterConfig.OpenMode.CREATE_OR_APPEND);
-            indexWriterConfig.setMergeScheduler(new SerialMergeScheduler());
-            this.writer = new IndexWriter(directory, indexWriterConfig);
-            this.searcherManager = new SearcherManager(writer, null);
+            this.tablesDirectory = new NIOFSDirectory(dataPath.resolve(TABLES_STATS));
+            this.colsDirectory = new NIOFSDirectory(dataPath.resolve(COLS_STATS));
+            IndexWriterConfig tablesIndexWriterConfig = new IndexWriterConfig(new KeywordAnalyzer());
+            tablesIndexWriterConfig.setOpenMode(IndexWriterConfig.OpenMode.CREATE_OR_APPEND);
+            tablesIndexWriterConfig.setMergeScheduler(new SerialMergeScheduler());
+            IndexWriterConfig colsIndexWriterConfig = new IndexWriterConfig(new KeywordAnalyzer());
+            colsIndexWriterConfig.setOpenMode(IndexWriterConfig.OpenMode.CREATE_OR_APPEND);
+            colsIndexWriterConfig.setMergeScheduler(new SerialMergeScheduler());
+            this.tablesWriter = new IndexWriter(tablesDirectory, tablesIndexWriterConfig);
+            this.tablesSearcherManager = new SearcherManager(tablesWriter, null);
+            this.colsWriter = new IndexWriter(colsDirectory, colsIndexWriterConfig);
+            this.colsSearcherManager = new SearcherManager(colsWriter, null);
 
             // ensure index files exist for reads
             this.update(Map.of());
@@ -170,7 +186,13 @@ public class TableStatsService extends AbstractLifecycleComponent implements Run
     @Override
     protected void doClose() throws IOException {
         cache.invalidateAll();
-        IOUtils.closeWhileHandlingException(searcherManager, writer, directory);
+        IOUtils.closeWhileHandlingException(
+            tablesSearcherManager,
+            colsSearcherManager,
+            tablesWriter,
+            colsWriter,
+            tablesDirectory,
+            colsDirectory);
     }
 
     @Override
@@ -242,8 +264,15 @@ public class TableStatsService extends AbstractLifecycleComponent implements Run
 
     public void remove(RelationName relationName) {
         try {
-            writer.deleteDocuments(relTerm(relationName));
-            writer.commit();
+            PersistedTable persistedTable = loadTableStats(relationName);
+            if (persistedTable != null) {
+                for (ColumnIdent columnIdent : persistedTable.cols()) {
+                    colsWriter.deleteDocuments(new TermQuery(colTerm(relationName, columnIdent)));
+                }
+                colsWriter.commit();
+                tablesWriter.deleteDocuments(relTerm(relationName));
+                tablesWriter.commit();
+            }
             cache.invalidate(relationName);
         } catch (IOException e) {
             throw new UncheckedIOException("Can't delete TableStats from disk", e);
@@ -252,8 +281,10 @@ public class TableStatsService extends AbstractLifecycleComponent implements Run
 
     public void clear() {
         try {
-            writer.deleteAll();
-            writer.commit();
+            tablesWriter.deleteAll();
+            tablesWriter.commit();
+            colsWriter.deleteAll();
+            colsWriter.commit();
             cache.invalidateAll();
         } catch (IOException e) {
             throw new UncheckedIOException("Can't delete TableStats from disk", e);
@@ -263,50 +294,29 @@ public class TableStatsService extends AbstractLifecycleComponent implements Run
     @VisibleForTesting
     @Nullable
     Stats loadFromDisk(RelationName relationName) {
-        try {
-            searcherManager.maybeRefreshBlocking();
-            IndexSearcher searcher = searcherManager.acquire();
-            try {
-                searcher.setQueryCache(null);
-                Query query = new TermQuery(relTerm(relationName));
-                Weight weight = searcher.createWeight(query, ScoreMode.COMPLETE_NO_SCORES, 0.0f);
-                IndexReader reader = searcher.getIndexReader();
-                for (LeafReaderContext leafReaderContext : reader.leaves()) {
-                    Scorer scorer = weight.scorer(leafReaderContext);
-                    if (scorer == null) {
-                        continue;
-                    }
-                    DocIdSetIterator docIdSetIterator = scorer.iterator();
-                    StoredFields storedFields = leafReaderContext.reader().storedFields();
-                    if (docIdSetIterator.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
-                        Document doc = storedFields.document(docIdSetIterator.docID());
-                        BytesRef binaryValue = doc.getBinaryValue(DATA_FIELD);
-                        ByteArrayInputStream bis = new ByteArrayInputStream(binaryValue.bytes);
-                        InputStreamStreamInput in = new InputStreamStreamInput(bis);
-                        Version version = Version.readVersion(in);
-                        in.setVersion(version);
-                        return Stats.readFrom(new InputStreamStreamInput(in));
-                    }
-                }
-            } finally {
-                searcherManager.release(searcher);
-            }
-        } catch (IOException ex) {
-            throw new UncheckedIOException(ex);
+        PersistedTable persistedTable = loadTableStats(relationName);
+        if (persistedTable == null) {
+            return null;
         }
-        return null;
+        Map<ColumnIdent, ColumnStats<?>> columnStatsMap = loadColumnStats(relationName, persistedTable.cols());
+        return new Stats(persistedTable.numDocs(), persistedTable.sizeInBytes(), columnStatsMap);
     }
 
     public void update(Map<RelationName, Stats> stats) {
         try {
             for (Map.Entry<RelationName, Stats> entry : stats.entrySet()) {
                 RelationName relationName = entry.getKey();
-                Document doc = makeDocument(relationName, entry.getValue());
-                writer.updateDocument(relTerm(relationName), doc);
+                DocsToPersist docs = makeDocument(relationName, entry.getValue());
+                tablesWriter.updateDocument(relTerm(relationName), docs.table());
+                for (Map.Entry<ColumnIdent, Document> docsEntry : docs.cols().entrySet()) {
+                    colsWriter.updateDocument(colTerm(relationName, docsEntry.getKey()), docsEntry.getValue());
+                }
             }
-            writer.commit();
+            tablesWriter.commit();
+            colsWriter.commit();
+            tablesSearcherManager.maybeRefresh();
+            colsSearcherManager.maybeRefresh();
             cache.invalidateAll(stats.keySet());
-            searcherManager.maybeRefresh();
         } catch (IOException e) {
             throw new UncheckedIOException("Can't write TableStats to disk", e);
         }
@@ -316,14 +326,35 @@ public class TableStatsService extends AbstractLifecycleComponent implements Run
         return new Term(RELATION_NAME_FIELD, relationName.fqn());
     }
 
-    private static Document makeDocument(RelationName relationName, Stats stats) throws IOException {
+    private static Term colTerm(RelationName relationName, ColumnIdent columnIdent) {
+        return new Term(COLUMN_NAME_FIELD, relationName.fqn() + "." + columnIdent.sqlFqn());
+    }
+
+    private static DocsToPersist makeDocument(RelationName relationName, Stats stats) throws IOException {
+        // table stats
         BytesStreamOutput bytesStreamOutput = new BytesStreamOutput();
         Version.writeVersion(Version.CURRENT, bytesStreamOutput);
-        stats.writeTo(bytesStreamOutput);
-        Document document = new Document();
-        document.add(new StringField(RELATION_NAME_FIELD, relationName.fqn(), Field.Store.NO));
-        document.add(new StoredField(DATA_FIELD, bytesStreamOutput.bytes().toBytesRef()));
-        return document;
+        bytesStreamOutput.writeVLong(stats.numDocs());
+        bytesStreamOutput.writeVLong(stats.sizeInBytes());
+        Document tableDocument = new Document();
+        tableDocument.add(new StringField(RELATION_NAME_FIELD, relationName.fqn(), Field.Store.NO));
+        tableDocument.add(new StoredField(DATA_FIELD, bytesStreamOutput.bytes().toBytesRef()));
+
+        // column stats
+        Map<ColumnIdent, Document> colDocuments = HashMap.newHashMap(stats.statsByColumn().size());
+        for (var entry : stats.statsByColumn().entrySet()) {
+            String colName = entry.getKey().sqlFqn();
+            // Add the column name to table doc
+            tableDocument.add(new StringField(COLUMN_NAMES_FIELD, colName, Field.Store.YES));
+
+            Document colDocument = new Document();
+            bytesStreamOutput = new BytesStreamOutput();
+            entry.getValue().writeTo(bytesStreamOutput);
+            colDocument.add(new StringField(COLUMN_NAME_FIELD, relationName.fqn() + "." + colName, Field.Store.NO));
+            colDocument.add(new StoredField(DATA_FIELD, bytesStreamOutput.bytes().toBytesRef()));
+            colDocuments.put(entry.getKey(), colDocument);
+        }
+        return new DocsToPersist(tableDocument, colDocuments);
     }
 
     @Override
@@ -341,5 +372,94 @@ public class TableStatsService extends AbstractLifecycleComponent implements Run
             }
         }
     }
+
+    private PersistedTable loadTableStats(RelationName relationName) {
+        try {
+            PersistedTable persistedTable = null;
+            IndexSearcher tablesSearcher = null;
+            try {
+                tablesSearcherManager.maybeRefreshBlocking();
+                tablesSearcher = tablesSearcherManager.acquire();
+                tablesSearcher.setQueryCache(null);
+                Query query = new TermQuery(relTerm(relationName));
+                Weight weight = tablesSearcher.createWeight(query, ScoreMode.COMPLETE_NO_SCORES, 0.0f);
+                IndexReader reader = tablesSearcher.getIndexReader();
+                for (LeafReaderContext leafReaderContext : reader.leaves()) {
+                    Scorer scorer = weight.scorer(leafReaderContext);
+                    if (scorer == null) {
+                        continue;
+                    }
+                    DocIdSetIterator docIdSetIterator = scorer.iterator();
+                    StoredFields storedFields = leafReaderContext.reader().storedFields();
+                    if (docIdSetIterator.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
+                        Document doc = storedFields.document(docIdSetIterator.docID());
+                        BytesRef binaryValue = doc.getBinaryValue(DATA_FIELD);
+                        ByteArrayInputStream bis = new ByteArrayInputStream(binaryValue.bytes);
+                        InputStreamStreamInput in = new InputStreamStreamInput(bis);
+                        Version version = Version.readVersion(in);
+                        in.setVersion(version);
+                        long numDocs = in.readVLong();
+                        long sizeInBytes = in.readVLong();
+                        String[] colNames = doc.getValues(COLUMN_NAMES_FIELD);
+                        List<ColumnIdent> cols = new ArrayList<>(colNames.length);
+                        for (String colName : colNames) {
+                            cols.add(ColumnIdent.of(colName));
+                        }
+                        persistedTable = new PersistedTable(relationName, numDocs, sizeInBytes, cols);
+                        break;
+                    }
+                }
+            } finally {
+                tablesSearcherManager.release(tablesSearcher);
+            }
+            return persistedTable;
+        } catch (IOException ex) {
+            throw new UncheckedIOException(ex);
+        }
+    }
+
+    @VisibleForTesting
+    Map<ColumnIdent, ColumnStats<?>> loadColumnStats(RelationName relationName, List<ColumnIdent> cols) {
+        Map<ColumnIdent, ColumnStats<?>> columnStatsMap = new HashMap<>();
+        for (ColumnIdent columnIdent : cols) {
+            try {
+                IndexSearcher searcher = null;
+                try {
+                    colsSearcherManager.maybeRefreshBlocking();
+                    searcher = colsSearcherManager.acquire();
+                    searcher.setQueryCache(null);
+                    Query query = new TermQuery(colTerm(relationName, columnIdent));
+                    Weight weight = searcher.createWeight(query, ScoreMode.COMPLETE_NO_SCORES, 0.0f);
+                    IndexReader reader = searcher.getIndexReader();
+                    for (LeafReaderContext leafReaderContext : reader.leaves()) {
+                        Scorer scorer = weight.scorer(leafReaderContext);
+                        if (scorer == null) {
+                            continue;
+                        }
+                        DocIdSetIterator docIdSetIterator = scorer.iterator();
+                        StoredFields storedFields = leafReaderContext.reader().storedFields();
+                        if (docIdSetIterator.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
+                            Document colsDoc = storedFields.document(docIdSetIterator.docID());
+                            BytesRef colsBinaryValue = colsDoc.getBinaryValue(DATA_FIELD);
+                            ByteArrayInputStream colsBis = new ByteArrayInputStream(colsBinaryValue.bytes);
+                            InputStreamStreamInput colsIn = new InputStreamStreamInput(colsBis);
+                            ColumnStats<?> columnStats = new ColumnStats<>(colsIn);
+                            columnStatsMap.put(columnIdent, columnStats);
+                        }
+                    }
+                } finally {
+                    colsSearcherManager.release(searcher);
+                }
+
+            } catch (IOException ex) {
+                throw new UncheckedIOException(ex);
+            }
+        }
+        return columnStatsMap;
+    }
+
+    private record DocsToPersist(Document table, Map<ColumnIdent, Document> cols){}
+
+    private record PersistedTable(RelationName relationName, long numDocs, long sizeInBytes, List<ColumnIdent> cols){}
 }
 

--- a/server/src/main/java/io/crate/statistics/TableStatsService.java
+++ b/server/src/main/java/io/crate/statistics/TableStatsService.java
@@ -93,7 +93,7 @@ import io.crate.session.Sessions;
  * based on {@link #refreshInterval}.
  */
 @Singleton
-public class TableStatsService extends AbstractLifecycleComponent implements Runnable, ClusterStateListener {
+public class TableStatsService extends AbstractLifecycleComponent implements StatsLookup, Runnable, ClusterStateListener {
 
     private static final Logger LOGGER = LogManager.getLogger(TableStatsService.class);
 
@@ -435,6 +435,16 @@ public class TableStatsService extends AbstractLifecycleComponent implements Run
             }
         }
         return columnStatsMap;
+    }
+
+    public Stats getStats(RelationName relationName) {
+        Stats stats = cache.get(relationName);
+        return stats == null ? Stats.EMPTY : stats;
+    }
+
+    @Override
+    public long numDocs(RelationName relationName) {
+        return getStats(relationName).numDocs();
     }
 
     private record DocsToPersist(Document table, Map<ColumnIdent, Document> cols){}

--- a/server/src/test/java/io/crate/integrationtests/DiskThresholdDeciderIT.java
+++ b/server/src/test/java/io/crate/integrationtests/DiskThresholdDeciderIT.java
@@ -166,7 +166,7 @@ public class DiskThresholdDeciderIT extends IntegTestCase {
         });
 
         // increase disk size of node 0 to allow enough room for one shard, and check that it's rebalanced back
-        fileSystemProvider.getTestFileStore(dataNode0Path).setTotalSpace(minShardSize + WATERMARK_BYTES + 150L);
+        fileSystemProvider.getTestFileStore(dataNode0Path).setTotalSpace(minShardSize + WATERMARK_BYTES + 100L);
         assertBusy(() -> {
             refreshDiskUsage();
             assertThat(getShardRoutings(dataNode0Id, indexName)).hasSize(1);
@@ -216,7 +216,7 @@ public class DiskThresholdDeciderIT extends IntegTestCase {
         execute("reset global \"cluster.routing.rebalance.enable\"");
 
         //// increase disk size of node 0 to allow enough room for one shard, and check that it's rebalanced back
-        fileSystemProvider.getTestFileStore(dataNode0Path).setTotalSpace(minShardSize + WATERMARK_BYTES + 150L);
+        fileSystemProvider.getTestFileStore(dataNode0Path).setTotalSpace(minShardSize + WATERMARK_BYTES + 100L);
         assertBusy(() -> {
             refreshDiskUsage();
             assertThat(getShardRoutings(dataNode0Id, "tbl")).hasSize(1);

--- a/server/src/test/java/io/crate/integrationtests/DiskThresholdDeciderIT.java
+++ b/server/src/test/java/io/crate/integrationtests/DiskThresholdDeciderIT.java
@@ -166,7 +166,7 @@ public class DiskThresholdDeciderIT extends IntegTestCase {
         });
 
         // increase disk size of node 0 to allow enough room for one shard, and check that it's rebalanced back
-        fileSystemProvider.getTestFileStore(dataNode0Path).setTotalSpace(minShardSize + WATERMARK_BYTES + 100L);
+        fileSystemProvider.getTestFileStore(dataNode0Path).setTotalSpace(minShardSize + WATERMARK_BYTES + 150L);
         assertBusy(() -> {
             refreshDiskUsage();
             assertThat(getShardRoutings(dataNode0Id, indexName)).hasSize(1);
@@ -216,7 +216,7 @@ public class DiskThresholdDeciderIT extends IntegTestCase {
         execute("reset global \"cluster.routing.rebalance.enable\"");
 
         //// increase disk size of node 0 to allow enough room for one shard, and check that it's rebalanced back
-        fileSystemProvider.getTestFileStore(dataNode0Path).setTotalSpace(minShardSize + WATERMARK_BYTES + 100L);
+        fileSystemProvider.getTestFileStore(dataNode0Path).setTotalSpace(minShardSize + WATERMARK_BYTES + 150L);
         assertBusy(() -> {
             refreshDiskUsage();
             assertThat(getShardRoutings(dataNode0Id, "tbl")).hasSize(1);

--- a/server/src/test/java/io/crate/statistics/TableStatsServiceTest.java
+++ b/server/src/test/java/io/crate/statistics/TableStatsServiceTest.java
@@ -221,14 +221,16 @@ public class TableStatsServiceTest extends CrateDummyClusterServiceUnitTest {
     }
 
     @Test
-    public void test_remove_stats() throws IOException {
+    public void test_remove_stats() {
         ColumnStats<Integer> columnStats = StatsUtils.statsFromValues(
             DataTypes.INTEGER, List.of(1, 2, 3, 4, 5, 6, 7, 8, 9)
         );
 
+        var aColIdent = ColumnIdent.of("a");
+        var bColIdent = ColumnIdent.of("b");
         Stats stats1 = new Stats(9L, 9L * DataTypes.INTEGER.fixedSize(), Map.of(
-            ColumnIdent.of("a"), columnStats,
-            ColumnIdent.of("b"), columnStats)
+            aColIdent, columnStats,
+            bColIdent, columnStats)
         );
 
         Stats stats2 = new Stats(9L, 9L * DataTypes.INTEGER.fixedSize(), Map.of(
@@ -261,19 +263,22 @@ public class TableStatsServiceTest extends CrateDummyClusterServiceUnitTest {
             assertThat(statsService.get(table2)).isEqualTo(stats2);
 
             statsService.remove(table1);
+            assertThat(statsService.loadFromDisk(table1)).isNull();
+            assertThat(statsService.loadColumnStats(table1, List.of(aColIdent, bColIdent))).isEmpty();
             assertThat(statsService.get(table1)).isNull();
         }
     }
 
     @Test
-    public void test_clear() throws IOException {
+    public void test_clear() {
         ColumnStats<Integer> columnStats = StatsUtils.statsFromValues(
             DataTypes.INTEGER, List.of(1, 2, 3, 4, 5, 6, 7, 8, 9)
         );
-
+        var xColIdent = ColumnIdent.of("x");
+        var yColIdent = ColumnIdent.of("y");
         Stats stats = new Stats(9L, 9L * DataTypes.INTEGER.fixedSize(), Map.of(
-            ColumnIdent.of("x"), columnStats,
-            ColumnIdent.of("y"), columnStats)
+            xColIdent, columnStats,
+            yColIdent, columnStats)
         );
         RelationName relationName = RelationName.fromIndexName("doc.test");
 
@@ -289,9 +294,10 @@ public class TableStatsServiceTest extends CrateDummyClusterServiceUnitTest {
                 createTempDir())) {
 
             statsService.update(Map.of(relationName, stats));
-            statsService.clear();;
-            Stats loaded = statsService.get(relationName);
-            assertThat(loaded).isNull();
+            statsService.clear();
+            assertThat(statsService.loadFromDisk(relationName)).isNull();
+            assertThat(statsService.loadColumnStats(relationName, List.of(xColIdent, yColIdent))).isEmpty();
+            assertThat(statsService.get(relationName)).isNull();
         }
     }
 }

--- a/server/src/test/java/io/crate/statistics/TableStatsTest.java
+++ b/server/src/test/java/io/crate/statistics/TableStatsTest.java
@@ -76,8 +76,8 @@ public class TableStatsTest extends ESTestCase {
     @Test
     public void test_estimating_row_size_with_with_stats() {
         TableStats tableStats = new TableStats();
-        tableStats.updateTableStats(Map.of(docTableInfo.ident(), new Stats(1L, 1000L, Map.of()))::get);
-        long sizeEstimate = tableStats.estimatedSizePerRow(docTableInfo.ident());
+        tableStats.updateTableStats(Map.of(docTableInfo.ident(), new Stats(1L, 1000L))::get);
+        long sizeEstimate = tableStats.estimatedSizePerRow(docTableInfo);
         assertThat(sizeEstimate).isEqualTo(1000L);
     }
 
@@ -87,5 +87,4 @@ public class TableStatsTest extends ESTestCase {
         long sizeEstimate = tableStats.estimatedSizePerRow(docTableInfo);
         assertThat(sizeEstimate).isEqualTo(1168L);
     }
-
 }


### PR DESCRIPTION
Add more flexibility, so that we can load statistics from disk for specific columns instead of loading everything at once.

Follows: #18071

