### PR TITLE
Optimize streaming of SchemaMetadata diffs

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/AbstractDiffable.java
+++ b/server/src/main/java/org/elasticsearch/cluster/AbstractDiffable.java
@@ -31,7 +31,15 @@ import org.jetbrains.annotations.Nullable;
  */
 public abstract class AbstractDiffable<T extends Diffable<T>> implements Diffable<T> {
 
-    static final Diff<?> EMPTY = new CompleteDiff<>();
+    public static final Diff<?> EMPTY = new CompleteDiff<>();
+
+    public static <T extends Diffable<T>> Diff<T> of(T before, T after) {
+        if (after.equals(before)) {
+            return Diffs.empty();
+        } else {
+            return new CompleteDiff<>(after);
+        }
+    }
 
     @SuppressWarnings("unchecked")
     @Override
@@ -51,7 +59,7 @@ public abstract class AbstractDiffable<T extends Diffable<T>> implements Diffabl
         return (Diff<T>) EMPTY;
     }
 
-    private static class CompleteDiff<T extends Diffable<T>> implements Diff<T> {
+    public static class CompleteDiff<T extends Diffable<T>> implements Diff<T> {
 
         @Nullable
         private final T part;
@@ -59,7 +67,7 @@ public abstract class AbstractDiffable<T extends Diffable<T>> implements Diffabl
         /**
          * Creates simple diff with changes
          */
-        CompleteDiff(T part) {
+        public CompleteDiff(T part) {
             this.part = part;
         }
 

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/RelationMetadataTest.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/RelationMetadataTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package org.elasticsearch.cluster.metadata;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.elasticsearch.cluster.Diff;
+import org.elasticsearch.cluster.metadata.IndexMetadata.State;
+import org.elasticsearch.common.UUIDs;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.settings.Settings;
+import org.junit.Test;
+
+import io.crate.metadata.RelationName;
+
+public class RelationMetadataTest {
+
+    @Test
+    public void test_diff_streaming() throws Exception {
+        RelationName t1 = new RelationName("blob", "t1");
+        RelationMetadata.BlobTable t1Open = new RelationMetadata.BlobTable(
+            t1,
+            UUIDs.randomBase64UUID(),
+            Settings.EMPTY,
+            State.OPEN
+        );
+        RelationMetadata.BlobTable t1Close = new RelationMetadata.BlobTable(
+            t1,
+            UUIDs.randomBase64UUID(),
+            Settings.EMPTY,
+            State.CLOSE
+        );
+
+        Diff<RelationMetadata> diff = t1Close.diff(t1Open);
+        try (var out = new BytesStreamOutput()) {
+            diff.writeTo(out);
+            try (var in = out.bytes().streamInput()) {
+                Diff<RelationMetadata> diffIn = RelationMetadata.readDiffFrom(in);
+                RelationMetadata relIn = diffIn.apply(null);
+
+                RelationMetadata.BlobTable blobIn = (RelationMetadata.BlobTable) relIn;
+                assertThat(blobIn.state()).isEqualTo(State.CLOSE);
+            }
+        }
+    }
+}
+

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/SchemaMetadataTest.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/SchemaMetadataTest.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package org.elasticsearch.cluster.metadata;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.Diff;
+import org.elasticsearch.cluster.metadata.IndexMetadata.State;
+import org.elasticsearch.common.UUIDs;
+import org.elasticsearch.common.collect.ImmutableOpenMap;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.ESTestCase;
+import org.junit.Test;
+
+import io.crate.metadata.RelationName;
+
+public class SchemaMetadataTest extends ESTestCase {
+
+    RelationName t1 = new RelationName("blob", "t1");
+    RelationMetadata.BlobTable relT1 = new RelationMetadata.BlobTable(
+        t1,
+        UUIDs.randomBase64UUID(),
+        Settings.EMPTY,
+        State.OPEN
+    );
+    RelationName t2 = new RelationName("blob", "t2");
+    RelationMetadata.BlobTable relT2 = new RelationMetadata.BlobTable(
+        t2,
+        UUIDs.randomBase64UUID(),
+        Settings.EMPTY,
+        State.OPEN
+    );
+    RelationName t3 = new RelationName("blob", "t3");
+    RelationMetadata.BlobTable relT3 = new RelationMetadata.BlobTable(
+        t3,
+        UUIDs.randomBase64UUID(),
+        Settings.EMPTY,
+        State.OPEN
+    );
+
+    private void assertRelations(int expected, SchemaMetadata schemaMetadata) {
+        ArrayList<RelationMetadata> actualRelations = new ArrayList<>();
+        schemaMetadata.relations().valuesIt().forEachRemaining(actualRelations::add);
+        if (expected == 3) {
+            assertThat(actualRelations).containsExactlyInAnyOrder(relT1, relT2, relT3);
+        } else {
+            assertThat(actualRelations).containsExactlyInAnyOrder(relT1, relT2);
+        }
+    }
+
+    @Test
+    public void test_diff_streaming() throws Exception {
+        ImmutableOpenMap.Builder<String, RelationMetadata> relationsV1 = ImmutableOpenMap.builder();
+        relationsV1.put("t1", relT1);
+        relationsV1.put("t2", relT2);
+        SchemaMetadata schemaV1 = new SchemaMetadata(relationsV1.build());
+
+        ImmutableOpenMap.Builder<String, RelationMetadata> relationsV2 = ImmutableOpenMap.builder();
+        relationsV2.put("t1", relT1);
+        relationsV2.put("t2", relT2);
+        relationsV2.put("t3", relT3);
+        SchemaMetadata schemaV2 = new SchemaMetadata(relationsV2.build());
+
+        SchemaMetadata before;
+        SchemaMetadata after;
+        int expectedRelations;
+        if (randomBoolean()) {
+            before = schemaV1;
+            after = schemaV2;
+            expectedRelations = 3;
+        } else {
+            before = schemaV2;
+            after = schemaV1;
+            expectedRelations = 2;
+        }
+
+        Diff<SchemaMetadata> diff = after.diff(before);
+        try (var out = new BytesStreamOutput()) {
+            diff.writeTo(out);
+            try (var in = out.bytes().streamInput()) {
+                Diff<SchemaMetadata> diffFrom = SchemaMetadata.readDiffFrom(in);
+                SchemaMetadata schemaIn = diffFrom.apply(after);
+                assertRelations(expectedRelations, schemaIn);
+            }
+        }
+
+        try (var out = new BytesStreamOutput()) {
+            out.setVersion(Version.V_6_1_0);
+            diff.writeTo(out);
+
+            try (var in = out.bytes().streamInput()) {
+                in.setVersion(Version.V_6_1_0);
+                Diff<SchemaMetadata> diffFrom = SchemaMetadata.readDiffFrom(in);
+                SchemaMetadata schemaIn = diffFrom.apply(after);
+                assertRelations(expectedRelations, schemaIn);
+
+                // ensure that deserialized diff can also be written back to 6.2.0 or 6.1.0
+                try (var out2 = new BytesStreamOutput()) {
+                    diffFrom.writeTo(out2);
+                    try (var in2 = out2.bytes().streamInput()) {
+                        Diff<SchemaMetadata> diffFrom2 = SchemaMetadata.readDiffFrom(in2);
+                        SchemaMetadata schemaIn2 = diffFrom2.apply(schemaV1);
+                        assertRelations(expectedRelations, schemaIn2);
+                    }
+                }
+
+                try (var out2 = new BytesStreamOutput()) {
+                    out2.setVersion(Version.V_6_1_0);
+                    diffFrom.writeTo(out2);
+                    try (var in2 = out2.bytes().streamInput()) {
+                        in2.setVersion(Version.V_6_1_0);
+                        Diff<SchemaMetadata> diffFrom2 = SchemaMetadata.readDiffFrom(in2);
+                        SchemaMetadata schemaIn2 = diffFrom2.apply(after);
+                        assertRelations(expectedRelations, schemaIn2);
+                    }
+                }
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
Instead of relying on `CompleteDiff` which always streams the full component
(all tables within a schema), this implements a custom diff to only stream the
changed table entries on metadata updates.

Creating 200 tables with 1000 columns each with data disk using tmpfs (in-memory) for exaggerated effects:

```
- In 5.10:      ~  5 sec
- In 6.0:       ~ 26 sec
- With this PR: ~ 10 sec
```

With nvme disk:

```
- 5.10:         ~50 sec
- 6.0:          ~61 sec
- With this PR: ~49 sec
```


To improve this further we probably have to look into: https://github.com/crate/crate/issues/18445
