### PR TITLE
Add WITH (timeout = ...) for ALTER TABLE SET

### DIFF
--- a/docs/appendices/release-notes/6.2.0.rst
+++ b/docs/appendices/release-notes/6.2.0.rst
@@ -147,6 +147,9 @@ Performance and Resilience Improvements
 Administration and Operations
 -----------------------------
 
+- Added a ``WITH`` clause with a ``timeout`` property to
+  :ref:`ALTER TABLE .. SET <sql-alter-table>`.
+
 - Enabled TCP fallback for SRV DNS queries used when
   :ref:`Node Discovery via DNS <conf_dns_discovery>` is enabled.
 

--- a/docs/sql/statements/alter-table.rst
+++ b/docs/sql/statements/alter-table.rst
@@ -17,8 +17,8 @@ Synopsis
 
     ALTER [ BLOB ] TABLE { ONLY table_ident
                            | table_ident [ PARTITION (partition_column = value [ , ... ]) ] }
-      { SET ( parameter = value [ , ... ] )
-        | RESET ( parameter [ , ... ] )
+      { SET ( parameter = value [ , ... ] ) [ WITH ( property = value [ , ...] ) ]
+        | RESET ( parameter [ , ... ] ) [ WITH ( property = value [ , ...] ) ]
         | { ADD [ COLUMN ] column_name data_type [ column_constraint [ ... ] ] } [, ... ]
         | { DROP [ COLUMN ] [ IF EXISTS ] column_name } [, ... ]
         | { RENAME [ COLUMN ] column_name TO new_name } [, ... ]
@@ -147,6 +147,16 @@ changing the number of :ref:`allocated shards <gloss-shard-allocation>`, the
 parameter ``number_of_shards`` can be used. For more info on that, see
 :ref:`alter-shard-number`.
 
+
+The additional ``WITH`` clause can be used to set properties changing the
+behavior of the statement. Supported properties are:
+
+
+:timeout:
+  Sets the timeout for the statement. Defaults to 60 seconds for resize
+  operations and 30 seconds for other setting changes.
+  Note that if a global or per session :ref:`statement_timeout
+  <conf-session-statement-timeout>` is shorter, it will take effect first.
 
 .. _sql-alter-table-add-column:
 

--- a/libs/sql-parser/src/main/antlr/io/crate/sql/parser/antlr/SqlBaseParser.g4
+++ b/libs/sql-parser/src/main/antlr/io/crate/sql/parser/antlr/SqlBaseParser.g4
@@ -124,7 +124,8 @@ alterStmt
     | ALTER TABLE alterTableDefinition DROP CONSTRAINT ident                         #dropCheckConstraint
     | ALTER TABLE alterTableDefinition
         (SET OPEN_ROUND_BRACKET genericProperties CLOSE_ROUND_BRACKET
-        | RESET (OPEN_ROUND_BRACKET ident (COMMA ident)* CLOSE_ROUND_BRACKET)?)      #alterTableProperties
+        | RESET (OPEN_ROUND_BRACKET ident (COMMA ident)* CLOSE_ROUND_BRACKET)?)
+        withProperties?                                                              #alterTableProperties
     | ALTER BLOB TABLE alterTableDefinition
         (SET OPEN_ROUND_BRACKET genericProperties CLOSE_ROUND_BRACKET
         | RESET (OPEN_ROUND_BRACKET ident (COMMA ident)* CLOSE_ROUND_BRACKET)?)      #alterBlobTableProperties

--- a/libs/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
@@ -47,6 +47,7 @@ import io.crate.sql.tree.AlterRoleReset;
 import io.crate.sql.tree.AlterRoleSet;
 import io.crate.sql.tree.AlterServer;
 import io.crate.sql.tree.AlterSubscription;
+import io.crate.sql.tree.AlterTable;
 import io.crate.sql.tree.Assignment;
 import io.crate.sql.tree.AstVisitor;
 import io.crate.sql.tree.CascadeMode;
@@ -734,6 +735,37 @@ public final class SqlFormatter {
                 appendNewLineOrSpace();
                 node.properties().accept(this, indent);
             }
+            return null;
+        }
+
+        @Override
+        public Void visitAlterTable(AlterTable<?> node, Integer indent) {
+            builder.append("ALTER TABLE ");
+            node.table().accept(this, indent);
+
+            if (node.resetProperties().isEmpty()) {
+                builder.append(" SET (");
+                appendProperties(node.setProperties(), indent);
+                builder.append(")");
+            } else {
+                builder.append(" RESET (");
+                Iterator<String> iterator = node.resetProperties().iterator();
+                while (iterator.hasNext()) {
+                    String property = iterator.next();
+                    builder.append(property);
+                    if (iterator.hasNext()) {
+                        builder.append(", ");
+                    }
+                }
+                builder.append(")");
+            }
+
+            if (!node.withProperties().isEmpty()) {
+                builder.append(" WITH (");
+                appendProperties(node.withProperties(), indent);
+                builder.append(")");
+            }
+
             return null;
         }
 

