### PR TITLE
Add `primary` flag to `ShardInfo` of `NodeInfo` MBean

### DIFF
--- a/blackbox/test_jmx.py
+++ b/blackbox/test_jmx.py
@@ -133,6 +133,7 @@ class JmxIntegrationTest(unittest.TestCase):
             )
             self.assertEqual(1, len(result))
             shardInfo = result[0]
+            self.assertTrue(shardInfo.containsKey("primary"))
             self.assertTrue(shardInfo.containsKey("partitionIdent"))
             self.assertTrue(shardInfo.containsKey("routingState"))
             self.assertTrue(shardInfo.containsKey("shardId"))

--- a/docs/admin/monitoring.rst
+++ b/docs/admin/monitoring.rst
@@ -183,6 +183,8 @@ NodeInfo can be accessed using the JMX MXBean object name
 |                         | the node.                                         |
 +-------------------------+---------------------------------------------------+
 
+.. _node_info_mxbean_shardstats:
+
 ``ShardStats`` returns a `CompositeData`_ object containing statistics about
 the number of shards located on the node with the following attributes:
 
@@ -200,6 +202,8 @@ the number of shards located on the node with the following attributes:
 |                   | will show the total number of unassigned shards in the  |
 |                   | cluster, otherwise 0.                                   |
 +-------------------+---------------------------------------------------------+
+
+.. _node_info_mxbean_shardinfo:
 
 ``ShardInfo`` returns an Array of `CompositeData`_ objects containing detailed
 information about the shards located on the node with the following attributes:
@@ -237,6 +241,9 @@ information about the shards located on the node with the following attributes:
 +--------------------+--------------------------------------------------------+
 | ``Size``           | The estimated cumulated size in bytes of all files of  |
 |                    | this shard.                                            |
++--------------------+--------------------------------------------------------+
+| ``Primary``        | Boolean flag, which shows whether the shard is a       |
+|                    | primary or a replica.                                  |
 +--------------------+--------------------------------------------------------+
 
 .. _jmx_monitoring-connections:

--- a/docs/appendices/release-notes/6.2.0.rst
+++ b/docs/appendices/release-notes/6.2.0.rst
@@ -150,6 +150,10 @@ Administration and Operations
 - Enabled TCP fallback for SRV DNS queries used when
   :ref:`Node Discovery via DNS <conf_dns_discovery>` is enabled.
 
+- Added a ``primary`` flag to :ref:`ShardInfo <node_info_mxbean_shardinfo>` to
+  expose whether the shard is primary or replica.
+
+
 Client interfaces
 -----------------
 

--- a/extensions/jmx-monitoring/src/main/java/io/crate/beans/NodeInfo.java
+++ b/extensions/jmx-monitoring/src/main/java/io/crate/beans/NodeInfo.java
@@ -146,7 +146,8 @@ public class NodeInfo implements NodeInfoMXBean {
                         partitionName.ident() == null ? "" : partitionName.ident(),
                         routingState.name(),
                         stateAndStoreSize.state().name(),
-                        stateAndStoreSize.storeSizeBytes())
+                        stateAndStoreSize.storeSizeBytes(),
+                        shardRouting.primary())
                     );
                 }
             }

