### PR TITLE
Fix `test_connection_reset_doesnt_leak_bufs_or_sessions` on MacOS

### DIFF
--- a/server/src/main/java/io/crate/protocols/http/MainAndStaticFileHandler.java
+++ b/server/src/main/java/io/crate/protocols/http/MainAndStaticFileHandler.java
@@ -112,8 +112,8 @@ public class MainAndStaticFileHandler extends SimpleChannelInboundHandler<FullHt
                     .addListener(ChannelFutureListener.CLOSE);
             }
             case IOException _ -> {
-                if (message.contains("Connection reset by peer")) {
-                    LOGGER.debug("Connection reset by peer");
+                if (message.contains("Connection reset")) {
+                    LOGGER.debug(message);
                 } else {
                     LOGGER.warn(message, cause);
                     send500(ctx, message);

--- a/server/src/test/java/io/crate/integrationtests/RestSQLActionIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/RestSQLActionIntegrationTest.java
@@ -23,7 +23,6 @@ package io.crate.integrationtests;
 
 import static io.crate.execution.engine.indexing.ShardingUpsertExecutor.BULK_RESPONSE_MAX_ERRORS_PER_SHARD;
 import static io.crate.testing.Asserts.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.OutputStream;
 import java.net.Socket;
@@ -82,7 +81,7 @@ public class RestSQLActionIntegrationTest extends SQLHttpIntegrationTest {
                 "connection reset is logged",
                 "io.crate.protocols.http.MainAndStaticFileHandler",
                 Level.DEBUG,
-                "Connection reset by peer"
+                "Connection reset"
             ));
 
             // This tries to cause a connection reset via soLinger with timeout=0, which means that it won't wait for


### PR DESCRIPTION
The exception message issued on MacOS on a connection reset seems to be slightly different, it only contains `Connection reset`, leaving out the trailing ` by peer`.