### PR TITLE
Fix oid clash on ADD COLUMN after RESTORE SNAPSHOT

### DIFF
--- a/server/src/main/java/io/crate/execution/ddl/Templates.java
+++ b/server/src/main/java/io/crate/execution/ddl/Templates.java
@@ -54,7 +54,7 @@ public final class Templates {
             .putMapping(new CompressedXContent(Map.of(
                 Constants.DEFAULT_MAPPING_TYPE,
                 MappingUtil.createMapping(
-                    MappingUtil.AllocPosition.forNewTable(),
+                    MappingUtil.AllocCounter.forNewTable(),
                     table.pkConstraintName(),
                     table.columns(),
                     table.primaryKeys(),

--- a/server/src/main/java/io/crate/metadata/doc/DocTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocTableInfo.java
@@ -68,7 +68,7 @@ import io.crate.common.collections.Lists;
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.exceptions.InvalidColumnNameException;
 import io.crate.execution.ddl.tables.MappingUtil;
-import io.crate.execution.ddl.tables.MappingUtil.AllocPosition;
+import io.crate.execution.ddl.tables.MappingUtil.AllocCounter;
 import io.crate.expression.symbol.DynamicReference;
 import io.crate.expression.symbol.RefReplacer;
 import io.crate.expression.symbol.Symbol;
@@ -86,6 +86,7 @@ import io.crate.metadata.PartitionName;
 import io.crate.metadata.Reference;
 import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.ReferenceTree;
+import io.crate.metadata.RelationInfo;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.Routing;
 import io.crate.metadata.RoutingProvider;
@@ -1075,9 +1076,9 @@ public class DocTableInfo implements TableInfo, ShardedTable, StoredTable {
         for (var check : checkConstraints) {
             checkConstraintMap.put(check.name(), check.expressionStr());
         }
-        AllocPosition allocPosition = AllocPosition.forTable(this);
+        AllocCounter allocCounter = AllocCounter.forTable(this, RelationInfo::maxPosition, Reference::position);
         Map<String, Object> mapping = Map.of("default", MappingUtil.createMapping(
-            allocPosition,
+            allocCounter,
             pkConstraintName,
             allColumns,
             primaryKeys,

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/create/TransportCreatePartitions.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/create/TransportCreatePartitions.java
@@ -74,6 +74,8 @@ import io.crate.exceptions.RelationUnknown;
 import io.crate.execution.ddl.tables.MappingUtil;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.PartitionName;
+import io.crate.metadata.Reference;
+import io.crate.metadata.RelationInfo;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.doc.DocTableInfoFactory;
@@ -241,7 +243,8 @@ public class TransportCreatePartitions extends TransportMasterNodeAction<CreateP
             // "Probe" creation of the first index passed validation. Now add all indices to the cluster state metadata and update routing.
 
             final MappingMetadata mapping = new MappingMetadata(Map.of("default", MappingUtil.createMapping(
-                MappingUtil.AllocPosition.forTable(docTableInfo),
+                //
+                MappingUtil.AllocCounter.forTable(docTableInfo, RelationInfo::maxPosition, Reference::position),
                 table.pkConstraintName(),
                 table.columns(),
                 table.primaryKeys(),

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexTemplateMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexTemplateMetadata.java
@@ -44,6 +44,7 @@ import io.crate.Constants;
 import io.crate.common.collections.MapBuilder;
 import io.crate.execution.ddl.tables.MappingUtil;
 import io.crate.metadata.PartitionName;
+import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
 
 /**
@@ -377,7 +378,7 @@ public class IndexTemplateMetadata extends AbstractDiffable<IndexTemplateMetadat
                 .putMapping(new CompressedXContent(Map.of(
                     Constants.DEFAULT_MAPPING_TYPE,
                     MappingUtil.createMapping(
-                        MappingUtil.AllocPosition.forTable(table),
+                        MappingUtil.AllocCounter.forTable(table, Reference::position),
                         table.pkConstraintName(),
                         table.columns(),
                         table.primaryKeys(),

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
@@ -595,7 +595,7 @@ public class MetadataCreateIndexService {
 
         Metadata.Builder metadataBuilder = Metadata.builder(metadata);
         final MappingMetadata mapping = new MappingMetadata(Map.of("default", MappingUtil.createMapping(
-            MappingUtil.AllocPosition.forNewTable(),
+            MappingUtil.AllocCounter.forNewTable(),
             table.pkConstraintName(),
             DocReferences.applyOid(table.columns(), metadataBuilder.columnOidSupplier()),
             table.primaryKeys(),

--- a/server/src/testFixtures/java/io/crate/operation/aggregation/AggregationTestCase.java
+++ b/server/src/testFixtures/java/io/crate/operation/aggregation/AggregationTestCase.java
@@ -93,7 +93,7 @@ import io.crate.data.Row;
 import io.crate.data.breaker.RamAccounting;
 import io.crate.data.testing.TestingRowConsumer;
 import io.crate.execution.ddl.tables.MappingUtil;
-import io.crate.execution.ddl.tables.MappingUtil.AllocPosition;
+import io.crate.execution.ddl.tables.MappingUtil.AllocCounter;
 import io.crate.execution.dml.IndexItem;
 import io.crate.execution.dml.Indexer;
 import io.crate.execution.dsl.phases.CollectPhase;
@@ -443,7 +443,7 @@ public abstract class AggregationTestCase extends ESTestCase {
 
     private static XContentBuilder buildMapping(List<Reference> targetColumns) throws IOException {
         Map<String, Map<String, Object>> properties = MappingUtil.toProperties(
-            AllocPosition.forNewTable(),
+            AllocCounter.forNewTable(),
             Reference.buildTree(targetColumns)
         );
         return JsonXContent.builder()

--- a/server/src/testFixtures/java/io/crate/testing/TestingHelpers.java
+++ b/server/src/testFixtures/java/io/crate/testing/TestingHelpers.java
@@ -368,7 +368,7 @@ public class TestingHelpers {
         }
 
         return createMapping(
-            MappingUtil.AllocPosition.forNewTable(),
+            MappingUtil.AllocCounter.forNewTable(),
             boundCreateTable.pkConstraintName(),
             references,
             Lists.map(boundCreateTable.primaryKeys(), Reference::column),


### PR DESCRIPTION
See commits

It's not needed to have global scoped oid for columns for pg compatibility:

https://www.postgresql.org/docs/current/catalog-pg-attribute.html has only relation oid and type oid.

`has_column_privilege` resolves column by table scope (table name or oid, column name or attnum(position) https://www.postgresql.org/docs/current/functions-info.html

This PR changes AllocPosition to reusable AllocCounter (table scoped counters) and uses it for ADD COLUMN to deal with potential oid clash on restore. 

`CREATE TABLE` usage is not fixing anything (because we can't have clash on a new table) but using it for complete migration from global oid.

No need for BWC - for new tables we just create oids from scratch, for existing tables (ADD COLUMN), we take over from the current valid state and continue with local scope (so difference is that new oids can clash with other tables oids but it's not a problem) 
UPD: Casting aspect needs to be checked, https://github.com/crate/crate/pull/18592/files#r2471873697