### PR TITLE
Speed up integrity check for doc values (segment merge)

### DIFF
--- a/server/src/main/java/io/crate/lucene/codec/UnbufferedChecksumIndexInput.java
+++ b/server/src/main/java/io/crate/lucene/codec/UnbufferedChecksumIndexInput.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.lucene.codec;
+
+import java.io.IOException;
+import java.util.zip.CRC32;
+
+import org.apache.lucene.store.ChecksumIndexInput;
+import org.apache.lucene.store.IndexInput;
+
+public class UnbufferedChecksumIndexInput extends ChecksumIndexInput {
+
+    final IndexInput main;
+    final CRC32 digest;
+
+    public UnbufferedChecksumIndexInput(IndexInput main) {
+        super("BufferedChecksumIndexInput(" + main + ")");
+        this.main = main;
+        this.digest = new CRC32();
+    }
+
+    @Override
+    public byte readByte() throws IOException {
+        final byte b = main.readByte();
+        digest.update(b);
+        return b;
+    }
+
+    @Override
+    public void readBytes(byte[] b, int offset, int len) throws IOException {
+        main.readBytes(b, offset, len);
+        digest.update(b, offset, len);
+    }
+
+    @Override
+    public short readShort() throws IOException {
+        throw new UnsupportedOperationException("NYI");
+    }
+
+    @Override
+    public int readInt() throws IOException {
+        throw new UnsupportedOperationException("NYI");
+    }
+
+    @Override
+    public long readLong() throws IOException {
+        throw new UnsupportedOperationException("NYI");
+    }
+
+    @Override
+    public void readLongs(long[] dst, int offset, int length) throws IOException {
+        throw new UnsupportedOperationException("NYI");
+    }
+
+    @Override
+    public long getChecksum() {
+        return digest.getValue();
+    }
+
+    @Override
+    public void close() throws IOException {
+        main.close();
+    }
+
+    @Override
+    public long getFilePointer() {
+        return main.getFilePointer();
+    }
+
+    @Override
+    public long length() {
+        return main.length();
+    }
+
+    @Override
+    public IndexInput clone() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public IndexInput slice(String sliceDescription, long offset, long length) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+}
+


### PR DESCRIPTION
Not sure if this is worth diverging from upstream Lucene. I first thought it hits copy operations in:

https://github.com/apache/lucene/blob/8e8e37d9e94c290cf8d02e9f318e601baedf28bc/lucene/core/src/java/org/apache/lucene/store/BufferedChecksum.java?plain=1#L59-L63

But that's never the case because the .seek operation uses a skip buffer with a length equal to the buffer in `BufferedChecksum`. So the difference is mostly the additional branch (which likely gets JITTED away) and the `BufferedChecksum` constructor call - which overall likely trades out the few `readByte()` calls in `checkFooter` 

---

`CodecUtil.checksumEntireFile` uses a `BufferedChecksumIndexInput` which
in turn uses `BufferedChecksum`. `BufferedChecksum` keeps a local
`byte[]` buffer. Based on the docs the idea is to speed up
checksum calculations by avoiding byte-by-byte processing.

But in the case of `checksumEntireFile` we know that the input stream is
mostly processed using seek -> skipByReading -> readBytes.
Only checking the footer requires a few individual byte reads.

