### PR TITLE
Minor: Fix START TRANSACTION documentation formatting

### DIFF
--- a/docs/sql/statements/start-transaction.rst
+++ b/docs/sql/statements/start-transaction.rst
@@ -9,6 +9,7 @@
 CrateDB accepts the ``START TRANSACTION`` statement for compatibility with the
 :ref:`PostgreSQL wire protocol <interface-postgresql>`. However, CrateDB does
 not support transactions and will silently ignore this statement.
+
 .. SEEALSO::
 
     :ref:`Appendix: SQL compatibility <appendix-compatibility>`


### PR DESCRIPTION
Formatting was wrong, resulting in broken HTML output.

## Before
<img width="907" height="326" alt="Screenshot 2025-11-20 at 13 43 41" src="https://github.com/user-attachments/assets/1a9d9ec0-7a3c-4c91-b353-9cf6df885a4f" />

## Now
<img width="914" height="330" alt="Screenshot 2025-11-20 at 13 44 07" src="https://github.com/user-attachments/assets/14053d73-0d14-471b-9e06-87c48536143a" />
