### PR TITLE
Apply Lucene changes to CrateDB's CustomLucene90DocValuesProducer

### DIFF
--- a/server/src/main/java/io/crate/lucene/codec/CustomLucene90DocValuesProducer.java
+++ b/server/src/main/java/io/crate/lucene/codec/CustomLucene90DocValuesProducer.java
@@ -50,9 +50,11 @@ import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.store.ByteArrayDataInput;
 import org.apache.lucene.store.ChecksumIndexInput;
 import org.apache.lucene.store.DataInput;
+import org.apache.lucene.store.FileTypeHint;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.RandomAccessInput;
 import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.FixedBitSet;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.LongValues;
 import org.apache.lucene.util.compress.LZ4;
@@ -117,7 +119,8 @@ final class CustomLucene90DocValuesProducer extends DocValuesProducer {
         }
 
         String dataName = IndexFileNames.segmentFileName(state.segmentInfo.name, state.segmentSuffix, dataExtension);
-        this.data = state.directory.openInput(dataName, state.context);
+        // Doc-values have a forward-only access pattern
+        this.data = state.directory.openInput(dataName, state.context.withHints(FileTypeHint.DATA));
         boolean success = false;
         try {
             final int version2 = CodecUtil.checkIndexHeader(
@@ -476,6 +479,11 @@ final class CustomLucene90DocValuesProducer extends DocValuesProducer {
         public long cost() {
             return maxDoc;
         }
+
+        @Override
+        public int docIDRunEnd() throws IOException {
+            return maxDoc;
+        }
     }
 
     private abstract static class SparseNumericDocValues extends NumericDocValues {
@@ -507,8 +515,18 @@ final class CustomLucene90DocValuesProducer extends DocValuesProducer {
         }
 
         @Override
+        public void intoBitSet(int upTo, FixedBitSet bitSet, int offset) throws IOException {
+            disi.intoBitSet(upTo, bitSet, offset);
+        }
+
+        @Override
         public long cost() {
             return disi.cost();
+        }
+
+        @Override
+        public int docIDRunEnd() throws IOException {
+            return disi.docIDRunEnd();
         }
     }
 
@@ -743,6 +761,11 @@ final class CustomLucene90DocValuesProducer extends DocValuesProducer {
             doc = target;
             return true;
         }
+
+        @Override
+        public int docIDRunEnd() throws IOException {
+            return maxDoc;
+        }
     }
 
     private abstract static class SparseBinaryDocValues extends BinaryDocValues {
@@ -776,6 +799,16 @@ final class CustomLucene90DocValuesProducer extends DocValuesProducer {
         @Override
         public boolean advanceExact(int target) throws IOException {
             return disi.advanceExact(target);
+        }
+
+        @Override
+        public void intoBitSet(int upTo, FixedBitSet bitSet, int offset) throws IOException {
+            disi.intoBitSet(upTo, bitSet, offset);
+        }
+
+        @Override
+        public int docIDRunEnd() throws IOException {
+            return disi.docIDRunEnd();
         }
     }
 
@@ -937,6 +970,11 @@ final class CustomLucene90DocValuesProducer extends DocValuesProducer {
                     public long cost() {
                         return maxDoc;
                     }
+
+                    @Override
+                    public int docIDRunEnd() throws IOException {
+                        return maxDoc;
+                    }
                 };
             } else if (ordsEntry.docsWithFieldOffset >= 0) { // sparse but non-empty
                 final IndexedDISI disi = new IndexedDISI(
@@ -975,8 +1013,18 @@ final class CustomLucene90DocValuesProducer extends DocValuesProducer {
                     }
 
                     @Override
+                    public void intoBitSet(int upTo, FixedBitSet bitSet, int offset) throws IOException {
+                        disi.intoBitSet(upTo, bitSet, offset);
+                    }
+
+                    @Override
                     public long cost() {
                         return disi.cost();
+                    }
+
+                    @Override
+                    public int docIDRunEnd() throws IOException {
+                        return disi.docIDRunEnd();
                     }
                 };
             }
@@ -1013,6 +1061,11 @@ final class CustomLucene90DocValuesProducer extends DocValuesProducer {
             @Override
             public long cost() {
                 return ords.cost();
+            }
+
+            @Override
+            public int docIDRunEnd() throws IOException {
+                return ords.docIDRunEnd();
             }
         };
     }
