### PR TITLE
Fixed an issue that led to deletion of persisted table stats

### DIFF
--- a/docs/appendices/release-notes/6.1.1.rst
+++ b/docs/appendices/release-notes/6.1.1.rst
@@ -48,3 +48,7 @@ Fixes
 
 - Fixed an issue where generated and default sub-columns were missing from
   results returned by the ``RETURNING`` clause.
+
+- Fixed an issue that led to deleting persisted
+  :ref:`pg_catalog.pg_stats <pg_stats>` during full cluster restart, thus making
+  it necessary to run again :ref:`analyze`.

--- a/server/src/main/java/io/crate/statistics/TableStatsService.java
+++ b/server/src/main/java/io/crate/statistics/TableStatsService.java
@@ -188,9 +188,6 @@ public class TableStatsService extends AbstractLifecycleComponent implements Run
             this.tablesSearcherManager = new SearcherManager(tablesWriter, null);
             this.colsWriter = new IndexWriter(colsDirectory, colsIndexWriterConfig);
             this.colsSearcherManager = new SearcherManager(colsWriter, null);
-
-            // ensure index files exist for reads
-            this.update(Map.of());
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
@@ -298,6 +295,7 @@ public class TableStatsService extends AbstractLifecycleComponent implements Run
         }
     }
 
+    @VisibleForTesting
     public void clear() {
         try {
             tablesWriter.deleteAll();


### PR DESCRIPTION
The `update()` call with empty stats led to deleting all stats, since the method first deletes all existing table and col stats before starting to rewrite them to disk.

Follows: #18244

