### PR TITLE
Ensure pgwire messages are always sent in correct order

### DIFF
--- a/docs/appendices/release-notes/6.0.3.rst
+++ b/docs/appendices/release-notes/6.0.3.rst
@@ -47,6 +47,10 @@ series.
 Fixes
 =====
 
+- Fixed a race condition that could lead to PostgreSQL wire protocol messages to
+  get mixed up and cause errors like ``IllegalStateException: Received resultset
+  tuples, but no field structure for them`` in clients.
+
 - Fixed an issue that could lead to stuck jobs, memory leaks and even make a
   cluster unstable when a query with a ``LIMIT`` clause was interrupted by a
   ``CircuitBreakingException``.

--- a/server/src/main/java/io/crate/protocols/postgres/ResultSetReceiver.java
+++ b/server/src/main/java/io/crate/protocols/postgres/ResultSetReceiver.java
@@ -112,16 +112,21 @@ class ResultSetReceiver extends BaseResultReceiver {
     @Override
     public void allFinished() {
         ChannelFuture sendCommandComplete = Messages.sendCommandComplete(directChannel, query, rowCount);
-        channel.writePendingMessages(delayedWrites);
-        channel.flush();
-        sendCommandComplete.addListener(_ -> super.allFinished());
+        directChannel.flush();
+        sendCommandComplete.addListener(_ -> {
+            channel.writePendingMessages(delayedWrites);
+            channel.flush();
+            super.allFinished();
+        });
     }
 
     @Override
     public void fail(@NotNull Throwable throwable) {
         ChannelFuture sendErrorResponse = Messages.sendErrorResponse(directChannel, accessControl, throwable);
-        channel.writePendingMessages(delayedWrites);
-        channel.flush();
-        sendErrorResponse.addListener(_ -> super.fail(throwable));
+        sendErrorResponse.addListener(_ -> {
+            channel.writePendingMessages(delayedWrites);
+            channel.flush();
+            super.fail(throwable);
+        });
     }
 }

--- a/server/src/main/java/io/crate/protocols/postgres/RowCountReceiver.java
+++ b/server/src/main/java/io/crate/protocols/postgres/RowCountReceiver.java
@@ -26,10 +26,10 @@ import java.util.concurrent.CompletableFuture;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import io.crate.session.BaseResultReceiver;
 import io.crate.auth.AccessControl;
 import io.crate.data.Row;
 import io.crate.protocols.postgres.DelayableWriteChannel.DelayedWrites;
