### PR TITLE
Fix `RETURNING` columns omitting generated sub-columns

### DIFF
--- a/docs/appendices/release-notes/6.0.4.rst
+++ b/docs/appendices/release-notes/6.0.4.rst
@@ -75,3 +75,5 @@ Fixes
   ``OutOfMemoryError`` when a large result set was returned by the ``HTTP``
   endpoint.
 
+- Fixed an issue where generated and default sub-columns were missing from
+  results returned by the ``RETURNING`` clause.

--- a/docs/appendices/release-notes/6.1.0.rst
+++ b/docs/appendices/release-notes/6.1.0.rst
@@ -94,3 +94,6 @@ Administration and Operations
   available after a cluster restart.
 
 - Added ``last_job_id`` column to the :ref:`sys.sessions <sys-sessions>` table.
+
+- Fixed an issue where generated and default sub-columns were missing from
+  results returned by the ``RETURNING`` clause.

--- a/libs/shared/src/main/java/io/crate/common/collections/Maps.java
+++ b/libs/shared/src/main/java/io/crate/common/collections/Maps.java
@@ -139,6 +139,27 @@ public final class Maps {
         return newList;
     }
 
+    public static boolean pathExists(Map<?, ?> map, List<String> path) {
+        Map<?, ?> current = map;
+        for (int i = 0; i < path.size(); i++) {
+            String key = path.get(i);
+            // must use Map.containsKey instead of Map.get because a column can be mapped to a null value
+            if (!current.containsKey(key)) {
+                return false;
+            }
+            if (i + 1 == path.size()) {
+                return true;
+            }
+            var val = current.get(key);
+            if (val instanceof Map<?, ?> nested) {
+                current = nested;
+            } else {
+                return false;
+            }
+        }
+        return true;
+    }
+
     @Nullable
     @SuppressWarnings("unchecked")
     public static <T> T removeByPath(Map<String, T> map, List<String> path) {
@@ -270,5 +291,32 @@ public final class Maps {
             return map.put(key, value);
         }
         return null;
+    }
+
+    /**
+     * Returns a modifiable deep copy of the given map.
+     */
+    public static <K, V> Map<K, V> deepCopy(Map<K, V> map) {
+        Map<K, V> copy = new HashMap<>();
+        for (Map.Entry<K, V> e : map.entrySet()) {
+            K key = e.getKey();
+            V value = e.getValue();
+            if (value instanceof Map<?, ?> nested) {
+                copy.put(key, (V) deepCopy(nested));
+            } else if (value instanceof List<?> list) {
+                List<Object> newList = new ArrayList<>();
+                for (Object item : list) {
+                    if (item instanceof Map<?, ?> m) {
+                        newList.add(deepCopy(m));
+                    } else {
+                        newList.add(item);
+                    }
+                }
+                copy.put(key, (V) newList);
+            } else {
+                copy.put(key, value);
+            }
+        }
+        return copy;
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes:

```
cr> create table t (o object as (a int default 1, b int as o['a']+1));
CREATE OK, 1 row affected (1.666 sec)

cr> insert into t values ({}) returning *;
+----+
| o  |
+----+
| {} | -- wrong
+----+
INSERT 1 row in set (0.045 sec)
```
With the fix:
```
cr> create table t (o object as (a int default 1, b int as o['a']+1));
CREATE OK, 1 row affected (2.059 sec)

cr> insert into t values ({}) returning *;
+------------------+
| o                |
+------------------+
| {"a": 1, "b": 2} |
+------------------+
INSERT 1 row in set (3.240 sec)
```

The root cause was that the `collect expression` for `o` only retrieved the value available in `insertValues` without combining default/generated values.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
