### PR TITLE
Remove second argument for cast functions

### DIFF
--- a/server/src/main/java/io/crate/analyze/where/WhereClauseValidator.java
+++ b/server/src/main/java/io/crate/analyze/where/WhereClauseValidator.java
@@ -158,10 +158,11 @@ public final class WhereClauseValidator {
                 || insideNotPredicate(context)) {
                 throw error.get();
             }
-            assert function.arguments().size() == 2 : "function's number of arguments must be 2";
-            Symbol right = function.arguments().get(1);
-            if (!right.symbolType().isValueSymbol() && right.symbolType() != SymbolType.PARAMETER) {
-                throw error.get();
+            if (function.arguments().size() > 1) {
+                Symbol right = function.arguments().get(1);
+                if (!right.symbolType().isValueSymbol() && right.symbolType() != SymbolType.PARAMETER) {
+                    throw error.get();
+                }
             }
         }
     }

--- a/server/src/main/java/io/crate/expression/predicate/NotPredicate.java
+++ b/server/src/main/java/io/crate/expression/predicate/NotPredicate.java
@@ -152,13 +152,6 @@ public class NotPredicate extends Scalar<Boolean, Boolean> {
                         return null;
                     }
                 }
-                // For casts the second argument is always a null-literal carrying the target type
-                // Only visit the first argument to prevent visitLiteral on the second argument
-                // to set enforceThreeValuedLogic = true
-                boolean isNullable = context.isNullable;
-                a.accept(this, context);
-                context.isNullable = isNullable;
-                return null;
             } else if (Ignore3vlFunction.NAME.equals(functionName)) {
                 context.isNullable = false;
                 return null;

--- a/server/src/main/java/io/crate/expression/scalar/cast/ImplicitCastFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/cast/ImplicitCastFunction.java
@@ -42,8 +42,9 @@ public class ImplicitCastFunction extends Scalar<Object, Object> {
 
     public static final String NAME = "_cast";
     public static final Signature SIGNATURE = Signature.builder(NAME, FunctionType.SCALAR)
-        .argumentTypes(TypeSignature.parse("E"), TypeSignature.parse("V"))
-        .returnType(TypeSignature.parse("V"))
+        .argumentTypes(TypeSignature.parse("E"))
+        // concrete returnType is part of the `Function` symbol and will be available in the BoundSignature.
+        .returnType(DataTypes.UNDEFINED.getTypeSignature())
         .features(Feature.DETERMINISTIC)
         .typeVariableConstraints(typeVariable("E"))
         .build();

--- a/server/src/main/java/io/crate/expression/symbol/Function.java
+++ b/server/src/main/java/io/crate/expression/symbol/Function.java
@@ -279,7 +279,8 @@ public class Function implements Symbol, Cloneable {
         Function function = (Function) o;
         return Objects.equals(arguments, function.arguments) &&
                Objects.equals(signature, function.signature) &&
-               Objects.equals(filter, function.filter);
+               Objects.equals(filter, function.filter) &&
+               Objects.equals(returnType, function.returnType);
     }
 
     @Override
@@ -287,6 +288,7 @@ public class Function implements Symbol, Cloneable {
         int result = arguments.hashCode();
         result = 31 * result + signature.hashCode();
         result = 31 * result + (filter == null ? 0 : filter.hashCode());
+        result = 31 * result + returnType.hashCode();
         return result;
     }
 
@@ -502,12 +504,10 @@ public class Function implements Symbol, Cloneable {
 
     private void printCastFunction(StringBuilder builder, Style style) {
         var name = signature.getName().name();
-        assert arguments.size() == 2 : "Expecting 2 arguments for function " + name;
         if (name.equalsIgnoreCase(ImplicitCastFunction.NAME)) {
             builder.append(arguments().get(0).toString(style));
         } else {
-            var targetType = arguments.get(1).valueType();
-            var columnType = targetType.toColumnType(null);
+            var columnType = returnType.toColumnType(null);
             builder
                 .append(name)
                 .append("(")

--- a/server/src/main/java/io/crate/expression/symbol/Symbol.java
+++ b/server/src/main/java/io/crate/expression/symbol/Symbol.java
@@ -236,9 +236,7 @@ public interface Symbol extends Writeable, Accountable {
             case EXPLICIT -> ExplicitCastFunction.SIGNATURE;
             case TRY -> TryCastFunction.SIGNATURE;
         };
-        // a literal with a NULL value is passed as an argument
-        // to match the method signature
-        List<Symbol> arguments = List.of(sourceSymbol, Literal.of(targetType, null));
+        List<Symbol> arguments = List.of(sourceSymbol);
         return new Function(signature, arguments, targetType);
     }
 }

--- a/server/src/test/java/io/crate/analyze/CopyAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/CopyAnalyzerTest.java
@@ -25,8 +25,6 @@ import static com.carrotsearch.randomizedtesting.RandomizedTest.$;
 import static io.crate.analyze.TableDefinitions.TEST_PARTITIONED_TABLE_IDENT;
 import static io.crate.analyze.TableDefinitions.USER_TABLE_IDENT;
 import static io.crate.testing.Asserts.assertThat;
-import static io.crate.testing.Asserts.isFunction;
-import static io.crate.testing.Asserts.isLiteral;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -419,22 +417,20 @@ public class CopyAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         AnalyzedCopyFrom analyzedCopyFrom = e.analyze("copy users from '/tmp/t_' || curdate()");
         assertThat(analyzedCopyFrom.uri()).isFunction(
             ConcatFunction.OPERATOR_NAME,
-            isLiteral("/tmp/t_"),
-            isFunction(
+            x -> assertThat(x).isLiteral("/tmp/t_"),
+            x -> assertThat(x).isFunction(
                 ImplicitCastFunction.NAME,
-                x -> assertThat(x).isFunction(CurrentDateFunction.NAME),
-                x -> assertThat(x).hasDataType(DataTypes.STRING)
-            )
+                y -> assertThat(y).isFunction(CurrentDateFunction.NAME)
+            ).hasDataType(DataTypes.STRING)
         );
         AnalyzedCopyTo analyzedCopyTo = e.analyze("copy users to directory '/tmp/' || curdate()");
         assertThat(analyzedCopyTo.uri()).isFunction(
             ConcatFunction.OPERATOR_NAME,
-            isLiteral("/tmp/"),
-            isFunction(
+            x -> assertThat(x).isLiteral("/tmp/"),
+            x -> assertThat(x).isFunction(
                 ImplicitCastFunction.NAME,
-                x -> assertThat(x).isFunction(CurrentDateFunction.NAME),
-                x -> assertThat(x).hasDataType(DataTypes.STRING)
-            )
+                y -> assertThat(y).isFunction(CurrentDateFunction.NAME)
+            ).hasDataType(DataTypes.STRING)
         );
     }
 }

--- a/server/src/test/java/io/crate/analyze/InsertAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/InsertAnalyzerTest.java
@@ -526,20 +526,18 @@ public class InsertAnalyzerTest extends CrateDummyClusterServiceUnitTest {
                 ValuesFunction.NAME,
                 isFunction(
                     ArrayFunction.NAME,
-                    isFunction(
+                    x -> assertThat(x).isFunction(
                         ImplicitCastFunction.NAME,
-                        x -> assertThat(x).isFunction(NowFunction.NAME),
-                        x -> assertThat(x).hasDataType(DataTypes.LONG)
-                    )
+                        y -> assertThat(y).isFunction(NowFunction.NAME)
+                    ).hasDataType(DataTypes.LONG)
                 )
             );
         assertThat(analyzedInsertStatement.onDuplicateKeyAssignments().values())
             .satisfiesExactly(
-                isFunction(
+                x -> assertThat(x).isFunction(
                     ImplicitCastFunction.NAME,
-                    x -> assertThat(x).isFunction(CurrentDateFunction.NAME),
-                    x -> assertThat(x).hasDataType(DataTypes.TIMESTAMPZ)
-                )
+                    y -> assertThat(y).isFunction(CurrentDateFunction.NAME)
+                ).hasDataType(DataTypes.TIMESTAMPZ)
             );
     }
 }