+import io.crate.session.BaseResultReceiver;
 import io.netty.channel.ChannelFuture;
 
 class RowCountReceiver extends BaseResultReceiver {
@@ -67,16 +67,21 @@ class RowCountReceiver extends BaseResultReceiver {
     @Override
     public void allFinished() {
         ChannelFuture sendCommandComplete = Messages.sendCommandComplete(channel.bypassDelay(), query, rowCount);
-        channel.writePendingMessages(delayedWrites);
         channel.flush();
-        sendCommandComplete.addListener(f -> super.allFinished());
+        sendCommandComplete.addListener(_ -> {
+            channel.writePendingMessages(delayedWrites);
+            channel.flush();
+            super.allFinished();
+        });
     }
 
     @Override
     public void fail(@NotNull Throwable throwable) {
         ChannelFuture sendErrorResponse = Messages.sendErrorResponse(channel.bypassDelay(), accessControl, throwable);
-        channel.writePendingMessages(delayedWrites);
-        channel.flush();
-        sendErrorResponse.addListener(f -> super.fail(throwable));
+        sendErrorResponse.addListener(_ -> {
+            channel.writePendingMessages(delayedWrites);
+            channel.flush();
+            super.fail(throwable);
+        });
     }
 }

--- a/server/src/testFixtures/java/io/crate/testing/SQLExecutor.java
+++ b/server/src/testFixtures/java/io/crate/testing/SQLExecutor.java
@@ -476,6 +476,7 @@ public class SQLExecutor {
         this.dependencyMock = mock(DependencyCarrier.class, Answers.RETURNS_MOCKS);
         when(dependencyMock.clusterService()).thenReturn(clusterService);
         when(dependencyMock.schemas()).thenReturn(schemas);
+        when(dependencyMock.settings()).thenReturn(clusterService.getSettings());
         this.sqlOperations = new Sessions(
             nodeCtx,
             analyzer,


### PR DESCRIPTION
Still not entirely sure if this fixes the issue, but wasn't able to produce a failure in ~2 hours. Without the fix I usually got at least one failure within 90 minutes.

---

Hopefully fixes:

    java.lang.AssertionError: Shouldn't throw an exception: Received resultset tuples, but no field structure for them
    	at __randomizedtesting.SeedInfo.seed([E84634093B1327FF:C58B783FCFCCD64]:0)
    	at io.crate.integrationtests.PostgresJobsLogsITest.lambda$assertJobLogContains$0(PostgresJobsLogsITest.java:200)
    	at org.elasticsearch.test.ESTestCase.assertBusy(ESTestCase.java:709)
    	at org.elasticsearch.test.ESTestCase.assertBusy(ESTestCase.java:683)
    	at io.crate.integrationtests.PostgresJobsLogsITest.assertJobLogContains(PostgresJobsLogsITest.java:186)
    	at io.crate.integrationtests.PostgresJobsLogsITest.testBatchOperationStatsTableFailure(PostgresJobsLogsITest.java:176)

In the test case it could happen that the pending messages were sent out
in a non-netty thread, which can delay them compared to messages written
in a netty thread. Concrete example of a failure with verbose logging:

    [i.c.s.Sessions           ] [[cratedb[node_s0][netty-worker][T#1]]] method=parse stmtName= query=insert into t (a, x) values (3, 'f7615d2e-c275-4966-904b-31060b1f9915') paramTypes=[]
    [i.c.p.p.PostgresWireProtocol] [[cratedb[node_s0][netty-worker][T#1]]] msg=B msgLength=8 readableBytes=8
    [i.c.s.Sessions           ] [[cratedb[node_s0][netty-worker][T#1]]] method=bind portalName= statementName= params=[]
    [i.c.p.p.PostgresWireProtocol] [[cratedb[node_s0][netty-worker][T#1]]] msg=D msgLength=2 readableBytes=2
    [i.c.s.Sessions           ] [[cratedb[node_s0][netty-worker][T#1]]] method=describe type=P portalOrStatement=
    [i.c.p.p.PostgresWireProtocol] [[cratedb[node_s0][netty-worker][T#1]]] msg=E msgLength=5 readableBytes=5
    [i.c.s.Sessions           ] [[cratedb[node_s0][netty-worker][T#1]]] method=execute portalName= maxRows=0
    [i.c.p.p.PostgresWireProtocol] [[cratedb[node_s0][netty-worker][T#1]]] msg=S msgLength=0 readableBytes=0
    [i.c.s.Sessions           ] [[cratedb[node_s0][netty-worker][T#1]]] method=sync deferredExecutions=3
    [i.c.p.p.DelayableWriteChannel] [[cratedb[node_s0][write][T#1]]] writePendingMessages Delayed{id=2, size=3}
    [i.c.p.p.DelayableWriteChannel] [[cratedb[node_s0][write][T#1]]] writeDelayed msg=AdvancedLeakAwareByteBuf(AdaptivePoolingAllocator$AdaptiveByteBuf(ridx: 0, widx: 5, cap: 5))
    [i.c.p.p.DelayableWriteChannel] [[cratedb[node_s0][write][T#1]]] writeDelayed msg=AdvancedLeakAwareByteBuf(AdaptivePoolingAllocator$AdaptiveByteBuf(ridx: 0, widx: 5, cap: 5))
    [i.c.p.p.DelayableWriteChannel] [[cratedb[node_s0][write][T#1]]] writeDelayed msg=AdvancedLeakAwareByteBuf(AdaptivePoolingAllocator$AdaptiveByteBuf(ridx: 0, widx: 5, cap: 5))
    [i.c.p.p.Messages         ] [[cratedb[node_s0][netty-worker][T#1]]] sentParseComplete
    [i.c.p.p.Messages         ] [[cratedb[node_s0][netty-worker][T#1]]] sentBindComplete
    [i.c.p.p.Messages         ] [[cratedb[node_s0][netty-worker][T#1]]] sentNoData
    [i.c.p.p.Messages         ] [[cratedb[node_s0][netty-worker][T#1]]] sentCommandComplete
    [i.c.p.p.Messages         ] [[cratedb[node_s0][netty-worker][T#1]]] sentParseComplete
    [i.c.p.p.Messages         ] [[cratedb[node_s0][netty-worker][T#1]]] sentBindComplete
    [i.c.p.p.Messages         ] [[cratedb[node_s0][netty-worker][T#1]]] sentNoData
    [i.c.p.p.DelayableWriteChannel] [[cratedb[node_s0][write][T#1]]] writePendingMessages Delayed{id=3, size=3, parent=Delayed{id=2, size=0}}
    [i.c.p.p.DelayableWriteChannel] [[cratedb[node_s0][write][T#1]]] writeDelayed msg=AdvancedLeakAwareByteBuf(AdaptivePoolingAllocator$AdaptiveByteBuf(ridx: 0, widx: 5, cap: 5))
    [i.c.p.p.DelayableWriteChannel] [[cratedb[node_s0][write][T#1]]] writeDelayed msg=AdvancedLeakAwareByteBuf(AdaptivePoolingAllocator$AdaptiveByteBuf(ridx: 0, widx: 5, cap: 5))
    [i.c.p.p.DelayableWriteChannel] [[cratedb[node_s0][write][T#1]]] writeDelayed msg=AdvancedLeakAwareByteBuf(AdaptivePoolingAllocator$AdaptiveByteBuf(ridx: 0, widx: 5, cap: 5))
    [i.c.p.p.Messages         ] [[cratedb[node_s0][netty-worker][T#1]]] sentErrorResponse msg="a" must not be null
    [i.c.p.p.DelayableWriteChannel] [[cratedb[node_s0][netty-worker][T#1]]] writePendingMessages Delayed{id=4, size=0, parent=Delayed{id=3, size=0, parent=Delayed{id=2, size=0}}}
    [i.c.p.p.Messages         ] [[cratedb[node_s0][netty-worker][T#1]]] sentCommandComplete
    [i.c.p.p.Messages         ] [[cratedb[node_s0][netty-worker][T#1]]] sentReadyForQuery
    [i.c.p.p.Messages         ] [[cratedb[node_s0][netty-worker][T#1]]] sentParseComplete
    [i.c.p.p.Messages         ] [[cratedb[node_s0][netty-worker][T#1]]] sentBindComplete
    [i.c.p.p.Messages         ] [[cratedb[node_s0][netty-worker][T#1]]] sentNoData
    [i.c.i.PostgresJobsLogsITest] [[Time-limited test]] execute sys.jobs_log query filtering for stmt=insert into t (a, x) values (1, '864ab38f-be96-459e-91a9-6172a30370ac')
    [i.c.p.p.PostgresWireProtocol] [[cratedb[node_s0][netty-worker][T#1]]] msg=P msgLength=60 readableBytes=60
    [i.c.s.Sessions           ] [[cratedb[node_s0][netty-worker][T#1]]] method=parse stmtName= query=select stmt, error from sys.jobs_log where stmt = $1 paramTypes=[text]
    [i.c.p.p.PostgresWireProtocol] [[cratedb[node_s0][netty-worker][T#1]]] msg=B msgLength=85 readableBytes=85
    [i.c.s.Sessions           ] [[cratedb[node_s0][netty-worker][T#1]]] method=bind portalName= statementName= params=[insert into t (a, x) values (1, '864ab38f-be96-459e-91a9-6172a30370ac')]
    [i.c.p.p.PostgresWireProtocol] [[cratedb[node_s0][netty-worker][T#1]]] msg=D msgLength=2 readableBytes=2
    [i.c.s.Sessions           ] [[cratedb[node_s0][netty-worker][T#1]]] method=describe type=P portalOrStatement=
    [i.c.p.p.PostgresWireProtocol] [[cratedb[node_s0][netty-worker][T#1]]] msg=E msgLength=5 readableBytes=5
    [i.c.s.Sessions           ] [[cratedb[node_s0][netty-worker][T#1]]] method=execute portalName= maxRows=0
    [i.c.p.p.DelayableWriteChannel] [[cratedb[node_s0][netty-worker][T#1]]] writePendingMessages Delayed{id=5, size=0}
    [i.c.p.p.Messages         ] [[cratedb[node_s0][netty-worker][T#1]]] sentParseComplete
    [i.c.p.p.Messages         ] [[cratedb[node_s0][netty-worker][T#1]]] sentBindComplete
    [i.c.p.p.Messages         ] [[cratedb[node_s0][netty-worker][T#1]]] sentRowDescription
    [i.c.p.p.Messages         ] [[cratedb[node_s0][netty-worker][T#1]]] sentCommandComplete
    [i.c.p.p.PostgresWireProtocol] [[cratedb[node_s0][netty-worker][T#1]]] msg=S msgLength=0 readableBytes=0
    [i.c.s.Sessions           ] [[cratedb[node_s0][netty-worker][T#1]]] method=sync activeExecution=java.util.concurrent.CompletableFuture@15c105d2[Completed normally]
    [i.c.p.p.Messages         ] [[cratedb[node_s0][netty-worker][T#1]]] sentReadyForQuery
    [i.c.i.PostgresJobsLogsITest] [[Time-limited test]] java.util.NoSuchElementException
    [i.c.i.PostgresJobsLogsITest] [[Time-limited test]] execute sys.jobs_log query filtering for stmt=insert into t (a, x) values (1, '864ab38f-be96-459e-91a9-6172a30370ac')
    [i.c.i.PostgresJobsLogsITest] [[Time-limited test]] java.lang.IllegalStateException: Received resultset tuples, but no field structure for them

This moves writing delayed messages into the `sendCommandComplete`
future callback, to ensure the write happens in the thread which
processed the `CommandComplete` message.
