### PR TITLE
Fix distributed execution of window functions with PARTITION BY on object subscripts

### DIFF
--- a/docs/appendices/release-notes/5.10.15.rst
+++ b/docs/appendices/release-notes/5.10.15.rst
@@ -47,6 +47,10 @@ See the :ref:`version_5.10.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an issue that could lead to incorrect results for window functions when
+  the window function used a ``PARTITION BY`` clause on an object subscript
+  coming from a view or CTE and if running in a cluster with more than one node.
+
 - Fixed a translog recovery issue, happening when a ``NULL`` value was stored
   in an :ref:`type-object` with policy :ref:`type-object-columns-ignored` on
   tables created before :ref:`version 5.5.0 <version_5.5.0>`.

--- a/docs/appendices/release-notes/6.0.4.rst
+++ b/docs/appendices/release-notes/6.0.4.rst
@@ -46,6 +46,10 @@ series.
 Fixes
 =====
 
+- Fixed an issue that could lead to incorrect results for window functions when
+  the window function used a ``PARTITION BY`` clause on an object subscript
+  coming from a view or CTE and if running in a cluster with more than one node.
+
 - Fixed an issue that could lead to a deadlock when executing a statement
   containing a ``JOIN`` that got executed using a hash join algorithm on a
   cluster with more than one node.

--- a/docs/appendices/release-notes/6.1.1.rst
+++ b/docs/appendices/release-notes/6.1.1.rst
@@ -46,6 +46,10 @@ series.
 Fixes
 =====
 
+- Fixed an issue that could lead to incorrect results for window functions when
+  the window function used a ``PARTITION BY`` clause on an object subscript
+  coming from a view or CTE and if running in a cluster with more than one node.
+
 - Fixed an issue that could cause a ``ALTER TABLE`` operation changing the
   number of shards of a table to interrupt a concurrent ``ALTER TABLE``
   operation also changing the number of shards.

--- a/server/src/main/java/io/crate/execution/jobs/JobSetup.java
+++ b/server/src/main/java/io/crate/execution/jobs/JobSetup.java
@@ -517,7 +517,13 @@ public class JobSetup {
                 case BROADCAST:
                 case MODULO:
                     RowConsumer consumer = distributingConsumerFactory.create(
-                        nodeOperation, ramAccounting, phase.distributionInfo(), jobId(), pageSize);
+                        transactionContext,
+                        nodeOperation,
+                        ramAccounting,
+                        phase.distributionInfo(),
+                        jobId(),
+                        pageSize
+                    );
                     if (logger.isTraceEnabled()) {
                         logger.trace(
                             "action=getRowReceiver, distributionType={}, phase={}, targetConsumer={}, target={}/{},",

--- a/server/src/main/java/io/crate/planner/operators/WindowAgg.java
+++ b/server/src/main/java/io/crate/planner/operators/WindowAgg.java
@@ -32,6 +32,7 @@ import java.util.SequencedCollection;
 import java.util.Set;
 import java.util.function.Function;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.UUIDs;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.VisibleForTesting;
@@ -184,45 +185,54 @@ public class WindowAgg extends ForwardingLogicalPlan {
             for (Projection projection : projections) {
                 sourcePlan.addProjection(projection);
             }
-        } else {
-            Symbol firstPartition = windowDefinition.partitions().getFirst();
-            int index = source.outputs().indexOf(firstPartition);
-            if (index == -1) {
-                //  We can have a top-level object column in outputs and partition by a sub-column.
-                //  Find index of the top column.
-                List<Symbol> intersection = new ArrayList<>();
-                Symbols.intersection(firstPartition, source.outputs(), intersection::add);
-                assert !intersection.isEmpty() : "Intersection of source outputs and partition definition must not be empty";
-                index = source.outputs().indexOf(intersection.getFirst());
+            return sourcePlan;
+        }
+
+        Symbol firstPartition = windowDefinition.partitions().getFirst();
+        int index = source.outputs().indexOf(firstPartition);
+        if (index == -1) {
+            // PARTITION BY on subscript/expression not contained in source outputs
+            // Modulo bucketing in nodes < 6.1.1 can't handle arbitrary expressions -> fallback to non distributed execution
+            if (plannerContext.clusterState().nodes().getSmallestNonClientNodeVersion().before(Version.V_6_1_1)) {
+                sourcePlan = Merge.ensureOnHandler(sourcePlan, plannerContext);
+                for (Projection projection : projections) {
+                    sourcePlan.addProjection(projection);
+                }
+                return sourcePlan;
             }
+
+            Symbol partitionInput = InputColumns.create(firstPartition, source.outputs());
+            sourcePlan.setDistributionInfo(
+                new DistributionInfo(DistributionType.MODULO, partitionInput)
+            );
+        } else {
             assert index >= 0 && index < source.outputs().size() : "Column to distribute must be present in the source plan outputs";
             sourcePlan.setDistributionInfo(
                 new DistributionInfo(DistributionType.MODULO, index)
             );
-            MergePhase distWindowAgg = new MergePhase(
-                UUIDs.dirtyUUID(),
-                plannerContext.nextExecutionPhaseId(),
-                "distWindowAgg",
-                resultDescription.nodeIds().size(),
-                resultDescription.numOutputs(),
-                resultDescription.nodeIds(),
-                resultDescription.streamOutputs(),
-                projections,
-                resultDescription.nodeIds(),
-                DistributionInfo.DEFAULT_BROADCAST,
-                null
-            );
-            return new Merge(
-                sourcePlan,
-                distWindowAgg,
-                LimitAndOffset.NO_LIMIT,
-                LimitAndOffset.NO_OFFSET,
-                windowAggProjection.outputs().size(),
-                resultDescription.maxRowsPerNode(),
-                null
-            );
         }
-        return sourcePlan;
+        MergePhase distWindowAgg = new MergePhase(
+            UUIDs.dirtyUUID(),
+            plannerContext.nextExecutionPhaseId(),
+            "distWindowAgg",
+            resultDescription.nodeIds().size(),
+            resultDescription.numOutputs(),
+            resultDescription.nodeIds(),
+            resultDescription.streamOutputs(),
+            projections,
+            resultDescription.nodeIds(),
+            DistributionInfo.DEFAULT_BROADCAST,
+            null
+        );
+        return new Merge(
+            sourcePlan,
+            distWindowAgg,
+            LimitAndOffset.NO_LIMIT,
+            LimitAndOffset.NO_OFFSET,
+            windowAggProjection.outputs().size(),
+            resultDescription.maxRowsPerNode(),
+            null
+        );
     }
 
     @Nullable

--- a/server/src/test/java/io/crate/execution/engine/distribution/DistributingConsumerTest.java
+++ b/server/src/test/java/io/crate/execution/engine/distribution/DistributingConsumerTest.java
@@ -54,6 +54,7 @@ import io.crate.data.testing.BatchSimulatingIterator;
 import io.crate.data.testing.FailingBatchIterator;
 import io.crate.data.testing.TestingBatchIterators;
 import io.crate.data.testing.TestingRowConsumer;
+import io.crate.execution.engine.collect.RowCollectExpression;
 import io.crate.execution.engine.distribution.merge.PassThroughPagingIterator;
 import io.crate.execution.jobs.CumulativePageBucketReceiver;
 import io.crate.execution.jobs.DistResultRXTask;
@@ -165,10 +166,11 @@ public class DistributingConsumerTest extends ESTestCase {
 
     private DistributingConsumer createDistributingConsumer(Streamer<?>[] streamers, TransportDistributedResultAction distributedResultAction) {
         int pageSize = 2;
+        RowCollectExpression rowCollectExpression = new RowCollectExpression(0);
         return new DistributingConsumer(
             executorService,
             UUID.randomUUID(),
-            new ModuloBucketBuilder(streamers, 1, 0, RamAccounting.NO_ACCOUNTING),
+            new ModuloBucketBuilder(streamers, 1, rowCollectExpression, List.of(rowCollectExpression), RamAccounting.NO_ACCOUNTING),
             1,
             (byte) 0,
             0,

--- a/server/src/test/java/io/crate/execution/engine/distribution/ModuloBucketBuilderTest.java
+++ b/server/src/test/java/io/crate/execution/engine/distribution/ModuloBucketBuilderTest.java
@@ -23,6 +23,8 @@ package io.crate.execution.engine.distribution;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.List;
+
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Test;
 
@@ -30,6 +32,7 @@ import io.crate.Streamer;
 import io.crate.data.Bucket;
 import io.crate.data.Row1;
 import io.crate.data.breaker.RamAccounting;
+import io.crate.execution.engine.collect.RowCollectExpression;
 import io.crate.testing.TestingHelpers;
 import io.crate.types.DataTypes;
 
@@ -37,8 +40,14 @@ public class ModuloBucketBuilderTest extends ESTestCase {
 
     @Test
     public void testRowsAreDistributedByModulo() throws Exception {
+        RowCollectExpression rowCollectExpression = new RowCollectExpression(0);
         final ModuloBucketBuilder builder = new ModuloBucketBuilder(
-            new Streamer[]{DataTypes.INTEGER.streamer()}, 2, 0, RamAccounting.NO_ACCOUNTING);
+            new Streamer[]{DataTypes.INTEGER.streamer()},
+            2,
+            rowCollectExpression,
+            List.of(rowCollectExpression),
+            RamAccounting.NO_ACCOUNTING
+        );
 
         builder.add(new Row1(1));
         builder.add(new Row1(2));

--- a/server/src/test/java/io/crate/execution/engine/distribution/MultiBucketBuilderTest.java
+++ b/server/src/test/java/io/crate/execution/engine/distribution/MultiBucketBuilderTest.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 import io.crate.Streamer;
 import io.crate.data.Row1;
 import io.crate.data.breaker.RamAccounting;
+import io.crate.execution.engine.collect.RowCollectExpression;
 import io.crate.types.DataTypes;
 
 public class MultiBucketBuilderTest {
@@ -40,7 +41,14 @@ public class MultiBucketBuilderTest {
 
     @Before
     public void setUp() throws Exception {
-        builders.add(new ModuloBucketBuilder(new Streamer[]{DataTypes.INTEGER.streamer()}, 1, 0, RamAccounting.NO_ACCOUNTING));
+        RowCollectExpression rowCollectExpression = new RowCollectExpression(0);
+        builders.add(new ModuloBucketBuilder(
+            new Streamer[]{DataTypes.INTEGER.streamer()},
+            1,
+            rowCollectExpression,
+            List.of(rowCollectExpression),
+            RamAccounting.NO_ACCOUNTING
+        ));
         builders.add(new BroadcastingBucketBuilder(new Streamer[]{DataTypes.INTEGER.streamer()}, 1, RamAccounting.NO_ACCOUNTING));
     }
 

--- a/server/src/test/java/io/crate/planner/PlanPrinterTest.java
+++ b/server/src/test/java/io/crate/planner/PlanPrinterTest.java
@@ -67,7 +67,7 @@ public class PlanPrinterTest extends CrateDummyClusterServiceUnitTest {
         assertThat(map.toString()).isEqualTo(
             "{Collect={" +
             "collectPhase={COLLECT={" +
-                "distribution={distributedByColumn=0, type=BROADCAST}, executionNodes=[n1], id=0, " +
+                "distribution={distributedByColumn=INPUT(0), type=BROADCAST}, executionNodes=[n1], id=0, " +
 
                 "projections=[" +
                     "{keys=INPUT(1), type=HashAggregation, aggregations=max(INPUT(0))}, " +
@@ -107,7 +107,7 @@ public class PlanPrinterTest extends CrateDummyClusterServiceUnitTest {
                                             "limit 10");
         assertThat(map.toString()).isEqualTo("{UnionExecutionPlan={" +
                "left={Collect={" +
-                    "collectPhase={COLLECT={distribution={distributedByColumn=0, type=BROADCAST}, " +
+                    "collectPhase={COLLECT={distribution={distributedByColumn=INPUT(0), type=BROADCAST}, " +
                     "executionNodes=[n1], id=0, orderBy=x ASC, " +
                     "routing={n1={t1=[0, 1, 2, 3]}}, " +
                     "toCollect=[x], " +
@@ -115,12 +115,12 @@ public class PlanPrinterTest extends CrateDummyClusterServiceUnitTest {
                     "where=true}}, " +
                     "type=executionPlan}}, " +
                "mergePhase={MERGE={" +
-                    "distribution={distributedByColumn=0, type=BROADCAST}, " +
+                    "distribution={distributedByColumn=INPUT(0), type=BROADCAST}, " +
                     "executionNodes=[n1], id=2, " +
                     "projections=[{outputs=INPUT(0), offset=0, limit=10, type=LimitAndOffset}], " +
                     "type=executionPhase}}, " +
                "right={Collect={" +
-                    "collectPhase={COLLECT={distribution={distributedByColumn=0, type=BROADCAST}, " +
+                    "collectPhase={COLLECT={distribution={distributedByColumn=INPUT(0), type=BROADCAST}, " +
                     "executionNodes=[n1], id=1, orderBy=y ASC, " +
                     "routing={n1={t2=[0, 1, 2, 3]}}, " +
                     "toCollect=[y], " +
@@ -136,10 +136,10 @@ public class PlanPrinterTest extends CrateDummyClusterServiceUnitTest {
                                             "where t1.x > 10");
         assertThat(map.toString()).isEqualTo("{CountPlan={type=executionPlan}, " +
                "countPhase={COUNT={executionNodes=[n1], id=0, type=executionPhase}, " +
-                   "distribution={distributedByColumn=0, type=BROADCAST}, " +
+                   "distribution={distributedByColumn=INPUT(0), type=BROADCAST}, " +
                    "routing={n1={t1=[0, 1, 2, 3]}}, " +
                    "where=(x > 10)}, " +
-               "mergePhase={MERGE={distribution={distributedByColumn=0, type=BROADCAST}, " +
+               "mergePhase={MERGE={distribution={distributedByColumn=INPUT(0), type=BROADCAST}, " +
                     "executionNodes=[n1], id=1, " +
                     "projections=[{type=MERGE_COUNT_AGGREGATION}], type=executionPhase}}}");
     }


### PR DESCRIPTION
Follow up to the fix in https://github.com/crate/crate/pull/17226
The comment in https://github.com/crate/crate/pull/17226#discussion_r1922009393 was correct

The bucketing logic on object columns doesn't work as it can lead to
data being split that ought to belong together.

For example with an object `data` with two columns `attribute` and `id`.

If partitioning on `data` instead of `data['attribute']`:

    bucketIdx=0 value={attribute=a-1, id=1844} hash=13034888
    bucketIdx=0 value={attribute=a-1, id=1838} hash=13034894
    bucketIdx=1 value={attribute=a-1, id=1851} hash=13034873

The correct partitioning on `data['attribute']` would send all
data to the same bucket:

    bucketIdx=1 value=a-1 hash=94661
    bucketIdx=1 value=a-1 hash=94661
    bucketIdx=1 value=a-1 hash=94661

To fix the issue, this extends `DistributionInfo` / modulo bucketing to
support arbitrary expressions on >= 6.1.1.
For < 6.1.1 it switches the plan to execute without distribution.

Closes https://github.com/crate/crate/issues/18708
