### PR TITLE
Fix resolution of same named columns in nested join conditions

### DIFF
--- a/docs/appendices/release-notes/5.10.15.rst
+++ b/docs/appendices/release-notes/5.10.15.rst
@@ -71,3 +71,7 @@ Fixes
 
 - Fixed an issue causing a ``GROUP BY ... LIMIT 0`` statement to not release
   it's accounted memory on the ``QUERY`` circuit breaker.
+
+- Fixed an issue where certain join queries returned incorrect results when the
+  join condition referenced unknown object sub-columns coming from aliased CTEs
+  in nested joins.

--- a/docs/appendices/release-notes/6.0.4.rst
+++ b/docs/appendices/release-notes/6.0.4.rst
@@ -127,3 +127,7 @@ Fixes
 
 - Fixed an issue causing a ``GROUP BY ... LIMIT 0`` statement to not release
   it's accounted memory on the ``QUERY`` circuit breaker.
+
+- Fixed an issue where certain join queries returned incorrect results when the
+  join condition referenced unknown object sub-columns coming from aliased CTEs
+  in nested joins.

--- a/docs/appendices/release-notes/6.1.1.rst
+++ b/docs/appendices/release-notes/6.1.1.rst
@@ -109,3 +109,7 @@ Fixes
 
 - Fixed an issue causing a ``GROUP BY ... LIMIT 0`` statement to not release
   it's accounted memory on the ``QUERY`` circuit breaker.
+
+- Fixed an issue where certain join queries returned incorrect results when the
+  join condition referenced unknown object sub-columns coming from aliased CTEs
+  in nested joins.

--- a/server/src/main/java/io/crate/execution/dsl/projection/builder/InputColumns.java
+++ b/server/src/main/java/io/crate/execution/dsl/projection/builder/InputColumns.java
@@ -53,6 +53,7 @@ import io.crate.expression.symbol.WindowFunction;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.GeneratedReference;
 import io.crate.metadata.Reference;
