### PR TITLE
Account for potentially big resize when building HTTP result set

### DIFF
--- a/docs/appendices/release-notes/6.0.4.rst
+++ b/docs/appendices/release-notes/6.0.4.rst
@@ -71,3 +71,7 @@ Fixes
 
     SELECT * FROM t INNER JOIN t2 ON t.a = t2.a;
 
+- Fixed an issue that caused RAM under-accounting, potentially leading to an
+  ``OutOfMemoryError`` when a large result set was returned by the ``HTTP``
+  endpoint.
+

--- a/server/src/main/java/io/crate/collections/accountable/AccountableList.java
+++ b/server/src/main/java/io/crate/collections/accountable/AccountableList.java
@@ -181,7 +181,7 @@ public class AccountableList<T> extends AbstractList<T> {
     /**
      * Copy of ArraysSupport.newLength
      */
-    private static int newLength(int oldLength, int minGrowth, int prefGrowth) {
+    public static int newLength(int oldLength, int minGrowth, int prefGrowth) {
         int prefLength = oldLength + Math.max(minGrowth, prefGrowth); // might overflow
         if (0 < prefLength && prefLength <= SOFT_MAX_ARRAY_LENGTH) {
             return prefLength;

--- a/server/src/main/java/io/crate/rest/action/SqlHttpHandler.java
+++ b/server/src/main/java/io/crate/rest/action/SqlHttpHandler.java
@@ -55,6 +55,7 @@ import io.crate.auth.AuthSettings;
 import io.crate.auth.Credentials;
 import io.crate.auth.HttpAuthUpstreamHandler;
 import io.crate.auth.Protocol;
+import io.crate.collections.accountable.AccountableList;
 import io.crate.data.breaker.BlockBasedRamAccounting;
 import io.crate.data.breaker.RamAccounting;
 import io.crate.exceptions.SQLExceptions;
@@ -338,14 +339,29 @@ public class SqlHttpHandler extends SimpleChannelInboundHandler<FullHttpRequest>
 
         @Override
         public void write(byte[] b, int off, int len) {
-            ramAccounting.addBytes(len);
+            ensureCapacity(count + len);
             super.write(b, off, len);
         }
 
         @Override
         public void write(int b) {
-            ramAccounting.addBytes(1);
+            ensureCapacity(count + 1);
             super.write(b);
+        }
+
+        /**
+         * Inlined growth estimation logic from "ByteArrayOutputStream.ensureCapacity()"
+         * to ensure that we account before potentially large resize to avoid OOM-s.
+         */
+        private void ensureCapacity(int minCapacity) {
+            int oldCapacity = this.buf.length;
+            int minGrowth = minCapacity - oldCapacity;
+            // If prev resizes were enough to handle current write, RamAccounting was already updated,
+            // so we only add bytes on resize.
+            if (minGrowth > 0) {
+                int newCapacity = AccountableList.newLength(oldCapacity, minGrowth, oldCapacity);
+                ramAccounting.addBytes(newCapacity - oldCapacity);
+            }
         }
 
         @Override

--- a/server/src/test/java/io/crate/rest/action/RestActionReceiversTest.java
+++ b/server/src/test/java/io/crate/rest/action/RestActionReceiversTest.java
@@ -194,17 +194,17 @@ public class RestActionReceiversTest extends ESTestCase {
         resultReceiver.setNextRow(rows.get(0));
         jsonXContentBuilder.flush(); // flush the internal buffer to OutputStream to trigger ram-accounting
         long bytesFirstRow = ramAccounting.totalBytes();
+        assertThat(bytesFirstRow).isEqualTo(32L);
 
         resultReceiver.setNextRow(rows.get(1));
         jsonXContentBuilder.flush();
         long bytesSecondRow = ramAccounting.totalBytes() - bytesFirstRow;
+        assertThat(bytesSecondRow).isEqualTo(64L);
 
         resultReceiver.setNextRow(rows.get(2));
         jsonXContentBuilder.flush();
         long bytesThirdRow = ramAccounting.totalBytes() - bytesSecondRow - bytesFirstRow;
 
-        assertThat(bytesThirdRow - bytesSecondRow).isEqualTo(
-            String.valueOf(Long.MAX_VALUE).length() - String.valueOf(2L).length()
-        );
+        assertThat(bytesThirdRow).isEqualTo(0); // Array is resized and already accounted for.
     }
 }


### PR DESCRIPTION
Follow up to https://github.com/crate/crate/pull/18021

`ByteArrayOutputStream` resizing can sometimes double the size of the underlying array. We must be precise in accounting and don't rely on eventual catch up as double the size of already big structure is significant.

We have seen a heap dump with byte array of `ByteArrayOutputStream` occupying 998 MB.

```
  at java.lang.OutOfMemoryError.<init>()V (OutOfMemoryError.java:48)
  at java.util.Arrays.copyOf([BI)[B (Arrays.java:3540)
  at java.io.ByteArrayOutputStream.ensureCapacity(I)V (ByteArrayOutputStream.java:100)
  at java.io.ByteArrayOutputStream.write([BII)V (ByteArrayOutputStream.java:132)
  at io.crate.rest.action.SqlHttpHandler$RamAccountingOutputStream.write([BII)V (SqlHttpHandler.java:347)
  at com.fasterxml.jackson.core.json.UTF8JsonGenerator._flushBuffer()V (UTF8JsonGenerator.java:2243)
  at com.fasterxml.jackson.core.json.UTF8JsonGenerator.writeNumber(J)V (UTF8JsonGenerator.java:1010)
  at org.elasticsearch.common.xcontent.json.JsonXContentGenerator.writeNumber(J)V (JsonXContentGenerator.java:193)
  at org.elasticsearch.common.xcontent.XContentBuilder.value(J)Lorg/elasticsearch/common/xcontent/XContentBuilder; (XContentBuilder.java:478)
  at org.elasticsearch.common.xcontent.XContentBuilder.value(Ljava/lang/Long;)Lorg/elasticsearch/common/xcontent/XContentBuilder; (XContentBuilder.java:474)
  at org.elasticsearch.common.xcontent.XContentBuilder.lambda$static$9(Lorg/elasticsearch/common/xcontent/XContentBuilder;Ljava/lang/Object;)V (XContentBuilder.java:81)
  at org.elasticsearch.common.xcontent.XContentBuilder$$Lambda+0x000000001d21ebf0.write(Lorg/elasticsearch/common/xcontent/XContentBuilder;Ljava/lang/Object;)V (Unknown Source)
  at org.elasticsearch.common.xcontent.XContentBuilder.unknownValue(Ljava/lang/Object;Ljava/util/Map;)V (XContentBuilder.java:787)
  at org.elasticsearch.common.xcontent.XContentBuilder.mapContents(Ljava/util/Map;ZLjava/util/Map;)Lorg/elasticsearch/common/xcontent/XContentBuilder; (XContentBuilder.java:837)
  at org.elasticsearch.common.xcontent.XContentBuilder.map(Ljava/util/Map;Ljava/util/Map;)Lorg/elasticsearch/common/xcontent/XContentBuilder; (XContentBuilder.java:820)
  at org.elasticsearch.common.xcontent.XContentBuilder.unknownValue(Ljava/lang/Object;Ljava/util/Map;)V (XContentBuilder.java:794)
  at org.elasticsearch.common.xcontent.XContentBuilder.value(Ljava/lang/Object;)Lorg/elasticsearch/common/xcontent/XContentBuilder; (XContentBuilder.java:771)
  at io.crate.rest.action.ResultToXContentBuilder.addRow(Lio/crate/data/Row;I)Lio/crate/rest/action/ResultToXContentBuilder; (ResultToXContentBuilder.java:123)
```

