### PR TITLE
Add support for having more than one column in EXISTS subquery

### DIFF
--- a/docs/appendices/release-notes/6.2.0.rst
+++ b/docs/appendices/release-notes/6.2.0.rst
@@ -64,7 +64,8 @@ None
 SQL Standard and PostgreSQL Compatibility
 -----------------------------------------
 
-None
+- Added support for selecting more than one column within a subquery used in a
+  ``EXISTS`` clause.
 
 Data Types
 ----------

--- a/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
@@ -670,9 +670,6 @@ public class ExpressionAnalyzer {
             }
             var relation = subQueryAnalyzer.analyze(node.getSubquery());
             List<Symbol> fields = relation.outputs();
-            if (fields.size() > 1) {
-                throw new UnsupportedOperationException("Subqueries with more than 1 column are not supported");
-            }
             DataType<?> innerType = fields.getFirst().valueType();
             SelectSymbol selectSymbol = new SelectSymbol(
                 relation,

--- a/server/src/test/java/io/crate/analyze/SubSelectAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/SubSelectAnalyzerTest.java
@@ -30,6 +30,7 @@ import static io.crate.testing.Asserts.isField;
 import static io.crate.testing.Asserts.isFunction;
 import static io.crate.testing.Asserts.isLiteral;
 import static io.crate.testing.Asserts.isReference;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
@@ -309,9 +310,11 @@ public class SubSelectAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     }
 
     @Test
-    public void test_exists_subquery_cannot_select_more_than_1_column() {
-        assertThatThrownBy(() -> analyze("select * from sys.summits where EXISTS (select 1, 2)"))
-            .hasMessage("Subqueries with more than 1 column are not supported");
+    public void test_exists_subquery_can_select_more_than_1_column() {
+        QueriedSelectRelation rel = analyze(
+            "select mountain from sys.summits where EXISTS (select 1, 2)");
+        assertThat(rel.where()).isSQL("EXISTS (SELECT 1, 2 FROM (empty_row))");
+
     }
 
     @Test


### PR DESCRIPTION
Restricting a EXISTS subquery to 1 column was a bit of an artificial
limitation.

The way the execution works is that the subquery will select the
requested columns and the `FirstColumnConsumers` will only take the
value from the first column.

Closes https://github.com/crate/crate/issues/18528

## TODO

- [x] Check interaction with correlated subquery