### PR TITLE
Fix mergify by modifying the queue rules

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -5,9 +5,9 @@ merge_queue:
 queue_rules:
   - name: default
     batch_size: 1
-    branch_protection_injection_mode: merge
-    autoqueue: true
-    merge_conditions:
+    branch_protection_injection_mode: none
+    merge_method: rebase
+    queue_conditions:
       - label=ready-to-merge
       - '#approved-reviews-by>=1'
       - status-success~=^check-author-signed-cla
@@ -17,7 +17,6 @@ queue_rules:
       - status-success~=^checkstyle
       - status-success~=^forbiddenApis
       - status-success~=^Vale
-    merge_method: rebase
 
 pull_request_rules:
   - name: default


### PR DESCRIPTION
get rid of:
```
The branch protection setting Require branches to be up to
date before merging is not compatible with draft PR checks.
To keep this branch protection enabled, update your Mergify
configuration to enable in-place checks:
set merge_queue.max_parallel_checks: 1,
set every queue rule batch_size: 1,
and avoid two-step CI (make merge_conditions identical to
queue_conditions). Otherwise, disable this branch protection.
```
