### PR TITLE
Apply writePendingMessage write in callback change to portalSuspended case

### DIFF
--- a/server/src/main/java/io/crate/protocols/postgres/ResultSetReceiver.java
+++ b/server/src/main/java/io/crate/protocols/postgres/ResultSetReceiver.java
@@ -100,13 +100,16 @@ class ResultSetReceiver extends BaseResultReceiver {
     @Override
     public void batchFinished() {
         ChannelFuture sendPortalSuspended = Messages.sendPortalSuspended(directChannel);
-        channel.writePendingMessages(delayedWrites);
-        channel.flush();
+        directChannel.flush();
 
         // Trigger the completion future but by-pass `sendCompleteComplete`
         // This resultReceiver shouldn't be used anymore. The next `execute` message
         // from the client will create a new one.
-        sendPortalSuspended.addListener(_ -> super.allFinished());
+        sendPortalSuspended.addListener(_ -> {
+            channel.writePendingMessages(delayedWrites);
+            channel.flush();
+            super.allFinished();
+        });
     }
 
     @Override


### PR DESCRIPTION
Follow up to https://github.com/crate/crate/pull/18417
Didn't verify yet if related, but this came to mind seeing node-postgres
failures:

    FAIL ./cratedb.test.js
      ✕ can use cursor to fetch subset of result with many reads (210 ms)
      ✕ can use cursor to fetch full result with many reads (2 ms)
      queries on table
        ✓ Can insert timestamp via parameter (679 ms)
        ✓ Can insert multiple values (456 ms)
        ✓ Can use update returning (325 ms)

      ● can use cursor to fetch subset of result with many reads
        expect(received).toHaveLength(expected)

        Expected length: 10
        Received length: 0
        Received array:  []
          39 |   expect(res1).toHaveLength(5);
          40 |   expect(res2).toHaveLength(10);
        > 41 |   expect(res3).toHaveLength(10);
             |                ^
          42 |
          43 |   await cursor.close();
          44 | });
          at Object.toHaveLength (cratedb.test.js:41:16)
      ● can use cursor to fetch full result with many reads
        error: Cannot find portal: C_1
          at Parser.parseErrorMessage (node_modules/pg-protocol/src/parser.ts:369:69)
          at Parser.handlePacket (node_modules/pg-protocol/src/parser.ts:188:21)
          at Parser.parse (node_modules/pg-protocol/src/parser.ts:103:30)
          at Socket.<anonymous> (node_modules/pg-protocol/src/index.ts:7:48)
