### PR TITLE
Fix left-outer-join missing rows when different keys map to the same hash bucket

### DIFF
--- a/docs/appendices/release-notes/6.1.2.rst
+++ b/docs/appendices/release-notes/6.1.2.rst
@@ -48,3 +48,9 @@ Fixes
 
 - Fixed an issue that caused ``SELECT COUNT(NULL) FROM tbl`` to return one
   record per row in the table instead of a single row with value ``0``.
+
+- Fixed a hash collision issue resulting in some unmatched rows not being
+  returned when using a ``LEFT JOIN`` query with an equal join condition.
+  Example::
+
+    SELECT * FROM t1 LEFT JOIN t2 ON t1.id = t2.id;

--- a/server/src/main/java/io/crate/execution/engine/join/HashJoinBatchIterator.java
+++ b/server/src/main/java/io/crate/execution/engine/join/HashJoinBatchIterator.java
@@ -22,15 +22,19 @@
 package io.crate.execution.engine.join;
 
 import java.util.ArrayList;
+import java.util.BitSet;
 import java.util.Iterator;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.NoSuchElementException;
 import java.util.function.LongToIntFunction;
 import java.util.function.Predicate;
 import java.util.function.ToIntFunction;
 
 import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.jetbrains.annotations.Nullable;
 
-import com.carrotsearch.hppc.IntArrayList;
-
+import io.crate.common.collections.Iterables;
 import io.crate.data.BatchIterator;
 import io.crate.data.Row;
 import io.crate.data.UnsafeArrayRow;
