### PR TITLE
Fix stuck query on PostgreSQL client disconnect after full write buffers

### DIFF
--- a/docs/appendices/release-notes/5.10.15.rst
+++ b/docs/appendices/release-notes/5.10.15.rst
@@ -47,6 +47,9 @@ See the :ref:`version_5.10.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed a memory leak that could happen if running a query with a large result
+  set via a PostgreSQL client and then interrupting the connection.
+
 - Fixed an issue that allowed inserting values into ``ARRAY`` columns that
   violated the array's inner type constraints. For example it was possible to
   insert ``['aa']`` into a column of type ``ARRAY(VARCHAR(1))``.

--- a/docs/appendices/release-notes/6.0.4.rst
+++ b/docs/appendices/release-notes/6.0.4.rst
@@ -46,6 +46,9 @@ series.
 Fixes
 =====
 
+- Fixed a memory leak that could happen if running a query with a large result
+  set via a PostgreSQL client and then interrupting the connection.
+
 - Fixed an issue that allowed inserting values into ``ARRAY`` columns that
   violated the array's inner type constraints. For example it was possible to
   insert ``['aa']`` into a column of type ``ARRAY(VARCHAR(1))``.

--- a/docs/appendices/release-notes/6.1.1.rst
+++ b/docs/appendices/release-notes/6.1.1.rst
@@ -46,6 +46,9 @@ series.
 Fixes
 =====
 
+- Fixed a memory leak that could happen if running a query with a large result
+  set via a PostgreSQL client and then interrupting the connection.
+
 - Fixed an issue that allowed inserting values into ``ARRAY`` columns that
   violated the array's inner type constraints. For example it was possible to
   insert ``['aa']`` into a column of type ``ARRAY(VARCHAR(1))``.


### PR DESCRIPTION
If a PostgreSQL client selected enough data for the write buffer to get
full, the setNextRow operation paused. If the client then disconnected the
setNextRow operation future failed. `thenRun` wasn't triggered, leaving
the operation suspended indefinitely.

Closes https://github.com/crate/crate/issues/18721
