### PR TITLE
Ensure that circuit breaker's memory is released when a subquery fails

### DIFF
--- a/docs/appendices/release-notes/5.10.13.rst
+++ b/docs/appendices/release-notes/5.10.13.rst
@@ -69,3 +69,8 @@ Fixes
 - Upgraded Lucene to ``9.12.3`` that fixed an issue with ``MMapDirectory``
   leaking maps that could cause exceeding of the ``vm.max_map_count`` limit
   and lead to a node crash.
+
+- Fixed an issue that caused ``query`` CircuitBreaker's state to not be reset
+  if a sub-query failed (for example, due to a ``CircuitBreakingException``).
+  If repeated, could bring CircuitBreaker to the point when each consequent
+  query is tripped and make a cluster unresponsive.

--- a/docs/appendices/release-notes/6.0.3.rst
+++ b/docs/appendices/release-notes/6.0.3.rst
@@ -64,3 +64,8 @@ Fixes
 
 - Fixed an issue where null-valued sub-columns of objects were omitted when
   queried.
+
+- Fixed an issue that caused ``query`` CircuitBreaker's state to not be reset
+  if a sub-query failed (for example, due to a ``CircuitBreakingException``).
+  If repeated, could bring CircuitBreaker to the point when each consequent
+  query is tripped and make a cluster unresponsive.

