### PR TITLE
Fix `type` storage for TableStatsService

### DIFF
--- a/server/src/main/java/io/crate/statistics/TableStatsService.java
+++ b/server/src/main/java/io/crate/statistics/TableStatsService.java
@@ -352,9 +352,7 @@ public class TableStatsService extends AbstractLifecycleComponent implements Run
                             numDocs = doc.getField(TableDocFields.NUM_DOCS).storedValue().getLongValue();
                             sizeInBytes = doc.getField(TableDocFields.SIZE_IN_BYTES).storedValue().getLongValue();
                         }
-                        default -> {
-                            throw new AssertionError("Unexpected fieldType: " + fieldType);
-                        }
+                        default -> throw new AssertionError("Unexpected fieldType: " + fieldType);
                     }
                 }
             }
@@ -380,7 +378,7 @@ public class TableStatsService extends AbstractLifecycleComponent implements Run
         Streamer<T> streamer = type.streamer();
         MostCommonValues<T> mostCommonValues = decode(
             version,
-            in -> new MostCommonValues<T>(streamer, in),
+            in -> new MostCommonValues<>(streamer, in),
             doc.getBinaryValue(ColumnDocFields.MOST_COMMON_VALUES)
         );
         List<T> histogram = decode(


### PR DESCRIPTION

  To be able to retrieve simple stats per table or
  ColumnStats per column in the future, we need to use an IntField,
  to be able to add it as a condition in BooleanQuery, e.g.:
  ```
  @VisibleForTesting
  @Nullable
  ColumnStats<?> loadColStatsFromDisk(RelationName relationName, ColumnIdent columnIdent) {
    ColumnStats<?> columnStats = null;
    IndexSearcher tablesSearcher = null;
    try {
      searcherManager.maybeRefreshBlocking();
      tablesSearcher = searcherManager.acquire();
      tablesSearcher.setQueryCache(null);
      Query query = new BooleanQuery.Builder()
        .add(new TermQuery(new Term(ColumnDocFields.REL_NAME, relationName.fqn())), BooleanClause.Occur.MUST)
        .add(new TermQuery(new Term(ColumnDocFields.COLUMN, columnIdent.sqlFqn())), BooleanClause.Occur.MUST)
        .add(IntPoint.newExactQuery(FIELD_TYPE, FieldType.COLUMN.ordinal()), BooleanClause.Occur.MUST)
        .build();
      Weight weight = tablesSearcher.createWeight(query, ScoreMode.COMPLETE_NO_SCORES, 0.0f);
      IndexReader reader = tablesSearcher.getIndexReader();
      for (LeafReaderContext leafReaderContext : reader.leaves()) {
        ...
  ```