+import io.crate.metadata.RelationName;
 import io.crate.types.DataType;
 
 /**
@@ -250,7 +251,7 @@ public final class InputColumns extends SymbolVisitor<InputColumns.SourceSymbols
         }
         InputColumn inputColumn = sourceSymbols.inputs.get(ref);
         if (inputColumn == null) {
-            Symbol subscriptOnRoot = tryCreateSubscriptOnRoot(ref, ref.column(), sourceSymbols.inputs);
+            Symbol subscriptOnRoot = tryCreateSubscriptOnRoot(ref.ident().tableIdent(), ref, ref.column(), sourceSymbols.inputs);
             if (subscriptOnRoot != null) {
                 return subscriptOnRoot;
             }
@@ -267,7 +268,7 @@ public final class InputColumns extends SymbolVisitor<InputColumns.SourceSymbols
     public Symbol visitField(ScopedSymbol field, SourceSymbols sourceSymbols) {
         InputColumn inputColumn = sourceSymbols.inputs.get(field);
         if (inputColumn == null) {
-            Symbol subscriptOnRoot = tryCreateSubscriptOnRoot(field, field.column(), sourceSymbols.inputs);
+            Symbol subscriptOnRoot = tryCreateSubscriptOnRoot(field.relation(), field, field.column(), sourceSymbols.inputs);
             if (subscriptOnRoot == null) {
                 throw new IllegalArgumentException("Couldn't find " + field + " in " + sourceSymbols);
             } else {
@@ -297,12 +298,12 @@ public final class InputColumns extends SymbolVisitor<InputColumns.SourceSymbols
     }
 
     @Nullable
-    private static Symbol tryCreateSubscriptOnRoot(Symbol symbol, ColumnIdent column, HashMap<Symbol, InputColumn> inputs) {
+    private static Symbol tryCreateSubscriptOnRoot(RelationName relationName, Symbol symbol, ColumnIdent column, HashMap<Symbol, InputColumn> inputs) {
         if (column.isRoot()) {
             return null;
         }
         ColumnIdent root = column.getRoot();
-        InputColumn rootIC = lookupValueByColumn(inputs, root);
+        InputColumn rootIC = lookupValueByColumn(relationName, inputs, root);
         if (rootIC == null) {
             return symbol;
         }

--- a/server/src/main/java/io/crate/expression/symbol/Symbols.java
+++ b/server/src/main/java/io/crate/expression/symbol/Symbols.java
@@ -41,6 +41,7 @@ import io.crate.common.collections.Lists;
 import io.crate.expression.symbol.format.Style;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Reference;
+import io.crate.metadata.RelationName;
 import io.crate.types.DataType;
 
 public final class Symbols {
@@ -69,13 +70,17 @@ public final class Symbols {
     }
 
     @Nullable
-    public static <V> V lookupValueByColumn(Map<? extends Symbol, V> valuesBySymbol, ColumnIdent column) {
+    public static <V> V lookupValueByColumn(RelationName relationName, Map<? extends Symbol, V> valuesBySymbol, ColumnIdent column) {
         for (Map.Entry<? extends Symbol, V> entry : valuesBySymbol.entrySet()) {
             Symbol key = entry.getKey();
-            if (key instanceof Reference ref && ref.column().equals(column)) {
+            if (key instanceof Reference ref
+                    && ref.column().equals(column)
+                    && ref.ident().tableIdent().equals(relationName)) {
                 return entry.getValue();
             }
-            if (key instanceof ScopedSymbol scopedSymbol && scopedSymbol.column().equals(column)) {
+            if (key instanceof ScopedSymbol scopedSymbol
+                    && scopedSymbol.column().equals(column)
+                    && scopedSymbol.relation().equals(relationName)) {
                 return entry.getValue();
             }
         }

--- a/server/src/test/java/io/crate/expression/symbol/SymbolsTest.java
+++ b/server/src/test/java/io/crate/expression/symbol/SymbolsTest.java
@@ -24,13 +24,18 @@ package io.crate.expression.symbol;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.junit.Test;
 
+import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Reference;
+import io.crate.metadata.RelationName;
+import io.crate.metadata.SimpleReference;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 
@@ -83,5 +88,32 @@ public class SymbolsTest extends CrateDummyClusterServiceUnitTest {
         assertThat(Symbols.contains(List.of(o), o1)).isEqualTo(true);
         assertThat(Symbols.contains(List.of(o), y)).isEqualTo(false);
         assertThat(Symbols.contains(List.of(o1), ox)).isEqualTo(true);
+    }
+
+    @Test
+    public void test_lookupValueByColumn_must_compare_scoped_symbols_relations() throws IOException {
+        var e = SQLExecutor.of(clusterService)
+            .addTable("create table tbl1 (o object)")
+            .addTable("create table tbl2 (o object)")
+            .addTable("create table tbl3 (o object)")
+            .addTable("create table tbl4 (o object)");
+
+        ScopedSymbol t1o = (ScopedSymbol) e.analyze("select t1.o from tbl1 as t1").outputs().getFirst();
+        ScopedSymbol t2o = (ScopedSymbol) e.analyze("select t2.o from tbl2 as t2").outputs().getFirst();
+        SimpleReference tbl3oRef = (SimpleReference) e.analyze("select o from tbl3").outputs().getFirst();
+        SimpleReference tbl4oRef = (SimpleReference) e.analyze("select o from tbl4").outputs().getFirst();
+
+        Map<Symbol, String> valuesBySymbol = new LinkedHashMap<>();
+        valuesBySymbol.put(t1o, "lookupValueByColumn returned ScopedSymbol t1.o");
+        valuesBySymbol.put(t2o, "lookupValueByColumn returned ScopedSymbol t2.o");
+        valuesBySymbol.put(tbl3oRef, "lookupValueByColumn returned Reference tbl3.o");
+        valuesBySymbol.put(tbl4oRef, "lookupValueByColumn returned Reference tbl4.o");
+
+        ColumnIdent o = ColumnIdent.of("o");
+
+        assertThat(Symbols.lookupValueByColumn(new RelationName(null, "t1"), valuesBySymbol, o)).isEqualTo("lookupValueByColumn returned ScopedSymbol t1.o");
+        assertThat(Symbols.lookupValueByColumn(new RelationName(null, "t2"), valuesBySymbol, o)).isEqualTo("lookupValueByColumn returned ScopedSymbol t2.o");
+        assertThat(Symbols.lookupValueByColumn(new RelationName("doc", "tbl3"), valuesBySymbol, o)).isEqualTo("lookupValueByColumn returned Reference tbl3.o");
+        assertThat(Symbols.lookupValueByColumn(new RelationName("doc", "tbl4"), valuesBySymbol, o)).isEqualTo("lookupValueByColumn returned Reference tbl4.o");
     }
 }

--- a/server/src/test/java/io/crate/planner/SelectPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/SelectPlannerTest.java
@@ -1722,4 +1722,33 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(pkAndVersions).hasSize(1);
         assertThat(pkAndVersions.iterator().next()).hasSize(1);
     }
+
+    @Test
+    public void test_join_condition_on_object_subscript_with_same_name() throws Exception {
+        var e = SQLExecutor.of(clusterService)
+            .addTable("create table t1 (o object as (x int))")
+            .addTable("create table t2 (o object as (x int))");
+        String statement =
+            """
+            WITH cte as (SELECT * FROM t1)
+            SELECT
+                t2.o
+            FROM
+                t2
+                INNER JOIN cte on t2.o['x'] = cte.o['x']
+            """;
+        LogicalPlan logicalPlan = e.logicalPlan(statement);
+        assertThat(logicalPlan).hasOperators(
+            "Eval[o]",
+            "  └ HashJoin[INNER | (o['x'] = o['x'])]",
+            "    ├ Collect[doc.t2 | [o, o['x']] | true]",
+            "    └ Rename[o] AS cte",
+            "      └ Collect[doc.t1 | [o] | true]"
+        );
+        Join join = e.plan(statement);
+        // join inputs are left.outputs() + right.outputs()
+        //   [o, o['x'], o]
+        //    0, 1,      2
+        assertThat(join.joinPhase().joinCondition()).isSQL("(INPUT(1) = INPUT(2)['x'])");
+    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes https://github.com/crate/support/issues/759 - certain join queries failed when the join condition referenced unknown object sub-columns coming from aliased CTEs in nested joins.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
