### PR TITLE
Update links in docs to follow permanent redirects

### DIFF
--- a/docs/admin/ssl.rst
+++ b/docs/admin/ssl.rst
@@ -196,7 +196,7 @@ information including the different SSL modes please visit the
 `PSQL documentation`_.
 
 .. _JDBC SSL documentation: https://jdbc.postgresql.org/documentation/ssl/#configuring-the-client
-.. _PSQL documentation: https://www.postgresql.org/docs/current/static/app-psql.html
+.. _PSQL documentation: https://www.postgresql.org/docs/current/app-psql.html
 
 
 Setting up a Keystore/Truststore with a certificate chain

--- a/docs/admin/system-information.rst
+++ b/docs/admin/system-information.rst
@@ -1635,6 +1635,8 @@ partitioning.
 
   <span id="tables-need-to-be-upgraded"></span>
 
+.. _table_reindex_required:
+
 Tables need to be recreated
 ...........................
 

--- a/docs/appendices/release-notes/2.0.0.rst
+++ b/docs/appendices/release-notes/2.0.0.rst
@@ -348,7 +348,6 @@ Boolean Data Type
 -----------------
 
 Tables that have been created with CrateDB version ``0.54.x`` or smaller and
-that contain a column of type ``BOOLEAN`` must be re-created_ to be able to
+that contain a column of type ``BOOLEAN`` must be :ref:`re-created
+<table_reindex_required>` to be able to
 perform all supported operations on that column.
-
-.. _re-created: https://cratedb.com/docs/crate/reference/en/latest/sql/system.html#tables-need-to-be-recreated

--- a/docs/appendices/release-notes/2.1.0.rst
+++ b/docs/appendices/release-notes/2.1.0.rst
@@ -121,7 +121,7 @@ Clients that use the `PostgreSQL Wire Protocol`_ need to connect with a valid
 database user to get access to the server. See the official `Crate JDBC
 Driver`_ documentation for further information.
 
-.. _PostgreSQL Wire Protocol: https://cratedb.com/docs/crate/reference/en/latest/protocols/postgres.html
+.. _PostgreSQL Wire Protocol: https://cratedb.com/docs/crate/reference/en/latest/interfaces/postgres.html
 .. _Crate JDBC Driver: https://cratedb.com/docs/jdbc/en/latest/
 
 

--- a/docs/appendices/release-notes/3.0.0.rst
+++ b/docs/appendices/release-notes/3.0.0.rst
@@ -315,5 +315,5 @@ Other Changes
 .. _Admin UI: https://cratedb.com/docs/crate/admin-ui/en/latest/
 .. _backup: https://cratedb.com/docs/crate/reference/en/latest/admin/snapshots.html
 .. _full cluster restart: https://cratedb.com/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
-.. _HTTP Authorization header: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization
+.. _HTTP Authorization header: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Authorization
 .. _inserting the data into a new table: https://cratedb.com/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated

--- a/docs/appendices/release-notes/4.0.0.rst
+++ b/docs/appendices/release-notes/4.0.0.rst
@@ -315,7 +315,7 @@ SQL Standard and PostgreSQL compatibility improvements
   <aggregation-functions>`.
 
 - Added support for `SQL Standard Timestamp Format
-  <https://cratedb.com/docs/sql-99/en/latest/chapters/08.html#timestamp-literal>`_
+  <https://sql-99.readthedocs.io/en/latest/chapters/08.html>`_
   to the :ref:`data-types-dates-times`.
 
 - Added the :ref:`TIMESTAMP WITHOUT TIME ZONE <type-timestamp-without-tz>`

--- a/docs/appendices/resiliency.rst
+++ b/docs/appendices/resiliency.rst
@@ -6,7 +6,7 @@ Resiliency Issues
 
 CrateDB uses Elasticsearch for data distribution and replication. Most of the
 resiliency issues `exist in the Elasticsearch layer
-<https://www.elastic.co/guide/en/elasticsearch/resiliency/current/>`_ and can
+<https://www.elastic.co/guide/en/elasticsearch/resiliency/current/index.html>`_ and can
 be tested by `Jepsen <https://github.com/jepsen-io/jepsen/tree/master/crate>`_.
 
 
@@ -182,8 +182,7 @@ partitioned).
 There are two different versions of the same row using the same version number.
 When the primary shard rejoins the cluster and its data is replicated, the
 update that was made on the replicated shard is lost but the new version number
-matches the lost update. This will break `Optimistic Concurrency Control
-<https://cratedb.com/docs/reference/sql/occ.html>`_.
+matches the lost update. This will break :ref:`sql_occ`.
 
 .. _resiliency_replicas_fall_out_of_sync:
 