--- a/extensions/jmx-monitoring/src/main/java/io/crate/beans/ShardInfo.java
+++ b/extensions/jmx-monitoring/src/main/java/io/crate/beans/ShardInfo.java
@@ -32,15 +32,17 @@ public class ShardInfo {
     final String table;
     final String partitionIdent;
     final long size;
+    final boolean primary;
 
-    @ConstructorProperties({"shardId", "schema", "table", "partitionIdent", "routingState", "state", "size"})
+    @ConstructorProperties({"shardId", "schema", "table", "partitionIdent", "routingState", "state", "size", "primary"})
     public ShardInfo(int shardId,
                      String schema,
                      String table,
                      String partitionIdent,
                      String routingState,
                      String state,
-                     long size) {
+                     long size,
+                     boolean primary) {
         this.shardId = shardId;
         this.routingState = routingState;
         this.state = state;
@@ -48,6 +50,7 @@ public class ShardInfo {
         this.table = table;
         this.partitionIdent = partitionIdent;
         this.size = size;
+        this.primary = primary;
     }
 
     @SuppressWarnings("unused")
@@ -82,5 +85,10 @@ public class ShardInfo {
     @SuppressWarnings("unused")
     public long getSize() {
         return size;
+    }
+
+    @SuppressWarnings("unused")
+    public boolean isPrimary() {
+        return primary;
     }
 }

--- a/extensions/jmx-monitoring/src/test/java/io/crate/beans/NodeInfoTest.java
+++ b/extensions/jmx-monitoring/src/test/java/io/crate/beans/NodeInfoTest.java
@@ -123,9 +123,9 @@ public class NodeInfoTest extends CrateDummyClusterServiceUnitTest {
 
         assertThat(nodeInfo.getShardInfo())
             .satisfiesExactlyInAnyOrder(
-                isShardInfo(1, "test", "", "STARTED", "STARTED", 100),
-                isShardInfo(2, "test", "", "STARTED", "STARTED", 100),
-                isShardInfo(3, "test", "", "STARTED", "STARTED", 100));
+                isShardInfo(1, "test", "", "STARTED", "STARTED", 100, true),
+                isShardInfo(2, "test", "", "STARTED", "STARTED", 100, false),
+                isShardInfo(3, "test", "", "STARTED", "STARTED", 100, false));
     }
 
     @Test
@@ -193,9 +193,9 @@ public class NodeInfoTest extends CrateDummyClusterServiceUnitTest {
 
         assertThat(nodeInfo.getShardInfo())
             .satisfiesExactlyInAnyOrder(
-               isShardInfo(1, relationName.name(), "", "STARTED", "STARTED", 100),
-               isShardInfo(2, relationName.name(), "", "STARTED", "STARTED", 100),
-               isShardInfo(3, relationName.name(), "", "STARTED", "STARTED", 100));
+               isShardInfo(1, relationName.name(), "", "STARTED", "STARTED", 100, true),
+               isShardInfo(2, relationName.name(), "", "STARTED", "STARTED", 100, false),
+               isShardInfo(3, relationName.name(), "", "STARTED", "STARTED", 100, false));
     }
 
     @Test
@@ -248,9 +248,9 @@ public class NodeInfoTest extends CrateDummyClusterServiceUnitTest {
 
         assertThat(nodeInfo.getShardInfo())
             .satisfiesExactlyInAnyOrder(
-               isShardInfo(1, relationName.name(), partitionName.ident(), "STARTED", "STARTED", 100),
-               isShardInfo(2, relationName.name(), partitionName.ident(), "STARTED", "STARTED", 100),
-               isShardInfo(3, relationName.name(), partitionName.ident(), "STARTED", "STARTED", 100));
+               isShardInfo(1, relationName.name(), partitionName.ident(), "STARTED", "STARTED", 100, true),
+               isShardInfo(2, relationName.name(), partitionName.ident(), "STARTED", "STARTED", 100, false),
+               isShardInfo(3, relationName.name(), partitionName.ident(), "STARTED", "STARTED", 100, false));
 
     }
 
@@ -267,13 +267,20 @@ public class NodeInfoTest extends CrateDummyClusterServiceUnitTest {
                                  Version.CURRENT);
     }
 
-    ThrowingConsumer<ShardInfo> isShardInfo(int shardId, String table, String partitionIdent, String routingState, String state, long size) {
+    ThrowingConsumer<ShardInfo> isShardInfo(int shardId,
+                                            String table,
+                                            String partitionIdent,
+                                            String routingState,
+                                            String state,
+                                            long size,
+                                            boolean primary) {
         return s -> assertThat(s)
             .satisfies(si -> assertThat(si.shardId).isEqualTo(shardId))
             .satisfies(si -> assertThat(si.table).isEqualTo(table))
             .satisfies(si -> assertThat(si.routingState).isEqualTo(routingState))
             .satisfies(si -> assertThat(si.state).isEqualTo(state))
             .satisfies(si -> assertThat(si.partitionIdent).isEqualTo(partitionIdent))
-            .satisfies(si -> assertThat(si.size).isEqualTo(size));
+            .satisfies(si -> assertThat(si.size).isEqualTo(size))
+            .satisfies(si -> assertThat(si.primary).isEqualTo(primary));
     }
 }


### PR DESCRIPTION
This enables to have an overview on how many primary shards are allocated per table/partition on each node.

