### PR TITLE
Fix hash join deadlock scenario

### DIFF
--- a/docs/appendices/release-notes/6.0.4.rst
+++ b/docs/appendices/release-notes/6.0.4.rst
@@ -46,6 +46,10 @@ series.
 Fixes
 =====
 
+- Fixed an issue that could lead to a deadlock when executing a statement
+  containing a ``JOIN`` that got executed using a hash join algorithm on a
+  cluster with more than one node.
+
 - Fixed an issue that caused ``EXPLAIN ANALYZE`` on queries using a sub-query
   returning multiple-rows (like with ``WHERE x IN (SELECT ...)``) to not release
   the memory accounted within the query circuit breaker. This could later on

--- a/docs/appendices/release-notes/6.1.1.rst
+++ b/docs/appendices/release-notes/6.1.1.rst
@@ -46,6 +46,10 @@ series.
 Fixes
 =====
 
+- Fixed an issue that could lead to a deadlock when executing a statement
+  containing a ``JOIN`` that got executed using a hash join algorithm on a
+  cluster with more than one node.
+
 - Fixed an issue that caused ``EXPLAIN ANALYZE`` on queries using a sub-query
   returning multiple-rows (like with ``WHERE x IN (SELECT ...)``) to not release
   the memory accounted within the query circuit breaker. This could later on

--- a/server/src/main/java/io/crate/execution/engine/distribution/DistributedResultResponse.java
+++ b/server/src/main/java/io/crate/execution/engine/distribution/DistributedResultResponse.java
@@ -21,11 +21,11 @@
 
 package io.crate.execution.engine.distribution;
 
+import java.io.IOException;
+
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.transport.TransportResponse;
-
-import java.io.IOException;
 
 public class DistributedResultResponse extends TransportResponse {
 
@@ -46,5 +46,10 @@ public class DistributedResultResponse extends TransportResponse {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeBoolean(needMore);
+    }
+
+    @Override
+    public String toString() {
+        return "DistributedResultResponse{needMore=" + needMore + "}";
     }
 }

