### PR TITLE
Cache the shard size when exposed via JMX

### DIFF
--- a/docs/appendices/release-notes/6.1.0.rst
+++ b/docs/appendices/release-notes/6.1.0.rst
@@ -57,6 +57,10 @@ Breaking Changes
   the relative paths are resolved, thus conforming to the behavior already
   described in the :ref:`documentation <conf-node-settings_paths>`.
 
+- Cache each shard size information exposed via the
+  :ref:`JMX NodeInfo MXBean<node_info_mxbean>` for 10 seconds to avoid expensive
+  disk usage calls on every request.
+
 Deprecations
 ============
 

--- a/extensions/jmx-monitoring/src/main/java/io/crate/beans/NodeInfo.java
+++ b/extensions/jmx-monitoring/src/main/java/io/crate/beans/NodeInfo.java
@@ -169,7 +169,7 @@ public class NodeInfo implements NodeInfoMXBean {
             if (shard == null) {
                 return null;
             }
-            return new ShardStateStoreSize(shard.state(), shard.storeStats().sizeInBytes());
+            return new ShardStateStoreSize(shard.state(), shard.storeStatsCached().sizeInBytes());
         }
     }
 }

--- a/server/src/main/java/io/crate/expression/reference/sys/shard/ShardRowContext.java
+++ b/server/src/main/java/io/crate/expression/reference/sys/shard/ShardRowContext.java
@@ -115,7 +115,11 @@ public class ShardRowContext {
         if (blobShard != null) {
             return blobShard.getTotalSize();
         }
-        return indexShard.storeStatsCached().sizeInBytes();
+        try {
+            return indexShard.storeStatsCached().sizeInBytes();
+        } catch (AlreadyClosedException e) {
+            return 0L;
+        }
     }
 
     @Nullable

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -1033,6 +1033,8 @@ public class IndexShard extends AbstractIndexShardComponent {
      * Returns store stats whereas the size is computed from a cached value to avoid costly file system calls.
      * Use this method when exposing the size to the user frequently.
      * For a precise actual value use {@link #storeStats()}.
+     *
+     * @throws AlreadyClosedException if the shard is closed
      */
     public StoreStats storeStatsCached() {
         final RecoveryState recoveryState = this.recoveryState;

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -1030,6 +1030,17 @@ public class IndexShard extends AbstractIndexShardComponent {
     }
 
     /**
+     * Returns store stats whereas the size is computed from a cached value to avoid costly file system calls.
+     * Use this method when exposing the size to the user frequently.
+     * For a precise actual value use {@link #storeStats()}.
+     */
+    public StoreStats storeStatsCached() {
+        final RecoveryState recoveryState = this.recoveryState;
+        final long bytesStillToRecover = recoveryState == null ? -1L : recoveryState.getIndex().bytesStillToRecover();
+        return store.statsCached(bytesStillToRecover == -1 ? StoreStats.UNKNOWN_RESERVED_BYTES : bytesStillToRecover);
+    }
+
+    /**
      * Executes a flush against the engine
      * @param waitIfOngoing if {@code true} will block until all concurrent flushes are complete
      * @return the commit ID

--- a/server/src/main/java/org/elasticsearch/index/store/Store.java
+++ b/server/src/main/java/org/elasticsearch/index/store/Store.java
@@ -370,6 +370,7 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
      * Returns the store stats with a cached size. The size is cached for a short period of time (defaults to 10s).
      * Use this method when exposing the store size to the user, and it's expected to be called frequently.
      *
+     * @throws AlreadyClosedException if the shard is closed
      * @param reservedBytes a prediction of how much larger the store is expected to grow, or {@link StoreStats#UNKNOWN_RESERVED_BYTES}.
      */
     public StoreStats statsCached(long reservedBytes) {

--- a/server/src/test/java/io/crate/expression/reference/sys/SysShardsExpressionsTest.java
+++ b/server/src/test/java/io/crate/expression/reference/sys/SysShardsExpressionsTest.java
@@ -135,7 +135,7 @@ public class SysShardsExpressionsTest extends CrateDummyClusterServiceUnitTest {
         when(indexShard.state()).thenReturn(IndexShardState.STARTED);
 
         StoreStats storeStats = new StoreStats(123456L, 0L);
-        when(indexShard.storeStats()).thenReturn(storeStats);
+        when(indexShard.storeStatsCached()).thenReturn(storeStats);
 
         Path dataPath = Paths.get("/dummy/" + indexUUID + "/" + shardId.id());
         when(indexShard.shardPath()).thenReturn(new ShardPath(false, dataPath, dataPath, shardId));
@@ -399,7 +399,7 @@ public class SysShardsExpressionsTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testShardSizeExpressionWhenIndexShardHasBeenClosed() throws Exception {
         IndexShard mock = mockIndexShard(indexShard.shardId().getIndexName(), indexShard.shardId().getIndexUUID());
-        doThrow(new AlreadyClosedException("dummy")).when(mock).storeStats();
+        doThrow(new AlreadyClosedException("dummy")).when(mock).storeStatsCached();
         ShardReferenceResolver res = new ShardReferenceResolver(schemas, new ShardRowContext(mock, clusterService));
         Reference refInfo = refInfo("sys.shards.size", DataTypes.LONG, RowGranularity.SHARD);
         Input<?> shardExpression = res.getImplementation(refInfo);


### PR DESCRIPTION
Moves the shard size caching logic into the shard store to make the cache available also to the JMX NodeInfo which iterates over all available shards.

I've run some quite rough benchmark with a [custom cr8 fork](https://github.com/seut/cr8/commit/88224b15481c882e37495fe82316aa73d477cbcb) using a special [jmx-exporter.toml spec](https://github.com/crate/crate-benchmarks/commit/6a2bc7d3c1ebac6e9960b3fbf2666db31d4fe2c0), timings are collected on the client side of the complete request/response session.
These benchmarks should be treat with care and are mainly only verifying that the change does not cause any regression.
(timings do not really change, HEAP usages slightly drops)

<summar>Benchmark results</summary>
<details>

```
# Results (client side duration in ms)
V1: 6.1.0-088b64c0f0cb986d4362c98f0695d69b393530fa
V2: 6.1.0-684893278e242fb340a1b646584b594f280e6ee5

Q: None
C: 1
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |        0.004 ±    0.003 |      0.002 |      0.003 |      0.004 |      0.035 |
|   V2    |        0.004 ±    0.002 |      0.002 |      0.003 |      0.005 |      0.025 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -   1.69%                           +   1.87%   
There is a 43.47% probability that the observed difference is not random, and the best estimate of that difference is 1.69%
The test has no statistical significance


System/JVM Metrics (durations in ms, byte-values in MB)
    |    YOUNG GC            |       OLD GC           |      HEAP         |     ALLOC     
    |  cnt      avg      max |  cnt      avg      max |  initial     used |     rate      total
 V1 |  295     2.14     0.91 |    1    57.30    57.30 |      268      423 |  1890.71      74290
 V2 |  269     2.22     0.94 |    1    42.95    42.95 |      268       91 |  1860.35      74561
    
Top allocation frames
  V1
    CharBuffer.wrap(...) total=27083191176, count=2008
    BaseNCodec.ensureBufferSize(...) total=18964195034, count=1223
    StreamEncoder.write(int) total=7198697480, count=537
    StreamEncoder.write(...) total=3927591104, count=338
    TreeMap.addEntry(...) total=1735994456, count=181
    ServerImpl$Exchange.run() total=1395281240, count=83
    Arrays.copyOf(...) total=1139618408, count=144
    ArrayList.spliterator() total=762064656, count=496
    Arrays.copyOfRange(...) total=731652569, count=174
    DoubleToDecimal.toString(double) total=654359130, count=39
  V2
    CharBuffer.wrap(...) total=25646984368, count=1796
    BaseNCodec.ensureBufferSize(...) total=16048476746, count=1056
    StreamEncoder.write(int) total=8220440864, count=541
    StreamEncoder.write(...) total=4203492160, count=325
    TreeMap.addEntry(...) total=1683398688, count=168
    Unsafe.allocateUninitializedArray(Class, int) total=1472900536, count=187
    ServerImpl$Exchange.run() total=1329020944, count=81
    Arrays.copyOf(...) total=1017564304, count=165
    Arrays.copyOfRange(...) total=928749242, count=138
    Integer.toString(int) total=850633792, count=35

Top frames (by count)
  V1
    CharBuffer.wrap(...) total=27083191176, count=2008
    BaseNCodec.ensureBufferSize(...) total=18964195034, count=1223
    StreamEncoder.write(int) total=7198697480, count=537
    ArrayList.spliterator() total=762064656, count=496
    BufferedOutputStream.<init>(...) total=50256488, count=369
    StreamEncoder.write(...) total=3927591104, count=338
    HashMap.resize() total=191250280, count=297
    StreamEncoder.implWrite(CharBuffer) total=250, count=250
    ArrayList.grow(int) total=534634776, count=245
    HeapByteBuffer.<init>(...) total=9102952, count=235
  V2
    CharBuffer.wrap(...) total=25646984368, count=1796
    BaseNCodec.ensureBufferSize(...) total=16048476746, count=1056
    ArrayList.spliterator() total=558608744, count=636
    StreamEncoder.write(int) total=8220440864, count=541
    BufferedOutputStream.<init>(...) total=128094752, count=433
    StreamEncoder.write(...) total=4203492160, count=325
    HashMap.resize() total=112341393, count=312
    HeapByteBuffer.<init>(...) total=9565928, count=281
    StreamEncoder.implWrite(CharBuffer) total=239, count=239
    ArrayList.grow(int) total=647416241, count=231
```
</details>

