### PR TITLE
Implement PG wire version negotiate response

### DIFF
--- a/docs/appendices/release-notes/6.2.0.rst
+++ b/docs/appendices/release-notes/6.2.0.rst
@@ -100,6 +100,11 @@ SQL Standard and PostgreSQL Compatibility
 - Added support for selecting more than one column within a subquery used in a
   ``EXISTS`` clause.
 
+- Implemented protocol version negotiation support in the PostgresSQL wire
+  protocol, adding support for clients initially requesting higher minor
+  versions than the server supports. The client is expected to downgrade it's
+  used minor version in such cases.
+
 Data Types
 ----------
 

--- a/server/src/main/java/io/crate/protocols/postgres/ClientMessages.java
+++ b/server/src/main/java/io/crate/protocols/postgres/ClientMessages.java
@@ -54,10 +54,13 @@ class ClientMessages {
     }
 
     static ByteBuf sendStartupMessage(ByteBuf buffer, String dbName, Map<String, String> properties) {
+        return sendStartupMessage(buffer, PgDecoder.PROTOCOL_VERSION, dbName, properties);
+    }
+
+    static ByteBuf sendStartupMessage(ByteBuf buffer, int protocolVersion, String dbName, Map<String, String> properties) {
         // length itself and protocol version number
         // updated later to include the body
         int length = 8;
-        int protocolVersion = 3 << 16;
         final int lengthIndex = buffer.writerIndex();
         buffer.writeInt(length);
         buffer.writeInt(protocolVersion);


### PR DESCRIPTION
Adds support for clients initially requesting high minor versions than the server supports. The client is expected to downgrade it's used minor version in such cases.

Closes #18333.