--- a/docs/cli-tools.rst
+++ b/docs/cli-tools.rst
@@ -217,7 +217,7 @@ Options
 .. _Detach a node from its cluster: https://cratedb.com/docs/crate/howtos/en/latest/best-practices/crate-node.html#detach-a-node-from-its-cluster
 .. _CrateDB installation tutorial: https://cratedb.com/docs/crate/tutorials/en/latest/install.html
 .. _graceful stop: https://cratedb.com/docs/crate/howtos/en/latest/admin/rolling-upgrade.html#step-2-graceful-stop
-.. _PATH: https://kb.iu.edu/d/acar
+.. _PATH: https://servicenow.iu.edu/kb?id=kb_article_view&sysparm_article=KB0022615
 .. _Perform an unsafe cluster bootstrap: https://cratedb.com/docs/crate/howtos/en/latest/best-practices/crate-node.html#perform-an-unsafe-cluster-bootstrap
 .. _Repurpose a node: https://cratedb.com/docs/crate/howtos/en/latest/best-practices/crate-node.html#repurpose-a-node
 .. _Rolling Upgrade: https://cratedb.com/docs/crate/howtos/en/latest/admin/rolling-upgrade.html

--- a/docs/concepts/clustering.rst
+++ b/docs/concepts/clustering.rst
@@ -182,12 +182,6 @@ the latest voting configuration.
    To bring the cluster back online at this point you will require two nodes
    among 1, 2, and 3. Bringing back nodes 3, 4, and 5, will not be sufficient.
 
-.. NOTE::
-
-   Special `settings and considerations
-   <https://cratedb.com/docs/crate/reference/en/5.1/concepts/clustering.html#master-node-election>`_
-   applied prior to CrateDB version 4.0.0.
-
 .. _concept-discovery:
 
 Discovery

--- a/docs/concepts/joins.rst
+++ b/docs/concepts/joins.rst
@@ -126,12 +126,12 @@ Primitive nested loop
 .....................
 
 For joins on some relations, the nested loop operation can be executed directly
-on the handler node. Specifically for queries involving a CROSS JOIN or joins
-on `system tables`_ /`information_schema`_ each shard sends the data to the
-handler node. Afterwards, this node runs the nested loop, applies limits, etc.
-and ultimately returns the results. Similarly, joins can be nested, so instead
-of collecting data from shards the rows can be the result of a previous join or
-:ref:`table function <table-functions>`.
+on the handler node. Specifically for queries involving a CROSS JOIN or joins on
+tables from :ref:`system-information` or :ref:`information_schema`. Each shard
+sends the data to the handler node. Afterwards, this node runs the nested loop,
+applies limits, etc. and ultimately returns the results. Similarly, joins can be
+nested, so instead of collecting data from shards the rows can be the result of
+a previous join or :ref:`table function <table-functions>`.
 
 
 .. _join-algos-nested-loop-dist:
@@ -376,5 +376,3 @@ Note that this setting is experimental, and may change in the future.
 
 .. _hash table: https://en.wikipedia.org/wiki/Hash_table
 .. _here: http://www.dcs.ed.ac.uk/home/tz/phd/thesis.pdf
-.. _information_schema: https://cratedb.com/docs/reference/sql/information_schema.html
-.. _system tables: https://cratedb.com/docs/reference/sql/system.html

--- a/docs/concepts/storage-consistency.rst
+++ b/docs/concepts/storage-consistency.rst
@@ -75,7 +75,7 @@ case, regardless of the nesting depth or size of the document.
 
 CrateDB does not provide transactions. Since every document in CrateDB has a
 version number assigned, which gets increased every time a change occurs,
-patterns like `Optimistic Concurrency Control`_ can help to work around that
+patterns like :ref:`sql_occ` can help to work around that
 limitation.
 
 
@@ -144,7 +144,7 @@ performed on shared ``IndexReaders`` which besides other functionality, provide
 caching and reverse lookup capabilities for shards. An ``IndexReader`` is
 always bound to the Lucene_ segment it was started from, which means it has to
 be refreshed in order to see new changes, this is done on a time based manner,
-but can also be done manually (see `refresh`_). Therefore a search only sees a
+but can also be done manually (see :ref:`sql-refresh`). Therefore a search only sees a
 change if the according ``IndexReader`` was refreshed after that change
 occurred.
 
@@ -253,8 +253,6 @@ flow for an ``ALTER TABLE`` statement which changes the schema of a table:
 #. Every node might take some local action depending on the type of cluster
    state change.
 
