### PR TITLE
Change resize to only remove its owned dangling indices

### DIFF
--- a/docs/appendices/release-notes/6.0.4.rst
+++ b/docs/appendices/release-notes/6.0.4.rst
@@ -46,6 +46,10 @@ series.
 Fixes
 =====
 
+- Fixed an issue that could cause a ``ALTER TABLE`` operation changing the
+  number of shards of a table to interrupt a concurrent ``ALTER TABLE``
+  operation also changing the number of shards.
+
 - Fixed an issue that could lead to a deadlock when executing a statement
   containing a ``JOIN`` that got executed using a hash join algorithm on a
   cluster with more than one node.

--- a/docs/appendices/release-notes/6.1.1.rst
+++ b/docs/appendices/release-notes/6.1.1.rst
@@ -46,6 +46,10 @@ series.
 Fixes
 =====
 
+- Fixed an issue that could cause a ``ALTER TABLE`` operation changing the
+  number of shards of a table to interrupt a concurrent ``ALTER TABLE``
+  operation also changing the number of shards.
+
 - Fixed an issue that could lead to a deadlock when executing a statement
   containing a ``JOIN`` that got executed using a hash join algorithm on a
   cluster with more than one node.

--- a/server/src/main/java/io/crate/planner/GCDanglingArtifactsPlan.java
+++ b/server/src/main/java/io/crate/planner/GCDanglingArtifactsPlan.java
@@ -42,7 +42,7 @@ public final class GCDanglingArtifactsPlan implements Plan {
                               Row params,
                               SubQueryResults subQueryResults) {
         var listener = OneRowActionListener.oneIfAcknowledged(consumer);
-        dependencies.client().execute(TransportGCDanglingArtifacts.ACTION, GCDanglingArtifactsRequest.INSTANCE)
+        dependencies.client().execute(TransportGCDanglingArtifacts.ACTION, GCDanglingArtifactsRequest.ALL)
             .whenComplete(listener);
     }
 }

