### PR TITLE
Ensure UDFs don't cause metadata upgrade errors

### DIFF
--- a/server/src/main/java/io/crate/metadata/cluster/OpenTableClusterStateTaskExecutor.java
+++ b/server/src/main/java/io/crate/metadata/cluster/OpenTableClusterStateTaskExecutor.java
@@ -109,7 +109,7 @@ public class OpenTableClusterStateTaskExecutor extends DDLClusterStateTaskExecut
 
             // The index might be closed because we couldn't import it due to old incompatible version
             // We need to check that this index can be upgraded to the current version
-            updatedIndexMetadata = metadataIndexUpgradeService.upgradeIndexMetadata(updatedIndexMetadata, null, minIndexCompatibilityVersion, null);
+            updatedIndexMetadata = metadataIndexUpgradeService.upgradeIndexMetadata(updatedIndexMetadata, null, minIndexCompatibilityVersion);
             try {
                 indicesService.verifyIndexMetadata(updatedIndexMetadata, updatedIndexMetadata);
             } catch (Exception e) {

--- a/server/src/main/java/org/elasticsearch/gateway/LocalAllocateDangledIndices.java
+++ b/server/src/main/java/org/elasticsearch/gateway/LocalAllocateDangledIndices.java
@@ -154,8 +154,7 @@ public class LocalAllocateDangledIndices {
                                 IndexName.isPartitioned(indexName) ?
                                     currentState.metadata().templates().get(PartitionName.templateName(indexName)) :
                                     null,
-                                minIndexCompatibilityVersion,
-                                null);
+                                minIndexCompatibilityVersion);
                             upgradedIndexMetadata = IndexMetadata.builder(upgradedIndexMetadata).settings(
                                 Settings.builder().put(upgradedIndexMetadata.getSettings()).put(
                                     IndexMetadata.SETTING_HISTORY_UUID, UUIDs.randomBase64UUID())).build();

--- a/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -449,8 +449,7 @@ public class RestoreService implements ClusterStateApplier {
                     IndexName.isPartitioned(indexName) ?
                         currentMetadata.templates().get(PartitionName.templateName(indexName)) :
                         null,
-                    minIndexCompatibilityVersion,
-                    null
+                    minIndexCompatibilityVersion
                 );
                 // Check that the index is closed or doesn't exist
                 String renamedIndexName = indexEntry.getKey();

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataUpgradeServiceTest.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataUpgradeServiceTest.java
@@ -49,11 +49,27 @@ import io.crate.types.DataTypes;
 
 public class MetadataUpgradeServiceTest extends CrateDummyClusterServiceUnitTest {
 
+    private SQLExecutor e;
     private MetadataUpgradeService metadataUpgradeService;
+    private String minimalTemplateMappingSource =
+        """
+        {
+            "default": {
+                "_meta": {
+                    "partitioned_by": [["p", "integer"]]
+                },
+                "properties": {
+                    "p": {
+                        "type": "integer"
+                    }
+                }
+            }
+        }
+        """;
 
     @Before
     public void setUpUpgradeService() throws Exception {
-        SQLExecutor e = SQLExecutor.of(clusterService);
+        e = SQLExecutor.of(clusterService);
         e.udfService().registerLanguage(UdfUnitTest.DUMMY_LANG);
         metadataUpgradeService = new MetadataUpgradeService(
             e.nodeCtx,
@@ -64,32 +80,34 @@ public class MetadataUpgradeServiceTest extends CrateDummyClusterServiceUnitTest
 
     @Test
     public void test_upgradeIndexMetadata_ensure_UDFs_are_loaded_before_checkMappingsCompatibility_is_called() throws IOException {
-        SQLExecutor e = SQLExecutor.of(clusterService);
-        e.udfService().registerLanguage(UdfUnitTest.DUMMY_LANG);
-        var metadataUpgradeService = new MetadataUpgradeService(
-            e.nodeCtx,
-            IndexScopedSettings.DEFAULT_SCOPED_SETTINGS,
-            e.udfService()
-        );
-        metadataUpgradeService.upgradeIndexMetadata(
-            IndexMetadata.builder("test")
-                .settings(settings(Version.V_5_7_0))
-                .numberOfShards(1)
-                .numberOfReplicas(1)
-                .build(),
-            IndexTemplateMetadata.builder("test")
-                .patterns(List.of("*"))
-                .putMapping("{\"default\": {}}")
-                .build(),
-            Version.V_5_7_0,
-            UserDefinedFunctionsMetadata.of(new UserDefinedFunctionMetadata(
-                "custom",
-                "foo",
-                List.of(),
-                DataTypes.INTEGER,
-                "dummy",
-                "def foo(): return 1"
-            )));
+        IndexMetadata indexMetadata = IndexMetadata.builder("test")
+            .settings(settings(Version.V_5_7_0))
+            .numberOfShards(1)
+            .numberOfReplicas(1)
+            .build();
+        Settings tmplSettings = Settings.builder()
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 4)
+            .build();
+        IndexTemplateMetadata indexTemplateMetadata = IndexTemplateMetadata.builder("test")
+            .patterns(List.of("*"))
+            .settings(tmplSettings)
+            .putMapping(minimalTemplateMappingSource)
+            .build();
+
+        UserDefinedFunctionsMetadata udfs = UserDefinedFunctionsMetadata.of(new UserDefinedFunctionMetadata(
+            "custom",
+            "foo",
+            List.of(),
+            DataTypes.INTEGER,
+            "dummy",
+            "def foo(): return 1"
+        ));
+        Metadata metadata = Metadata.builder()
+            .put(indexMetadata, false)
+            .put(indexTemplateMetadata)
+            .putCustom(UserDefinedFunctionsMetadata.TYPE, udfs)
+            .build();
+        metadataUpgradeService.upgradeMetadata(metadata);
         FunctionImplementation functionImplementation = e.nodeCtx.functions().get(
             "custom",
             "foo",
@@ -98,6 +116,50 @@ public class MetadataUpgradeServiceTest extends CrateDummyClusterServiceUnitTest
         );
         assertThat(functionImplementation).isNotNull();
     }
+
+    @Test
+    public void test_can_migrate_templates_using_udfs() throws Exception {
+        var template = IndexTemplateMetadata.builder("test")
+            .patterns(List.of("*"))
+            .settings(Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1))
+            .putMapping(
+                """
+                {
+                    "default": {
+                        "_meta": {
+                            "partitioned_by": [["p", "integer"]],
+                            "generated_columns": {
+                                "x": "custom.foo()"
+                            }
+                        },
+                        "properties": {
+                            "p": {
+                                "type": "integer"
+                            },
+                            "x": {
+                                "type": "integer"
+                            }
+                        }
+                    }
+                }
+                """
+            )
+            .build();
+        UserDefinedFunctionsMetadata udfs = UserDefinedFunctionsMetadata.of(new UserDefinedFunctionMetadata(
+            "custom",
+            "foo",
+            List.of(),
+            DataTypes.INTEGER,
+            "dummy",
+            "def foo(): return 1"
+        ));
+        Metadata metadata = Metadata.builder()
+            .putCustom(UserDefinedFunctionsMetadata.TYPE, udfs)
+            .put(template)
+            .build();
+        metadataUpgradeService.upgradeMetadata(metadata);
+    }
+
 
     @Test
     public void test_no_metadata_upgrade_build_relation_metadata() {


### PR DESCRIPTION
Port of https://github.com/crate/crate/pull/18443

No release notes because so far there was no user facing issue (other
than with unsupported downgrades  to testing only versions).
But not having this could cause issues with the next release.
