### PR TITLE
Adapt test_s3 for breaking changes in minio python sdk

### DIFF
--- a/blackbox/requirements.txt
+++ b/blackbox/requirements.txt
@@ -8,7 +8,7 @@ cr8>=0.19.1
 tqdm>=4.66.4
 pycodestyle==2.4.0
 zc.customdoctests==1.0.1
-minio>=5.0.0
+minio>=7.2.19
 pyjnius
 
 # used for dns-discovery tests


### PR DESCRIPTION
See https://github.com/minio/minio-py/compare/7.2.18...7.2.19
It is now forcing named arguments in more places
