### PR TITLE
Store table column stats separately per column

### DIFF
--- a/server/src/main/java/io/crate/statistics/ColumnStats.java
+++ b/server/src/main/java/io/crate/statistics/ColumnStats.java
@@ -88,6 +88,10 @@ public final class ColumnStats<T> implements Writeable {
         }
     }
 
+    public DataType<T> type() {
+        return type;
+    }
+
     public double averageSizeInBytes() {
         return averageSizeInBytes;
     }

--- a/server/src/main/java/io/crate/statistics/TableStatsService.java
+++ b/server/src/main/java/io/crate/statistics/TableStatsService.java
@@ -22,11 +22,9 @@
 package io.crate.statistics;
 
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -36,6 +34,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.lucene.analysis.core.KeywordAnalyzer;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
+import org.apache.lucene.document.IntField;
 import org.apache.lucene.document.StoredField;
 import org.apache.lucene.document.StringField;
 import org.apache.lucene.index.IndexReader;
@@ -46,12 +45,14 @@ import org.apache.lucene.index.SerialMergeScheduler;
 import org.apache.lucene.index.StoredFields;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.FieldExistsQuery;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.SearcherManager;
 import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.Weight;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.NIOFSDirectory;
@@ -65,7 +66,8 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.common.inject.Singleton;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
-import org.elasticsearch.common.io.stream.InputStreamStreamInput;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
@@ -79,6 +81,7 @@ import org.jetbrains.annotations.VisibleForTesting;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 
+import io.crate.Streamer;
 import io.crate.common.io.IOUtils;
 import io.crate.common.unit.TimeValue;
 import io.crate.data.Row;
@@ -87,6 +90,8 @@ import io.crate.metadata.RelationName;
 import io.crate.session.BaseResultReceiver;
 import io.crate.session.Session;
 import io.crate.session.Sessions;
