### PR TITLE
Don't expand/resolve partitions on already optimized where clause

### DIFF
--- a/docs/appendices/release-notes/6.0.4.rst
+++ b/docs/appendices/release-notes/6.0.4.rst
@@ -46,4 +46,13 @@ series.
 Fixes
 =====
 
-None
+- Improved ``WHERE`` clause analysis for queries on tables with both ``PARTITION
+  BY`` and ``CLUSTERED BY`` clause to narrow the partitions and shards that are
+  hit if the query filters on the ``PARTITIONED BY`` and ``CLUSTERED BY``
+  columns. An example::
+
+    CREATE TABLE tbl (x int, c int, p int) clustered by (c) partitioned by (p);
+    SELECT * FROM tbl WHERE c = 1 and p = 1;
+
+  In this case the query will only search in the partition ``p=1`` and hit a
+  single shard depending on the routing for ``c=1``

--- a/server/src/main/java/io/crate/planner/operators/Collect.java
+++ b/server/src/main/java/io/crate/planner/operators/Collect.java
@@ -123,6 +123,14 @@ public class Collect implements LogicalPlan {
         this.tableInfo = relation.tableInfo();
     }
 
+    /// @return a new Collect operator with changed outputs
+    public Collect withOutputs(List<Symbol> newOutputs) {
+        Collect collect = new Collect(relation, newOutputs, immutableWhere);
+        collect.mutableBoundWhere = mutableBoundWhere;
+        collect.detailedQuery = detailedQuery;
+        return collect;
+    }
+
     @Override
     public ExecutionPlan build(DependencyCarrier executor,
                                PlannerContext plannerContext,
@@ -348,7 +356,7 @@ public class Collect implements LogicalPlan {
         if (newOutputs.size() == outputs.size() && newOutputs.containsAll(outputs)) {
             return this;
         }
-        return new Collect(relation, List.copyOf(newOutputs), immutableWhere);
+        return withOutputs(List.copyOf(newOutputs));
     }
 
     @Nullable
@@ -385,14 +393,7 @@ public class Collect implements LogicalPlan {
             return null;
         }
         newOutputs.add(0, fetchMarker);
-        return new FetchRewrite(
-            replacedOutputs,
-            new Collect(
-                relation,
-                newOutputs,
-                immutableWhere
-            )
-        );
+        return new FetchRewrite(replacedOutputs, withOutputs(newOutputs));
     }
 
     @Override

--- a/server/src/test/java/io/crate/planner/PlannerTest.java
+++ b/server/src/test/java/io/crate/planner/PlannerTest.java
@@ -32,6 +32,8 @@ import static org.mockito.Mockito.when;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.UUID;
 
 import org.elasticsearch.action.UnavailableShardsException;
@@ -40,13 +42,18 @@ import org.elasticsearch.index.shard.ShardId;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.carrotsearch.hppc.IntIndexedContainer;
+
 import io.crate.data.Row1;
 import io.crate.exceptions.ConversionException;
+import io.crate.execution.dsl.phases.RoutedCollectPhase;
 import io.crate.expression.symbol.Literal;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.RoutingProvider;
 import io.crate.metadata.settings.CoordinatorSessionSettings;
 import io.crate.planner.node.ddl.UpdateSettingsPlan;
+import io.crate.planner.node.dql.Collect;
+import io.crate.planner.node.dql.QueryThenFetch;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.LogicalPlanner;
 import io.crate.planner.operators.SubQueryResults;
@@ -151,5 +158,33 @@ public class PlannerTest extends CrateDummyClusterServiceUnitTest {
             .hasPGError(INTERNAL_ERROR)
             .hasHTTPError(INTERNAL_SERVER_ERROR, 5002)
             .hasMessageContaining("[tbl] shard 11 is not available");
+    }
+
+    @Test
+    public void test_table_with_clustered_by_and_partition_filter_routing() throws Exception {
+        e.addTable(
+            """
+            CREATE TABLE t1 (
+               a int,
+               impression_id text,
+               "time" TIMESTAMP WITH TIME ZONE,
+               "daypart" TIMESTAMP WITH TIME ZONE GENERATED ALWAYS AS date_trunc('day', "time")
+           ) CLUSTERED BY ("impression_id") INTO 10 SHARDS PARTITIONED BY ("daypart")
+            """,
+            List.of("1760392800000"),
+            List.of("1760306400000"),
+            List.of("1760220000000")
+        );
+        QueryThenFetch qtf = e.plan(
+            "SELECT * FROM t1 WHERE impression_id='10-uuid' AND daypart=1760306400000 ORDER BY a DESC LIMIT 3");
+        RoutedCollectPhase collectPhase = (RoutedCollectPhase) ((Collect) qtf.subPlan()).collectPhase();
+        Map<String, IntIndexedContainer> indicesAndShards = collectPhase.routing().locations().entrySet().iterator().next().getValue();
+        assertThat(indicesAndShards)
+            .as("Routing includes only one partition because of daypart filter")
+            .hasSize(1);
+        Entry<String, IntIndexedContainer> firstEntry = indicesAndShards.entrySet().iterator().next();
+        assertThat(firstEntry.getValue())
+            .as("Routing includes only one shard because of impression_id filter (clustered by)")
+            .hasSize(1);
     }
 }


### PR DESCRIPTION
A `detailedQuery` has already gone through partition value expansion and
`detailedQuery.toBoundWhereClause` is resolving partitions.
There was another `resolvePartitions` right afterwards.
