### PR TITLE
Fix github actions `vale` run

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,6 +26,9 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Install docutils
+        run: sudo apt-get install -y docutils
+
       - name: Run vale
         uses: errata-ai/vale-action@v2.1.1
         with:


### PR DESCRIPTION
Currently it throws:
```
  /home/runner/vale --output=/home/runner/work/_actions/errata-ai/vale-action/v2.1.1/lib/rdjsonl.tmpl docs/
  E100 [lintRST] Runtime error

  rst2html not found

  Execution stopped with code 1.
Error: Vale and reviewdog exited with status code: 2
```

According to their docs:
```
If you're using a markup format other than Markdown, you may need to install an external parser before calling vale-action:

  # For AsciiDoc users:
  - name: Install Asciidoctor
    run: sudo apt-get install -y asciidoctor

  # For reStructuredText users:
  - name: Install docutils
    run: sudo apt-get install -y docutils
```

Follows: #18524