### PR TITLE
README: Fix Docker invocation on Windows/PowerShell

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,7 +75,7 @@ Run CrateDB via the official `Docker Image`_:
 
 .. code-block:: console
 
-    sh$ docker run --publish 4200:4200 --publish 5432:5432 --env CRATE_HEAP_SIZE=1g crate -Cdiscovery.type=single-node
+    sh$ docker run --publish 4200:4200 --publish 5432:5432 --env CRATE_HEAP_SIZE=1g crate '-Cdiscovery.type=single-node'
 
 Or visit the `installation documentation`_ to see all the available download and
 install options.


### PR DESCRIPTION
## About
Fix README to make CrateDB start properly on Windows+PowerShell+Docker.

## Details
> The workaround for Docker is to include each setting in single
> quotes, like `'-Cdiscovery.type=single-node'`.

Otherwise, users will receive an error like this:
```java
NullPointerException: Cannot invoke "String.isEmpty()"
```

## References
- https://github.com/crate/cratedb-guide/issues/325
- https://github.com/crate/cratedb-guide/issues/390#issuecomment-3410751473
- https://github.com/crate/cratedb-guide/pull/460