--- a/server/src/main/java/io/crate/execution/jobs/CumulativePageBucketReceiver.java
+++ b/server/src/main/java/io/crate/execution/jobs/CumulativePageBucketReceiver.java
@@ -144,7 +144,7 @@ public class CumulativePageBucketReceiver implements PageBucketReceiver {
         final boolean allBucketsOfPageReceived;
         synchronized (lock) {
             if (traceEnabled) {
-                LOGGER.trace("method=setBucket phaseId={} bucket={} istLast={}", phaseId, bucketIdx, isLast);
+                LOGGER.trace("method=setBucket phaseId={} bucket={} size={} istLast={}", phaseId, bucketIdx, rows.size(), isLast);
             }
 
             if (bucketsByIdx.putIfAbsent(bucketIdx, rows) != null) {

--- a/server/src/test/java/io/crate/execution/engine/join/HashJoinBatchIteratorBehaviouralTest.java
+++ b/server/src/test/java/io/crate/execution/engine/join/HashJoinBatchIteratorBehaviouralTest.java
@@ -137,7 +137,11 @@ public class HashJoinBatchIteratorBehaviouralTest {
         TestingRowConsumer consumer = new TestingRowConsumer();
         consumer.accept(batchIterator, null);
         List<Object[]> result = consumer.getResult();
-        assertThat(result).containsExactly(new Object[]{2, 2}, new Object[]{1, null}, new Object[]{4, 4});
+        assertThat(result).containsExactly(
+            new Object[]{1, null},
+            new Object[]{2, 2},
+            new Object[]{4, 4}
+        );
 
         // as the blocksize is defined of 2 but the left batch size 1, normally it would call left loadNextBatch until
         // the blocksize is reached. we don't want that as parallel running hash iterators must call loadNextBatch always
@@ -169,6 +173,11 @@ public class HashJoinBatchIteratorBehaviouralTest {
         TestingRowConsumer consumer = new TestingRowConsumer();
         consumer.accept(batchIterator, null);
         List<Object[]> result = consumer.getResult();
-        assertThat(result).containsExactly(new Object[]{2, 2}, new Object[]{4, 4}, new Object[]{1, null}, new Object[]{3, null});
+        assertThat(result).containsExactly(
+            new Object[]{2, 2},
+            new Object[]{1, null},
+            new Object[]{4, 4},
+            new Object[]{3, null}
+        );
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
@@ -24,6 +24,7 @@ package io.crate.integrationtests;
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
 import static io.crate.testing.Asserts.assertThat;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Arrays;


### PR DESCRIPTION
It could happen that a hash join got stuck when executing on more than
one node and if the number of rows within a page was smaller then the
expected block size despite having `allLoaded() = false`.

This happened if the page size didn't divide cleanly by the number
of nodes, resulting in one downstream receiving fewer rows.

One downstream would then move from the build phase to the probe phase,
and process the right side, while the node who received fewer rows would
attempt to fetch more from the left side.

This left/right fetch-more mix caused the deadlock because the upstreams
were then waiting for `DistributedResultResponse` answers from the
_other_ downstream.

---

Single node benchmarks shows no significant negative impact:

(Some of the multi node benchmarks didn't finish due to this bug - that's how I found this, so don't have results for that)


```
# Results (server side duration in ms)
V1: 6.2.0-16d50eed9fdb31d1a4b4f9718ed7ff358a9101d4
V2: 6.2.0-71f98e54d9c83e65240b4416edba40603d998e98

Q: select t1."sourceIP" from uservisits_large t1 inner join uservisits_small t2 on t1."sourceIP" = t2."sourceIP" limit 1000
C: 1
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |       76.194 ±   33.875 |     58.387 |     61.158 |     65.508 |    174.914 |
|   V2    |       65.953 ±   23.767 |     57.421 |     59.712 |     61.126 |    165.933 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -  14.41%                           -   2.39%
There is a 72.47% probability that the observed difference is not random, and the best estimate of that difference is 14.41%
The test has no statistical significance

Q: select t1."sourceIP" from uservisits_large t1 inner join uservisits_small t2 on t1."sourceIP" = t2."sourceIP" limit 1000
C: 5
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |      172.445 ±  162.387 |     75.855 |     81.851 |     85.991 |    449.973 |
|   V2    |      190.298 ±  186.793 |     70.263 |     85.205 |    107.849 |    510.049 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               +   9.84%                           +   4.02%
There is a 25.12% probability that the observed difference is not random, and the best estimate of that difference is 9.84%
The test has no statistical significance

Q: select t1."sourceIP" from uservisits_large t1 inner join uservisits_small t2 on t1."sourceIP" = t2."sourceIP" order by t1."sourceIP" limit 10
C: 1
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |     6615.653 ±  367.306 |   6388.725 |   6477.817 |   6585.917 |   7910.982 |
|   V2    |     6443.329 ±  107.121 |   6355.706 |   6421.174 |   6455.650 |   6850.035 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -   2.64%                           -   0.88%
There is a 94.89% probability that the observed difference is not random, and the best estimate of that difference is 2.64%
The test has no statistical significance

Q: select t1."sourceIP" from uservisits_large t1 inner join uservisits_small t2 on t1."sourceIP" = t2."sourceIP" order by t1."sourceIP" limit 1000
C: 5
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |     9544.803 ±  197.126 |   9237.670 |   9574.098 |   9637.447 |   9967.319 |
|   V2    |     9421.433 ±  154.878 |   9063.036 |   9421.906 |   9506.893 |   9698.773 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -   1.30%                           -   1.60%
There is a 96.61% probability that the observed difference is not random, and the best estimate of that difference is 1.30%
The test has no statistical significance

Q: select t1."sourceIP" from uservisits_large t1 inner join uservisits_small t2 on t1."sourceIP" = t2."sourceIP" limit 1000000
C: 1
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |     1486.032 ±   35.481 |   1441.658 |   1476.992 |   1514.788 |   1542.292 |
|   V2    |     1518.943 ±   46.967 |   1470.736 |   1507.564 |   1545.011 |   1638.416 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               +   2.19%                           +   2.05%
There is a 98.32% probability that the observed difference is not random, and the best estimate of that difference is 2.19%
The test has statistical significance

Q: select t1."sourceIP" from uservisits_large t1 inner join uservisits_small t2 on t1."sourceIP" = t2."sourceIP" order by t1."sourceIP" limit 1000000
C: 1
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |    10930.175 ±  312.679 |  10609.754 |  10811.852 |  10986.371 |  11776.734 |
|   V2    |    10750.451 ±  130.785 |  10550.384 |  10744.223 |  10842.798 |  10947.514 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -   1.66%                           -   0.63%
There is a 97.71% probability that the observed difference is not random, and the best estimate of that difference is 1.66%
The test has statistical significance


System/JVM Metrics (durations in ms, byte-values in MB)
    |    YOUNG GC            |       OLD GC           |      HEAP         |     ALLOC
    |  cnt      avg      max |  cnt      avg      max |  initial     used |     rate      total
 V1 |  137    39.78    64.39 |   46    41.61    76.40 |     8590     1367 |  1380.11     592122
 V2 |  140    39.67    68.15 |   47    39.64    46.93 |     8590      833 |  1404.39     591608
```
