### PR TITLE
Bump version to 6.0.3 in pom.xml files

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.crate</groupId>
     <artifactId>crate</artifactId>
-    <version>6.0.2</version>
+    <version>6.0.3</version>
   </parent>
 
   <artifactId>crate-app</artifactId>

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.crate</groupId>
     <artifactId>crate</artifactId>
-    <version>6.0.2</version>
+    <version>6.0.3</version>
   </parent>
 
   <artifactId>crate-benchmarks</artifactId>

--- a/extensions/functions/pom.xml
+++ b/extensions/functions/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.crate</groupId>
     <artifactId>crate</artifactId>
-    <version>6.0.2</version>
+    <version>6.0.3</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/extensions/jmx-monitoring/pom.xml
+++ b/extensions/jmx-monitoring/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.crate</groupId>
     <artifactId>crate</artifactId>
-    <version>6.0.2</version>
+    <version>6.0.3</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/extensions/lang-js/pom.xml
+++ b/extensions/lang-js/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.crate</groupId>
     <artifactId>crate</artifactId>
-    <version>6.0.2</version>
+    <version>6.0.3</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/jlink-jdk/pom.xml
+++ b/jlink-jdk/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.crate</groupId>
     <artifactId>crate</artifactId>
-    <version>6.0.2</version>
+    <version>6.0.3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>jlink-jdk</artifactId>

--- a/libs/azure-testing/pom.xml
+++ b/libs/azure-testing/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.crate</groupId>
         <artifactId>crate</artifactId>
-        <version>6.0.2</version>
+        <version>6.0.3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/libs/cli/pom.xml
+++ b/libs/cli/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.crate</groupId>
     <artifactId>crate</artifactId>
-    <version>6.0.2</version>
+    <version>6.0.3</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/libs/dex/pom.xml
+++ b/libs/dex/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>io.crate</groupId>
     <artifactId>crate</artifactId>
-    <version>6.0.2</version>
+    <version>6.0.3</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/libs/es-x-content/pom.xml
+++ b/libs/es-x-content/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.crate</groupId>
     <artifactId>crate</artifactId>
-    <version>6.0.2</version>
+    <version>6.0.3</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/libs/guice/pom.xml
+++ b/libs/guice/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.crate</groupId>
     <artifactId>crate</artifactId>
-    <version>6.0.2</version>
+    <version>6.0.3</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/libs/pgwire/pom.xml
+++ b/libs/pgwire/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.crate</groupId>
     <artifactId>crate</artifactId>
-    <version>6.0.2</version>
+    <version>6.0.3</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/libs/shared/pom.xml
+++ b/libs/shared/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.crate</groupId>
     <artifactId>crate</artifactId>
-    <version>6.0.2</version>
+    <version>6.0.3</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/libs/sql-parser/pom.xml
+++ b/libs/sql-parser/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.crate</groupId>
     <artifactId>crate</artifactId>
-    <version>6.0.2</version>
+    <version>6.0.3</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/plugins/cr8-copy-s3/pom.xml
+++ b/plugins/cr8-copy-s3/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.crate</groupId>
     <artifactId>crate</artifactId>
-    <version>6.0.2</version>
+    <version>6.0.3</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/plugins/crate-copy-azure/pom.xml
+++ b/plugins/crate-copy-azure/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.crate</groupId>
         <artifactId>crate</artifactId>
-        <version>6.0.2</version>
+        <version>6.0.3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugins/dns-discovery/pom.xml
+++ b/plugins/dns-discovery/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.crate</groupId>
     <artifactId>crate</artifactId>
-    <version>6.0.2</version>
+    <version>6.0.3</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/plugins/es-analysis-common/pom.xml
+++ b/plugins/es-analysis-common/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.crate</groupId>
     <artifactId>crate</artifactId>
-    <version>6.0.2</version>
+    <version>6.0.3</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/plugins/es-analysis-phonetic/pom.xml
+++ b/plugins/es-analysis-phonetic/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.crate</groupId>
     <artifactId>crate</artifactId>
-    <version>6.0.2</version>
+    <version>6.0.3</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/plugins/es-discovery-ec2/pom.xml
+++ b/plugins/es-discovery-ec2/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.crate</groupId>
     <artifactId>crate</artifactId>
-    <version>6.0.2</version>
+    <version>6.0.3</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/plugins/es-repository-azure/pom.xml
+++ b/plugins/es-repository-azure/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.crate</groupId>
     <artifactId>crate</artifactId>
-    <version>6.0.2</version>
+    <version>6.0.3</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/plugins/es-repository-s3/pom.xml
+++ b/plugins/es-repository-s3/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.crate</groupId>
     <artifactId>crate</artifactId>
-    <version>6.0.2</version>
+    <version>6.0.3</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/plugins/es-repository-url/pom.xml
+++ b/plugins/es-repository-url/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.crate</groupId>
     <artifactId>crate</artifactId>
-    <version>6.0.2</version>
+    <version>6.0.3</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/plugins/repository-gcs/pom.xml
+++ b/plugins/repository-gcs/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>io.crate</groupId>
         <artifactId>crate</artifactId>
-        <version>6.0.2</version>
+        <version>6.0.3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>io.crate</groupId>
   <artifactId>crate</artifactId>
-  <version>6.0.2</version>
+  <version>6.0.3</version>
   <packaging>pom</packaging>
 
   <build>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.crate</groupId>
     <artifactId>crate</artifactId>
-    <version>6.0.2</version>
+    <version>6.0.3</version>
   </parent>
 
   <artifactId>crate-server</artifactId>


### PR DESCRIPTION
Was missing in https://github.com/crate/crate/pull/18405
Not having the version bump causes hiccups with crate-qa tests:

https://github.com/crate/crate-qa/pull/367