--- a/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -33,6 +33,7 @@ import static io.crate.testing.Asserts.isReference;
 import static io.crate.testing.Asserts.toCondition;
 import static io.crate.types.ArrayType.makeArray;
 import static org.assertj.core.api.Assertions.anyOf;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
@@ -1700,14 +1701,14 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
             .addTable(TableDefinitions.USER_TABLE_DEFINITION);
         AnalyzedRelation relation = executor.analyze("select cast(other_id as text) from users");
         assertThat(relation.outputs().getFirst())
-            .isFunction(ExplicitCastFunction.NAME, List.of(DataTypes.LONG, DataTypes.STRING));
+            .isFunction(ExplicitCastFunction.NAME, List.of(DataTypes.LONG)).hasDataType(DataTypes.STRING);
 
         relation = executor.analyze("select cast(1+1 as string) from users");
         assertThat(relation.outputs().getFirst()).isLiteral("2", DataTypes.STRING);
 
         relation = executor.analyze("select cast(friends['id'] as array(text)) from users");
         assertThat(relation.outputs().getFirst())
-            .isFunction(ExplicitCastFunction.NAME, List.of(DataTypes.BIGINT_ARRAY, DataTypes.STRING_ARRAY));
+            .isFunction(ExplicitCastFunction.NAME, List.of(DataTypes.BIGINT_ARRAY)).hasDataType(DataTypes.STRING_ARRAY);
     }
 
     @Test
