### PR TITLE
Remove custom shard size caching on sys.shards

### DIFF
--- a/server/src/main/java/io/crate/expression/reference/sys/shard/ShardRowContext.java
+++ b/server/src/main/java/io/crate/expression/reference/sys/shard/ShardRowContext.java
@@ -24,7 +24,6 @@ package io.crate.expression.reference.sys.shard;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
 import org.apache.lucene.store.AlreadyClosedException;
@@ -42,7 +41,6 @@ import org.elasticsearch.index.store.StoreStats;
 import org.jetbrains.annotations.Nullable;
 
 import io.crate.blob.v2.BlobShard;
-import io.crate.common.Suppliers;
 import io.crate.metadata.IndexName;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.RelationName;
@@ -64,14 +62,14 @@ public class ShardRowContext {
     private final boolean orphanedPartition;
 
     public ShardRowContext(IndexShard indexShard, ClusterService clusterService) {
-        this(indexShard, null, clusterService, Suppliers.memoizeWithExpiration(() -> {
+        this(indexShard, null, clusterService, () -> {
             try {
                 StoreStats storeStats = indexShard.storeStats();
                 return storeStats.sizeInBytes();
             } catch (AlreadyClosedException e) {
                 return 0L;
             }
-        }, 10, TimeUnit.SECONDS));
+        });
     }
 
     public ShardRowContext(BlobShard blobShard, ClusterService clusterService) {


### PR DESCRIPTION
The `StoreStats` used to expose the shard size already uses a caching implementation configurable by the table setting `store.stats_refresh_interval`. The existing default time value is `10s`, which is equal to the removed custom caching setup, so nothing actually changes.
