### PR TITLE
Add warn logging when tripping parent circuit breaker

### DIFF
--- a/server/src/main/java/org/elasticsearch/indices/breaker/HierarchyCircuitBreakerService.java
+++ b/server/src/main/java/org/elasticsearch/indices/breaker/HierarchyCircuitBreakerService.java
@@ -251,6 +251,16 @@ public class HierarchyCircuitBreakerService extends CircuitBreakerService {
                 return;
             }
             this.parentTripCount.incrementAndGet();
+            if (LOGGER.isWarnEnabled()) {
+                LOGGER.warn(
+                    "[Parent] New used memory {} [{}] for [{}] would be larger than configured breaker: {} [{}], breaking",
+                    newBytesReserved,
+                    ByteSizeValue.humanReadableBytes(newBytesReserved),
+                    label,
+                    parentLimit,
+                    ByteSizeValue.humanReadableBytes(parentLimit)
+                );
+            }
             throw new CircuitBreakingException(newBytesReserved, totalUsed, parentLimit, "parent: " + label);
         }
     }


### PR DESCRIPTION
Aligns with query circuit breaker and helps debugging

Sometimes it's helpful to see label for parent CB but it's shown only to the client and not in the logs 
and leads to asking an exact error message to get more details

For example, in https://github.com/crate/support/issues/757#issuecomment-3517536574
 I saw
 >Allocating 2mb for 'parent: http-result' failed, 
 
 and decided to port https://github.com/crate/crate/pull/18741 to 5.10 as it was an indication that this cluster is producing heavy result sets via http
 
 Porting it as it's very small and to get it sooner on some clusters that are not likely to be upgraded soon - but can also wait for 6.2.