### PR TITLE
Don't throw away RelationMetadata in mixed clusters

### DIFF
--- a/server/src/main/java/io/crate/metadata/upgrade/ClusterStateUpgrader.java
+++ b/server/src/main/java/io/crate/metadata/upgrade/ClusterStateUpgrader.java
@@ -31,7 +31,6 @@ import org.elasticsearch.cluster.block.ClusterBlocks;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.metadata.MetadataUpgradeService;
-import org.elasticsearch.cluster.metadata.RelationMetadata;
 import org.elasticsearch.cluster.routing.IndexRoutingTable;
 import org.elasticsearch.cluster.routing.RoutingTable;
 
@@ -89,12 +88,6 @@ public class ClusterStateUpgrader {
         for (IndexMetadata indexMetadata : state.metadata()) {
             metadataBuilder.remove(indexMetadata.getIndexUUID());
             metadataBuilder.putWithIndexName(indexMetadata);
-        }
-        for (RelationMetadata relationMetadata : state.metadata().relations(RelationMetadata.Table.class)) {
-            metadataBuilder.dropRelation(relationMetadata.name());
-        }
-        for (RelationMetadata relationMetadata : state.metadata().relations(RelationMetadata.BlobTable.class)) {
-            metadataBuilder.dropRelation(relationMetadata.name());
         }
 
         return ClusterState.builder(state)


### PR DESCRIPTION
6.0 clusters can already handle RelationMetadata and even if the
`Metadata`/`IndexMetadata` are using indexName based resolving, the
indexUUID link in the RelationMetadata is still valid.

Throwing away the RelationMetadata caused partitioned tables with no
partitions to disappear.

This was caught in crate-qa after fixing a broken version check
(https://github.com/crate/crate-qa/commit/9f86884903cf8c88d91436f404b275c9be0b5b02)
