### PR TITLE
Avoid stacktrace generation for getReference lookups on strings

### DIFF
--- a/server/src/main/java/io/crate/metadata/doc/DocTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocTableInfo.java
@@ -63,6 +63,7 @@ import io.crate.analyze.WhereClause;
 import io.crate.analyze.expressions.ExpressionAnalysisContext;
 import io.crate.analyze.expressions.ExpressionAnalyzer;
 import io.crate.analyze.expressions.TableReferenceResolver;
+import io.crate.common.StringUtils;
 import io.crate.common.collections.Lists;
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.execution.ddl.tables.MappingUtil;
@@ -309,8 +310,9 @@ public class DocTableInfo implements TableInfo, ShardedTable, StoredTable {
 
     @Nullable
     public Reference getReference(String storageIdent) {
-        try {
-            long oid = Long.parseLong(storageIdent);
+        long[] out = StringUtils.PARSE_LONG_BUFFER.get();
+        if (StringUtils.tryParseLong(storageIdent, out)) {
+            long oid = out[0];
             for (var ref : allColumns.values()) {
                 if (ref.oid() == oid) {
                     return ref;
@@ -322,9 +324,8 @@ public class DocTableInfo implements TableInfo, ShardedTable, StoredTable {
                 }
             }
             return null;
-        } catch (NumberFormatException ex) {
-            return getReference(ColumnIdent.fromPath(storageIdent));
         }
+        return getReference(ColumnIdent.fromPath(storageIdent));
     }
 
     public List<Reference> getChildReferences(Reference parent) {


### PR DESCRIPTION
For older tables the `storageIdent` won't be a uid but the column name.
That led to an exception being thrown in `Long.parse` which is somewhat
expensive.
We already have a `tryParseLong` method for such cases

(https://github.com/crate/crate/commit/d312759eb43cc0e85b23788c6924bf43170308b8)

Thanks @BaurzhanSakhariev for spotting this:

<img width="3674" height="1070" alt="image" src="https://github.com/user-attachments/assets/fdcb0c60-2ccd-4fd6-a1b1-b90daccfa6ac" />