--- a/libs/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -1387,14 +1387,14 @@ class AstBuilder extends SqlBaseParserBaseVisitor<Node> {
 
     // Amending tables
 
-    @SuppressWarnings({"rawtypes", "unchecked"})
+    @SuppressWarnings({"unchecked"})
     @Override
     public Node visitAlterTableProperties(SqlBaseParser.AlterTablePropertiesContext context) {
-        Table<?> name = (Table<?>) visit(context.alterTableDefinition());
-        if (context.SET() != null) {
-            return new AlterTable(name, extractGenericProperties(context.genericProperties()));
-        }
-        return new AlterTable(name, identsToStrings(context.ident()));
+        Table<Expression> name = (Table<Expression>) visit(context.alterTableDefinition());
+        GenericProperties<Expression> withProperties = extractGenericProperties(context.withProperties());
+        GenericProperties<Expression> setProperties = extractGenericProperties(context.genericProperties());
+        List<String> resetProperties = identsToStrings(context.ident());
+        return new AlterTable<>(name, setProperties, resetProperties, withProperties);
     }
 
     @SuppressWarnings({"unchecked"})
@@ -1417,10 +1417,10 @@ class AstBuilder extends SqlBaseParserBaseVisitor<Node> {
             }
             default -> throw new IllegalArgumentException("Invalid tableName \"" + name + "\"");
         };
