### PR TITLE
Fix default/generated column value generation for COPY-FROM

### DIFF
--- a/server/src/main/java/io/crate/execution/dml/Indexer.java
+++ b/server/src/main/java/io/crate/execution/dml/Indexer.java
@@ -1048,11 +1048,6 @@ public class Indexer {
 
     public Object[] addGeneratedValues(IndexItem item, boolean forRawIndexer) {
         Object[] insertValues = item.insertValues();
-        // TODO: I think we can remove below return completely but it causes copy-from tests to fail, would not uncover that for now.
-        if (forRawIndexer && undeterministic.isEmpty()) {
-            return insertValues;
-        }
-
         assert onConflictIndexer() == null || new HashSet<>(onConflictIndexer().insertColumns().stream().map(Reference::column).toList())
             .containsAll(insertColumns().stream().map(Reference::column).toList()) : "onConflictIndexer().insertColumns() is a superset of this.insertColumns()";
         List<Reference> insertColumns = onConflictIndexer() == null ? insertColumns() : onConflictIndexer().insertColumns();

--- a/server/src/main/java/io/crate/execution/dml/RawIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/RawIndexer.java
@@ -58,6 +58,7 @@ public class RawIndexer {
 
     private Indexer currentRowIndexer;
     private IndexItem.StaticItem currentItem;
+    private List<Reference> insertColumns;
 
     public RawIndexer(List<String> partitionValues,
                       DocTableInfo table,
@@ -65,7 +66,8 @@ public class RawIndexer {
                       TransactionContext txnCtx,
                       NodeContext nodeCtx,
                       Symbol[] returnValues,
-                      @NotNull List<Reference> nonDeterministicSynthetics) {
+                      @NotNull List<Reference> nonDeterministicSynthetics,
+                      List<Reference> insertColumns) {
         this.partitionValues = partitionValues;
         this.table = table;
         this.txnCtx = txnCtx;
@@ -73,6 +75,7 @@ public class RawIndexer {
         this.returnValues = returnValues;
         this.nonDeterministicSynthetics = nonDeterministicSynthetics;
         this.shardVersionCreated = shardVersionCreated;
+        this.insertColumns = insertColumns;
     }
 
     /**
@@ -106,7 +109,12 @@ public class RawIndexer {
                 targetRefs,
                 null,
                 returnValues
-            );
+            ) {
+                @Override
+                public List<Reference> insertColumns() {
+                    return insertColumns;
+                }
+            };
         });
 
         int numExtra = item.insertValues().length - 1; // First value is _raw.

--- a/server/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
+++ b/server/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
@@ -176,7 +176,8 @@ public class TransportShardUpsertAction extends TransportShardAction<
                 txnCtx,
                 nodeCtx,
                 request.returnValues(),
-                List.of() // Non deterministic synthetics is not needed on primary
+                List.of(), // Non deterministic synthetics is not needed on primary
+                List.copyOf(indexer.insertColumns())
             );
         }
 
@@ -309,7 +310,8 @@ public class TransportShardUpsertAction extends TransportShardAction<
                 txnCtx,
                 nodeCtx,
                 null,
-                targetColumns.subList(1, targetColumns.size()) // expanded refs (non-deterministic synthetics)
+                targetColumns.subList(1, targetColumns.size()), // expanded refs (non-deterministic synthetics),
+                List.copyOf(targetColumns)
             );
         } else {
             rawIndexer = null;


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Follows https://github.com/crate/crate/pull/18323 which was mainly for `insert`, `update`, and `insert-on-conflict`. This is for `copy from`.

- Add copy equivalents of insert integration tests added by https://github.com/crate/crate/pull/18323.

- Remove https://github.com/crate/crate/blob/09d9d965c27d646321d20686268bde0a3541b8ed/server/src/main/java/io/crate/execution/dml/Indexer.java#L1051-L1054

## Checklist

 - [ ] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
