### PR TITLE
Add missing change entries and release 5.10.14

### DIFF
--- a/docs/appendices/release-notes/5.10.14.rst
+++ b/docs/appendices/release-notes/5.10.14.rst
@@ -1,16 +1,10 @@
 .. _version_5.10.14:
 
-============================
-Version 5.10.14 - Unreleased
-============================
+===============
+Version 5.10.14
+===============
 
-.. comment 1. Remove the " - Unreleased" from the header above and adjust the ==
-.. comment 2. Remove the NOTE below and replace with: "Released on 20XX-XX-XX."
-.. comment    (without a NOTE entry, simply starting from col 1 of the line)
-.. NOTE::
-
-    In development. 5.10.14 isn't released yet. These are the release notes for
-    the upcoming release.
+Released on 2025-11-03.
 
 .. NOTE::
 

--- a/server/src/main/java/org/elasticsearch/Version.java
+++ b/server/src/main/java/org/elasticsearch/Version.java
@@ -241,7 +241,7 @@ public class Version implements Comparable<Version> {
     public static final Version V_5_10_11 = new Version(8_10_11_99, false, org.apache.lucene.util.Version.LUCENE_9_12_0);
     public static final Version V_5_10_12 = new Version(8_10_12_99, false, org.apache.lucene.util.Version.LUCENE_9_12_0);
     public static final Version V_5_10_13 = new Version(8_10_13_99, false, org.apache.lucene.util.Version.LUCENE_9_12_3);
-    public static final Version V_5_10_14 = new Version(8_10_14_99, true, org.apache.lucene.util.Version.LUCENE_9_12_3);
+    public static final Version V_5_10_14 = new Version(8_10_14_99, false, org.apache.lucene.util.Version.LUCENE_9_12_3);
 
     public static final Version CURRENT = V_5_10_14;
 


### PR DESCRIPTION

Release 5.10.14 

Added change entries for https://github.com/crate/crate/pull/18629, https://github.com/crate/crate/pull/18627 and https://github.com/crate/crate/pull/18628 

https://github.com/crate/crate/pull/18626 was backported as well, but don't have a change entry

