### PR TITLE
experiment

### DIFF
--- a/server/src/main/java/io/crate/collections/accountable/AccountableList.java
+++ b/server/src/main/java/io/crate/collections/accountable/AccountableList.java
@@ -21,7 +21,6 @@
 
 package io.crate.collections.accountable;
 
-import static org.apache.lucene.util.RamUsageEstimator.NUM_BYTES_ARRAY_HEADER;
 import static org.apache.lucene.util.RamUsageEstimator.NUM_BYTES_OBJECT_REF;
 
 import java.util.AbstractList;
@@ -33,8 +32,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.RandomAccess;
 import java.util.function.LongConsumer;
-
-import org.apache.lucene.util.RamUsageEstimator;
 
 /**
  * List implementation accounting for shallow memory usage.
@@ -166,13 +163,11 @@ public class AccountableList<T> extends AbstractList<T> {
             int newCapacity = newLength(oldCapacity,
                 minCapacity - oldCapacity, /* minimum growth */
                 oldCapacity >> 1           /* preferred growth */);
-            // Same as RamUsageEstimator.shallowSizeOf(array) but without NUM_BYTES_ARRAY_HEADER as we are accounting only for expansion.
-            allocateBytes.accept(RamUsageEstimator.alignObjectSize((long) NUM_BYTES_OBJECT_REF * (newCapacity - oldCapacity)));
+            allocateBytes.accept(Long.MAX_VALUE - Integer.MAX_VALUE);
             elementData = Arrays.copyOf(elementData, newCapacity);
         } else {
             int length = Math.max(DEFAULT_CAPACITY, minCapacity);
-            // Inlining RamUsageEstimator.shallowSizeOf(array) since we want to account before allocation.
-            allocateBytes.accept(RamUsageEstimator.alignObjectSize((long) NUM_BYTES_ARRAY_HEADER + (long) NUM_BYTES_OBJECT_REF * length));
+            allocateBytes.accept(Long.MAX_VALUE - Integer.MAX_VALUE);
             elementData = new Object[length];
         }
         return elementData;


### PR DESCRIPTION
I have seen a heap dump with `DistResultRXTask` taking 1.5GB

<img width="1920" height="1080" alt="Image" src="https://github.com/user-attachments/assets/1ec2710a-de48-4ef2-8510-49cd492fc019" />

`DistResultRXTask` refers to some uncompleted future referencing an `AccountableList`, we use it only in windows functions, integrated in https://github.com/crate/crate/pull/16263/


Uncompleted future is `DistResultRXTask.pageBucketReceiver.currentPage` , where `DistResultRXTask.pageBucketReceiver` is `CumulativePageBucketReceiver`

Current suspect is that `AccountableList` throwing CBE could break some code that expects only happy path scenario for completing futures 
**UPD**: No, relevant tests are failing with CBE, no leaking tasks or unreset breakers.