### PR TITLE
Move circuit breaker name constants to 'CircuitBreaker'

### DIFF
--- a/extensions/jmx-monitoring/src/main/java/io/crate/beans/CircuitBreakers.java
+++ b/extensions/jmx-monitoring/src/main/java/io/crate/beans/CircuitBreakers.java
@@ -24,7 +24,6 @@ package io.crate.beans;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.indices.breaker.CircuitBreakerStats;
-import org.elasticsearch.indices.breaker.HierarchyCircuitBreakerService;
 
 public class CircuitBreakers implements CircuitBreakersMXBean {
 
@@ -59,16 +58,16 @@ public class CircuitBreakers implements CircuitBreakersMXBean {
 
     @Override
     public CircuitBreakerStats getQuery() {
-        return circuitBreakerService.stats(HierarchyCircuitBreakerService.QUERY);
+        return circuitBreakerService.stats(CircuitBreaker.QUERY);
     }
 
     @Override
     public CircuitBreakerStats getJobsLog() {
-        return circuitBreakerService.stats(HierarchyCircuitBreakerService.JOBS_LOG);
+        return circuitBreakerService.stats(CircuitBreaker.JOBS_LOG);
     }
 
     @Override
     public CircuitBreakerStats getOperationsLog() {
-        return circuitBreakerService.stats(HierarchyCircuitBreakerService.OPERATIONS_LOG);
+        return circuitBreakerService.stats(CircuitBreaker.OPERATIONS_LOG);
     }
 }

--- a/server/src/main/java/io/crate/execution/MultiPhaseExecutor.java
+++ b/server/src/main/java/io/crate/execution/MultiPhaseExecutor.java
@@ -29,7 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
-import org.elasticsearch.indices.breaker.HierarchyCircuitBreakerService;
+import org.elasticsearch.common.breaker.CircuitBreaker;
 
 import io.crate.breaker.ConcurrentRamAccounting;
 import io.crate.data.CollectingRowConsumer;
@@ -55,7 +55,7 @@ public final class MultiPhaseExecutor {
                                                              Row params) {
         var ramAccounting = ConcurrentRamAccounting.forCircuitBreaker(
             "multi-phase",
-            executor.circuitBreaker(HierarchyCircuitBreakerService.QUERY),
+            executor.circuitBreaker(CircuitBreaker.QUERY),
             plannerContext.transactionContext().sessionSettings().memoryLimitInBytes()
         );
 

--- a/server/src/main/java/io/crate/execution/dml/TransportShardAction.java
+++ b/server/src/main/java/io/crate/execution/dml/TransportShardAction.java
@@ -39,7 +39,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
-import org.elasticsearch.indices.breaker.HierarchyCircuitBreakerService;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
@@ -136,7 +135,7 @@ public abstract class TransportShardAction<
 
     private <WrapperResponse> WrapperResponse withActiveOperation(ShardRequest<?, ?> request,
                                                                   KillableCallable<WrapperResponse> callable) {
-        CircuitBreaker breaker = circuitBreakerService.getBreaker(HierarchyCircuitBreakerService.QUERY);
+        CircuitBreaker breaker = circuitBreakerService.getBreaker(CircuitBreaker.QUERY);
         // Request is already accounted by the transport layer, but we account extra to account for the replica request copy
         long ramBytesUsed = request.ramBytesUsed();
         breaker.addEstimateBytesAndMaybeBreak(ramBytesUsed, "upsert request");

--- a/server/src/main/java/io/crate/execution/engine/collect/sources/ShardCollectorProviderFactory.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/sources/ShardCollectorProviderFactory.java
@@ -27,6 +27,7 @@ import java.util.Map;
 
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
 import org.elasticsearch.common.settings.Settings;
@@ -34,7 +35,6 @@ import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.PageCacheRecycler;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
-import org.elasticsearch.indices.breaker.HierarchyCircuitBreakerService;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.threadpool.ThreadPool;
 
@@ -85,7 +85,7 @@ public class ShardCollectorProviderFactory {
         this.nodeCtx = nodeCtx;
         this.luceneQueryBuilder = luceneQueryBuilder;
         this.nodeJobsCounter = nodeJobsCounter;
-        this.bigArrays = new BigArrays(pageCacheRecycler, circuitBreakerService, HierarchyCircuitBreakerService.QUERY, true);
+        this.bigArrays = new BigArrays(pageCacheRecycler, circuitBreakerService, CircuitBreaker.QUERY, true);
         this.fileOutputFactoryMap = fileOutputFactoryMap;
     }
 

--- a/server/src/main/java/io/crate/execution/engine/collect/stats/JobsLogService.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/stats/JobsLogService.java
@@ -33,6 +33,7 @@ import java.util.function.ToLongFunction;
 
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.common.inject.Provider;
 import org.elasticsearch.common.inject.Singleton;
@@ -41,7 +42,6 @@ import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
-import org.elasticsearch.indices.breaker.HierarchyCircuitBreakerService;
 import org.jetbrains.annotations.VisibleForTesting;
 
 import io.crate.analyze.ParamTypeHints;
@@ -220,7 +220,7 @@ public class JobsLogService extends AbstractLifecycleComponent implements Provid
     @VisibleForTesting
     void updateJobSink(int size, TimeValue expiration) {
         LogSink<JobContextLog> sink = createSink(
-            size, expiration, JobContextLog::ramBytesUsed, HierarchyCircuitBreakerService.JOBS_LOG);
+            size, expiration, JobContextLog::ramBytesUsed, CircuitBreaker.JOBS_LOG);
         LogSink<JobContextLog> newSink = sink.equals(NoopLogSink.instance()) ? sink : new FilteredLogSink<>(
             memoryFilter,
             persistFilter,
@@ -304,7 +304,7 @@ public class JobsLogService extends AbstractLifecycleComponent implements Provid
             size,
             expiration,
             OperationContextLog::ramBytesUsed,
-            HierarchyCircuitBreakerService.OPERATIONS_LOG);
+            CircuitBreaker.OPERATIONS_LOG);
         jobsLogs.updateOperationsLog(newSink);
     }
 

--- a/server/src/main/java/io/crate/execution/engine/fetch/TransportFetchNodeAction.java
+++ b/server/src/main/java/io/crate/execution/engine/fetch/TransportFetchNodeAction.java
@@ -27,12 +27,12 @@ import java.util.concurrent.ThreadPoolExecutor;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionListenerResponseHandler;
 import org.elasticsearch.action.support.TransportAction;
+import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
-import org.elasticsearch.indices.breaker.HierarchyCircuitBreakerService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
@@ -65,7 +65,7 @@ public class TransportFetchNodeAction extends TransportAction<NodeFetchRequest, 
             EsExecutors.numberOfProcessors(settings),
             jobsLogs,
             tasksService,
-            circuitBreakerService.getBreaker(HierarchyCircuitBreakerService.QUERY)
+            circuitBreakerService.getBreaker(CircuitBreaker.QUERY)
         );
 
         transportService.registerRequestHandler(

--- a/server/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
+++ b/server/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
@@ -41,13 +41,13 @@ import java.util.stream.Collector;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.lucene.uid.Versions;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.index.seqno.SequenceNumbers;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
-import org.elasticsearch.indices.breaker.HierarchyCircuitBreakerService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.jetbrains.annotations.Nullable;
 
@@ -431,7 +431,7 @@ public class ProjectionToProjectorVisitor
         return new IndexWriterProjector(
             clusterService,
             nodeJobsCounter,
-            circuitBreakerService.getBreaker(HierarchyCircuitBreakerService.QUERY),
+            circuitBreakerService.getBreaker(CircuitBreaker.QUERY),
             context.ramAccounting,
             threadPool.scheduler(),
             threadPool.executor(ThreadPool.Names.SEARCH),
@@ -495,7 +495,7 @@ public class ProjectionToProjectorVisitor
             clusterService,
             constraintsChecker,
             nodeJobsCounter,
-            circuitBreakerService.getBreaker(HierarchyCircuitBreakerService.QUERY),
+            circuitBreakerService.getBreaker(CircuitBreaker.QUERY),
             context.ramAccounting,
             threadPool.scheduler(),
             threadPool.executor(ThreadPool.Names.SEARCH),
@@ -564,7 +564,7 @@ public class ProjectionToProjectorVisitor
             resolveUidCollectExpression(context.txnCtx, projection.uidSymbol()),
             clusterService,
             context.ramAccounting,
-            circuitBreakerService.getBreaker(HierarchyCircuitBreakerService.QUERY),
+            circuitBreakerService.getBreaker(CircuitBreaker.QUERY),
             nodeJobsCounter,
             () -> builder.newRequest(shardId),
             id -> {
@@ -595,7 +595,7 @@ public class ProjectionToProjectorVisitor
             resolveUidCollectExpression(context.txnCtx, projection.uidSymbol()),
             clusterService,
             context.ramAccounting,
-            circuitBreakerService.getBreaker(HierarchyCircuitBreakerService.QUERY),
+            circuitBreakerService.getBreaker(CircuitBreaker.QUERY),
             nodeJobsCounter,
             () -> new ShardDeleteRequest(shardId, context.jobId).timeout(reqTimeout),
             ShardDeleteRequest.Item::new,
@@ -623,7 +623,7 @@ public class ProjectionToProjectorVisitor
             projection,
             context.ramAccounting,
             () -> FetchProjector.computeReaderBucketsByteThreshold(
-                circuitBreakerService.getBreaker(HierarchyCircuitBreakerService.QUERY)
+                circuitBreakerService.getBreaker(CircuitBreaker.QUERY)
             ),
             context.txnCtx,
             nodeCtx,

--- a/server/src/main/java/io/crate/execution/jobs/JobSetup.java
+++ b/server/src/main/java/io/crate/execution/jobs/JobSetup.java
@@ -49,7 +49,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
-import org.elasticsearch.indices.breaker.HierarchyCircuitBreakerService;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.jetbrains.annotations.Nullable;
@@ -201,7 +200,7 @@ public class JobSetup {
             distributingConsumerFactory,
             nodeOperations,
             sharedShardContexts,
-            circuitBreakerService.getBreaker(HierarchyCircuitBreakerService.QUERY)
+            circuitBreakerService.getBreaker(CircuitBreaker.QUERY)
         );
         registerContextPhases(nodeOperations, context);
         LOGGER.trace(
@@ -231,7 +230,7 @@ public class JobSetup {
             distributingConsumerFactory,
             nodeOperations,
             sharedShardContexts,
-            circuitBreakerService.getBreaker(HierarchyCircuitBreakerService.QUERY)
+            circuitBreakerService.getBreaker(CircuitBreaker.QUERY)
         );
         for (var handlerPhase : handlerPhases) {
             context.registerLeaf(handlerPhase.phase(), handlerPhase.consumer());

--- a/server/src/main/java/io/crate/planner/DeclarePlan.java
+++ b/server/src/main/java/io/crate/planner/DeclarePlan.java
@@ -24,7 +24,6 @@ package io.crate.planner;
 import java.util.concurrent.CompletableFuture;
 
 import org.elasticsearch.common.breaker.CircuitBreaker;
-import org.elasticsearch.indices.breaker.HierarchyCircuitBreakerService;
 import org.jetbrains.annotations.Nullable;
 
 import io.crate.analyze.AnalyzedDeclare;
@@ -69,7 +68,7 @@ public class DeclarePlan implements Plan {
         CursorRowConsumer cursorRowConsumer = new CursorRowConsumer(consumer);
         Cursors cursors = plannerContext.cursors();
         Declare declareStmt = declare.declare();
-        CircuitBreaker circuitBreaker = dependencies.circuitBreaker(HierarchyCircuitBreakerService.QUERY);
+        CircuitBreaker circuitBreaker = dependencies.circuitBreaker(CircuitBreaker.QUERY);
         Cursor cursor = new Cursor(
             circuitBreaker,
             declareStmt.cursorName(),

--- a/server/src/main/java/io/crate/planner/node/management/ExplainProfilePlan.java
+++ b/server/src/main/java/io/crate/planner/node/management/ExplainProfilePlan.java
@@ -36,7 +36,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 import org.elasticsearch.client.Client;
-import org.elasticsearch.indices.breaker.HierarchyCircuitBreakerService;
+import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.jetbrains.annotations.Nullable;
 
 import io.crate.breaker.ConcurrentRamAccounting;
@@ -94,7 +94,7 @@ public class ExplainProfilePlan implements Plan {
                               SubQueryResults subQueryResults) throws Exception {
         var ramAccounting = ConcurrentRamAccounting.forCircuitBreaker(
             "multi-phase",
-            dependencies.circuitBreaker(HierarchyCircuitBreakerService.QUERY),
+            dependencies.circuitBreaker(CircuitBreaker.QUERY),
             plannerContext.transactionContext().sessionSettings().memoryLimitInBytes()
         );
         consumer.completionFuture().whenComplete((_, _) -> ramAccounting.close());

--- a/server/src/main/java/io/crate/rest/action/SqlHttpHandler.java
+++ b/server/src/main/java/io/crate/rest/action/SqlHttpHandler.java
@@ -45,7 +45,6 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.http.netty4.Netty4HttpServerTransport;
-import org.elasticsearch.indices.breaker.HierarchyCircuitBreakerService;
 import org.elasticsearch.transport.netty4.Netty4Utils;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.VisibleForTesting;
@@ -256,7 +255,7 @@ public class SqlHttpHandler extends SimpleChannelInboundHandler<FullHttpRequest>
         if (resultFields == null) {
             resultReceiver = new RestRowCountReceiver(resultBuffer, startTimeInNs, includeTypes);
         } else {
-            CircuitBreaker breaker = circuitBreakerProvider.apply(HierarchyCircuitBreakerService.QUERY);
+            CircuitBreaker breaker = circuitBreakerProvider.apply(CircuitBreaker.QUERY);
             RamAccounting ramAccounting = new BlockBasedRamAccounting(
                 b -> breaker.addEstimateBytesAndMaybeBreak(b, "http-result"),
                 MAX_BLOCK_SIZE_IN_BYTES);

--- a/server/src/main/java/io/crate/statistics/ReservoirSampler.java
+++ b/server/src/main/java/io/crate/statistics/ReservoirSampler.java
@@ -63,7 +63,6 @@ import org.elasticsearch.index.shard.IllegalIndexShardStateException;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
-import org.elasticsearch.indices.breaker.HierarchyCircuitBreakerService;
 import org.jetbrains.annotations.VisibleForTesting;
 
 import com.carrotsearch.hppc.LongArrayList;
@@ -145,7 +144,7 @@ public final class ReservoirSampler {
         }
         Random random = Randomness.get();
         Metadata metadata = clusterService.state().metadata();
-        CircuitBreaker breaker = circuitBreakerService.getBreaker(HierarchyCircuitBreakerService.QUERY);
+        CircuitBreaker breaker = circuitBreakerService.getBreaker(CircuitBreaker.QUERY);
         RamAccounting ramAccounting = new BlockBasedRamAccounting(
             b -> breaker.addEstimateBytesAndMaybeBreak(b, "Reservoir-sampling"),
             MAX_BLOCK_SIZE_IN_BYTES);

--- a/server/src/main/java/org/elasticsearch/common/breaker/CircuitBreaker.java
+++ b/server/src/main/java/org/elasticsearch/common/breaker/CircuitBreaker.java
@@ -48,6 +48,15 @@ public interface CircuitBreaker {
      */
     String IN_FLIGHT_REQUESTS = "in_flight_requests";
 
+    /// For generic query execution
+    String QUERY = "query";
+
+    /// sys.jobs_log
+    String JOBS_LOG = "jobs_log";
+
+    /// sys.operations_log
+    String OPERATIONS_LOG = "operations_log";
+
     /**
      * add bytes to the breaker and maybe trip
      * @param bytes number of bytes to add

--- a/server/src/main/java/org/elasticsearch/indices/breaker/HierarchyCircuitBreakerService.java
+++ b/server/src/main/java/org/elasticsearch/indices/breaker/HierarchyCircuitBreakerService.java
@@ -62,16 +62,12 @@ public class HierarchyCircuitBreakerService extends CircuitBreakerService {
     public static final Setting<ByteSizeValue> IN_FLIGHT_REQUESTS_CIRCUIT_BREAKER_LIMIT_SETTING =
         Setting.memorySizeSetting("network.breaker.inflight_requests.limit", "100%", Property.Dynamic, Property.NodeScope);
 
-    public static final String QUERY = "query";
-
     public static final Setting<ByteSizeValue> QUERY_CIRCUIT_BREAKER_LIMIT_SETTING = Setting.memorySizeSetting(
         "indices.breaker.query.limit", "60%", Property.Dynamic, Property.NodeScope, Property.Exposed);
 
-    public static final String JOBS_LOG = "jobs_log";
     public static final Setting<ByteSizeValue> JOBS_LOG_CIRCUIT_BREAKER_LIMIT_SETTING = Setting.memorySizeSetting(
         "stats.breaker.log.jobs.limit", "5%", Property.Dynamic, Property.NodeScope, Property.Exposed);
 
-    public static final String OPERATIONS_LOG = "operations_log";
     public static final Setting<ByteSizeValue> OPERATIONS_LOG_CIRCUIT_BREAKER_LIMIT_SETTING = Setting.memorySizeSetting(
         "stats.breaker.log.operations.limit", "5%", Property.Dynamic, Property.NodeScope, Property.Exposed);
 
@@ -106,17 +102,17 @@ public class HierarchyCircuitBreakerService extends CircuitBreakerService {
         );
 
         queryBreakerSettings = new BreakerSettings(
-            QUERY,
+            CircuitBreaker.QUERY,
             QUERY_CIRCUIT_BREAKER_LIMIT_SETTING.get(settings).getBytes()
         );
 
         logJobsBreakerSettings = new BreakerSettings(
-            JOBS_LOG,
+            CircuitBreaker.JOBS_LOG,
             JOBS_LOG_CIRCUIT_BREAKER_LIMIT_SETTING.get(settings).getBytes()
         );
 
         logOperationsBreakerSettings = new BreakerSettings(
-            OPERATIONS_LOG,
+            CircuitBreaker.OPERATIONS_LOG,
             OPERATIONS_LOG_CIRCUIT_BREAKER_LIMIT_SETTING.get(settings).getBytes()
         );
 
@@ -135,14 +131,14 @@ public class HierarchyCircuitBreakerService extends CircuitBreakerService {
         clusterSettings.addSettingsUpdateConsumer(REQUEST_CIRCUIT_BREAKER_LIMIT_SETTING, this::setRequestBreakerLimit);
         clusterSettings.addSettingsUpdateConsumer(
             QUERY_CIRCUIT_BREAKER_LIMIT_SETTING,
-            (newLimit) -> setBreakerLimit(queryBreakerSettings, QUERY, s -> this.queryBreakerSettings = s, newLimit));
+            (newLimit) -> setBreakerLimit(queryBreakerSettings, CircuitBreaker.QUERY, s -> this.queryBreakerSettings = s, newLimit));
         clusterSettings.addSettingsUpdateConsumer(
             JOBS_LOG_CIRCUIT_BREAKER_LIMIT_SETTING,
-            (newLimit) -> setBreakerLimit(logJobsBreakerSettings, JOBS_LOG, s -> this.logJobsBreakerSettings = s, newLimit));
+            (newLimit) -> setBreakerLimit(logJobsBreakerSettings, CircuitBreaker.JOBS_LOG, s -> this.logJobsBreakerSettings = s, newLimit));
         clusterSettings.addSettingsUpdateConsumer(
             OPERATIONS_LOG_CIRCUIT_BREAKER_LIMIT_SETTING,
             (newLimit) ->
-                setBreakerLimit(logOperationsBreakerSettings, OPERATIONS_LOG, s -> this.logOperationsBreakerSettings = s, newLimit));
+                setBreakerLimit(logOperationsBreakerSettings, CircuitBreaker.OPERATIONS_LOG, s -> this.logOperationsBreakerSettings = s, newLimit));
     }
 
     public static String breakingExceptionMessage(String label, long limit) {

--- a/server/src/test/java/io/crate/breaker/CrateCircuitBreakerServiceTest.java
+++ b/server/src/test/java/io/crate/breaker/CrateCircuitBreakerServiceTest.java
@@ -21,7 +21,7 @@
 
 package io.crate.breaker;
 
-import static io.crate.testing.Asserts.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Locale;
 
@@ -44,10 +44,10 @@ public class CrateCircuitBreakerServiceTest extends CrateDummyClusterServiceUnit
             clusterService.getClusterSettings()
         )) {
 
-            CircuitBreaker breaker = breakerService.getBreaker(HierarchyCircuitBreakerService.QUERY);
+            CircuitBreaker breaker = breakerService.getBreaker(CircuitBreaker.QUERY);
             assertThat(breaker).isNotNull();
             assertThat(breaker).isInstanceOf(CircuitBreaker.class);
-            assertThat(breaker.getName()).isEqualTo(HierarchyCircuitBreakerService.QUERY);
+            assertThat(breaker.getName()).isEqualTo(CircuitBreaker.QUERY);
         }
     }
 
@@ -61,7 +61,7 @@ public class CrateCircuitBreakerServiceTest extends CrateDummyClusterServiceUnit
             clusterService.getClusterSettings()
         )) {
 
-            CircuitBreaker breaker = breakerService.getBreaker(HierarchyCircuitBreakerService.QUERY);
+            CircuitBreaker breaker = breakerService.getBreaker(CircuitBreaker.QUERY);
             assertThat(breaker.getLimit()).isEqualTo(10_485_760L);
 
             Settings newSettings = Settings.builder()
@@ -69,7 +69,7 @@ public class CrateCircuitBreakerServiceTest extends CrateDummyClusterServiceUnit
                 .build();
             clusterService.getClusterSettings().applySettings(newSettings);
 
-            breaker = breakerService.getBreaker(HierarchyCircuitBreakerService.QUERY);
+            breaker = breakerService.getBreaker(CircuitBreaker.QUERY);
             assertThat(breaker.getLimit()).isEqualTo(104_857_600L);
         }
     }
@@ -84,10 +84,10 @@ public class CrateCircuitBreakerServiceTest extends CrateDummyClusterServiceUnit
                 settings,
                 clusterService.getClusterSettings()
         )) {
-            CircuitBreaker breaker = breakerService.getBreaker(HierarchyCircuitBreakerService.JOBS_LOG);
+            CircuitBreaker breaker = breakerService.getBreaker(CircuitBreaker.JOBS_LOG);
             assertThat(breaker.getLimit()).isEqualTo(10_485_760L);
 
-            breaker = breakerService.getBreaker(HierarchyCircuitBreakerService.OPERATIONS_LOG);
+            breaker = breakerService.getBreaker(CircuitBreaker.OPERATIONS_LOG);
             assertThat(breaker.getLimit()).isEqualTo(10_485_760L);
 
             Settings newSettings = Settings.builder()
@@ -97,10 +97,10 @@ public class CrateCircuitBreakerServiceTest extends CrateDummyClusterServiceUnit
 
             clusterService.getClusterSettings().applySettings(newSettings);
 
-            breaker = breakerService.getBreaker(HierarchyCircuitBreakerService.JOBS_LOG);
+            breaker = breakerService.getBreaker(CircuitBreaker.JOBS_LOG);
             assertThat(breaker.getLimit()).isEqualTo(104_857_600L);
 
-            breaker = breakerService.getBreaker(HierarchyCircuitBreakerService.OPERATIONS_LOG);
+            breaker = breakerService.getBreaker(CircuitBreaker.OPERATIONS_LOG);
             assertThat(breaker.getLimit()).isEqualTo(104_857_600L);
         }
     }
@@ -116,7 +116,7 @@ public class CrateCircuitBreakerServiceTest extends CrateDummyClusterServiceUnit
         try (CircuitBreakerService breakerService = new HierarchyCircuitBreakerService(
             Settings.EMPTY, clusterService.getClusterSettings()
         )) {
-            CircuitBreakerStats queryBreakerStats = breakerService.stats(HierarchyCircuitBreakerService.QUERY);
+            CircuitBreakerStats queryBreakerStats = breakerService.stats(CircuitBreaker.QUERY);
             assertThat(queryBreakerStats.getUsed()).isEqualTo(0L);
         }
     }

--- a/server/src/test/java/io/crate/execution/engine/collect/stats/JobsLogsTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/stats/JobsLogsTest.java
@@ -387,7 +387,7 @@ public class JobsLogsTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void test_accounted_memory_is_released_on_sink_change() throws Exception {
-        CircuitBreaker breaker = breakerService.getBreaker(HierarchyCircuitBreakerService.JOBS_LOG);
+        CircuitBreaker breaker = breakerService.getBreaker(CircuitBreaker.JOBS_LOG);
         assertThat(breaker.getUsed()).isEqualTo(0);
         Settings settings = Settings.builder()
             .put(JobsLogService.STATS_ENABLED_SETTING.getKey(), true)

--- a/server/src/test/java/io/crate/integrationtests/CircuitBreakerIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/CircuitBreakerIntegrationTest.java
@@ -27,7 +27,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
-import org.elasticsearch.indices.breaker.HierarchyCircuitBreakerService;
 import org.elasticsearch.test.IntegTestCase;
 import org.junit.After;
 import org.junit.Test;
@@ -49,7 +48,7 @@ public class CircuitBreakerIntegrationTest extends IntegTestCase {
         execute("refresh table t1");
 
         CircuitBreakerService circuitBreakerService = cluster().getInstance(CircuitBreakerService.class);
-        CircuitBreaker queryBreaker = circuitBreakerService.getBreaker(HierarchyCircuitBreakerService.QUERY);
+        CircuitBreaker queryBreaker = circuitBreakerService.getBreaker(CircuitBreaker.QUERY);
         long breakerBytesUsedBeforeQuery = queryBreaker.getUsed();
 
         execute("select text from t1 group by text");

--- a/server/src/test/java/io/crate/integrationtests/GroupByAggregateTest.java
+++ b/server/src/test/java/io/crate/integrationtests/GroupByAggregateTest.java
@@ -26,6 +26,7 @@ import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
 import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.TestingHelpers.printedTable;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
 
@@ -38,7 +39,6 @@ import org.assertj.core.data.Percentage;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
-import org.elasticsearch.indices.breaker.HierarchyCircuitBreakerService;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.IntegTestCase;
 import org.elasticsearch.test.transport.MockTransportService;
@@ -1498,7 +1498,7 @@ public class GroupByAggregateTest extends IntegTestCase {
         assertBusy(() -> {
             for (var node : cluster().getNodeNames()) {
                 var breakerService = cluster().getInstance(CircuitBreakerService.class, node);
-                CircuitBreaker queryCircuitBreaker = breakerService.getBreaker(HierarchyCircuitBreakerService.QUERY);
+                CircuitBreaker queryCircuitBreaker = breakerService.getBreaker(CircuitBreaker.QUERY);
                 assertThat(queryCircuitBreaker.getUsed())
                     .withFailMessage("QUERY breaker did not reset on node=%s, used=%d", node, queryCircuitBreaker.getUsed())
                     .isEqualTo(0L);

--- a/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
@@ -36,7 +36,6 @@ import java.util.Random;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
-import org.elasticsearch.indices.breaker.HierarchyCircuitBreakerService;
 import org.elasticsearch.test.IntegTestCase;
 import org.junit.After;
 import org.junit.Test;
@@ -896,7 +895,7 @@ public class JoinIntegrationTest extends IntegTestCase {
 
         long memoryLimit = 6 * 1024 * 1024;
         execute("set global \"indices.breaker.query.limit\" = '" + memoryLimit + "b'");
-        CircuitBreaker queryCircuitBreaker = cluster().getInstance(CircuitBreakerService.class).getBreaker(HierarchyCircuitBreakerService.QUERY);
+        CircuitBreaker queryCircuitBreaker = cluster().getInstance(CircuitBreakerService.class).getBreaker(CircuitBreaker.QUERY);
         randomiseAndConfigureJoinBlockSize("t1", 5L, queryCircuitBreaker);
         randomiseAndConfigureJoinBlockSize("t2", 5L, queryCircuitBreaker);
 
@@ -970,7 +969,7 @@ public class JoinIntegrationTest extends IntegTestCase {
 
         long memoryLimit = 6 * 1024 * 1024;
         execute("set global \"indices.breaker.query.limit\" = '" + memoryLimit + "b'");
-        CircuitBreaker queryCircuitBreaker = cluster().getInstance(CircuitBreakerService.class).getBreaker(HierarchyCircuitBreakerService.QUERY);
+        CircuitBreaker queryCircuitBreaker = cluster().getInstance(CircuitBreakerService.class).getBreaker(CircuitBreaker.QUERY);
         randomiseAndConfigureJoinBlockSize("t1", 10L, queryCircuitBreaker);
 
         execute("select x from t1 left_rel JOIN (select x x2, count(x) from t1 group by x2) right_rel " +

--- a/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
@@ -23,6 +23,7 @@ package io.crate.planner.operators;
 
 import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.MemoryLimits.assertMaxBytesAllocated;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -41,7 +42,6 @@ import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.indices.IndicesService;
-import org.elasticsearch.indices.breaker.HierarchyCircuitBreakerService;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -808,7 +808,7 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
 
         DependencyCarrier dependencies = sqlExecutor.dependencyMock;
         CircuitBreaker circuitBreaker = mock(CircuitBreaker.class);
-        when(dependencies.circuitBreaker(HierarchyCircuitBreakerService.QUERY)).thenReturn(circuitBreaker);
+        when(dependencies.circuitBreaker(CircuitBreaker.QUERY)).thenReturn(circuitBreaker);
 
         // Setup CircuitBreakingException for a sub-plan.
         PhasesTaskFactory phasesTaskFactory = mock(PhasesTaskFactory.class);

--- a/server/src/testFixtures/java/org/elasticsearch/indices/breaker/NoneCircuitBreakerService.java
+++ b/server/src/testFixtures/java/org/elasticsearch/indices/breaker/NoneCircuitBreakerService.java
@@ -28,7 +28,7 @@ import org.elasticsearch.common.breaker.NoopCircuitBreaker;
  */
 public class NoneCircuitBreakerService extends CircuitBreakerService {
 
-    private final CircuitBreaker breaker = new NoopCircuitBreaker(HierarchyCircuitBreakerService.QUERY);
+    private final CircuitBreaker breaker = new NoopCircuitBreaker(CircuitBreaker.QUERY);
 
     public NoneCircuitBreakerService() {
     }
@@ -40,7 +40,7 @@ public class NoneCircuitBreakerService extends CircuitBreakerService {
 
     @Override
     public CircuitBreakerStats stats(String name) {
-        return new CircuitBreakerStats(HierarchyCircuitBreakerService.QUERY, -1, -1, 0, 0);
+        return new CircuitBreakerStats(CircuitBreaker.QUERY, -1, -1, 0, 0);
     }
 
     @Override


### PR DESCRIPTION
Some name constants were already within `CircuitBreaker`, others in
`HierarchyCircuitBreakerService`. This split was a bit confusing
