### PR TITLE
Optimize containsKey/get pair to single get in Indexer

### DIFF
--- a/server/src/main/java/io/crate/execution/dml/Indexer.java
+++ b/server/src/main/java/io/crate/execution/dml/Indexer.java
@@ -887,13 +887,12 @@ public class Indexer {
                     continue;
                 }
             }
-            if (synthetics.containsKey(ref.column())) {
-                ColumnIdent column = ref.column();
-                if (!column.isRoot()) {
-                    continue;
-                }
-                Synthetic synthetic = synthetics.get(column);
-
+            ColumnIdent column = ref.column();
+            if (!column.isRoot()) {
+                continue;
+            }
+            Synthetic synthetic = synthetics.get(column);
+            if (synthetic != null) {
                 Object value = synthetic.value();
                 if (value == null) {
                     continue;


### PR DESCRIPTION
Micro optimization to hash the key value only once. Also flips the
isRoot check to avoid the lookup altogether if the lookup result
wouldn't be used.