-.. _Elasticsearch: https://www.elasticsearch.org/
+.. _Elasticsearch: https://www.elastic.co
 .. _Lucene: https://lucene.apache.org/core/
 .. _WAL: https://en.wikipedia.org/wiki/Write-ahead_logging
-.. _Optimistic Concurrency Control: https://cratedb.com/docs/crate/reference/sql/occ.html
-.. _refresh: https://cratedb.com/docs/crate/reference/sql/refresh.html

--- a/docs/config/logging.rst
+++ b/docs/config/logging.rst
@@ -179,8 +179,8 @@ garbage collection logging.
 
     Make sure you have enough available disk space for configuration.
 
-.. _configuration section: https://logging.apache.org/log4j/1.2/manual.html#Configuration
-.. _Log4j: https://logging.apache.org/log4j/1.2/
-.. _PropertyConfigurator: https://logging.apache.org/log4j/1.2/apidocs/org/apache/log4j/PropertyConfigurator.html
+.. _configuration section: https://logging.apache.org/log4j/1.x/manual.html#Configuration
+.. _Log4j: https://logging.apache.org/log4j/1.x/
+.. _PropertyConfigurator: https://logging.apache.org/log4j/1.x/apidocs/org/apache/log4j/PropertyConfigurator.html
 .. _rotated: https://en.wikipedia.org/wiki/Log_rotation
 .. _YAML: https://yaml.org/

--- a/docs/config/node.rst
+++ b/docs/config/node.rst
@@ -839,7 +839,7 @@ sharing`_ settings in CrateDB allow for configuring these.
   Add the ``Access-Control-Allow-Credentials`` header to responses.
 
 .. _`same-origin policy`: https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy
-.. _`cross-origin resource sharing`: https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS
+.. _`cross-origin resource sharing`: https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CORS
 
 Blobs
 =====

--- a/docs/config/session.rst
+++ b/docs/config/session.rst
@@ -281,4 +281,4 @@ consumption for the particular query.
    operation is terminated. The number of already written records is not
    reported.
 
-.. _search_path: https://www.postgresql.org/docs/10/static/ddl-schemas.html#DDL-SCHEMAS-PATH
+.. _search_path: https://www.postgresql.org/docs/10/ddl-schemas.html

--- a/docs/general/ddl/data-types.rst
+++ b/docs/general/ddl/data-types.rst
@@ -3864,15 +3864,15 @@ However, you cannot use it with any :ref:`scalar functions
 .. _fixed-point fractional number: https://en.wikipedia.org/wiki/Fixed-point_arithmetic
 .. _Fully Qualified Domain Name: https://en.wikipedia.org/wiki/Fully_qualified_domain_name
 .. _Geohash: https://en.wikipedia.org/wiki/Geohash
-.. _GeoJSON geometry objects: https://tools.ietf.org/html/rfc7946#section-3.1
+.. _GeoJSON geometry objects: https://datatracker.ietf.org/doc/html/rfc7946
 .. _GeoJSON: https://geojson.org/
 .. _IEEE 754: https://en.wikipedia.org/wiki/IEEE_754
 .. _IP address: https://en.wikipedia.org/wiki/IP_address
 .. _ISO 8601 duration format: https://en.wikipedia.org/wiki/ISO_8601#Durations
 .. _ISO 8601 time zone designators: https://en.wikipedia.org/wiki/ISO_8601#Time_zone_designators
 .. _Java 15\: Patterns for Formatting and Parsing: https://docs.oracle.com/en/java/javase/15/docs/api/java.base/java/time/format/DateTimeFormatter.html#patterns
-.. _pg_class: https://www.postgresql.org/docs/10/static/catalog-pg-class.html
-.. _pg_proc: https://www.postgresql.org/docs/10/static/catalog-pg-proc.html
+.. _pg_class: https://www.postgresql.org/docs/14/catalog-pg-class.html
+.. _pg_proc: https://www.postgresql.org/docs/14/catalog-pg-proc.html
 .. _PostgreSQL interval format: https://www.postgresql.org/docs/current/datatype-datetime.html#DATATYPE-INTERVAL-INPUT
 .. _Quadtree: https://en.wikipedia.org/wiki/Quadtree
 .. _single-precision floating-point: https://en.wikipedia.org/wiki/Single-precision_floating-point_format

