### PR TITLE
Fix issue with crate.bat and PowerShell

### DIFF
--- a/app/src/main/dist/bin/crate.bat
+++ b/app/src/main/dist/bin/crate.bat
@@ -116,6 +116,8 @@ if "%CRATE_CLASSPATH%" == "" (
 set CRATE_PARAMS=-Cpath.home="%CRATE_HOME%"
 
 set params='%*'
+REM PowerShell splits setting keys/values on `.`, so this joins again the splitted keys/values
+set params=%params: .=.%
 
 for /F "usebackq tokens=* delims= " %%A in (!params!) do (
     set param=%%A

--- a/docs/appendices/release-notes/6.0.4.rst
+++ b/docs/appendices/release-notes/6.0.4.rst
@@ -59,3 +59,8 @@ Fixes
 
 - Fixed a replication issue happening when an integral value, not fitting to
   ``INT`` or ``LONG`` types, was stored in an OBJECT with policy ``IGNORED``.
+
+- Fixed an issue with ``crate.bat`` Windows startup script throwing error and
+  preventing bootstrap of CrateDB, if ``PowerShell`` was used instead of plain
+  ``CMD`` and parameters were passed with ``-C<key>=value`` command line
+  arguments.


### PR DESCRIPTION
PowerShell splits arguments (when using `%*`) also on the 1st dot of a setting `key`. e.g.:
```
-Cdiscovery.type=single-node
```
would become:
```
-Cdiscovery .type=single-node
```

Add a replacement of ` .` to `.` to rejoin them. The replacement doesn't affect normal runs with standard `cmd`.

Fixes: #18378

