### PR TITLE
mergify: Write the merge rules differently

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -6,9 +6,6 @@ merge_queue:
 queue_rules:
   - name: default
     batch_size: 1
-    queue_conditions:
-      - label=ready-to-merge
-      - '#approved-reviews-by>=1'
     merge_conditions:
       - label=ready-to-merge
       - '#approved-reviews-by>=1'


### PR DESCRIPTION
Try to fix message:
```
Configuration not compatible with a branch protection setting
The branch protection setting Require branches to be up to date
before merging is not compatible with draft PR checks. To keep
this branch protection enabled, update your Mergify configuration
to enable in-place checks: set merge_queue.max_parallel_checks: 1,
set every queue rule batch_size: 1, and avoid two-step CI
(make merge_conditions identical to queue_conditions).
Otherwise, disable this branch protection.
```
