### PR TITLE
Use DiscoveryNodes instead of `Collection<DiscoveryNode>`

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodes.java
+++ b/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodes.java
@@ -100,6 +100,10 @@ public class DiscoveryNodes implements Diffable<DiscoveryNodes>, Iterable<Discov
         return localNodeId.equals(masterNodeId);
     }
 
+    public boolean isEmpty() {
+        return nodes.isEmpty();
+    }
+
     /**
      * Get the number of known nodes
      *
@@ -514,7 +518,7 @@ public class DiscoveryNodes implements Diffable<DiscoveryNodes>, Iterable<Discov
                 summary.append("]}");
             }
             if (removed()) {
-                if (summary.length() > 0) {
+                if (!summary.isEmpty()) {
                     summary.append(", ");
                 }
                 summary.append("removed {");
@@ -526,7 +530,7 @@ public class DiscoveryNodes implements Diffable<DiscoveryNodes>, Iterable<Discov
             if (added()) {
                 // don't print if there is one added, and it is us
                 if (!(addedNodes().size() == 1 && addedNodes().get(0).getId().equals(localNodeId))) {
-                    if (summary.length() > 0) {
+                    if (!summary.isEmpty()) {
                         summary.append(", ");
                     }
                     summary.append("added {");


### PR DESCRIPTION
DiscoverNodes is already and `Iterable<DiscoveryNode>` with `getSize()`, so no need to create and pass around a List<DiscoveryNode>. This will also help with implementation for #18453, where we need to pass around the masterNodeId, which is already contained in `DiscoverNodes`.

