### PR TITLE
Fix incorrect application of `equi_join_to_lookup_join` on complex equi-join query

### DIFF
--- a/docs/appendices/release-notes/6.0.4.rst
+++ b/docs/appendices/release-notes/6.0.4.rst
@@ -64,3 +64,10 @@ Fixes
   preventing bootstrap of CrateDB, if ``PowerShell`` was used instead of plain
   ``CMD`` and parameters were passed with ``-C<key>=value`` command line
   arguments.
+
+- Fixed a ``SQLParseException`` thrown when ``optimizer_equi_join_to_lookup_join``
+  was incorrectly applied to a complex equi-join query. The optimizer rule
+  currently supports only simple equi-join queries like ::
+
+    SELECT * FROM t INNER JOIN t2 ON t.a = t2.a;
+

--- a/server/src/main/java/io/crate/planner/operators/EquiJoinDetector.java
+++ b/server/src/main/java/io/crate/planner/operators/EquiJoinDetector.java
@@ -66,6 +66,13 @@ public final class EquiJoinDetector {
     }
 
     /**
+     * Returns true if the join condition is a simple equi join condition of the form, 'col1 = col2'.
+     */
+    public static boolean isTopLevelEquiJoin(Symbol joinCondition) {
+        return joinCondition instanceof Function f && f.signature().equals(EqOperator.SIGNATURE) && isEquiJoin(joinCondition);
+    }
+
+    /**
      * insideEqualOperand is used to mark starting point of the computation of the either sides of equality.
      *
      */

--- a/server/src/main/java/io/crate/planner/optimizer/rule/EquiJoinToLookupJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/EquiJoinToLookupJoin.java
@@ -75,7 +75,7 @@ public class EquiJoinToLookupJoin implements Rule<JoinPlan> {
             // only inner-equi-joins
             j.joinType() == JoinType.INNER &&
             j.joinCondition() != null &&
-            EquiJoinDetector.isEquiJoin(j.joinCondition()) &&
+            EquiJoinDetector.isTopLevelEquiJoin(j.joinCondition()) &&
             // no nested subqueries
             j.lhs().relationNames().size() == 1 &&
             j.rhs().relationNames().size() == 1

--- a/server/src/test/java/io/crate/planner/operators/EquiJoinDetectorTest.java
+++ b/server/src/test/java/io/crate/planner/operators/EquiJoinDetectorTest.java
@@ -165,4 +165,23 @@ public class EquiJoinDetectorTest extends CrateDummyClusterServiceUnitTest {
         Symbol joinCondition = sqlExpressions.asSymbol("(t1.a > 1) = (t2.b < 5 OR t2.b > 10)");
         assertThat(EquiJoinDetector.isEquiJoin(joinCondition)).isTrue();
     }
+
+    @Test
+    public void test_detect_pure_equi_join() {
+        Symbol joinCondition = sqlExpressions.asSymbol("t1.a = t2.b AND t1.x = t2.y");
+        assertThat(EquiJoinDetector.isEquiJoin(joinCondition)).isTrue();
+        assertThat(EquiJoinDetector.isTopLevelEquiJoin(joinCondition)).isFalse();
+
+        joinCondition = sqlExpressions.asSymbol("t1.x = t2.y");
+        assertThat(EquiJoinDetector.isEquiJoin(joinCondition)).isTrue();
+        assertThat(EquiJoinDetector.isTopLevelEquiJoin(joinCondition)).isTrue();
+
+        joinCondition = sqlExpressions.asSymbol("abs(t1.x) + 10 = abs(t2.y) - 10");
+        assertThat(EquiJoinDetector.isEquiJoin(joinCondition)).isTrue();
+        assertThat(EquiJoinDetector.isTopLevelEquiJoin(joinCondition)).isTrue();
+
+        joinCondition = sqlExpressions.asSymbol("t1.x = t2.y AND t1.x = 10 AND t2.y = 20");
+        assertThat(EquiJoinDetector.isEquiJoin(joinCondition)).isTrue();
+        assertThat(EquiJoinDetector.isTopLevelEquiJoin(joinCondition)).isFalse();
+    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Fixes https://github.com/crate/support/issues/731,

the optimizer rule `EquiJoinToLookupJoin`, falsely allowed unsupported complex equi join conditions like `<equality> AND <equality>` to be consumed then threw an exception.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
