### PR TITLE
Add lightweight method `numDocs` to the index shard

### DIFF
--- a/server/src/main/java/io/crate/expression/reference/sys/shard/ShardRowContext.java
+++ b/server/src/main/java/io/crate/expression/reference/sys/shard/ShardRowContext.java
@@ -153,7 +153,7 @@ public class ShardRowContext {
     public Long numDocs() {
         if (blobShard == null) {
             try {
-                return indexShard.docStats().getCount();
+                return indexShard.numDocs();
             } catch (IllegalIndexShardStateException e) {
                 return null;
             }
@@ -174,7 +174,7 @@ public class ShardRowContext {
     public String minLuceneVersion() {
         long numDocs;
         try {
-            numDocs = indexShard.docStats().getCount();
+            numDocs = indexShard.numDocs();
         } catch (IllegalIndexShardStateException e) {
             return null;
         }

--- a/server/src/main/java/org/elasticsearch/index/engine/Engine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/Engine.java
@@ -187,6 +187,17 @@ public abstract class Engine implements Closeable {
     }
 
     /**
+     * Returns the number of documents (excluding deletions) in the index.
+     * Compared to building the full {@link DocsStats} this method avoids expensive file system calls to calculate the
+     * size of the index.
+     */
+    public long numDocs() {
+        try (Searcher searcher = acquireSearcher("numDocs", SearcherScope.INTERNAL)) {
+            return searcher.getIndexReader().numDocs();
+        }
+    }
+
+    /**
      * Performs the pre-closing checks on the {@link Engine}.
      *
      * @throws IllegalStateException if the sanity checks failed

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -998,6 +998,11 @@ public class IndexShard extends AbstractIndexShardComponent {
         return getEngine().docStats();
     }
 
+    public long numDocs() {
+        readAllowed();
+        return getEngine().numDocs();
+    }
+
     /**
      * @return {@link CommitStats}
      * @throws AlreadyClosedException if shard is closed

--- a/server/src/test/java/io/crate/expression/reference/sys/SysShardsExpressionsTest.java
+++ b/server/src/test/java/io/crate/expression/reference/sys/SysShardsExpressionsTest.java
@@ -47,7 +47,6 @@ import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexService;
-import org.elasticsearch.index.shard.DocsStats;
 import org.elasticsearch.index.shard.IllegalIndexShardStateException;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.IndexShardClosedException;
@@ -140,8 +139,7 @@ public class SysShardsExpressionsTest extends CrateDummyClusterServiceUnitTest {
         Path dataPath = Paths.get("/dummy/" + indexUUID + "/" + shardId.id());
         when(indexShard.shardPath()).thenReturn(new ShardPath(false, dataPath, dataPath, shardId));
 
-        DocsStats docsStats = new DocsStats(654321L, 0L, 200L);
-        when(indexShard.docStats()).thenReturn(docsStats).thenThrow(IllegalIndexShardStateException.class);
+        when(indexShard.numDocs()).thenReturn(654321L).thenThrow(IllegalIndexShardStateException.class);
 
         ShardRouting shardRouting = ShardRouting.newUnassigned(
             shardId, true, RecoverySource.PeerRecoverySource.INSTANCE, new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "foo"));

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -997,6 +997,9 @@ public class IndexShardTests extends IndexShardTestCase {
                     assertThat(searcher.getIndexReader().numDocs() <= docStats.getCount()).isTrue();
                 }
                 assertThat(docStats.getCount()).isEqualTo(numDocs);
+
+                // Ensure that the lightweight numDocs() call is consistent with the DocsStats
+                assertThat(indexShard.numDocs()).isEqualTo(docStats.getCount());
             }
 
             // merge them away


### PR DESCRIPTION
On calls to the `sys.shards` table, the `DocStats` object was build which does expensive FS calls to calculate the index size, while only the `numDocs` value was actually used.

Using the new `numDocs` implementation for this purpose avoids this.

Saw this as top dominator while looking at some heap dump:
```
cratedb[data-hot-0][get][T#5]
  at sun.nio.fs.UnixPath.resolve([B[B)[B (UnixPath.java:379)
  at sun.nio.fs.UnixPath.resolve(Ljava/nio/file/Path;)Lsun/nio/fs/UnixPath; (UnixPath.java:392)
  at sun.nio.fs.UnixPath.resolve(Ljava/nio/file/Path;)Ljava/nio/file/Path; (UnixPath.java:52)
  at java.nio.file.Path.resolve(Ljava/lang/String;)Ljava/nio/file/Path; (Path.java:516)
  at org.apache.lucene.store.FSDirectory.fileLength(Ljava/lang/String;)J (FSDirectory.java:208)
  at org.apache.lucene.store.FilterDirectory.fileLength(Ljava/lang/String;)J (FilterDirectory.java:70)
  at org.apache.lucene.store.FilterDirectory.fileLength(Ljava/lang/String;)J (FilterDirectory.java:70)
  at org.apache.lucene.index.SegmentCommitInfo.sizeInBytes()J (SegmentCommitInfo.java:230)
  at org.elasticsearch.index.engine.Engine.docsStats(Lorg/apache/lucene/index/IndexReader;)Lorg/elasticsearch/index/shard/DocsStats; (Engine.java:176)
  at org.elasticsearch.index.engine.Engine.docStats()Lorg/elasticsearch/index/shard/DocsStats; (Engine.java:159)
  at org.elasticsearch.index.shard.IndexShard.docStats()Lorg/elasticsearch/index/shard/DocsStats; (IndexShard.java:1003)
  at io.crate.expression.reference.sys.shard.ShardRowContext.numDocs()Ljava/lang/Long; (ShardRowContext.java:148)
  at io.crate.metadata.sys.SysShardsTableInfo$$Lambda+0x000000000769b7c8.apply(Ljava/lang/Object;)Ljava/lang/Object; ()
  at io.crate.metadata.SystemTable$Expression.value()Ljava/lang/Object; (SystemTable.java:504)
  at io.crate.expression.InputRow.get(I)Ljava/lang/Object; (InputRow.java:45)
  at io.crate.execution.engine.collect.RowCollectExpression.setNextRow(Lio/crate/data/Row;)V (RowCollectExpression.java:42)
  at io.crate.execution.engine.collect.RowCollectExpression.setNextRow(Ljava/lang/Object;)V (RowCollectExpression.java:29)
  at io.crate.execution.engine.aggregation.GroupingCollector.iter(Ljava/util/Map;Lio/crate/data/Row;)V (GroupingCollector.java:228)
  at io.crate.execution.engine.aggregation.GroupingCollector$$Lambda+0x0000000007c30f78.accept(Ljava/lang/Object;Ljava/lang/Object;)V ()
  at io.crate.data.BatchIterator.lambda$collect$1(Ljava/util/function/BiConsumer;Ljava/lang/Object;Ljava/lang/Object;)V (BatchIterator.java:228)
  at io.crate.data.BatchIterator$$Lambda+0x0000000007c31ed8.accept(Ljava/lang/Object;)V ()
  at io.crate.data.BatchIterator.move(ILjava/util/function/Consumer;Ljava/util/function/Consumer;)V (BatchIterator.java:164)
  at io.crate.data.BatchIterator.collect(Ljava/util/stream/Collector;Z)Ljava/util/concurrent/CompletableFuture; (BatchIterator.java:228)
  at io.crate.data.BatchIterator.collect(Ljava/util/stream/Collector;)Ljava/util/concurrent/CompletableFuture; (BatchIterator.java:249)
  at io.crate.data.CollectingBatchIterator.lambda$newInstance$2(Lio/crate/data/BatchIterator;Ljava/util/stream/Collector;)Ljava/util/concurrent/CompletableFuture; (CollectingBatchIterator.java:87)
  at io.crate.data.CollectingBatchIterator$$Lambda+0x0000000007c31610.get()Ljava/lang/Object; ()
  at io.crate.data.CollectingBatchIterator.loadNextBatch()Ljava/util/concurrent/CompletionStage; (CollectingBatchIterator.java:146)
  at io.crate.execution.engine.distribution.DistributingConsumer.consumeIt(Lio/crate/data/BatchIterator;)V (DistributingConsumer.java:145)
  at io.crate.execution.engine.distribution.DistributingConsumer.accept(Lio/crate/data/BatchIterator;Ljava/lang/Throwable;)V (DistributingConsumer.java:121)
  at io.crate.execution.engine.collect.CollectTask.lambda$new$0(Lio/crate/data/RowConsumer;Lio/crate/data/BatchIterator;)V (CollectTask.java:103)
  at io.crate.execution.engine.collect.CollectTask$$Lambda+0x0000000007c31a70.run()V ()
  at java.util.concurrent.ThreadPoolExecutor.runWorker(Ljava/util/concurrent/ThreadPoolExecutor$Worker;)V (ThreadPoolExecutor.java:1144)
  at java.util.concurrent.ThreadPoolExecutor$Worker.run()V (ThreadPoolExecutor.java:642)
  at java.lang.Thread.runWith(Ljava/lang/Object;Ljava/lang/Runnable;)V (Thread.java:1588)
  at java.lang.Thread.run()V (Thread.java:1575)
```