--- a/server/src/main/java/org/elasticsearch/Version.java
+++ b/server/src/main/java/org/elasticsearch/Version.java
@@ -206,8 +206,11 @@ public class Version implements Comparable<Version> {
     public static final Version V_6_0_1 = new Version(9_00_01_99, false, org.apache.lucene.util.Version.LUCENE_10_2_2);
     public static final Version V_6_0_2 = new Version(9_00_02_99, false, org.apache.lucene.util.Version.LUCENE_10_2_2);
     public static final Version V_6_0_3 = new Version(9_00_03_99, false, org.apache.lucene.util.Version.LUCENE_10_2_2);
+    public static final Version V_6_0_4 = new Version(9_00_04_99, true, org.apache.lucene.util.Version.LUCENE_10_2_2);
 
     public static final Version V_6_1_0 = new Version(9_01_00_99, false, org.apache.lucene.util.Version.LUCENE_10_2_2);
+    public static final Version V_6_1_1 = new Version(9_01_01_99, true, org.apache.lucene.util.Version.LUCENE_10_2_2);
+
     public static final Version V_6_2_0 = new Version(9_02_00_99, true, org.apache.lucene.util.Version.LUCENE_10_3_1);
 
     public static final Version CURRENT = V_6_2_0;

--- a/server/src/test/java/io/crate/execution/ddl/tables/GCDanglingArtifactsRequestTest.java
+++ b/server/src/test/java/io/crate/execution/ddl/tables/GCDanglingArtifactsRequestTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.execution.ddl.tables;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.junit.Test;
+
+public class GCDanglingArtifactsRequestTest {
+
+    @Test
+    public void test_bwc_streaming() throws Exception {
+        String indexUUID = "uuid1";
+        var req = new GCDanglingArtifactsRequest(List.of(indexUUID));
+        List<Version> noUUIDVersions = List.of(Version.V_6_0_2, Version.V_6_1_0);
+        for (var version : noUUIDVersions) {
+            try (var out = new BytesStreamOutput()) {
+                out.setVersion(version);
+                req.writeTo(out);
+
+                try (var in = out.bytes().streamInput()) {
+                    in.setVersion(version);
+                    var reqIn = new GCDanglingArtifactsRequest(in);
+                    assertThat(reqIn.indexUUIDs()).isEmpty();
+                }
+            }
+        }
+
+        List<Version> uuidVersions = List.of(Version.V_6_0_4, Version.V_6_1_1, Version.CURRENT);
+        for (var version : uuidVersions) {
+            try (var out = new BytesStreamOutput()) {
+                out.setVersion(version);
+                req.writeTo(out);
+
+                try (var in = out.bytes().streamInput()) {
+                    in.setVersion(version);
+                    var reqIn = new GCDanglingArtifactsRequest(in);
+                    assertThat(reqIn.indexUUIDs()).containsExactly(indexUUID);
+                }
+            }
+        }
+    }
+}
+

--- a/server/src/test/java/io/crate/integrationtests/ResizeShardsITest.java
+++ b/server/src/test/java/io/crate/integrationtests/ResizeShardsITest.java
@@ -26,6 +26,12 @@ import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
 import static io.crate.testing.Asserts.assertSQLError;
 import static io.crate.testing.Asserts.assertThat;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.TimeUnit;
 
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -129,14 +135,39 @@ public class ResizeShardsITest extends IntegTestCase {
     }
 
     @Test
-    public void testNumberOfShardsOfATableCanBeIncreased() throws Exception {
+    public void test_number_of_shards_on_tables_can_be_increased() throws Exception {
         execute("create table t1 (x int, p int) clustered into 1 shards " +
                 "with (number_of_replicas = 1, number_of_routing_shards = 10)");
+        execute("create table t2 (x int) clustered into 1 shards with (number_of_replicas = 1)");
+
         execute("insert into t1 (x, p) values (1, 1), (2, 1)");
+        execute("insert into t2 (x) values (10), (20)");
 
         execute("alter table t1 set (\"blocks.write\" = true)");
+        execute("alter table t2 set (\"blocks.write\" = true)");
 
-        execute("alter table t1 set (number_of_shards = 2)");
+        CyclicBarrier barrier = new CyclicBarrier(2);
+        CountDownLatch threadsDone = new CountDownLatch(2);
+        var t1 = new Thread(() -> {
+            try {
+                barrier.await();
+                execute("alter table t1 set (number_of_shards = 2)");
+                threadsDone.countDown();
+            } catch (InterruptedException | BrokenBarrierException e) {
+            }
+        });
+        var t2 = new Thread(() -> {
+            try {
+                barrier.await();
+                execute("alter table t2 set (number_of_shards = 2)");
+                threadsDone.countDown();
+            } catch (InterruptedException | BrokenBarrierException e) {
+            }
+        });
+        t1.start();
+        t2.start();
+
+        threadsDone.await(5, TimeUnit.SECONDS);
         ensureYellow();
 
         execute("select count(*), primary from sys.shards where table_name = 't1' group by primary order by 2");
@@ -145,6 +176,25 @@ public class ResizeShardsITest extends IntegTestCase {
             "2| true");
         execute("select x from t1");
         assertThat(response).hasRowCount(2L);
+
+        ClusterService clusterService = cluster().getInstance(ClusterService.class);
+        ClusterState state = clusterService.state();
+        assertThat(state.metadata().indices()).hasSize(2);
+
+        execute("alter table t2 set (number_of_shards = 4)");
+        ensureYellow();
+        state = clusterService.state();
+        assertThat(state.metadata().indices()).hasSize(2);
+
+        execute("select count(*), primary from sys.shards where table_name = 't2' group by primary order by 2");
+        assertThat(response).hasRows(
+            "4| false",
+            "4| true");
+        execute("select x from t2 order by 1");
+        assertThat(response).hasRows(
+            "10",
+            "20"
+        );
     }
 
     @Test

--- a/server/src/test/java/io/crate/planner/node/ddl/AlterTablePlanTest.java
+++ b/server/src/test/java/io/crate/planner/node/ddl/AlterTablePlanTest.java
@@ -28,11 +28,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
-import java.util.concurrent.CompletableFuture;
 
 import org.elasticsearch.action.admin.indices.shrink.ResizeRequest;
 import org.elasticsearch.action.admin.indices.shrink.TransportResize;
-import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.settings.IndexScopedSettings;
@@ -51,6 +49,7 @@ import io.crate.execution.ddl.tables.AlterTableClient;
 import io.crate.execution.ddl.tables.AlterTableRequest;
 import io.crate.execution.ddl.tables.GCDanglingArtifactsRequest;
 import io.crate.execution.ddl.tables.TransportAlterTable;
+import io.crate.execution.ddl.tables.TransportGCDanglingArtifacts;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.planner.operators.SubQueryResults;
 import io.crate.replication.logical.LogicalReplicationService;
@@ -170,8 +169,9 @@ public class AlterTablePlanTest extends CrateDummyClusterServiceUnitTest {
             IndexScopedSettings.DEFAULT_SCOPED_SETTINGS,
             mock(LogicalReplicationService.class)
         );
-        Mockito.when(client.execute(Mockito.any(), Mockito.eq(GCDanglingArtifactsRequest.INSTANCE)))
-            .thenReturn(CompletableFuture.completedFuture(new AcknowledgedResponse(true)));
+
+        Mockito.verify(client, Mockito.times(0))
+            .execute(Mockito.eq(TransportGCDanglingArtifacts.ACTION), Mockito.any(GCDanglingArtifactsRequest.class));
 
         var reqCaptor = ArgumentCaptor.forClass(ResizeRequest.class);
         alterTableClient.setSettingsOrResize(alterTable);


### PR DESCRIPTION
A resize operation always triggered a `ALTER CLUSTER GC DANGLING
ARTIFACTS`.
That could lead to removing temporary resize indices for other tables
(of concurrent resize operations).

This adds a indexUUIDs filter to GCDanglingArtifactsRequest to only
delete dangling indices related to the source table.

Relates to https://github.com/crate/crate/issues/18517
A step towards adding KILL handling