+import io.crate.types.DataType;
+import io.crate.types.DataTypes;
 
 /**
  * Handles persistence for {@link TableStats} and periodically refreshes {@link TableStats}
@@ -105,10 +110,42 @@ public class TableStatsService extends AbstractLifecycleComponent implements Run
 
     static final String STMT = "ANALYZE";
     private static final String STATS = "_stats";
-    private static final String DATA_FIELD = "data";
-    private static final String RELATION_NAME_FIELD = "relationName";
-    private static final String COLUMN_NAME_FIELD = "columnName";
-    private static final String COLUMN_NAMES_FIELD = "columnNames";
+
+    private static final String FIELD_TYPE = "type";
+
+    private enum FieldType {
+        TABLE,
+        COLUMN;
+
+        private static final List<FieldType> VALUES = List.of(FieldType.values());
+
+        static FieldType of(int ordinal) {
+            return VALUES.get(ordinal);
+        }
+    }
+
+    private static class MetaDocFields {
+        static final String VERSION = "version";
+    }
+
+    private static class TableDocFields {
+
+        static final String NAME = "relation";
+        static final String NUM_DOCS = "numDocs";
+        static final String SIZE_IN_BYTES = "size";
+    }
+
+    private static class ColumnDocFields {
+
+        private static final String REL_NAME = "relation";
+        private static final String COLUMN = "column";
+        private static final String VALUE_TYPE = "valueType";
+        private static final String NULL_FRACTION = "nullFraction";
+        private static final String AVG_SIZE_IN_BYTES = "avgSize";
+        private static final String APPROX_DISTINCT = "approxDistinct";
+        private static final String MOST_COMMON_VALUES = "mcv";
+        private static final String HISTOGRAM = "histogram";
+    }
 
     private final ClusterService clusterService;
     private final ThreadPool threadPool;
@@ -125,7 +162,6 @@ public class TableStatsService extends AbstractLifecycleComponent implements Run
 
     @VisibleForTesting
     volatile Scheduler.ScheduledCancellable scheduledRefresh;
-
 
 
     public TableStatsService(Settings settings,
@@ -150,10 +186,10 @@ public class TableStatsService extends AbstractLifecycleComponent implements Run
 
         try {
             this.directory = new NIOFSDirectory(dataPath.resolve(STATS));
-            IndexWriterConfig tablesIndexWriterConfig = new IndexWriterConfig(new KeywordAnalyzer());
-            tablesIndexWriterConfig.setOpenMode(IndexWriterConfig.OpenMode.CREATE_OR_APPEND);
-            tablesIndexWriterConfig.setMergeScheduler(new SerialMergeScheduler());
-            this.writer = new IndexWriter(directory, tablesIndexWriterConfig);
+            IndexWriterConfig writerConfig = new IndexWriterConfig(new KeywordAnalyzer());
+            writerConfig.setOpenMode(IndexWriterConfig.OpenMode.CREATE_OR_APPEND);
+            writerConfig.setMergeScheduler(new SerialMergeScheduler());
+            this.writer = new IndexWriter(directory, writerConfig);
             this.searcherManager = new SearcherManager(writer, null);
 
             // ensure index files exist for reads
@@ -248,14 +284,8 @@ public class TableStatsService extends AbstractLifecycleComponent implements Run
 
     public void remove(RelationName relationName) {
         try {
-            PersistedTable persistedTable = loadTableStats(relationName);
-            if (persistedTable != null) {
-                for (ColumnIdent columnIdent : persistedTable.cols()) {
-                    writer.deleteDocuments(new TermQuery(colTerm(relationName, columnIdent)));
-                }
-                writer.deleteDocuments(relTerm(relationName));
-                writer.commit();
-            }
+            writer.deleteDocuments(new Term(TableDocFields.NAME, relationName.fqn()));
+            writer.commit();
             cache.invalidate(relationName);
         } catch (IOException e) {
             throw new UncheckedIOException("Can't delete TableStats from disk", e);
@@ -275,65 +305,168 @@ public class TableStatsService extends AbstractLifecycleComponent implements Run
     @VisibleForTesting
     @Nullable
     Stats loadFromDisk(RelationName relationName) {
-        PersistedTable persistedTable = loadTableStats(relationName);
-        if (persistedTable == null) {
+        HashMap<ColumnIdent, ColumnStats<?>> columnStatsMap = new HashMap<>();
+        long numDocs = 0;
+        long sizeInBytes = 0;
+        IndexSearcher tablesSearcher = null;
+        boolean match = false;
+        try {
+            searcherManager.maybeRefreshBlocking();
+            tablesSearcher = searcherManager.acquire();
+            tablesSearcher.setQueryCache(null);
+            Query query = new TermQuery(new Term(TableDocFields.NAME, relationName.fqn()));
+            Weight weight = tablesSearcher.createWeight(query, ScoreMode.COMPLETE_NO_SCORES, 0.0f);
+            IndexReader reader = tablesSearcher.getIndexReader();
+            TopDocs versionTopDoc = tablesSearcher.search(new FieldExistsQuery(MetaDocFields.VERSION), 1);
+            if (versionTopDoc.totalHits.value() != 1L) {
+                return null;
+            }
+            int versionDocId = versionTopDoc.scoreDocs[0].doc;
+            Document versionDoc = reader.storedFields().document(versionDocId);
+            int internalVersion = versionDoc.getField(MetaDocFields.VERSION).storedValue().getIntValue();
+            Version version = Version.fromId(internalVersion);
+            for (LeafReaderContext leafReaderContext : reader.leaves()) {
+                Scorer scorer = weight.scorer(leafReaderContext);
+                if (scorer == null) {
+                    continue;
+                }
+                DocIdSetIterator docIdSetIterator = scorer.iterator();
+                StoredFields storedFields = leafReaderContext.reader().storedFields();
+                while (docIdSetIterator.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
+                    match = true;
+                    Document doc = storedFields.document(docIdSetIterator.docID());
+                    FieldType fieldType = FieldType.of(doc.getField(FIELD_TYPE).storedValue().getIntValue());
+                    switch (fieldType) {
+                        case COLUMN -> {
+                            String columnName = doc.getField(ColumnDocFields.COLUMN).stringValue();
+                            ColumnIdent column = ColumnIdent.of(columnName);
+                            DataType<?> valueType = decode(
+                                version,
+                                DataTypes::fromStream,
+                                doc.getBinaryValue(ColumnDocFields.VALUE_TYPE)
+                            );
+                            ColumnStats<?> columnStats = readColumnStats(version, doc, valueType);
+                            columnStatsMap.put(column, columnStats);
+                        }
+                        case TABLE -> {
+                            numDocs = doc.getField(TableDocFields.NUM_DOCS).storedValue().getLongValue();
+                            sizeInBytes = doc.getField(TableDocFields.SIZE_IN_BYTES).storedValue().getLongValue();
+                        }
+                        default -> {
+                            throw new AssertionError("Unexpected fieldType: " + fieldType);
+                        }
+                    }
+                }
+            }
+        } catch (IOException ex) {
+            throw new UncheckedIOException(ex);
+        } finally {
+            try {
+                searcherManager.release(tablesSearcher);
+            } catch (IOException ex) {
+                throw new UncheckedIOException(ex);
+            }
+        }
+        if (!match) {
             return null;
         }
-        Map<ColumnIdent, ColumnStats<?>> columnStatsMap = loadColumnStats(relationName, persistedTable.cols());
-        return new Stats(persistedTable.numDocs(), persistedTable.sizeInBytes(), columnStatsMap);
+        return new Stats(numDocs, sizeInBytes, columnStatsMap);
     }
 
-    public void update(Map<RelationName, Stats> stats) {
+    private static <T> ColumnStats<T> readColumnStats(Version version, Document doc, DataType<T> type) throws IOException {
+        double nullFraction = doc.getField(ColumnDocFields.NULL_FRACTION).storedValue().getDoubleValue();
+        double avgSizeInBytes = doc.getField(ColumnDocFields.AVG_SIZE_IN_BYTES).storedValue().getDoubleValue();
+        double approxDistinct = doc.getField(ColumnDocFields.APPROX_DISTINCT).storedValue().getDoubleValue();
+        Streamer<T> streamer = type.streamer();
+        MostCommonValues<T> mostCommonValues = decode(
+            version,
+            in -> new MostCommonValues<T>(streamer, in),
+            doc.getBinaryValue(ColumnDocFields.MOST_COMMON_VALUES)
+        );
+        List<T> histogram = decode(
+            version,
+            in -> in.readList(streamer::readValueFrom),
+            doc.getBinaryValue(ColumnDocFields.HISTOGRAM)
+        );
+        return new ColumnStats<>(
+            nullFraction,
+            avgSizeInBytes,
+            approxDistinct,
+            type,
+            mostCommonValues,
+            histogram
+        );
+    }
+
+    public void update(Map<RelationName, Stats> relationsStats) {
         try {
-            for (Map.Entry<RelationName, Stats> entry : stats.entrySet()) {
+            writer.deleteAll();
+            Document metaDoc = new Document();
+            metaDoc.add(new IntField(MetaDocFields.VERSION, Version.CURRENT.internalId, Field.Store.YES));
+            writer.addDocument(metaDoc);
+            for (var entry : relationsStats.entrySet()) {
                 RelationName relationName = entry.getKey();
-                DocsToPersist docs = makeDocument(relationName, entry.getValue());
-                writer.updateDocument(relTerm(relationName), docs.table());
-                for (Map.Entry<ColumnIdent, Document> docsEntry : docs.cols().entrySet()) {
-                    writer.updateDocument(colTerm(relationName, docsEntry.getKey()), docsEntry.getValue());
+                Stats stats = entry.getValue();
+
+                Document tableDoc = new Document();
+                String fqTableName = relationName.fqn();
+                tableDoc.add(new StringField(TableDocFields.NAME, fqTableName, Field.Store.NO));
+                tableDoc.add(new StoredField(FIELD_TYPE, FieldType.TABLE.ordinal()));
+                tableDoc.add(new StoredField(TableDocFields.NUM_DOCS, stats.numDocs()));
+                tableDoc.add(new StoredField(TableDocFields.SIZE_IN_BYTES, stats.sizeInBytes()));
+                writer.addDocument(tableDoc);
+
+                for (var columnEntry : stats.statsByColumn().entrySet()) {
+                    ColumnIdent column = columnEntry.getKey();
+                    ColumnStats<?> columnStats = columnEntry.getValue();
+                    writer.addDocument(createColDoc(fqTableName, column, columnStats));
                 }
             }
             writer.commit();
             searcherManager.maybeRefresh();
-            cache.invalidateAll(stats.keySet());
+            cache.invalidateAll(relationsStats.keySet());
         } catch (IOException e) {
             throw new UncheckedIOException("Can't write TableStats to disk", e);
         }
     }
 
-    private static Term relTerm(RelationName relationName) {
-        return new Term(RELATION_NAME_FIELD, relationName.fqn());
-    }
+    private static <T> Document createColDoc(String fqTableName, ColumnIdent column, ColumnStats<T> columnStats) throws IOException {
+        String sqlFqn = column.sqlFqn();
+        Document colDoc = new Document();
+        colDoc.add(new StringField(ColumnDocFields.REL_NAME, fqTableName, Field.Store.YES));
+        colDoc.add(new StoredField(FIELD_TYPE, FieldType.COLUMN.ordinal()));
+        colDoc.add(new StringField(ColumnDocFields.COLUMN, sqlFqn, Field.Store.YES));
+        colDoc.add(new StoredField(ColumnDocFields.NULL_FRACTION, columnStats.nullFraction()));
+        colDoc.add(new StoredField(ColumnDocFields.AVG_SIZE_IN_BYTES, columnStats.averageSizeInBytes()));
+        colDoc.add(new StoredField(ColumnDocFields.APPROX_DISTINCT, columnStats.approxDistinct()));
 
-    private static Term colTerm(RelationName relationName, ColumnIdent columnIdent) {
-        return new Term(COLUMN_NAME_FIELD, relationName.fqn() + "." + columnIdent.sqlFqn());
-    }
-
-    private static DocsToPersist makeDocument(RelationName relationName, Stats stats) throws IOException {
-        // table stats
-        BytesStreamOutput bytesStreamOutput = new BytesStreamOutput();
-        Version.writeVersion(Version.CURRENT, bytesStreamOutput);
-        bytesStreamOutput.writeVLong(stats.numDocs());
-        bytesStreamOutput.writeVLong(stats.sizeInBytes());
-        Document tableDocument = new Document();
-        tableDocument.add(new StringField(RELATION_NAME_FIELD, relationName.fqn(), Field.Store.NO));
-        tableDocument.add(new StoredField(DATA_FIELD, bytesStreamOutput.bytes().toBytesRef()));
-
-        // column stats
-        Map<ColumnIdent, Document> colDocuments = HashMap.newHashMap(stats.statsByColumn().size());
-        for (var entry : stats.statsByColumn().entrySet()) {
-            String colName = entry.getKey().sqlFqn();
-            // Add the column name to table doc
-            tableDocument.add(new StringField(COLUMN_NAMES_FIELD, colName, Field.Store.YES));
-
-            Document colDocument = new Document();
-            bytesStreamOutput = new BytesStreamOutput();
-            entry.getValue().writeTo(bytesStreamOutput);
-            colDocument.add(new StringField(COLUMN_NAME_FIELD, relationName.fqn() + "." + colName, Field.Store.NO));
-            colDocument.add(new StoredField(DATA_FIELD, bytesStreamOutput.bytes().toBytesRef()));
-            colDocuments.put(entry.getKey(), colDocument);
+        Streamer<T> streamer = columnStats.type().streamer();
+        try (var out = new BytesStreamOutput()) {
+            DataTypes.toStream(columnStats.type(), out);
+            colDoc.add(new StoredField(ColumnDocFields.VALUE_TYPE, out.bytes().toBytesRef()));
         }
-        return new DocsToPersist(tableDocument, colDocuments);
+        try (var out = new BytesStreamOutput()) {
+            columnStats.mostCommonValues().writeTo(streamer, out);
+            BytesRef bytesRef = out.bytes().toBytesRef();
+            colDoc.add(new StoredField(ColumnDocFields.MOST_COMMON_VALUES, bytesRef));
+        }
+        try (var out = new BytesStreamOutput()) {
+            List<T> histogram = columnStats.histogram();
+            out.writeVInt(histogram.size());
+            for (T value : histogram) {
+                streamer.writeValueTo(out, value);
+            }
+            BytesRef bytesRef = out.bytes().toBytesRef();
+            colDoc.add(new StoredField(ColumnDocFields.HISTOGRAM, bytesRef));
+        }
+        return colDoc;
+    }
+
+    private static <T> T decode(Version version, Writeable.Reader<T> reader, BytesRef bytesRef) throws IOException {
+        try (var in = StreamInput.wrap(bytesRef.bytes, bytesRef.offset, bytesRef.length)) {
+            in.setVersion(version);
+            return reader.read(in);
+        }
     }
 
     @Override
@@ -351,94 +484,5 @@ public class TableStatsService extends AbstractLifecycleComponent implements Run
             }
         }
     }
-
-    private PersistedTable loadTableStats(RelationName relationName) {
-        try {
-            PersistedTable persistedTable = null;
-            IndexSearcher tablesSearcher = null;
-            try {
-                searcherManager.maybeRefreshBlocking();
-                tablesSearcher = searcherManager.acquire();
-                tablesSearcher.setQueryCache(null);
-                Query query = new TermQuery(relTerm(relationName));
-                Weight weight = tablesSearcher.createWeight(query, ScoreMode.COMPLETE_NO_SCORES, 0.0f);
-                IndexReader reader = tablesSearcher.getIndexReader();
-                for (LeafReaderContext leafReaderContext : reader.leaves()) {
-                    Scorer scorer = weight.scorer(leafReaderContext);
-                    if (scorer == null) {
-                        continue;
-                    }
-                    DocIdSetIterator docIdSetIterator = scorer.iterator();
-                    StoredFields storedFields = leafReaderContext.reader().storedFields();
-                    if (docIdSetIterator.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
-                        Document doc = storedFields.document(docIdSetIterator.docID());
-                        BytesRef binaryValue = doc.getBinaryValue(DATA_FIELD);
-                        ByteArrayInputStream bis = new ByteArrayInputStream(binaryValue.bytes);
-                        InputStreamStreamInput in = new InputStreamStreamInput(bis);
-                        Version version = Version.readVersion(in);
-                        in.setVersion(version);
-                        long numDocs = in.readVLong();
-                        long sizeInBytes = in.readVLong();
-                        String[] colNames = doc.getValues(COLUMN_NAMES_FIELD);
-                        List<ColumnIdent> cols = new ArrayList<>(colNames.length);
-                        for (String colName : colNames) {
-                            cols.add(ColumnIdent.of(colName));
-                        }
-                        persistedTable = new PersistedTable(relationName, numDocs, sizeInBytes, cols);
-                        break;
-                    }
-                }
-            } finally {
-                searcherManager.release(tablesSearcher);
-            }
-            return persistedTable;
-        } catch (IOException ex) {
-            throw new UncheckedIOException(ex);
-        }
-    }
-
-    @VisibleForTesting
-    Map<ColumnIdent, ColumnStats<?>> loadColumnStats(RelationName relationName, List<ColumnIdent> cols) {
-        Map<ColumnIdent, ColumnStats<?>> columnStatsMap = new HashMap<>();
-        for (ColumnIdent columnIdent : cols) {
-            try {
-                IndexSearcher searcher = null;
-                try {
-                    searcherManager.maybeRefreshBlocking();
-                    searcher = searcherManager.acquire();
-                    searcher.setQueryCache(null);
-                    Query query = new TermQuery(colTerm(relationName, columnIdent));
-                    Weight weight = searcher.createWeight(query, ScoreMode.COMPLETE_NO_SCORES, 0.0f);
-                    IndexReader reader = searcher.getIndexReader();
-                    for (LeafReaderContext leafReaderContext : reader.leaves()) {
-                        Scorer scorer = weight.scorer(leafReaderContext);
-                        if (scorer == null) {
-                            continue;
-                        }
-                        DocIdSetIterator docIdSetIterator = scorer.iterator();
-                        StoredFields storedFields = leafReaderContext.reader().storedFields();
-                        if (docIdSetIterator.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
-                            Document colsDoc = storedFields.document(docIdSetIterator.docID());
-                            BytesRef colsBinaryValue = colsDoc.getBinaryValue(DATA_FIELD);
-                            ByteArrayInputStream colsBis = new ByteArrayInputStream(colsBinaryValue.bytes);
-                            InputStreamStreamInput colsIn = new InputStreamStreamInput(colsBis);
-                            ColumnStats<?> columnStats = new ColumnStats<>(colsIn);
-                            columnStatsMap.put(columnIdent, columnStats);
-                        }
-                    }
-                } finally {
-                    searcherManager.release(searcher);
-                }
-
-            } catch (IOException ex) {
-                throw new UncheckedIOException(ex);
-            }
-        }
-        return columnStatsMap;
-    }
-
-    private record DocsToPersist(Document table, Map<ColumnIdent, Document> cols){}
-
-    private record PersistedTable(RelationName relationName, long numDocs, long sizeInBytes, List<ColumnIdent> cols){}
 }
 

--- a/server/src/test/java/io/crate/integrationtests/DiskThresholdDeciderIT.java
+++ b/server/src/test/java/io/crate/integrationtests/DiskThresholdDeciderIT.java
@@ -166,7 +166,7 @@ public class DiskThresholdDeciderIT extends IntegTestCase {
         });
 
         // increase disk size of node 0 to allow enough room for one shard, and check that it's rebalanced back
-        fileSystemProvider.getTestFileStore(dataNode0Path).setTotalSpace(minShardSize + WATERMARK_BYTES + 100L);
+        fileSystemProvider.getTestFileStore(dataNode0Path).setTotalSpace(minShardSize + WATERMARK_BYTES + 2000L);
         assertBusy(() -> {
             refreshDiskUsage();
             assertThat(getShardRoutings(dataNode0Id, indexName)).hasSize(1);
@@ -216,7 +216,7 @@ public class DiskThresholdDeciderIT extends IntegTestCase {
         execute("reset global \"cluster.routing.rebalance.enable\"");
 
         //// increase disk size of node 0 to allow enough room for one shard, and check that it's rebalanced back
-        fileSystemProvider.getTestFileStore(dataNode0Path).setTotalSpace(minShardSize + WATERMARK_BYTES + 100L);
+        fileSystemProvider.getTestFileStore(dataNode0Path).setTotalSpace(minShardSize + WATERMARK_BYTES + 2000L);
         assertBusy(() -> {
             refreshDiskUsage();
             assertThat(getShardRoutings(dataNode0Id, "tbl")).hasSize(1);

--- a/server/src/test/java/io/crate/statistics/TableStatsServiceTest.java
+++ b/server/src/test/java/io/crate/statistics/TableStatsServiceTest.java
@@ -264,7 +264,6 @@ public class TableStatsServiceTest extends CrateDummyClusterServiceUnitTest {
 
             statsService.remove(table1);
             assertThat(statsService.loadFromDisk(table1)).isNull();
-            assertThat(statsService.loadColumnStats(table1, List.of(aColIdent, bColIdent))).isEmpty();
             assertThat(statsService.get(table1)).isNull();
         }
     }
@@ -296,7 +295,6 @@ public class TableStatsServiceTest extends CrateDummyClusterServiceUnitTest {
             statsService.update(Map.of(relationName, stats));
             statsService.clear();
             assertThat(statsService.loadFromDisk(relationName)).isNull();
-            assertThat(statsService.loadColumnStats(relationName, List.of(xColIdent, yColIdent))).isEmpty();
             assertThat(statsService.get(relationName)).isNull();
         }
     }


### PR DESCRIPTION
Changes the on disk layout for table stats. See second commit for details.
The first commit is from https://github.com/crate/crate/pull/18407

Things I'm not sure about:
- How the version is stored
- The `type` field usage to distinguish between table/column documents
- Storing the `type` for columns. We could also retrieve it from the metadata on reads/writes, but it is a bit annoying to introduce the `Schemas` dependency.