### PR TITLE
Try to fix mergify

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,11 +1,12 @@
 ---
 merge_queue:
   max_parallel_checks: 1
-  reset_on_external_merge: never
 
 queue_rules:
   - name: default
     batch_size: 1
+    branch_protection_injection_mode: merge
+    autoqueue: true
     merge_conditions:
       - label=ready-to-merge
       - '#approved-reviews-by>=1'
@@ -20,7 +21,8 @@ queue_rules:
 
 pull_request_rules:
   - name: default
-    conditions: []
+    conditions:
+      - label=ready-to-merge
     actions:
       queue:
 


### PR DESCRIPTION
get rid of:
```
The branch protection setting Require branches to be up to date before merging is not compatible with draft PR checks. To keep this branch protection enabled, update your Mergify configuration to enable in-place checks: set merge_queue.max_parallel_checks: 1, set every queue rule batch_size: 1, and avoid two-step CI (make merge_conditions identical to queue_conditions). Otherwise, disable this branch protection.
```