-        if (context.SET() != null) {
-            return new AlterTable<>(table, extractGenericProperties(context.genericProperties()));
-        }
-        return new AlterTable<>(table, identsToStrings(context.ident()));
+        GenericProperties<Expression> withProperties = GenericProperties.empty();
+        GenericProperties<Expression> setProperties = extractGenericProperties(context.genericProperties());
+        List<String> resetProperties = identsToStrings(context.ident());
+        return new AlterTable<>(table, setProperties, resetProperties, withProperties);
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/AlterTable.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/AlterTable.java
@@ -28,25 +28,18 @@ import java.util.function.Function;
 public class AlterTable<T> extends Statement {
 
     private final Table<T> table;
-    private final GenericProperties<T> genericProperties;
+    private final GenericProperties<T> setProperties;
     private final List<String> resetProperties;
+    private final GenericProperties<T> withProperties;
 
-    public AlterTable(Table<T> table, GenericProperties<T> genericProperties) {
+    public AlterTable(Table<T> table,
+                      GenericProperties<T> setProperties,
+                      List<String> resetProperties,
+                      GenericProperties<T> withProperties) {
         this.table = table;
-        this.genericProperties = genericProperties;
-        this.resetProperties = List.of();
-    }
-
-    public AlterTable(Table<T> table, List<String> resetProperties) {
-        this.table = table;
+        this.setProperties = setProperties;
         this.resetProperties = resetProperties;
-        this.genericProperties = GenericProperties.empty();
-    }
-
-    private AlterTable(Table<T> table, GenericProperties<T> genericProperties, List<String> resetProperties) {
-        this.table = table;
-        this.genericProperties = genericProperties;
-        this.resetProperties = resetProperties;
+        this.withProperties = withProperties;
     }
 
     @Override
@@ -58,19 +51,24 @@ public class AlterTable<T> extends Statement {
         return table;
     }
 
-    public GenericProperties<T> genericProperties() {
-        return genericProperties;
+    public GenericProperties<T> setProperties() {
+        return setProperties;
     }
 
     public List<String> resetProperties() {
         return resetProperties;
     }
 
+    public GenericProperties<T> withProperties() {
+        return withProperties;
+    }
+
     public <U> AlterTable<U> map(Function<? super T, ? extends U> mapper) {
         return new AlterTable<>(
             table.map(mapper),
-            genericProperties.map(mapper),
-            resetProperties
+            setProperties.map(mapper),
+            resetProperties,
+            withProperties.map(mapper)
         );
     }
 
@@ -83,22 +81,24 @@ public class AlterTable<T> extends Statement {
             return false;
         }
         AlterTable<?> that = (AlterTable<?>) o;
-        return Objects.equals(table, that.table) &&
-               Objects.equals(genericProperties, that.genericProperties) &&
-               Objects.equals(resetProperties, that.resetProperties);
+        return table.equals(that.table)
+            && setProperties.equals(that.setProperties)
+            && resetProperties.equals(that.resetProperties)
+            && withProperties.equals(that.withProperties);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(table, genericProperties, resetProperties);
+        return Objects.hash(table, setProperties, resetProperties, withProperties);
     }
 
     @Override
     public String toString() {
         return "AlterTable{" +
                "table=" + table +
-               ", genericProperties=" + genericProperties +
-               ", resetProperties=" + resetProperties +
+               ", set=" + setProperties +
+               ", reset=" + resetProperties +
+               ", with=" + withProperties +
                '}';
     }
 }

--- a/libs/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/libs/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -41,6 +41,7 @@ import io.crate.sql.tree.AlterRoleReset;
 import io.crate.sql.tree.AlterRoleSet;
 import io.crate.sql.tree.AlterServer;
 import io.crate.sql.tree.AlterSubscription;
+import io.crate.sql.tree.AlterTable;
 import io.crate.sql.tree.ArrayComparisonExpression;
 import io.crate.sql.tree.ArrayLikePredicate;
 import io.crate.sql.tree.ArrayLiteral;
@@ -647,6 +648,7 @@ public class TestStatementBuilder {
         printStatement("alter table t add foo integer null");
 
         printStatement("alter table t set (number_of_replicas=4)");
+        printStatement("alter table t set (number_of_replicas=4) with (timeout = '60s')");
         printStatement("alter table schema.t set (number_of_replicas=4)");
         printStatement("alter table t reset (number_of_replicas)");
         printStatement("alter table t reset (property1, property2, property3)");
@@ -2285,7 +2287,8 @@ public class TestStatementBuilder {
             statement instanceof CreateUserMapping ||
             statement instanceof DropServer ||
             statement instanceof DropForeignTable ||
-            statement instanceof DropUserMapping) {
+            statement instanceof DropUserMapping ||
+            statement instanceof AlterTable) {
 
 
             println(SqlFormatter.formatSql(statement));

--- a/server/src/main/java/io/crate/analyze/AlterTableAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/AlterTableAnalyzer.java
@@ -22,6 +22,7 @@
 package io.crate.analyze;
 
 import java.util.List;
+import java.util.Set;
 
 import io.crate.analyze.expressions.ExpressionAnalysisContext;
 import io.crate.analyze.expressions.ExpressionAnalyzer;
@@ -45,6 +46,8 @@ import io.crate.sql.tree.Table;
 
 class AlterTableAnalyzer {
 
+    private static final Set<String> SUPPORTED_WITH_PROPERTIES = Set.of("timeout");
+
     private final Schemas schemas;
     private final NodeContext nodeCtx;
 
@@ -62,12 +65,14 @@ class AlterTableAnalyzer {
         CoordinatorSessionSettings sessionSettings = txnCtx.sessionSettings();
         var exprCtx = new ExpressionAnalysisContext(sessionSettings);
         AlterTable<Symbol> alterTable = node.map(x -> exprAnalyzerWithFieldsAsString.convert(x, exprCtx));
+        alterTable.withProperties().ensureContainsOnly(SUPPORTED_WITH_PROPERTIES);
         TableInfo TableInfo = schemas.findRelation(
             alterTable.table().getName(),
             Operation.ALTER_BLOCKS,
             sessionSettings.sessionUser(),
             sessionSettings.searchPath()
         );
+
 
         return new AnalyzedAlterTable(TableInfo, alterTable);
     }

--- a/server/src/main/java/io/crate/analyze/AnalyzedAlterTable.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedAlterTable.java
@@ -53,7 +53,8 @@ public class AnalyzedAlterTable implements DDLStatement {
             consumer.accept(partitionProperty.expression());
             partitionProperty.expressions().forEach(consumer);
         }
-        alterTable.genericProperties().forValues(consumer);
+        alterTable.setProperties().forValues(consumer);
+        alterTable.withProperties().forValues(consumer);
     }
 
     @Override

--- a/server/src/main/java/io/crate/analyze/BoundAlterTable.java
+++ b/server/src/main/java/io/crate/analyze/BoundAlterTable.java
@@ -26,10 +26,12 @@ import org.jetbrains.annotations.Nullable;
 
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.table.TableInfo;
+import io.crate.sql.tree.GenericProperties;
 
 public record BoundAlterTable(TableInfo table,
                               @Nullable PartitionName partitionName,
                               Settings settings,
+                              GenericProperties<Object> withProperties,
                               boolean excludePartitions,
                               boolean isPartitioned) {
 }

--- a/server/src/main/java/io/crate/planner/node/ddl/AlterTablePlan.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/AlterTablePlan.java
@@ -137,6 +137,7 @@ public class AlterTablePlan implements Plan {
             tableInfo,
             partitionName,
             settings,
+            alterTable.withProperties(),
             table.excludePartitions(),
             isPartitioned
         );
@@ -155,8 +156,8 @@ public class AlterTablePlan implements Plan {
 
     private static Settings.Builder getTableParameter(AlterTable<Object> node, TableParameters tableParameters) {
         Settings.Builder settingsBuilder = Settings.builder();
-        if (!node.genericProperties().isEmpty()) {
-            TableProperties.analyze(settingsBuilder, tableParameters, node.genericProperties());
+        if (!node.setProperties().isEmpty()) {
+            TableProperties.analyze(settingsBuilder, tableParameters, node.setProperties());
         } else if (!node.resetProperties().isEmpty()) {
             TableProperties.analyzeResetProperties(settingsBuilder, tableParameters, node.resetProperties());
         }


### PR DESCRIPTION
Useful to increase the default timeout for operations like changing the
number of shards which can take a while.

Part of https://github.com/crate/crate/issues/18517

---

Does something in the transport need an extension to use the timeout? As far as I can tell it should be all good.