--- a/docs/general/ddl/replication.rst
+++ b/docs/general/ddl/replication.rst
@@ -181,7 +181,7 @@ CrateDB gives underreplicated tables a *yellow* :ref:`health status
 
 
 .. _availability: https://en.wikipedia.org/wiki/Availability
-.. _CrateDB Admin UI: https://cratedb.com/docs/clients/admin-ui/en/latest/
+.. _CrateDB Admin UI: https://cratedb.com/docs/crate/admin-ui/en/latest/
 .. _data redundancy: https://en.wikipedia.org/wiki/Data_redundancy
 .. _parallelize: https://en.wikipedia.org/wiki/Distributed_computing
 .. _partition tolerance: https://en.wikipedia.org/wiki/Network_partitioning

--- a/docs/interfaces/postgres.rst
+++ b/docs/interfaces/postgres.rst
@@ -541,30 +541,30 @@ CrateDB and we love to hear feedback.
 .. _pg_event_trigger: https://www.postgresql.org/docs/current/catalog-pg-event-trigger.html
 .. _pg_depend: https://www.postgresql.org/docs/current/catalog-pg-depend.html
 .. _pgjdbc: https://github.com/pgjdbc/pgjdbc
-.. _pgsql_pg_attrdef: https://www.postgresql.org/docs/14/static/catalog-pg-attrdef.html
-.. _pgsql_pg_attribute: https://www.postgresql.org/docs/14/static/catalog-pg-attribute.html
-.. _pgsql_pg_class: https://www.postgresql.org/docs/14/static/catalog-pg-class.html
-.. _pgsql_pg_constraint: https://www.postgresql.org/docs/14/static/catalog-pg-constraint.html
+.. _pgsql_pg_attrdef: https://www.postgresql.org/docs/14/catalog-pg-attrdef.html
+.. _pgsql_pg_attribute: https://www.postgresql.org/docs/14/catalog-pg-attribute.html
+.. _pgsql_pg_class: https://www.postgresql.org/docs/14/catalog-pg-class.html
+.. _pgsql_pg_constraint: https://www.postgresql.org/docs/14/catalog-pg-constraint.html
 .. _pgsql_pg_cursors: https://www.postgresql.org/docs/15/view-pg-cursors.html
-.. _pgsql_pg_database: https://www.postgresql.org/docs/14/static/catalog-pg-database.html
-.. _pgsql_pg_index: https://www.postgresql.org/docs/14/static/catalog-pg-index.html
+.. _pgsql_pg_database: https://www.postgresql.org/docs/14/catalog-pg-database.html
+.. _pgsql_pg_index: https://www.postgresql.org/docs/14/catalog-pg-index.html
 .. _pgsql_pg_indexes: https://www.postgresql.org/docs/14/view-pg-indexes.html
 .. _pgsql_pg_locks: https://www.postgresql.org/docs/14/view-pg-locks.html
 .. _pgsql_pg_matviews: https://www.postgresql.org/docs/current/view-pg-matviews.html
-.. _pgsql_pg_namespace: https://www.postgresql.org/docs/14/static/catalog-pg-namespace.html
-.. _pgsql_pg_proc: https://www.postgresql.org/docs/14/static/catalog-pg-proc.html
+.. _pgsql_pg_namespace: https://www.postgresql.org/docs/14/catalog-pg-namespace.html
+.. _pgsql_pg_proc: https://www.postgresql.org/docs/14/catalog-pg-proc.html
 .. _pgsql_pg_publication: https://www.postgresql.org/docs/14/catalog-pg-publication.html
 .. _pgsql_pg_publication_tables: https://www.postgresql.org/docs/14/view-pg-publication-tables.html
 .. _pgsql_pg_subscription: https://www.postgresql.org/docs/14/catalog-pg-subscription.html
 .. _pgsql_pg_subscription_rel: https://www.postgresql.org/docs/14/catalog-pg-subscription-rel.html
 .. _pgsql_pg_settings: https://www.postgresql.org/docs/14/view-pg-settings.html
-.. _pgsql_pg_type: https://www.postgresql.org/docs/14/static/catalog-pg-type.html
+.. _pgsql_pg_type: https://www.postgresql.org/docs/14/catalog-pg-type.html
 .. _PostgreSQL Arrays: https://www.postgresql.org/docs/14/static/arrays.html
-.. _PostgreSQL extended query: https://www.postgresql.org/docs/14/static/protocol-flow.html#PROTOCOL-FLOW-EXT-QUERY
-.. _PostgreSQL Fulltext Search: https://www.postgresql.org/docs/14/static/functions-textsearch.html
+.. _PostgreSQL extended query: https://www.postgresql.org/docs/14/protocol-flow.html
+.. _PostgreSQL Fulltext Search: https://www.postgresql.org/docs/14/functions-textsearch.html
 .. _PostgreSQL JDBC connection failover: https://jdbc.postgresql.org/documentation/use/#connection-fail-over
 .. _PostgreSQL JDBC Query docs: https://jdbc.postgresql.org/documentation/query
-.. _PostgreSQL simple query: https://www.postgresql.org/docs/14/static/protocol-flow.html#id-1.10.5.7.4
-.. _PostgreSQL value expressions: https://www.postgresql.org/docs/14/static/sql-expressions.html
-.. _PostgreSQL wire protocol v3: https://www.postgresql.org/docs/14/static/protocol.html
+.. _PostgreSQL simple query: https://www.postgresql.org/docs/14/protocol-flow.html
+.. _PostgreSQL value expressions: https://www.postgresql.org/docs/14/sql-expressions.html
+.. _PostgreSQL wire protocol v3: https://www.postgresql.org/docs/14/protocol.html
 .. _PostgreSQL cancelling requests: https://www.postgresql.org/docs/14/protocol-flow.html#id-1.10.5.7.10

--- a/docs/sql/statements/copy-from.rst
+++ b/docs/sql/statements/copy-from.rst
@@ -716,12 +716,12 @@ inserted records.
 
 
 .. _Amazon Simple Storage Service: https://aws.amazon.com/s3/
-.. _AWS documentation: https://docs.aws.amazon.com/AmazonS3/latest/dev/RESTAuthentication.html
-.. _AWS Java Documentation: https://docs.aws.amazon.com/AmazonS3/latest/dev/AuthUsingAcctOrUserCredJava.html
+.. _AWS documentation: https://docs.aws.amazon.com/AmazonS3/latest/API/RESTAuthentication.html
+.. _AWS Java Documentation: https://docs.aws.amazon.com/AmazonS3/latest/API/AuthUsingAcctOrUserCredentials.html
 .. _Azure Blob Storage: https://learn.microsoft.com/en-us/azure/storage/blobs/
 .. _Account Key: https://learn.microsoft.com/en-us/purview/sit-defn-azure-storage-account-key-generic#format
 .. _SAS: https://learn.microsoft.com/en-us/azure/storage/common/storage-sas-overview
-.. _Docker volume: https://docs.docker.com/storage/volumes/
+.. _Docker volume: https://docs.docker.com/engine/storage/volumes/
 .. _GeoJSON: https://geojson.org/
 .. _globbing: https://en.wikipedia.org/wiki/Glob_(programming)
 .. _percent-encoding: https://en.wikipedia.org/wiki/Percent-encoding
@@ -729,5 +729,5 @@ inserted records.
 .. _URL encoded: https://en.wikipedia.org/wiki/Percent-encoding
 .. _URL: https://docs.oracle.com/javase/8/docs/api/java/net/URL.html
 .. _well-formed URI: https://www.rfc-editor.org/rfc/rfc2396
-.. _Windows documentation: https://docs.microsoft.com/en-us/dotnet/standard/io/file-path-formats
+.. _Windows documentation: https://learn.microsoft.com/en-us/dotnet/standard/io/file-path-formats
 .. _WKT: https://en.wikipedia.org/wiki/Well-known_text

--- a/docs/sql/statements/create-repository.rst
+++ b/docs/sql/statements/create-repository.rst
@@ -784,10 +784,10 @@ Parameters
 .. _attach the IAM to each EC2 instance: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html
 .. _AWS API endpoint: https://docs.aws.amazon.com/general/latest/gr/rande.html
 .. _AWS region: https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services/
-.. _Azure Blob storage: https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blobs-introduction
+.. _Azure Blob storage: https://learn.microsoft.com/en-us/azure/storage/blobs/storage-blobs-introduction
 .. _Azure service region: https://azure.microsoft.com/en-us/explore/global-infrastructure/geographies/
 .. _Canned ACL: https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html#canned-acl
-.. _endpoint suffix: https://docs.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string#create-a-connection-string-with-an-endpoint-suffix
+.. _endpoint suffix: https://learn.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string
 .. _IAM roles: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html
 .. _plugins: https://github.com/crate/crate/blob/master/devs/docs/plugins.rst
 .. _regional endpoint: https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints

--- a/docs/sql/statements/deallocate.rst
+++ b/docs/sql/statements/deallocate.rst
@@ -32,4 +32,4 @@ Parameters
 :ALL:
   Deallocate all prepared statements
 
-.. _libpq: https://www.postgresql.org/docs/10/static/libpq.html
+.. _libpq: https://www.postgresql.org/docs/10/libpq.html


### PR DESCRIPTION
Based on the `./blackbox/bin/sphinx linkcheck` output like:

    (appendices/release-notes/3.0.0: line  301) redirect  https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization - permanently to https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Authorization

A few external links to content within the docs were also broken - this
replaces them with internal links/refs
