### PR TITLE
Fix race leading to bogus commandComplete msg during pgwire fetch

### DIFF
--- a/docs/appendices/release-notes/5.10.13.rst
+++ b/docs/appendices/release-notes/5.10.13.rst
@@ -48,6 +48,9 @@ See the :ref:`version_5.10.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed a race condition that could lead PostgreSQL clients to receive fewer
+  results than available if using protocol level fetch more than once.
+
 - Fixed an issue that could lead to PostgreSQL wire protocol messages being sent
   in the wrong order to the client. The issue was triggered when using batched
   statements where one of the statements caused a parse or bind error.

--- a/docs/appendices/release-notes/6.0.3.rst
+++ b/docs/appendices/release-notes/6.0.3.rst
@@ -47,6 +47,9 @@ series.
 Fixes
 =====
 
+- Fixed a race condition that could lead PostgreSQL clients to receive fewer
+  results than available if using protocol level fetch more than once.
+
 - Fixed a race condition that could lead to PostgreSQL wire protocol messages to
   get mixed up and cause errors like ``IllegalStateException: Received resultset
   tuples, but no field structure for them`` in clients.

--- a/server/src/main/java/io/crate/session/RowConsumerToResultReceiver.java
+++ b/server/src/main/java/io/crate/session/RowConsumerToResultReceiver.java
@@ -157,10 +157,6 @@ public class RowConsumerToResultReceiver implements RowConsumer {
     }
 
     public void replaceResultReceiver(ResultReceiver<?> resultReceiver, int maxRows) {
-        if (!this.resultReceiver.completionFuture().isDone()) {
-            // finish previous resultReceiver before replacing it, to ensure future triggers
-            this.resultReceiver.allFinished();
-        }
         this.rowCount = 0;
         this.resultReceiver = resultReceiver;
         this.maxRows = maxRows;


### PR DESCRIPTION
If a `Messages.sendPortalSuspended(channel)` took a while to complete it
could happen that we continue processing the next `execute` message
before completing the `ResultSetReceiver`s future. In that case the
resume/replaceResultReceiver logic completed the future - leading to an
unexpected `commandComplete` message, which caused the client to stop
receiving the remaining results.

This was caught by crate-qa node-postgres client tests.
I tried creating a unit tests emulating the message flow
(https://github.com/crate/crate/commit/fef38137975a89c9741f953404cc453727bab58f)
but given that it only happens on "slow" `channel.write` calls, I can't
easily simulate it with the `EmbeddedChannel`
