### PR TITLE
Rename roles() to getRoles() in NodeInfo MBean

### DIFF
--- a/extensions/jmx-monitoring/src/main/java/io/crate/beans/NodeInfo.java
+++ b/extensions/jmx-monitoring/src/main/java/io/crate/beans/NodeInfo.java
@@ -72,7 +72,7 @@ public class NodeInfo implements NodeInfoMXBean {
     }
 
     @Override
-    public List<String> roles() {
+    public List<String> getRoles() {
         return clusterState.get().nodes().getLocalNode().roles().stream()
             .map(DiscoveryNodeRole::externalName)
             .sorted()

--- a/extensions/jmx-monitoring/src/main/java/io/crate/beans/NodeInfoMXBean.java
+++ b/extensions/jmx-monitoring/src/main/java/io/crate/beans/NodeInfoMXBean.java
@@ -40,7 +40,7 @@ public interface NodeInfoMXBean {
 
     boolean isMaster();
 
-    List<String> roles();
+    List<String> getRoles();
 
     long getClusterStateVersion();
 

--- a/extensions/jmx-monitoring/src/test/java/io/crate/beans/NodeInfoTest.java
+++ b/extensions/jmx-monitoring/src/test/java/io/crate/beans/NodeInfoTest.java
@@ -107,7 +107,7 @@ public class NodeInfoTest extends CrateDummyClusterServiceUnitTest {
         assertThat(nodeInfo.getNodeId()).isEqualTo("node_1");
         assertThat(nodeInfo.getNodeName()).isEqualTo("node_1");
         assertThat(nodeInfo.isMaster()).isTrue();
-        assertThat(nodeInfo.roles()).containsExactly("data", "master_eligible");
+        assertThat(nodeInfo.getRoles()).containsExactly("data", "master_eligible");
 
         assertThat(nodeInfo.getClusterStateVersion()).isEqualTo(1L);
         ShardStats shardStats = nodeInfo.getShardStats();
@@ -139,7 +139,7 @@ public class NodeInfoTest extends CrateDummyClusterServiceUnitTest {
         assertThat(nodeInfo.getNodeId()).isEqualTo("node_2");
         assertThat(nodeInfo.getNodeName()).isEqualTo("node_2");
         assertThat(nodeInfo.isMaster()).isFalse();
-        assertThat(nodeInfo.roles()).containsExactly("data", "master_eligible");
+        assertThat(nodeInfo.getRoles()).containsExactly("data", "master_eligible");
 
         var shardStats = nodeInfo.getShardStats();
         assertThat(shardStats.getPrimaries()).isEqualTo(0);
@@ -163,7 +163,7 @@ public class NodeInfoTest extends CrateDummyClusterServiceUnitTest {
         assertThat(nodeInfo.getNodeId()).isEqualTo("node_2");
         assertThat(nodeInfo.getNodeName()).isEqualTo("node_2");
         assertThat(nodeInfo.isMaster()).isTrue();
-        assertThat(nodeInfo.roles()).containsExactly("master_eligible");
+        assertThat(nodeInfo.getRoles()).containsExactly("master_eligible");
 
         var shardStats = nodeInfo.getShardStats();
         assertThat(shardStats.getPrimaries()).isEqualTo(0);
@@ -189,7 +189,7 @@ public class NodeInfoTest extends CrateDummyClusterServiceUnitTest {
         assertThat(nodeInfo.getNodeId()).isEqualTo("node_1");
         assertThat(nodeInfo.getNodeName()).isEqualTo("node_1");
         assertThat(nodeInfo.isMaster()).isFalse();
-        assertThat(nodeInfo.roles()).containsExactly("data");
+        assertThat(nodeInfo.getRoles()).containsExactly("data");
 
         var shardStats = nodeInfo.getShardStats();
         assertThat(shardStats.getPrimaries()).isEqualTo(1);


### PR DESCRIPTION
Otherwise the attribute is not exposed from the MBeanServer. Add python blackbox test for getRoles() and isMaster()

Follows: #18646

