### PR TITLE
Bump forbiddenapis to 3.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -352,7 +352,7 @@
     <versions.plugin.puppycrawl>10.26.1</versions.plugin.puppycrawl>
     <versions.plugin.toolchains>4.5.0</versions.plugin.toolchains>
     <versions.plugin.jacoco>0.8.13</versions.plugin.jacoco>
-    <versions.plugin.forbiddenapis>3.9</versions.plugin.forbiddenapis>
+    <versions.plugin.forbiddenapis>3.10</versions.plugin.forbiddenapis>
     <versions.plugin.jlink>3.1.0</versions.plugin.jlink>
     <versions.plugin.assembly>3.7.1</versions.plugin.assembly>
     <versions.plugin.download>1.13.0</versions.plugin.download>


### PR DESCRIPTION
Mostly for the JDK 25 support:

https://github.com/policeman-tools/forbidden-apis/wiki/Changes#version-310-released-2025-10-04
