### PR TITLE
Add forward compatibility for 6.2.0 cast function representation

### DIFF
--- a/docs/appendices/release-notes/6.1.2.rst
+++ b/docs/appendices/release-notes/6.1.2.rst
@@ -46,5 +46,8 @@ series.
 Fixes
 =====
 
+- Added forward compatibility for cast function representation used in CrateDB
+  6.2.0+. As a side effect this also improves the performance of implicit casts.
+
 - Fixed an issue that caused ``SELECT COUNT(NULL) FROM tbl`` to return one
   record per row in the table instead of a single row with value ``0``.

--- a/server/src/main/java/io/crate/expression/scalar/cast/ExplicitCastFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/cast/ExplicitCastFunction.java
@@ -35,6 +35,7 @@ import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataType;
+import io.crate.types.DataTypes;
 import io.crate.types.TypeSignature;
 
 public class ExplicitCastFunction extends Scalar<Object, Object> {
@@ -47,8 +48,17 @@ public class ExplicitCastFunction extends Scalar<Object, Object> {
         .typeVariableConstraints(typeVariable("E"), typeVariable("V"))
         .build();
 
+    // Forward compatibility with 6.2.0 which uses single arg cast function symbols
+    public static final Signature FWC_SIGNATURE = Signature.builder(NAME, FunctionType.SCALAR)
+        .argumentTypes(TypeSignature.parse("E"))
+        .returnType(DataTypes.UNDEFINED.getTypeSignature())
+        .features(Feature.DETERMINISTIC)
+        .typeVariableConstraints(typeVariable("E"))
+        .build();
+
     public static void register(Functions.Builder module) {
         module.add(SIGNATURE, ExplicitCastFunction::new);
+        module.add(FWC_SIGNATURE, ExplicitCastFunction::new);
     }
 
     private final DataType<?> returnType;

--- a/server/src/main/java/io/crate/expression/scalar/cast/TryCastFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/cast/TryCastFunction.java
@@ -34,6 +34,7 @@ import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataType;
+import io.crate.types.DataTypes;
 import io.crate.types.TypeSignature;
 
 public class TryCastFunction extends Scalar<Object, Object> {
@@ -46,8 +47,17 @@ public class TryCastFunction extends Scalar<Object, Object> {
         .typeVariableConstraints(typeVariable("E"), typeVariable("V"))
         .build();
 
+    // Forward compatibility with 6.2.0 which uses single arg cast function symbols
+    static final Signature FWC_SIGNATURE = Signature.builder(NAME, FunctionType.SCALAR)
+        .argumentTypes(TypeSignature.parse("E"))
+        .returnType(DataTypes.UNDEFINED.getTypeSignature())
+        .features(Feature.DETERMINISTIC)
+        .typeVariableConstraints(typeVariable("E"))
+        .build();
+
     public static void register(Functions.Builder module) {
         module.add(SIGNATURE, TryCastFunction::new);
+        module.add(FWC_SIGNATURE, TryCastFunction::new);
     }
 
     private final DataType<?> returnType;

--- a/server/src/main/java/io/crate/expression/symbol/Function.java
+++ b/server/src/main/java/io/crate/expression/symbol/Function.java
@@ -279,7 +279,8 @@ public class Function implements Symbol, Cloneable {
         Function function = (Function) o;
         return Objects.equals(arguments, function.arguments) &&
                Objects.equals(signature, function.signature) &&
-               Objects.equals(filter, function.filter);
+               Objects.equals(filter, function.filter) &&
+               Objects.equals(returnType, function.returnType);
     }
 
     @Override
@@ -287,6 +288,7 @@ public class Function implements Symbol, Cloneable {
         int result = arguments.hashCode();
         result = 31 * result + signature.hashCode();
         result = 31 * result + (filter == null ? 0 : filter.hashCode());
+        result = 31 * result + returnType.hashCode();
         return result;
     }
 


### PR DESCRIPTION
(Bonus side effect is that 6.1.2 will now also have the perf improvement, even without the function symbol change)