@@ -1716,9 +1717,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
             .addTable(TableDefinitions.USER_TABLE_DEFINITION);
         AnalyzedRelation relation = executor.analyze("select try_cast(other_id as text) from users");
         assertThat(relation.outputs().getFirst())
-            .isFunction(
-                TryCastFunction.NAME,
-                List.of(DataTypes.LONG, DataTypes.STRING));
+            .isFunction(TryCastFunction.NAME, List.of(DataTypes.LONG)).hasDataType(DataTypes.STRING);
 
         relation = executor.analyze("select try_cast(1+1 as string) from users");
         assertThat(relation.outputs().getFirst()).isLiteral("2", DataTypes.STRING);
@@ -1729,8 +1728,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         relation = executor.analyze("select try_cast(counters as array(boolean)) from users");
         assertThat(relation.outputs().getFirst())
             .isFunction(
-                TryCastFunction.NAME,
-                List.of(DataTypes.BIGINT_ARRAY, DataTypes.BOOLEAN_ARRAY));
+                TryCastFunction.NAME, List.of(DataTypes.BIGINT_ARRAY)).hasDataType(DataTypes.BOOLEAN_ARRAY);
     }
 
     @Test
@@ -1844,7 +1842,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
 
         Symbol argument = ((Function) symbol).arguments().getFirst();
         assertThat(argument)
-            .isFunction(ExplicitCastFunction.NAME, List.of(DataTypes.STRING, DataTypes.TIMESTAMPZ));
+            .isFunction(ExplicitCastFunction.NAME, List.of(DataTypes.STRING)).hasDataType(DataTypes.TIMESTAMPZ);
     }
 
     @Test

--- a/server/src/test/java/io/crate/analyze/UpdateAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/UpdateAnalyzerTest.java
@@ -698,10 +698,9 @@ public class UpdateAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(stmt.assignmentByTargetCol()).hasEntrySatisfying(
             toCondition(isReference("a", new ArrayType<>(DataTypes.UNTYPED_OBJECT))),
             toCondition(isFunction("array_set",
-                isFunction("_cast",
-                    x -> assertThat(x).isReference().hasName("a"),
-                    x -> assertThat(x).hasDataType(expectedType)
-                ),
+                x -> assertThat(x).isFunction("_cast",
+                    y -> assertThat(y).isReference().hasName("a")
+                ).hasDataType(expectedType),
                 isFunction("_array", isLiteral(1)),
                 isFunction("_array", isLiteral(Map.of("c", 1))))));
 
@@ -729,20 +728,19 @@ public class UpdateAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(analyzedUpdateStatement.query())
             .isFunction(
                 LtOperator.NAME,
-                isReference("id"),
-                isFunction(
+                x -> assertThat(x).isReference().hasName("id"),
+                x -> assertThat(x).isFunction(
                     ImplicitCastFunction.NAME,
-                    x -> assertThat(x).isFunction(CurrentDateFunction.NAME),
-                    x -> assertThat(x).hasDataType(DataTypes.LONG)
-                )
+                    y -> assertThat(y).isFunction(CurrentDateFunction.NAME)
+                ).hasDataType(DataTypes.LONG)
             );
         assertThat(analyzedUpdateStatement.assignmentByTargetCol().values())
             .satisfiesExactly(
-                isFunction(
-                    ImplicitCastFunction.NAME,
-                    x -> assertThat(x).isFunction(CurrentDateFunction.NAME),
-                    x -> assertThat(x).hasDataType(DataTypes.TIMESTAMPZ)
-                )
+                x -> assertThat(x)
+                    .isFunction(
+                        ImplicitCastFunction.NAME,
+                        y -> assertThat(y).isFunction(CurrentDateFunction.NAME)
+                    ).hasDataType(DataTypes.TIMESTAMPZ)
             );
     }
 }

--- a/server/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
@@ -287,7 +287,9 @@ public class ExpressionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(eq).isFunction(
             EqOperator.NAME,
             x -> assertThat(x).isReference().hasName("w"),
-            x -> assertThat(x).isFunction(ImplicitCastFunction.NAME, List.of(DataTypes.INTEGER, DataTypes.LONG))
+            x -> assertThat(x)
+                .isFunction(ImplicitCastFunction.NAME, List.of(DataTypes.INTEGER))
+                .hasDataType(DataTypes.LONG)
         );
     }
 
