### PR TITLE
Don't write key twice to the translog

### DIFF
--- a/docs/appendices/release-notes/5.10.15.rst
+++ b/docs/appendices/release-notes/5.10.15.rst
@@ -47,4 +47,6 @@ See the :ref:`version_5.10.0` release notes for a full list of changes in the
 Fixes
 =====
 
-None
+- Fixed a translog recovery issue, happening when a ``NULL`` value was stored
+  in an :ref:`type-object` with policy :ref:`type-object-columns-ignored` on
+  tables created before :ref:`version 5.5.0 <version_5.5.0>`.

--- a/server/src/main/java/io/crate/execution/dml/ObjectIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/ObjectIndexer.java
@@ -132,8 +132,7 @@ public class ObjectIndexer implements ValueIndexer<Map<String, Object>> {
                     translogWriter.writeFieldName(this.unknownColumnPrefix + k);
                     translogWriter.writeValue(v);
                     columnsToStore.put(k, v);
-                }
-                if (v == null) {
+                } else if (v == null) {
                     translogWriter.writeFieldName(k);
                     translogWriter.writeValue(null);
                     columnsToStore.put(k, null);

--- a/server/src/test/java/io/crate/execution/dml/MixedVersionStorageTest.java
+++ b/server/src/test/java/io/crate/execution/dml/MixedVersionStorageTest.java
@@ -24,7 +24,9 @@ package io.crate.execution.dml;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.elasticsearch.Version;
 import org.junit.Test;
@@ -55,6 +57,32 @@ public class MixedVersionStorageTest extends CrateDummyClusterServiceUnitTest {
             var row = lookup.getStoredRow(new ReaderContext(reader), 0);
             assertThat(row.asRaw()).isNotEmpty();
             assertThat(row.get(List.of("numbers"))).isOfAnyClassIn(ArrayList.class);
+        }
+    }
+
+    @Test
+    public void test_writing_null_subcolumn_to_ignored_object_in_table_without_oids() throws Exception {
+        var columns = List.of("obj");
+        var builder = new QueryTester.Builder(
+            THREAD_POOL,
+            clusterService,
+            Version.V_5_4_0, // No oids
+            "create table t (obj object(ignored))"
+        );
+        Map<String, Object> map = new HashMap<>();
+        map.put("key", null);
+        builder.indexValues(columns, map);
+        try (var tester = builder.build()) {
+            // We write NULL-s to translog since 5.10.13 (https://github.com/crate/crate/pull/18369).
+            // This change introduced a regression, causing NULL values in the OBJECT(IGNORED)
+            // to be persisted twice in the translog, if table had no oids.
+            // We imitate translog lookup to ensure that we are not hitting JSON parsing exception when parsing the source.
+            boolean fromTranslog = true;
+            var lookup = StoredRowLookup.create(Version.V_5_4_0, tester.tableInfo(), List.of(), List.of(), fromTranslog);
+            var reader = tester.searcher().getTopReaderContext().leaves().getFirst();
+            var row = lookup.getStoredRow(new ReaderContext(reader), 0);
+            // Used to fail with "JsonParseException: Duplicate field 'key'".
+            assertThat(row.asMap().get("obj")).isEqualTo(map);
         }
     }
 }


### PR DESCRIPTION
Happens on tables without oids when a null subcolumn is written into IGNORED object

Fixes a regression introduced with https://github.com/crate/crate/pull/18369

Fixes https://github.com/crate/support/issues/749