A insert benchmark (1e6 rows; 800 int columns) seems to fluctuate
between -6% to + 3%, but amount of branches and cache misses is
consistently down:

    | Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
    |   V1    |      213.472 ±  236.889 |     87.529 |    132.598 |    173.560 |   2206.665 |
    |   V2    |      201.659 ±  189.878 |     85.016 |    132.757 |    167.701 |   1621.865 |
    ├---------┴-------------------------┴------------┴------------┴------------┴------------┘
    |               -   5.69%                           +   0.12%
    There is a 78.13% probability that the observed difference is not random, and the best estimate of that difference is 5.69%
    The test has no statistical significance

    System/JVM Metrics (durations in ms, byte-values in MB)
        |    YOUNG GC            |       OLD GC           |      HEAP         |     ALLOC
        |  cnt      avg      max |  cnt      avg      max |  initial     used |     rate      total
     V1 |  591    13.42    10.94 |  194   116.50   124.06 |     4295     1467 |  3681.86    1130008
     V2 |  561    15.16    17.41 |  167   108.44   235.89 |     4295     1653 |  2903.88    1084644

    Top allocation frames
      V1
        BufferedChecksum.<init>(...) total=336486538040, count=16462
        ChecksumIndexInput.skipByReading(long) total=334873213389, count=16876
        Arrays.copyOf(...) total=34393638029, count=1682
        IntField.binaryValue() total=33218710600, count=2663
        Integer.valueOf(int) total=31744564259, count=1865
        BaseImplementationSymbolVisitor.visitFunction(...) total=30491160240, count=1965
        Long.toString(long) total=29927438930, count=2447
        ArrayUtil.growExact(int[], int) total=29786073528, count=3672
        IntIndexer.indexValue(...) total=20972169136, count=1578
        BigArrays.newByteArray(...) total=17938760116, count=1281
      V2
        ChecksumIndexInput.skipByReading(long) total=314551154756, count=26947
        Unsafe.allocateUninitializedArray(Class, int) total=229400594803, count=14723
        Arrays.copyOf(...) total=40695715372, count=1961
        IntField.binaryValue() total=40582772744, count=3305
        Integer.valueOf(int) total=40350370482, count=2307
        ArrayUtil.growExact(int[], int) total=35279795400, count=4133
        Long.toString(long) total=34798254664, count=2765
        BaseImplementationSymbolVisitor.visitFunction(...) total=33352458699, count=2415
        IntIndexer.indexValue(...) total=23335843784, count=1832
        BigArrays.newByteArray(...) total=19667299184, count=1530

    Top frames (by count)
      V1
        ChecksumIndexInput.skipByReading(long) total=334873213389, count=16876
        BufferedChecksum.<init>(...) total=336486538040, count=16462
        ArrayList.indexOfRange(...) total=8879, count=8879
        ArrayUtil.growExact(int[], int) total=29786073528, count=3672
        CodecUtil.checksumEntireFile(IndexInput) total=758151408, count=3641
        IntField.binaryValue() total=33218710600, count=2663
        Long.toString(long) total=29927438930, count=2447
        BaseImplementationSymbolVisitor.visitFunction(...) total=30491160240, count=1965
        Integer.valueOf(int) total=31744564259, count=1865
        Unsafe.allocateUninitializedArray(Class, int) total=12976380147, count=1807
      V2
        ChecksumIndexInput.skipByReading(long) total=314551154756, count=26947
        Unsafe.allocateUninitializedArray(Class, int) total=229400594803, count=14723
        SimpleReference.equals(Object) total=11088, count=11088
        ArrayUtil.growExact(int[], int) total=35279795400, count=4133
        IntField.binaryValue() total=40582772744, count=3305
        Long.toString(long) total=34798254664, count=2765
        BaseImplementationSymbolVisitor.visitFunction(...) total=33352458699, count=2415
        Integer.valueOf(int) total=40350370482, count=2307
        HashMap.putVal(...) total=2088, count=2088
        Arrays.copyOf(...) total=40695715372, count=1961

    perf stat
      v1
        branches:u             :  3264988348455.00
        cache-misses:u         :    57805357439.00
        instructions:u         :              0.00
        faults:u               :        2103465.00
        context-switches:u     :              0.00
        L1-dcache-loads:u      :  5210516610122.00
        L1-dcache-load-misses:u:             10.15
      v2
        branches:u             :  3095059632928.00
        cache-misses:u         :    52455774911.00
        instructions:u         :              0.00
        faults:u               :        2049343.00
        context-switches:u     :              0.00
        L1-dcache-loads:u      :  4833559272262.00
        L1-dcache-load-misses:u:             10.85