@@ -296,7 +298,8 @@ public class ExpressionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         Function symbol = (Function) executor.asSymbol("doc.t5.i < doc.t5.w");
         assertThat(symbol).isFunction(LtOperator.NAME);
         assertThat(symbol.arguments().get(0))
-            .isFunction(ImplicitCastFunction.NAME, List.of(DataTypes.INTEGER, DataTypes.LONG));
+            .isFunction(ImplicitCastFunction.NAME, List.of(DataTypes.INTEGER))
+            .hasDataType(DataTypes.LONG);
         assertThat(symbol.arguments().get(1)).hasDataType(DataTypes.LONG);
     }
 
@@ -575,9 +578,8 @@ public class ExpressionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
             x -> assertThat(x).isReference().hasName("a"),
             x -> assertThat(x).isFunction(
                 ImplicitCastFunction.NAME,
-                y -> assertThat(y).isReference().hasName("b"),
-                y -> assertThat(y).hasDataType(DataTypes.NUMERIC)
-            )
+                y -> assertThat(y).isReference().hasName("b")
+            ).hasDataType(DataTypes.NUMERIC)
         );
     }
 

--- a/server/src/test/java/io/crate/expression/symbol/LiteralTest.java
+++ b/server/src/test/java/io/crate/expression/symbol/LiteralTest.java
@@ -121,9 +121,7 @@ public class LiteralTest extends ESTestCase {
     public void test_cast_on_literal_returns_cast_function() {
         Symbol intLiteral = Literal.of(1);
         Asserts.assertThat(intLiteral.cast(DataTypes.LONG, CastMode.IMPLICIT))
-            .isFunction(
-                ImplicitCastFunction.NAME,
-                List.of(intLiteral.valueType(), DataTypes.LONG)
-            ).hasDataType(DataTypes.LONG);
+            .isFunction(ImplicitCastFunction.NAME, List.of(intLiteral.valueType()))
+            .hasDataType(DataTypes.LONG);
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
@@ -22,6 +22,7 @@
 package io.crate.integrationtests;
 
 import static io.crate.testing.Asserts.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/server/src/test/java/io/crate/metadata/GeneratedReferenceTest.java
+++ b/server/src/test/java/io/crate/metadata/GeneratedReferenceTest.java
@@ -98,8 +98,7 @@ public class GeneratedReferenceTest extends CrateDummyClusterServiceUnitTest {
             arg1 -> {
                 assertThat(arg1).isExactlyInstanceOf(GeneratedReference.class);
                 assertThat(arg1).isReference().hasName("year");
-            },
-            arg2 -> assertThat(arg2).isLiteral(null)
-        );
+            }
+        ).hasDataType(DataTypes.STRING);
     }
 }

--- a/server/src/test/java/io/crate/planner/InsertPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/InsertPlannerTest.java
@@ -348,9 +348,10 @@ public class InsertPlannerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(projection.outputs())
             .satisfiesExactly(
                 s -> assertThat(s).isInputColumn(0),
-                s -> assertThat(s).isFunction(
-                    ImplicitCastFunction.NAME,
-                    List.of(DataTypes.LONG, DataTypes.STRING)));
+                s -> assertThat(s)
+                    .isFunction(ImplicitCastFunction.NAME, List.of(DataTypes.LONG))
+                    .hasDataType(DataTypes.STRING)
+            );
 
         ColumnIndexWriterProjection columnIndexWriterProjection = (ColumnIndexWriterProjection) collectPhase.projections().get(2);
         assertThat(columnIndexWriterProjection.allTargetColumns()).satisfiesExactly(
@@ -422,9 +423,9 @@ public class InsertPlannerTest extends CrateDummyClusterServiceUnitTest {
 
         assertThat(projections.getFirst().outputs())
             .satisfiesExactly(
-                s -> assertThat(s).isFunction(
-                    ImplicitCastFunction.NAME,
-                    List.of(DataTypes.INTEGER, DataTypes.LONG)),
+                s -> assertThat(s)
+                    .isFunction(ImplicitCastFunction.NAME, List.of(DataTypes.INTEGER))
+                    .hasDataType(DataTypes.LONG),
                 s -> assertThat(s).isInputColumn(1));
     }
 


### PR DESCRIPTION
Follow up to https://github.com/crate/crate/pull/18755

Turns out the null-literal to carry the target type isn't even required
because the target type is available via the function symbol return
type, which is carried over to the bound signature return type.

Removing the second argument reduces the memory footprint - especially
for object casts with many inner types.
