### PR TITLE
Fix eclipse compiler errors with jdtls 1.52

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/collect/collectors/NodeStats.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/collectors/NodeStats.java
@@ -139,8 +139,8 @@ public final class NodeStats {
 
         private CompletableFuture<List<NodeStatsContext>> getStatsFromRemote(Set<ColumnIdent> toCollect) {
             FutureActionListener<List<NodeStatsContext>> listener = new FutureActionListener<>();
-            MultiActionListener<NodeStatsContext, Object, List<NodeStatsContext>> multiListener
-                = new MultiActionListener<>(nodes.getSize(), Collectors.toList(), listener);
+            MultiActionListener<NodeStatsContext, ?, List<NodeStatsContext>> multiListener =
+                new MultiActionListener<>(nodes.getSize(), Collectors.toList(), listener);
             for (final DiscoveryNode node : nodes) {
                 final String nodeId = node.getId();
                 NodeStatsRequest request = new NodeStatsRequest(nodeId, REQUEST_TIMEOUT, toCollect);

--- a/server/src/main/java/io/crate/planner/node/management/ExplainProfilePlan.java
+++ b/server/src/main/java/io/crate/planner/node/management/ExplainProfilePlan.java
@@ -206,7 +206,7 @@ public class ExplainProfilePlan implements Plan {
 
         // Dummy collecting consumer.
         // The result is discarded. Instead fetch the profile timings from all nodes and output that
-        CollectingRowConsumer<Object, Long> discardingConsumer = new CollectingRowConsumer<>(Collectors.counting());
+        CollectingRowConsumer<?, Long> discardingConsumer = new CollectingRowConsumer<>(Collectors.counting());
         discardingConsumer.completionFuture()
             .whenComplete((_, _) -> context.stopTimerAndStoreDuration(timer))
             .thenCompose(_ -> fetchTimingResults(plannerContext.jobId(), executor, operationTree.nodeOperations()))

--- a/server/src/test/java/io/crate/execution/IncrementalPageBucketReceiverTest.java
+++ b/server/src/test/java/io/crate/execution/IncrementalPageBucketReceiverTest.java
@@ -51,7 +51,7 @@ public class IncrementalPageBucketReceiverTest {
     @Test
     public void test_processing_future_completed_when_finisher_throws() {
         TestingRowConsumer batchConsumer = new TestingRowConsumer();
-        Collector<Row, Object, Iterable<Row>> collector = Collectors.collectingAndThen(Collectors.toList(), _ -> {
+        Collector<Row, ?, Iterable<Row>> collector = Collectors.collectingAndThen(Collectors.toList(), _ -> {
             throw new CircuitBreakingException("dummy"); // Failing finisher
         });
         var pageBucketReceiver = new IncrementalPageBucketReceiver<>(


### PR DESCRIPTION
Looks like the latest eclipse compiler had a regression(?) which led to
errors around `Collectors.toList()` type inference.

E.g. "Cannot infer type arguments for MultiActionListener<>"
