### PR TITLE
Avoid capturing lambda's in TranslogWriter

### DIFF
--- a/server/src/main/java/io/crate/execution/dml/ArrayIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/ArrayIndexer.java
@@ -22,7 +22,6 @@
 package io.crate.execution.dml;
 
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -162,13 +161,11 @@ public class ArrayIndexer<T> implements ValueIndexer<List<T>> {
         }
     }
 
-    protected BytesReference arrayToBytes(List<T> values, IndexDocumentBuilder docBuilder) {
+    protected BytesReference arrayToBytes(List<T> values, IndexDocumentBuilder docBuilder) throws IOException {
         try (BytesStreamOutput output = new BytesStreamOutput()) {
             output.setVersion(docBuilder.getTableVersionCreated());
             bytesConverter.writeValueTo(output, values);
             return output.bytes();
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
         }
     }
 

--- a/server/src/main/java/io/crate/execution/dml/ArrayOfObjectIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/ArrayOfObjectIndexer.java
@@ -52,7 +52,7 @@ public class ArrayOfObjectIndexer<T> extends ArrayIndexer<T> {
     }
 
     @Override
-    protected BytesReference arrayToBytes(List<T> values, IndexDocumentBuilder docBuilder) {
+    protected BytesReference arrayToBytes(List<T> values, IndexDocumentBuilder docBuilder) throws IOException {
         return docBuilder.translogWriter().bytes();
     }
 }

--- a/server/src/main/java/io/crate/execution/dml/IndexDocumentBuilder.java
+++ b/server/src/main/java/io/crate/execution/dml/IndexDocumentBuilder.java
@@ -21,6 +21,7 @@
 
 package io.crate.execution.dml;
 
+import java.io.IOException;
 import java.util.Map;
 import java.util.function.UnaryOperator;
 
@@ -170,7 +171,7 @@ public class IndexDocumentBuilder {
     /**
      * Constructs a new ParsedDocument with the given id from the indexed values
      */
-    public ParsedDocument build(String id) {
+    public ParsedDocument build(String id) throws IOException {
 
         NumericDocValuesField version = new NumericDocValuesField(SysColumns.Names.VERSION, -1L);
         addField(version);

--- a/server/src/main/java/io/crate/execution/dml/SidecarTranslogWriter.java
+++ b/server/src/main/java/io/crate/execution/dml/SidecarTranslogWriter.java
@@ -21,6 +21,9 @@
 
 package io.crate.execution.dml;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
 import org.elasticsearch.common.bytes.BytesReference;
 
 /**
@@ -35,53 +38,57 @@ class SidecarTranslogWriter implements TranslogWriter {
     SidecarTranslogWriter(TranslogWriter inner, String oid) {
         this.inner = inner;
         this.sidecar = new XContentTranslogWriter();
-        this.sidecar.writeFieldName(oid);
+        try {
+            this.sidecar.writeFieldName(oid);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 
     @Override
-    public void startArray() {
+    public void startArray() throws IOException {
         inner.startArray();
         sidecar.startArray();
     }
 
     @Override
-    public void endArray() {
+    public void endArray() throws IOException {
         inner.endArray();
         sidecar.endArray();
     }
 
     @Override
-    public void startObject() {
+    public void startObject() throws IOException {
         inner.startObject();
         sidecar.startObject();
     }
 
     @Override
-    public void endObject() {
+    public void endObject() throws IOException {
         inner.endObject();
         sidecar.endObject();
     }
 
     @Override
-    public void writeFieldName(String fieldName) {
+    public void writeFieldName(String fieldName) throws IOException {
         inner.writeFieldName(fieldName);
         sidecar.writeFieldName(fieldName);
     }
 
     @Override
-    public void writeNull() {
+    public void writeNull() throws IOException {
         inner.writeNull();
         sidecar.writeNull();
     }
 
     @Override
-    public void writeValue(Object value) {
+    public void writeValue(Object value) throws IOException {
         inner.writeValue(value);
         sidecar.writeValue(value);
     }
 
     @Override
-    public BytesReference bytes() {
+    public BytesReference bytes() throws IOException {
         return sidecar.bytes();
     }
 }

--- a/server/src/main/java/io/crate/execution/dml/TranslogWriter.java
+++ b/server/src/main/java/io/crate/execution/dml/TranslogWriter.java
@@ -22,9 +22,7 @@
 package io.crate.execution.dml;
 
 import java.io.IOException;
-import java.io.UncheckedIOException;
 
-import org.apache.lucene.util.IORunnable;
 import org.elasticsearch.common.bytes.BytesReference;
 
 /**
@@ -33,25 +31,25 @@ import org.elasticsearch.common.bytes.BytesReference;
 public interface TranslogWriter {
 
     /** Start writing an array of values */
-    void startArray();
+    void startArray() throws IOException;
 
     /** Finish writing an array of values */
-    void endArray();
+    void endArray() throws IOException;
 
     /** Start writing a key-value object */
-    void startObject();
+    void startObject() throws IOException;
 
     /** Finish writing a key-value object */
-    void endObject();
+    void endObject() throws IOException;
 
     /** Write a field name */
-    void writeFieldName(String fieldName);
+    void writeFieldName(String fieldName) throws IOException;
 
     /** Write a null field value */
-    void writeNull();
+    void writeNull() throws IOException;
 
     /** Write a non-null field value */
-    void writeValue(Object value);
+    void writeValue(Object value) throws IOException;
 
     /**
      * Return a byte array representation of the transaction log entry
@@ -59,7 +57,7 @@ public interface TranslogWriter {
      * Once this method has been called, no other methods should be called
      * on the TranslogWriter
      */
-    BytesReference bytes();
+    BytesReference bytes() throws IOException;
 
     /**
      * Create a TranslogWriter that will ignore any write methods, and return
@@ -107,16 +105,5 @@ public interface TranslogWriter {
                 return source;
             }
         };
-    }
-
-    /**
-     * Wrap code that throws an IOException to rethrow an UncheckedIOException
-     */
-    static void uncheck(IORunnable runnable) {
-        try {
-            runnable.run();
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
     }
 }

--- a/server/src/main/java/io/crate/execution/dml/XContentTranslogWriter.java
+++ b/server/src/main/java/io/crate/execution/dml/XContentTranslogWriter.java
@@ -48,43 +48,43 @@ public class XContentTranslogWriter implements TranslogWriter {
     }
 
     @Override
-    public void startArray() {
-        TranslogWriter.uncheck(builder::startArray);
+    public void startArray() throws IOException {
+        builder.startArray();
     }
 
     @Override
-    public void endArray() {
-        TranslogWriter.uncheck(builder::endArray);
+    public void endArray() throws IOException {
+        builder.endArray();
     }
 
     @Override
-    public void startObject() {
-        TranslogWriter.uncheck(builder::startObject);
+    public void startObject() throws IOException {
+        builder.startObject();
     }
 
     @Override
-    public void endObject() {
-        TranslogWriter.uncheck(builder::endObject);
+    public void endObject() throws IOException {
+        builder.endObject();
     }
 
     @Override
-    public void writeNull() {
-        TranslogWriter.uncheck(builder::nullValue);
+    public void writeNull() throws IOException {
+        builder.nullValue();
     }
 
     @Override
-    public void writeFieldName(String fieldName) {
-        TranslogWriter.uncheck(() -> builder.field(fieldName));
+    public void writeFieldName(String fieldName) throws IOException {
+        builder.field(fieldName);
     }
 
     @Override
-    public void writeValue(Object value) {
-        TranslogWriter.uncheck(() -> builder.value(value));
+    public void writeValue(Object value) throws IOException {
+        builder.value(value);
     }
 
     @Override
-    public BytesReference bytes() {
-        TranslogWriter.uncheck(builder::endObject);
+    public BytesReference bytes() throws IOException {
+        builder.endObject();
         builder.close();
         return output.bytes();
     }


### PR DESCRIPTION
Using the `insert_bulk.toml` spec.
Could be noise, but shouldn't harm in any case:

```
# Results (server side duration in ms)
V1: 6.1.0-088b64c0f0cb986d4362c98f0695d69b393530fa
V2: 6.1.0-3750dd795d31876f9928ef10fde1bfa6ff20bbea

Q: insert into id_int_value_str ("id", "value") values ($1, $2)
C: 1
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |        3.071 ±    3.748 |      1.763 |      2.303 |      2.713 |     98.385 |
|   V2    |        3.050 ±    3.657 |      1.769 |      2.310 |      2.703 |     96.077 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -   0.69%                           +   0.29%
There is a 10.17% probability that the observed difference is not random, and the best estimate of that difference is 0.69%
The test has no statistical significance

Q: insert into id_int_value_str ("id", "value") values ($1, $2)
C: 10
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |        3.309 ±    5.209 |      1.279 |      2.186 |      2.504 |     44.516 |
|   V2    |        3.053 ±    4.676 |      1.351 |      2.024 |      2.331 |     36.521 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -   8.05%                           -   7.71%
There is a 75.27% probability that the observed difference is not random, and the best estimate of that difference is 8.05%
The test has no statistical significance

Q: insert into tbl ("id", "value") values ($1, $2)
C: 1
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |        2.163 ±    0.813 |      1.562 |      1.971 |      2.176 |     11.459 |
|   V2    |        2.061 ±    0.746 |      1.501 |      1.895 |      2.098 |     11.888 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -   4.85%                           -   3.93%
There is a 99.66% probability that the observed difference is not random, and the best estimate of that difference is 4.85%
The test has statistical significance

Q: insert into tbl ("id", "value") values ($1, $2)
C: 10
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |        4.814 ±    6.392 |      1.664 |      3.297 |      4.259 |     63.920 |
|   V2    |        4.498 ±    5.017 |      1.626 |      3.240 |      4.138 |     82.557 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -   6.79%                           -   1.75%
There is a 78.11% probability that the observed difference is not random, and the best estimate of that difference is 6.79%
The test has no statistical significance

Q: insert into uservisits ("adRevenue", "destinationURL", "searchWord", "UserAgent", "duration", "visitDate", "sourceIP", "lCode", "cCode") values ($1, $2, $3, $4, $5, $6, $7, $8, $9)
C: 10
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |       12.888 ±   26.639 |      4.483 |      6.748 |      8.366 |    232.361 |
|   V2    |       13.127 ±   27.786 |      4.542 |      6.526 |      7.924 |    233.130 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               +   1.84%                           -   3.35%
There is a 13.56% probability that the observed difference is not random, and the best estimate of that difference is 1.84%
The test has no statistical significance


System/JVM Metrics (durations in ms, byte-values in MB)
    |    YOUNG GC            |       OLD GC           |      HEAP         |     ALLOC
    |  cnt      avg      max |  cnt      avg      max |  initial     used |     rate      total
 V1 |   38     9.47    12.24 |    1    54.16    54.16 |     2147     1599 |  1618.03      44826
 V2 |   38     9.37    12.48 |    1    34.29    34.29 |     2147     1598 |  1602.59      44634

Top allocation frames
  V1
    BufferedChecksum.<init>(...) total=3571363696, count=651
    DirectMethodHandle.allocateInstance(Object) total=1799954210, count=338
    ParallelPostingsArray.<init>(int) total=1742161048, count=240
    Arrays.copyOf(...) total=1637599613, count=313
    FreqProxTermsWriterPerField$FreqProxPostingsArray.<init>(...) total=1274811749, count=197
    Lucene101PostingsWriter.newTermState() total=890275240, count=109
    Long.toString(long) total=874391137, count=154
    ArrayList.iterator() total=790103586, count=207
    ArrayUtil.growExact(int[], int) total=757518897, count=106
    ArrayList.<init>(int) total=734523808, count=164
  V2
    BufferedChecksum.<init>(...) total=3264669905, count=590
    Arrays.copyOf(...) total=1551824991, count=286
    FreqProxTermsWriterPerField$FreqProxPostingsArray.<init>(...) total=1360243825, count=176
    DirectMethodHandle.allocateInstance(Object) total=1335154420, count=327
    ParallelPostingsArray.<init>(int) total=1326085833, count=201
    Long.toString(long) total=1258380076, count=176
    BigArrays.newByteArray(...) total=859031393, count=123
    ArrayList.iterator() total=822625400, count=197
    ArrayUtil.growExact(int[], int) total=810759576, count=93
    BaseImplementationSymbolVisitor.visitFunction(...) total=786320968, count=155

Top frames (by count)
  V1
    BufferedChecksum.<init>(...) total=3571363696, count=651
    DirectMethodHandle.allocateInstance(Object) total=1799954210, count=338
    Arrays.copyOf(...) total=1637599613, count=313
    ParallelPostingsArray.<init>(int) total=1742161048, count=240
    ArraysSupport.mismatch(...) total=231, count=231
    ArrayList.iterator() total=790103586, count=207
    FreqProxTermsWriterPerField$FreqProxPostingsArray.<init>(...) total=1274811749, count=197
    BaseImplementationSymbolVisitor.visitFunction(...) total=652109512, count=190
    ArrayList.<init>(int) total=734523808, count=164
    ArrayList.grow(int) total=665941771, count=158
  V2
    BufferedChecksum.<init>(...) total=3264669905, count=590
    DirectMethodHandle.allocateInstance(Object) total=1335154420, count=327
    Arrays.copyOf(...) total=1551824991, count=286
    ParallelPostingsArray.<init>(int) total=1326085833, count=201
    ArrayList.iterator() total=822625400, count=197
    Long.toString(long) total=1258380076, count=176
    FreqProxTermsWriterPerField$FreqProxPostingsArray.<init>(...) total=1360243825, count=176
    BaseImplementationSymbolVisitor.visitFunction(...) total=786320968, count=155
    ArrayList.<init>(int) total=598025864, count=146
    ArraysSupport.mismatch(...) total=145, count=145

perf stat
  v1
    branches:u             :  121553645101.00
    cache-misses:u         :    3287818856.00
    instructions:u         :             0.00
    faults:u               :        440287.00
    context-switches:u     :             0.00
    L1-dcache-loads:u      :  242822096196.00
    L1-dcache-load-misses:u:             5.18
  v2
    branches:u             :  118916454624.00
    cache-misses:u         :    3282710449.00
    instructions:u         :             0.00
    faults:u               :        425718.00
    context-switches:u     :             0.00
    L1-dcache-loads:u      :  239371448682.00
    L1-dcache-load-misses:u:             5.20
```
