### PR TITLE
Upgrade Lucene to 9.12.3 to avoid mmap leaks

### DIFF
--- a/docs/appendices/release-notes/5.10.13.rst
+++ b/docs/appendices/release-notes/5.10.13.rst
@@ -62,3 +62,7 @@ Fixes
 
 - Fixed an issue where null-valued sub-columns of objects were omitted when
   queried.
+
+- Upgraded Lucene to ``9.12.3`` that fixed an issue with ``MMapDirectory``
+  leaking maps that could cause exceeding of the ``vm.max_map_count`` limit
+  and lead to a node crash.

--- a/pom.xml
+++ b/pom.xml
@@ -325,7 +325,7 @@
     <versions.quickcheck>1.0</versions.quickcheck>
     <versions.hppc>0.8.2</versions.hppc>
     <versions.netty>4.1.127.Final</versions.netty>
-    <versions.lucene>9.12.0</versions.lucene>
+    <versions.lucene>9.12.3</versions.lucene>
     <versions.spatial4j>0.8</versions.spatial4j>
     <versions.jts>1.20.0</versions.jts>
     <versions.jna>5.15.0</versions.jna>

--- a/server/src/main/java/org/elasticsearch/Version.java
+++ b/server/src/main/java/org/elasticsearch/Version.java
@@ -240,7 +240,7 @@ public class Version implements Comparable<Version> {
     public static final Version V_5_10_10 = new Version(8_10_10_99, false, org.apache.lucene.util.Version.LUCENE_9_12_0);
     public static final Version V_5_10_11 = new Version(8_10_11_99, false, org.apache.lucene.util.Version.LUCENE_9_12_0);
     public static final Version V_5_10_12 = new Version(8_10_12_99, false, org.apache.lucene.util.Version.LUCENE_9_12_0);
-    public static final Version V_5_10_13 = new Version(8_10_13_99, true, org.apache.lucene.util.Version.LUCENE_9_12_0);
+    public static final Version V_5_10_13 = new Version(8_10_13_99, true, org.apache.lucene.util.Version.LUCENE_9_12_3);
 
     public static final Version CURRENT = V_5_10_13;
 


### PR DESCRIPTION
https://lucene.apache.org/core/9_12_3/changes/Changes.html

See also https://github.com/apache/lucene/issues/15068 and https://github.com/apache/lucene/pull/15074

CrateDB 6.0+ is good as is, see https://github.com/apache/lucene/pull/15074#issuecomment-3189221977