@@ -100,20 +104,20 @@ public class HashJoinBatchIterator extends JoinBatchIterator<Row, Row, Row> {
     private final ToIntFunction<Row> hashBuilderForLeft;
     private final ToIntFunction<Row> hashBuilderForRight;
     private final LongToIntFunction calculateBlockSize;
-    private final IntObjectHashMap<Values> buffer;
-    private final boolean emitNullValues;
+    private final IntObjectHashMap<HashGroup> buffer;
 
     private final UnsafeArrayRow unsafeArrayRow = new UnsafeArrayRow();
 
     private int leftAverageRowSize = -1;
     private int blockSize;
-    private int numberOfRowsInBuffer = 0;
+    private int numberOfHashGroupsInBuffer = 0;
     private boolean leftBatchHasItems = false;
-    private Iterator<Object[]> leftMatchingRowsIterator;
-    private IntArrayList nonMatchingKeys;
-    private int nonMatchingKeysIdx = 0;
-    private Iterator<Object[]> nonMatchValuesIterator;
-    private Values leftMatchingRows;
+
+    private ListIterator<Object[]> matchedHashGroupRowsIterator;
+    private HashGroup matchedHashGroup;
+
+    private final boolean emitUnmatchedRows;
+    private Iterator<Object[]> unmatchedRowsIterator;
 
     public HashJoinBatchIterator(CircuitBreaker circuitBreaker,
                                  BatchIterator<Row> left,
@@ -124,7 +128,7 @@ public class HashJoinBatchIterator extends JoinBatchIterator<Row, Row, Row> {
                                  ToIntFunction<Row> hashBuilderForLeft,
                                  ToIntFunction<Row> hashBuilderForRight,
                                  LongToIntFunction calculateBlockSize,
-                                 boolean emitNullValues) {
+                                 boolean emitUnmatchedRows) {
         super(left, right, combiner);
         this.circuitBreaker = circuitBreaker;
         this.leftRowAccounting = leftRowAccounting;
@@ -136,7 +140,8 @@ public class HashJoinBatchIterator extends JoinBatchIterator<Row, Row, Row> {
         this.buffer = new IntObjectHashMap<>();
         resetBuffer();
         this.activeIt = left;
-        this.emitNullValues = emitNullValues;
+        this.emitUnmatchedRows = emitUnmatchedRows;
+        this.unmatchedRowsIterator = null;
     }
 
     @Override
@@ -150,11 +155,9 @@ public class HashJoinBatchIterator extends JoinBatchIterator<Row, Row, Row> {
         right.moveToStart();
         activeIt = left;
         resetBuffer();
-        leftMatchingRowsIterator = null;
-        nonMatchingKeys = null;
-        nonMatchingKeysIdx = 0;
-        nonMatchValuesIterator = null;
-        leftMatchingRows = null;
+        matchedHashGroup = null;
+        matchedHashGroupRowsIterator = null;
+        unmatchedRowsIterator = null;
     }
 
     @Override
@@ -162,31 +165,23 @@ public class HashJoinBatchIterator extends JoinBatchIterator<Row, Row, Row> {
         while (buildBufferAndMatchRight() == false) {
             if (right.allLoaded() && leftBatchHasItems == false && left.allLoaded()) {
                 // both sides are fully loaded
-                if (emitNullValues) {
-                    extractNonMatchingKeys();
-                    if (hasMoreNonMatchingKeys()) {
-                        return emitNullValuesPairs();
-                    }
-                }
+                return tryEmitUnmatchedRow();
                 // we are fully done
-                return false;
             } else if (activeIt == left) {
                 // left needs the next batch loaded
                 return false;
             } else if (right.allLoaded()) {
                 // one batch completed
-                if (emitNullValues) {
-                    extractNonMatchingKeys();
-                    if (hasMoreNonMatchingKeys()) {
-                        return emitNullValuesPairs();
-                    }
+                if (tryEmitUnmatchedRow()) {
+                    return true;
                 }
                 // get ready for the next batch
                 right.moveToStart();
                 activeIt = left;
                 resetBuffer();
-                nonMatchingKeys = null;
-                nonMatchingKeysIdx = 0;
+                matchedHashGroup = null;
+                matchedHashGroupRowsIterator = null;
+                unmatchedRowsIterator = null;
             } else {
                 return false;
             }
@@ -196,42 +191,27 @@ public class HashJoinBatchIterator extends JoinBatchIterator<Row, Row, Row> {
         return true;
     }
 
-    private boolean hasMoreNonMatchingKeys() {
-        return nonMatchingKeysIdx < nonMatchingKeys.size();
-    }
-
-    private void extractNonMatchingKeys() {
-        if (nonMatchingKeys == null) {
-            nonMatchingKeys = new IntArrayList();
-            for (var values : buffer.entries()) {
-                if (values.value().matched == false) {
-                    nonMatchingKeys.add(values.key());
-                }
-            }
+    private boolean tryEmitUnmatchedRow() {
+        if (!emitUnmatchedRows) {
+            return false;
         }
-    }
-
-    private boolean emitNullValuesPairs() {
-        if (nonMatchValuesIterator == null) {
-            var key = nonMatchingKeys.get(nonMatchingKeysIdx);
-            nonMatchValuesIterator = buffer.get(key).items.iterator();
+        if (unmatchedRowsIterator == null) {
+            unmatchedRowsIterator = Iterables.concat(buffer.values()).iterator();
+        }
+        if (!unmatchedRowsIterator.hasNext()) {
+            return false;
         }
 
-        combiner.setLeft(unsafeArrayRow.cells(nonMatchValuesIterator.next()));
+        Object[] unmatchedRow = unmatchedRowsIterator.next();
+        combiner.setLeft(unsafeArrayRow.cells(unmatchedRow));
         combiner.nullRight();
-
-        if (nonMatchValuesIterator.hasNext() == false) {
-            nonMatchingKeysIdx++;
-            nonMatchValuesIterator = null;
-        }
-
         return true;
     }
 
     private void resetBuffer() {
         blockSize = calculateBlockSize.applyAsInt(leftAverageRowSize);
         buffer.clear();
-        numberOfRowsInBuffer = 0;
+        numberOfHashGroupsInBuffer = 0;
         leftRowAccounting.release();
     }
 
@@ -264,13 +244,13 @@ public class HashJoinBatchIterator extends JoinBatchIterator<Row, Row, Row> {
                 numItems++;
                 int hash = hashBuilderForLeft.applyAsInt(unsafeArrayRow.cells(leftRow));
                 addToBuffer(leftRow, hash);
-                if (numberOfRowsInBuffer == blockSize || circuitBreaker.getFree() < 512 * 1024) {
+                if (numberOfHashGroupsInBuffer == blockSize || circuitBreaker.getFree() < 512 * 1024) {
                     break;
                 }
             }
             leftAverageRowSize = numItems > 0 ? (int) (sum / numItems) : -1;
 
-            if (numberOfRowsInBuffer == 0 && !left.allLoaded()) {
+            if (numberOfHashGroupsInBuffer == 0 && !left.allLoaded()) {
                 return false;
             } else {
                 activeIt = right;
@@ -278,32 +258,17 @@ public class HashJoinBatchIterator extends JoinBatchIterator<Row, Row, Row> {
         }
 
         // In case of multiple matches on the left side (duplicate values or hash collisions)
-        if (leftMatchingRowsIterator != null && findMatchingRows()) {
-            if (emitNullValues) {
-                // We found matching rows, therefore we mark the values to emit
-                // non-matching values later with null value pairs
-                if (leftMatchingRows.matched == false) {
-                    leftMatchingRows.matched = true;
-                }
-            }
+        if (matchedHashGroupRowsIterator != null && findMatchingRows()) {
             return true;
         }
 
-        leftMatchingRowsIterator = null;
         while (right.moveNext()) {
             int rightHash = hashBuilderForRight.applyAsInt(right.currentElement());
-            leftMatchingRows = buffer.get(rightHash);
-            if (leftMatchingRows != null) {
-                leftMatchingRowsIterator = leftMatchingRows.items.iterator();
+            matchedHashGroup = buffer.get(rightHash);
+            if (matchedHashGroup != null) {
+                matchedHashGroupRowsIterator = matchedHashGroup.listIterator();
                 combiner.setRight(right.currentElement());
                 if (findMatchingRows()) {
-                    if (emitNullValues) {
-                        // We found matching rows, therefore we mark the values to emit
-                        // non-matching values later with null value pairs
-                        if (leftMatchingRows.matched == false) {
-                            leftMatchingRows.matched = true;
-                        }
-                    }
                     return true;
                 }
             }
@@ -314,30 +279,87 @@ public class HashJoinBatchIterator extends JoinBatchIterator<Row, Row, Row> {
     }
 
     private void addToBuffer(Object[] currentRow, int hash) {
-        Values existingRows = buffer.get(hash);
-        if (existingRows == null) {
-            existingRows = new Values();
-            buffer.put(hash, existingRows);
+        HashGroup hashGroup = buffer.get(hash);
+        if (hashGroup == null) {
+            hashGroup = new HashGroup(emitUnmatchedRows);
+            buffer.put(hash, hashGroup);
         }
-        existingRows.items.add(currentRow);
-        numberOfRowsInBuffer++;
+        hashGroup.add(currentRow);
+        numberOfHashGroupsInBuffer++;
     }
 
     private boolean findMatchingRows() {
-        while (leftMatchingRowsIterator.hasNext()) {
-            leftRow.cells(leftMatchingRowsIterator.next());
+        while (matchedHashGroupRowsIterator.hasNext()) {
+            int currentIdx = matchedHashGroupRowsIterator.nextIndex();
+            leftRow.cells(matchedHashGroupRowsIterator.next());
             combiner.setLeft(leftRow);
             if (joinCondition.test(combiner.currentElement())) {
+                matchedHashGroup.markMatched(currentIdx);
                 return true;
             }
         }
+        matchedHashGroup = null;
+        matchedHashGroupRowsIterator = null;
         return false;
     }
 
-    private static final class Values {
+    private static final class HashGroup implements Iterable<Object[]> {
 
-        ArrayList<Object[]> items = new ArrayList<>();
-        boolean matched = false;
+        private final List<Object[]> rows = new ArrayList<>();
+        @Nullable
+        private final BitSet rowIsJoinedFlags;
 
+        public HashGroup(boolean emitUnmatchedRows) {
+            this.rowIsJoinedFlags = emitUnmatchedRows ? new BitSet() : null;
+        }
+
+        public void add(Object[] row) {
+            rows.add(row);
+        }
+
+        public void markMatched(int idx) {
+            if (rowIsJoinedFlags != null) {
+                rowIsJoinedFlags.set(idx, true);
+            }
+        }
+
+        public ListIterator<Object[]> listIterator() {
+            return rows.listIterator();
+        }
+
+        @Override
+        public Iterator<Object[]> iterator() {
+            assert rowIsJoinedFlags != null : "UnmatchedRowIterator->rowIsJoinedFlags must not be NULL";
+            return new UnmatchedRowsIterator(rows, rowIsJoinedFlags);
+        }
+
+        private static final class UnmatchedRowsIterator implements Iterator<Object[]> {
+            private final List<Object[]> rows;
+            private final BitSet rowIsJoinedFlags;
+            private int idx = 0;
+
+            public UnmatchedRowsIterator(List<Object[]> rows, BitSet rowIsJoinedFlags) {
+                this.rows = rows;
+                this.rowIsJoinedFlags = rowIsJoinedFlags;
+            }
+
+            @Override
+            public boolean hasNext() {
+                int nextIdx = rowIsJoinedFlags.nextClearBit(idx);
+                return nextIdx > -1 && nextIdx < rows.size() && nextIdx >= idx;
+            }
+
+            @Override
+            public Object[] next() {
+                int nextIdx = rowIsJoinedFlags.nextClearBit(idx);
+                if (nextIdx >= idx) {
+                    idx = nextIdx + 1;
+                }
+                if (nextIdx <= -1 || nextIdx >= rows.size()) {
+                    throw new NoSuchElementException("Iterator exhausted");
+                }
+                return rows.get(nextIdx);
+            }
+        }
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
@@ -1742,6 +1742,54 @@ public class JoinIntegrationTest extends IntegTestCase {
         );
     }
 
+    @Test
+    @UseRandomizedSchema(random = false)
+    @UseRandomizedOptimizerRules(0)
+    @UseHashJoins(1)
+    public void test_left_outer_join_emits_non_matching_rows_having_hash_collisions() throws Exception {
+        execute("CREATE TABLE t1 (x text)");
+        execute("CREATE TABLE t2 (x text)");
+
+        // 'Aa' and 'BB', null and '' are mapped to the same hash values
+        execute("insert into t1 values (null), (''), ('Aa'), ('BB')");
+        execute("insert into t2 values (''), ('BB')");
+        execute("refresh table t1, t2");
+
+        String query = "SELECT * FROM t1 LEFT JOIN t2 on t1.x = t2.x";
+
+        execute(query);
+
+        assertThat(response).hasRowsInAnyOrder(
+            "NULL| NULL",
+            "| ",
+            "Aa| NULL",
+            "BB| BB"
+        );
+
+        execute("insert into t2 values (null)");
+        execute("refresh table t2");
+
+        execute(query);
+
+        assertThat(response).hasRowsInAnyOrder(
+            "NULL| NULL",
+            "| ",
+            "Aa| NULL",
+            "BB| BB"
+        );
+
+        execute("insert into t2 values ('Aa')");
+        execute("refresh table t2");
+
+        execute(query);
+
+        assertThat(response).hasRowsInAnyOrder(
+            "NULL| NULL",
+            "| ",
+            "Aa| Aa",
+            "BB| BB"
+        );
+    }
 
     /**
      * https://github.com/crate/crate/issues/16951


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Fixes https://github.com/crate/crate/issues/18680.

```
cr> create table t (a varchar);
CREATE OK, 1 row affected (1.702 sec)
cr> insert into t values ('Aa'), ('BB');
INSERT OK, 2 rows affected (0.089 sec)

cr> create table t2 (a varchar);
CREATE OK, 1 row affected (1.569 sec)
cr> insert into t2 values ('BB');
INSERT OK, 1 row affected (0.145 sec)

cr> select * from t left join t2 on t.a=t2.a;
+----+----+
| a  | a  |
+----+----+
| BB | BB | -- 'Aa' is missing
+----+----+
SELECT 1 row in set (0.005 sec)
```

The output of the left outer join was missing `Aa`. Although `Aa` is an unmatched row, since it is part of the left table it must still be returned. However, `Aa` ended up in the same hash bucket as `BB` (both hash to `2112`), and `BB` matched a right-side row. This caused the whole bucket to be marked as matched, which incorrectly skipped `Aa` from being returned.

The same thing happens for `null` and `""` because both hash to 0.

The fix changes the unmatched-rows logic to track matched state per row instead of per hash bucket, so we don’t accidentally skip valid left-side rows anymore.

Follows https://github.com/crate/crate/pull/16780.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
