### PR TITLE
tests: don't start a new cluster

### DIFF
--- a/server/src/test/java/io/crate/execution/dml/IndexerTest.java
+++ b/server/src/test/java/io/crate/execution/dml/IndexerTest.java
@@ -88,7 +88,6 @@ import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.DataTypeTesting;
 import io.crate.testing.IndexEnv;
 import io.crate.testing.SQLExecutor;
-import io.crate.testing.UseNewCluster;
 import io.crate.types.ArrayType;
 import io.crate.types.BitStringType;
 import io.crate.types.BooleanType;
@@ -1368,7 +1367,6 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
         assertTranslogParses(doc, e.resolveTableInfo("tbl"), Version.V_5_4_0);
     }
 
-    @UseNewCluster
     @Test
     public void test_ignored_object_child_columns_are_prefixed() throws Exception {
         SQLExecutor e = SQLExecutor.of(clusterService)
@@ -1415,7 +1413,6 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
      * {@link TranslogIndexer#index(String, BytesReference)} is used to parse translog entries,
      * ensure it can parse a document containing OIDs instead of column names.
      */
-    @UseNewCluster
     @Test
     public void test_translog_indexer_can_read_source_with_oids() throws Exception {
         var tableName = "tbl";

--- a/server/src/test/java/io/crate/integrationtests/AlterTableIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/AlterTableIntegrationTest.java
@@ -42,7 +42,6 @@ import io.crate.common.unit.TimeValue;
 import io.crate.execution.ddl.tables.AlterTableClient;
 import io.crate.testing.Asserts;
 import io.crate.testing.TestingHelpers;
-import io.crate.testing.UseNewCluster;
 
 public class AlterTableIntegrationTest extends IntegTestCase {
 
@@ -221,7 +220,6 @@ public class AlterTableIntegrationTest extends IntegTestCase {
     }
 
     @Test
-    @UseNewCluster
     public void test_alter_table_drop_column_can_add_again() {
         execute("create table t(a integer, b integer, o object AS(a int, oo object AS(a int)))");
         execute("insert into t(a, b, o) values(1, 11, '{\"a\":111, \"oo\":{\"a\":1111}}')");
@@ -230,7 +228,6 @@ public class AlterTableIntegrationTest extends IntegTestCase {
     }
 
     @Test
-    @UseNewCluster
     public void test_alter_partitioned_table_drop_column_can_add_again() {
         // Method execute_statements_that_drop_and_add_column_with_the_same_name_again has some INSERT statements.
         // Using generated partitioned column in order not to adjust them.

--- a/server/src/test/java/io/crate/integrationtests/CopyIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/CopyIntegrationTest.java
@@ -26,7 +26,6 @@ import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
 import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.TestingHelpers.printedTable;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
@@ -63,7 +62,6 @@ import io.crate.session.Sessions;
 import io.crate.testing.Asserts;
 import io.crate.testing.SQLResponse;
 import io.crate.testing.UseJdbc;
-import io.crate.testing.UseNewCluster;
 import io.crate.testing.UseRandomizedSchema;
 
 @IntegTestCase.ClusterScope(numDataNodes = 2)
@@ -884,7 +882,6 @@ public class CopyIntegrationTest extends SQLHttpIntegrationTest {
         );
     }
 
-    @UseNewCluster
     @Test
     public void test_copy_excludes_partitioned_values_from_source() throws Exception {
         execute("create table tbl (x int, p int) partitioned by (p)");

--- a/server/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
@@ -54,7 +54,6 @@ import io.crate.sql.tree.ColumnPolicy;
 import io.crate.testing.Asserts;
 import io.crate.testing.TestingHelpers;
 import io.crate.testing.UseJdbc;
-import io.crate.testing.UseNewCluster;
 import io.crate.testing.UseRandomizedOptimizerRules;
 import io.crate.testing.UseRandomizedSchema;
 import io.crate.types.DataTypes;
@@ -66,7 +65,6 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 public class DDLIntegrationTest extends IntegTestCase {
 
     @Test
-    @UseNewCluster
     public void testCreateTable() throws Exception {
         execute("create table test (col1 integer primary key, col2 string) " +
                 "clustered into 5 shards with (number_of_replicas = 1, \"write.wait_for_active_shards\"=1)");
@@ -126,7 +124,6 @@ public class DDLIntegrationTest extends IntegTestCase {
     }
 
     @Test
-    @UseNewCluster
     public void testCreateTableWithReplicasAndShards() throws Exception {
         execute("create table test (col1 integer primary key, col2 string)" +
                 "clustered by (col1) into 10 shards with (number_of_replicas=2, \"write.wait_for_active_shards\"=1)");
@@ -145,7 +142,6 @@ public class DDLIntegrationTest extends IntegTestCase {
     }
 
     @Test
-    @UseNewCluster
     public void testCreateTableWithStrictColumnPolicy() throws Exception {
         execute("create table test (col1 integer primary key, col2 string) " +
                 "clustered into 5 shards " +
@@ -165,7 +161,6 @@ public class DDLIntegrationTest extends IntegTestCase {
     }
 
     @Test
-    @UseNewCluster
     public void testCreateGeoShapeExplicitIndex() throws Exception {
         execute("create table test (col1 geo_shape INDEX using QUADTREE with (precision='1m', distance_error_pct='0.25'))");
         DocTableInfo table = getTable("test");
@@ -183,7 +178,6 @@ public class DDLIntegrationTest extends IntegTestCase {
     }
 
     @Test
-    @UseNewCluster
     public void testCreateColumnWithDefaultExpression() throws Exception {
         execute("create table test (id int, col1 text default 'foo', col2 int[] default [1,2])");
         DocTableInfo table = getTable("test");
@@ -209,7 +203,6 @@ public class DDLIntegrationTest extends IntegTestCase {
     }
 
     @Test
-    @UseNewCluster
     public void testCreateGeoShape() throws Exception {
         execute("create table test (col1 geo_shape)");
         DocTableInfo table = getTable("test");
@@ -311,7 +304,6 @@ public class DDLIntegrationTest extends IntegTestCase {
     }
 
     @Test
-    @UseNewCluster
     public void testCreateTableWithCompositeIndex() throws Exception {
         execute("""
             create table novels (
@@ -595,7 +587,6 @@ public class DDLIntegrationTest extends IntegTestCase {
     }
 
     @Test
-    @UseNewCluster
     public void testAlterTableAddObjectColumnToExistingObject() throws IOException {
         execute("create table t (o object as (x string)) " +
                 "clustered into 1 shards " +
@@ -861,7 +852,6 @@ public class DDLIntegrationTest extends IntegTestCase {
     }
 
     @Test
-    @UseNewCluster
     public void testCreateTableWithGeneratedColumn() throws Exception {
         execute(
             "create table test (" +
@@ -885,7 +875,6 @@ public class DDLIntegrationTest extends IntegTestCase {
     }
 
     @Test
-    @UseNewCluster
     public void testAddGeneratedColumnToTableWithExistingGeneratedColumns() throws Exception {
         execute(
             "create table test (" +

--- a/server/src/test/java/io/crate/integrationtests/DynamicMappingUpdateITest.java
+++ b/server/src/test/java/io/crate/integrationtests/DynamicMappingUpdateITest.java
@@ -40,9 +40,7 @@ import org.junit.rules.TemporaryFolder;
 
 import io.crate.metadata.Reference;
 import io.crate.metadata.doc.DocTableInfo;
-import io.crate.testing.UseNewCluster;
 import io.crate.testing.UseRandomizedSchema;
-
 
 @UseRandomizedSchema(random = false)
 public class DynamicMappingUpdateITest extends IntegTestCase {
@@ -51,14 +49,12 @@ public class DynamicMappingUpdateITest extends IntegTestCase {
     public TemporaryFolder folder = new TemporaryFolder();
 
     @Test
-    @UseNewCluster
     public void test_concurrent_statements_that_add_columns_result_in_dynamic_mapping_updates() throws InterruptedException, IOException {
         execute("create table t (a int, b object as (x int))");
         execute_concurrent_statements_that_add_columns_result_in_dynamic_mapping_updates();
     }
 
     @Test
-    @UseNewCluster
     public void test_concurrent_statements_that_add_columns_to_partitioned_table_result_in_dynamic_mapping_updates() throws InterruptedException, IOException {
         execute("create table t (a int, b object as (x int)) partitioned by (a)");
         execute_concurrent_statements_that_add_columns_result_in_dynamic_mapping_updates();

--- a/server/src/test/java/io/crate/integrationtests/ObjectColumnTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ObjectColumnTest.java
@@ -39,7 +39,6 @@ import org.junit.Test;
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.testing.Asserts;
 import io.crate.testing.UseJdbc;
-import io.crate.testing.UseNewCluster;
 
 public class ObjectColumnTest extends IntegTestCase {
 
@@ -433,7 +432,6 @@ public class ObjectColumnTest extends IntegTestCase {
     }
 
     @Test
-    @UseNewCluster
     public void test_add_sub_column_with_numeric_name_into_ignored_object() {
         execute("create table t (o object(ignored) as (a int))");
 

--- a/server/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
@@ -63,7 +63,6 @@ import io.crate.testing.Asserts;
 import io.crate.testing.SQLResponse;
 import io.crate.testing.TestingHelpers;
 import io.crate.testing.UseJdbc;
-import io.crate.testing.UseNewCluster;
 import io.crate.testing.UseRandomizedOptimizerRules;
 import io.crate.testing.UseRandomizedSchema;
 
@@ -1869,7 +1868,6 @@ public class PartitionedTableIntegrationTest extends IntegTestCase {
         execute("alter table t set (number_of_replicas = 0)");
     }
 
-    @UseNewCluster
     @Test
     public void testPartitionedColumnIsNotIn_Raw() throws Exception {
         execute("create table t (p string primary key, v string) " +
@@ -2137,7 +2135,6 @@ public class PartitionedTableIntegrationTest extends IntegTestCase {
         assertThat(printedTable(execute("SELECT count(*) FROM test").rows())).isEqualTo("2\n");
     }
 
-    @UseNewCluster
     @Test
     public void test_nested_partition_column_is_included_when_selecting_the_object_but_not_in_the_source() {
         execute("create table tbl (pk object as (id text, part text), primary key (pk['id'], pk['part'])) " +

--- a/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
@@ -45,7 +45,6 @@ import io.crate.role.Roles;
 import io.crate.session.Sessions;
 import io.crate.testing.UseHashJoins;
 import io.crate.testing.UseJdbc;
-import io.crate.testing.UseNewCluster;
 import io.crate.testing.UseRandomizedOptimizerRules;
 import io.crate.testing.UseRandomizedSchema;
 
@@ -447,7 +446,6 @@ public class PgCatalogITest extends IntegTestCase {
     }
 
     @Test
-    @UseNewCluster // Dropped column prefix contains OID and must be deterministic.
     public void test_dropped_columns_shown_in_pg_attribute() {
         execute("create table t(a integer, o object AS(oo object AS(a int)))");
 


### PR DESCRIPTION
Not needed as we switched to table scoped OIDs in https://github.com/crate/crate/pull/18625

