### PR TITLE
Revert "Bump JDK to 25.0.1+8"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -279,8 +279,13 @@
     <!-- see surefire plugin configuration for explanation -->
     <skipRunTests>false</skipRunTests>
 
-    <versions.jdk>25.0.1</versions.jdk>
-    <versions.jdkbuild>25.0.1+8</versions.jdkbuild>
+    <!-- When bumping the JDK version run both:
+      ./mvnw -P jmods -Dos.arch=x86_64
+      ./mvnw -P jmods -Dos.arch=aarch64
+    To verify the version is available for both platforms
+    -->
+    <versions.jdk>25</versions.jdk>
+    <versions.jdkbuild>25+36</versions.jdkbuild>
 
     <versions.annotations>26.0.2-1</versions.annotations>
     <versions.log4j>2.25.2</versions.log4j>


### PR DESCRIPTION
This reverts commit cab49752cbe1df647c3827a63a2e1846e07fb9a2.

The aarch64 build for 25.0.1 is still missing, breaking nightly builds.