@@ -1433,6 +1486,11 @@ final class CustomLucene90DocValuesProducer extends DocValuesProducer {
                 public int docValueCount() {
                     return count;
                 }
+
+                @Override
+                public int docIDRunEnd() throws IOException {
+                    return maxDoc;
+                }
             };
         } else {
             // sparse
@@ -1489,6 +1547,12 @@ final class CustomLucene90DocValuesProducer extends DocValuesProducer {
                     return count;
                 }
 
+                @Override
+                public void intoBitSet(int upTo, FixedBitSet bitSet, int offset) throws IOException {
+                    set = false;
+                    disi.intoBitSet(upTo, bitSet, offset);
+                }
+
                 private void set() {
                     if (set == false) {
                         final int index = disi.index();
@@ -1497,6 +1561,11 @@ final class CustomLucene90DocValuesProducer extends DocValuesProducer {
                         count = (int) (end - start);
                         set = true;
                     }
+                }
+
+                @Override
+                public int docIDRunEnd() throws IOException {
+                    return disi.docIDRunEnd();
                 }
             };
         }
@@ -1583,6 +1652,11 @@ final class CustomLucene90DocValuesProducer extends DocValuesProducer {
                     public long cost() {
                         return maxDoc;
                     }
+
+                    @Override
+                    public int docIDRunEnd() throws IOException {
+                        return maxDoc;
+                    }
                 };
             } else if (ordsEntry.docsWithFieldOffset >= 0) { // sparse but non-empty
                 final IndexedDISI disi = new IndexedDISI(
@@ -1635,6 +1709,12 @@ final class CustomLucene90DocValuesProducer extends DocValuesProducer {
                     }
 
                     @Override
+                    public void intoBitSet(int upTo, FixedBitSet bitSet, int offset) throws IOException {
+                        set = false;
+                        disi.intoBitSet(upTo, bitSet, offset);
+                    }
+
+                    @Override
                     public long cost() {
                         return disi.cost();
                     }
@@ -1647,6 +1727,11 @@ final class CustomLucene90DocValuesProducer extends DocValuesProducer {
                             count = (int) (end - curr);
                             set = true;
                         }
+                    }
+
+                    @Override
+                    public int docIDRunEnd() throws IOException {
+                        return disi.docIDRunEnd();
                     }
                 };
             }
@@ -1688,6 +1773,11 @@ final class CustomLucene90DocValuesProducer extends DocValuesProducer {
             @Override
             public long cost() {
                 return ords.cost();
+            }
+
+            @Override
+            public int docIDRunEnd() throws IOException {
+                return ords.docIDRunEnd();
             }
         };
     }


### PR DESCRIPTION
Apply changes made between 10.2.2 and 10.3.1 versions:
```
$ g log --oneline releases/lucene/10.2.2..releases/lucene/10.3.1 lucene/core/src/java/org/apache/lucene/codecs/lucene90/{Lucene90DocValuesProducer.java,Lucene90DocValuesConsumer.java,Lucene90DocValuesFormat.java}
d176a42b659 Implement IndexedDISI#docIDRunEnd (#14753)
223d7a41e3c [10.x] Change uses of withReadAdvice to use hints instead (#14629) (#14510)
bb3167e57c6 Impl intoBitset for IndexedDISI and Docvalues (#14529)
```

Relevant PRs:
https://github.com/apache/lucene/pull/14753
https://github.com/apache/lucene/pull/14510
https://github.com/apache/lucene/pull/14529

Follows: #18545
