### PR TITLE
Change TableStatsService to use 2 separate Lucene indices and MMap dir

### DIFF
--- a/server/src/main/java/io/crate/statistics/TableStatsService.java
+++ b/server/src/main/java/io/crate/statistics/TableStatsService.java
@@ -55,7 +55,7 @@ import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.Weight;
 import org.apache.lucene.store.Directory;
-import org.apache.lucene.store.NIOFSDirectory;
+import org.apache.lucene.store.MMapDirectory;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterChangedEvent;
@@ -176,8 +176,8 @@ public class TableStatsService extends AbstractLifecycleComponent implements Run
             .build(this::loadFromDisk);
 
         try {
-            this.tablesDirectory = new NIOFSDirectory(dataPath.resolve(TABLES_STATS));
-            this.colsDirectory = new NIOFSDirectory(dataPath.resolve(COLS_STATS));
+            this.tablesDirectory = MMapDirectory.open(dataPath.resolve(TABLES_STATS));
+            this.colsDirectory = MMapDirectory.open(dataPath.resolve(COLS_STATS));
             IndexWriterConfig tablesIndexWriterConfig = new IndexWriterConfig(new KeywordAnalyzer());
             tablesIndexWriterConfig.setOpenMode(IndexWriterConfig.OpenMode.CREATE_OR_APPEND);
             tablesIndexWriterConfig.setMergeScheduler(new SerialMergeScheduler());


### PR DESCRIPTION
1. Change TableStatsService to use 2 separate Lucene indices
 
    After running benchmarks they showed that having both table and col
    stats in one index, lead to slower loading of stats, especially
    when trying to load only a specific table or col (future plan).
    ```
    Benchmark
    TableStatsServiceBenchmark.measureLoadColStatsFromDisk                  avgt   25  447.783 ± 2.687  ms/op
    TableStatsServiceBenchmark.measureLoadColStatsFromDisk_separateIndices  avgt   25  378.624 ± 2.228  ms/op
    TableStatsServiceBenchmark.measureLoadColStatsFromDisk_withoutType      avgt   25  401.765 ± 3.324  ms/op
    ```
    ```
    Benchmark                                                          Mode  Cnt   Score   Error  Units
    TableStatsServiceBenchmark.measureLoadAllFromDisk                  avgt   25  23.900 ± 0.101  ms/op
    TableStatsServiceBenchmark.measureLoadAllFromDisk_separateIndices  avgt   25  20.978 ± 0.251  ms/op
    ```
    
    The separate indices comes with a small hit on save though:
    ```
    Benchmark                                                               Mode  Cnt   Score   Error  Units
    TableStatsServiceBenchmark.measureSaveTableStatsToDisk                  avgt   25  34.159 ± 0.415  ms/op
    TableStatsServiceBenchmark.measureSaveTableStatsToDisk_separateIndices  avgt   25  53.407 ± 3.433  ms/op
    ```

3. Change TableStatsService to not explicitely use NIOFS

    After some benchmarking it seems that MMap performs better,
    so change to `MMapDirectory.open()` which fallbacks to NIOFS
    depending on the underlying system:

    ```
    Benchmark                                                    Mode  Cnt   Score   Error  Units
    TableStatsServiceBenchmark.measureSaveTableStatsToDisk_MMap  avgt   25  49.791 ± 0.660  ms/op
    TableStatsServiceBenchmark.measureSaveTableStatsToDisk_NIO   avgt   25  51.251 ± 1.962  ms/op
    ```
    ```
    Benchmark                                                    Mode  Cnt   Score   Error  Units
    TableStatsServiceBenchmark.measureLoadAllStatsFromDisk_MMap  avgt   25  15.983 ± 0.130  ms/op
    TableStatsServiceBenchmark.measureLoadAllStatsFromDisk_NIO   avgt   25  23.275 ± 0.178  ms/op
    ```