### PR TITLE
Parse invalid translog entries with plain Jackson parser

### DIFF
--- a/server/src/test/java/io/crate/expression/reference/doc/lucene/SourceParserTest.java
+++ b/server/src/test/java/io/crate/expression/reference/doc/lucene/SourceParserTest.java
@@ -532,4 +532,22 @@ public class SourceParserTest extends ESTestCase {
         ));
         assertThat(Maps.getByPath(result, "o.x")).isInstanceOf(BigDecimal.class);
     }
+
+    @Test
+    public void test_invalid_translog_entry_with_duplicate_keys_can_still_be_parsed() throws Exception {
+        SourceParser sourceParser = new SourceParser(UnaryOperator.identity(), true);
+        ObjectType objectType = ObjectType.of(ColumnPolicy.IGNORED).build();
+        sourceParser.register(ColumnIdent.of("_doc", List.of("o")), objectType);
+        Map<String, Object> result = sourceParser.parse(new BytesArray(
+            """
+                {
+                    "o": {
+                        "x": null,
+                        "x": null
+                    }
+                }
+            """
+        ));
+        assertThat(Maps.getByPath(result, "o.x")).isEqualTo(null);
+    }
 }


### PR DESCRIPTION
This way we don't throw on duplicate keys and try to parse again as a last resort.

`XContentParser` throws because `XContent.isStrictDuplicateDetectionEnabled()` is true by default

Follow up to https://github.com/crate/crate/commit/876fdd0e4b9a55df92ef565f4a0b4227e354a70a, in combination with it, fully closes https://github.com/crate/support/issues/749
