### PR TITLE
Add a hint for mitigating translog recovery issue

### DIFF
--- a/docs/appendices/release-notes/5.10.15.rst
+++ b/docs/appendices/release-notes/5.10.15.rst
@@ -50,3 +50,11 @@ Fixes
 - Fixed a translog recovery issue, happening when a ``NULL`` value was stored
   in an :ref:`type-object` with policy :ref:`type-object-columns-ignored` on
   tables created before :ref:`version 5.5.0 <version_5.5.0>`.
+  To mitigate the issue, run CrateDB with a CLI option
+  ``-Des.xcontent.strict_duplicate_detection=false``. Please note, that this
+  flag has a global effect, and it's recommended to set it back to the default
+  value ``true`` once invalid records are processed. Issue can be considered
+  as mitigated when ``translog_stats['uncommitted_size']`` in the
+  :ref:`sys.shards <sys-shards>` table stops exceeding
+  :ref:`flush_threshold_size <sql-create-table-translog-flush-threshold-size>`.
+

--- a/docs/appendices/release-notes/6.0.4.rst
+++ b/docs/appendices/release-notes/6.0.4.rst
@@ -106,3 +106,10 @@ Fixes
 - Fixed a translog recovery issue, happening when a ``NULL`` value was stored
   in an :ref:`type-object` with policy :ref:`type-object-columns-ignored` on
   tables created before :ref:`version 5.5.0 <version_5.5.0>`.
+  To mitigate the issue, run CrateDB with a CLI option
+  ``-Des.xcontent.strict_duplicate_detection=false``. Please note, that this
+  flag has a global effect, and it's recommended to set it back to the default
+  value ``true`` once invalid records are processed. Issue can be considered
+  as mitigated when ``translog_stats['uncommitted_size']`` in the
+  :ref:`sys.shards <sys-shards>` table stops exceeding
+  :ref:`flush_threshold_size <sql-create-table-translog-flush-threshold-size>`.

--- a/docs/appendices/release-notes/6.1.1.rst
+++ b/docs/appendices/release-notes/6.1.1.rst
@@ -88,3 +88,10 @@ Fixes
 - Fixed a translog recovery issue, happening when a ``NULL`` value was stored
   in an :ref:`type-object` with policy :ref:`type-object-columns-ignored` on
   tables created before :ref:`version 5.5.0 <version_5.5.0>`.
+  To mitigate the issue, run CrateDB with a CLI option
+  ``-Des.xcontent.strict_duplicate_detection=false``. Please note, that this
+  flag has a global effect, and it's recommended to set it back to the default
+  value ``true`` once invalid records are processed. Issue can be considered
+  as mitigated when ``translog_stats['uncommitted_size']`` in the
+  :ref:`sys.shards <sys-shards>` table stops exceeding
+  :ref:`flush_threshold_size <sql-create-table-translog-flush-threshold-size>`.


### PR DESCRIPTION
Follow up to https://github.com/crate/crate/commit/876fdd0e4b9a55df92ef565f4a0b4227e354a70a

Relates to https://github.com/crate/crate/pull/18710#issuecomment-3528003539

I confirmed that flipping this flag makes test pass even with reverted fix