--- a/libs/dex/src/main/java/io/crate/data/BatchIterator.java
+++ b/libs/dex/src/main/java/io/crate/data/BatchIterator.java
@@ -225,6 +225,7 @@ public interface BatchIterator<T> extends Killable {
         Function<A, R> finisher = collector.finisher();
         A state = collector.supplier().get();
         CompletableFuture<R> result = new CompletableFuture<>();
+        // Both onNext() and onFinish() can throw, but it's caught in the move() and future is completed.
         move(Integer.MAX_VALUE, row -> accumulator.accept(state, row), err -> {
             if (close) {
                 close();

--- a/libs/dex/src/main/java/io/crate/data/BatchIterators.java
+++ b/libs/dex/src/main/java/io/crate/data/BatchIterators.java
@@ -44,6 +44,7 @@ public class BatchIterators {
                                                          CompletableFuture<R> resultFuture) {
         BiConsumer<A, T> accumulator = collector.accumulator();
         Function<A, R> finisher = collector.finisher();
+        // Both onNext() and onFinish() can throw, but it's caught in the it.move() and future is completed.
         it.move(Integer.MAX_VALUE, row -> accumulator.accept(state, row), err -> {
             it.close();
             if (err == null) {

--- a/server/src/main/java/io/crate/execution/MultiPhaseExecutor.java
+++ b/server/src/main/java/io/crate/execution/MultiPhaseExecutor.java
@@ -79,10 +79,8 @@ public final class MultiPhaseExecutor {
         }
         return CompletableFuture
             .allOf(dependencyFutures.toArray(new CompletableFuture[0]))
-            .thenApply(ignored -> {
-                ramAccounting.release();
-                return new SubQueryResults(valueBySubQuery);
-            });
+            .thenApply(_ -> new SubQueryResults(valueBySubQuery))
+            .whenComplete((_, _) -> ramAccounting.release());
     }
 
     public static CollectingRowConsumer<?, ?> getConsumer(SelectSymbol selectSymbol, RamAccounting ramAccounting) {

--- a/server/src/main/java/io/crate/execution/engine/JobLauncher.java
+++ b/server/src/main/java/io/crate/execution/engine/JobLauncher.java
@@ -118,7 +118,7 @@ public class JobLauncher {
     private final IndicesService indicesService;
     private final boolean enableProfiling;
 
-    JobLauncher(UUID jobId,
+    public JobLauncher(UUID jobId,
                 ClusterService clusterService,
                 JobSetup jobSetup,
                 TasksService tasksService,

--- a/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
@@ -23,6 +23,13 @@ package io.crate.planner.operators;
 
 import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.MemoryLimits.assertMaxBytesAllocated;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -30,21 +37,33 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.unit.ByteSizeUnit;
+import org.elasticsearch.indices.IndicesService;
+import org.elasticsearch.indices.breaker.HierarchyCircuitBreakerService;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import io.crate.analyze.TableDefinitions;
 import io.crate.data.Row1;
+import io.crate.data.RowConsumer;
 import io.crate.execution.dsl.projection.FetchProjection;
 import io.crate.execution.dsl.projection.LimitDistinctProjection;
 import io.crate.execution.dsl.projection.Projection;
 import io.crate.execution.dsl.projection.ProjectionType;
+import io.crate.execution.engine.JobLauncher;
+import io.crate.execution.engine.PhasesTaskFactory;
+import io.crate.execution.jobs.JobSetup;
+import io.crate.execution.jobs.TasksService;
 import io.crate.expression.symbol.FetchReference;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.RowGranularity;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.table.TableInfo;
+import io.crate.planner.DependencyCarrier;
 import io.crate.planner.node.dql.QueryThenFetch;
 import io.crate.statistics.ColumnStats;
 import io.crate.statistics.MostCommonValues;
@@ -780,5 +799,43 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
             ),
             x -> assertThat(x).isInputColumn(1)
         );
+    }
+
+    @Test
+    public void test_ram_accounting_released_on_multi_phase_execution_failure() throws Exception {
+        var plan = sqlExecutor.logicalPlan(
+            "select name from users where id in (select a from t1 where x > 10)");
+
+        DependencyCarrier dependencies = sqlExecutor.dependencyMock;
+        CircuitBreaker circuitBreaker = mock(CircuitBreaker.class);
+        when(dependencies.circuitBreaker(HierarchyCircuitBreakerService.QUERY)).thenReturn(circuitBreaker);
+
+        // Setup CircuitBreakingException for a sub-plan.
+        PhasesTaskFactory phasesTaskFactory = mock(PhasesTaskFactory.class);
+        when(dependencies.phasesTaskFactory()).thenReturn(phasesTaskFactory);
+        JobLauncher jobLauncher = new JobLauncher(
+            UUID.randomUUID(),
+            clusterService,
+            Mockito.mock(JobSetup.class),
+            Mockito.mock(TasksService.class),
+            Mockito.mock(IndicesService.class),
+            null,
+            null,
+            List.of(),
+            false
+        ) {
+            @Override
+            public void execute(RowConsumer consumer, TransactionContext txnCtx) {
+                consumer.accept(null, new CircuitBreakingException("dummy"));
+            }
+        };
+        when(phasesTaskFactory.create(any(), any(), anyBoolean())).thenReturn(jobLauncher);
+        var consumer = sqlExecutor.execute(plan);
+        assertThat(consumer.completionFuture().isDone()).isTrue();
+
+        // addWithoutBreaking is used in ConcurrentRamAccounting to release bytes;
+        // Before 5.10.13, circuit breaker memory was not released
+        // if multiphased execution failed on sub-query and addWithoutBreaking() was never called.
+        verify(circuitBreaker, times(1)).addWithoutBreaking(anyLong());
     }
 }


### PR DESCRIPTION
I was checking if future is completed when `finisher.apply` throws an exception in the [BatchIterators.collect](https://github.com/crate/crate/blob/master/libs/dex/src/main/java/io/crate/data/BatchIterators.java#L50) and got 

`AggregateExpressionIntegrationTest` test cases failing locally with

```
org.opentest4j.AssertionFailedError: [Query breaker not reset to 0 on node: node_s1] 
expected: 0L
 but was: 2097152L
```

Note: `2097152L` is equal to `BlockBasedRamAccounting.MAX_BLOCK_SIZE_IN_BYTES`

It turns out that future is completed (added code comments) but `MultiPhaseExecutor` doesn't account for exceptionally completed future and closes `RamAccounting` only in happy path scenario.


