### PR TITLE
Replace ReferenceIdent with ColumnIdent in Reference

### DIFF
--- a/benchmarks/src/main/java/io/crate/execution/engine/collect/collectors/OrderedLuceneBatchIteratorBenchmark.java
+++ b/benchmarks/src/main/java/io/crate/execution/engine/collect/collectors/OrderedLuceneBatchIteratorBenchmark.java
@@ -58,11 +58,9 @@ import io.crate.execution.engine.sort.OrderingByPosition;
 import io.crate.expression.reference.doc.lucene.CollectorContext;
 import io.crate.expression.reference.doc.lucene.LuceneCollectorExpression;
 import io.crate.expression.reference.doc.lucene.OrderByCollectorExpression;
+import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Reference;
-import io.crate.metadata.ReferenceIdent;
-import io.crate.metadata.RelationName;
 import io.crate.metadata.RowGranularity;
-import io.crate.metadata.Schemas;
 import io.crate.metadata.SimpleReference;
 import io.crate.types.DataTypes;
 import io.crate.types.LongType;
@@ -102,7 +100,7 @@ public class OrderedLuceneBatchIteratorBenchmark {
             indexSearcher = new IndexSearcher(DirectoryReader.open(iw, true, true));
             collectorContext = new CollectorContext(() -> null);
             reference = new SimpleReference(
-                new ReferenceIdent(new RelationName(Schemas.DOC_SCHEMA_NAME, "dummyTable"), columnName),
+                ColumnIdent.of(columnName),
                 RowGranularity.DOC,
                 DataTypes.INTEGER,
                 1,

--- a/server/src/main/java/io/crate/analyze/AlterTableRenameColumnAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/AlterTableRenameColumnAnalyzer.java
@@ -36,7 +36,6 @@ import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
-import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.Schemas;
 import io.crate.metadata.doc.DocTableInfo;
@@ -129,7 +128,7 @@ public class AlterTableRenameColumnAnalyzer {
             if (reference == null) {
                 reference = table.indexColumn(columnIdent);
                 if (reference == null) {
-                    return new DynamicReference(new ReferenceIdent(table.ident(), columnIdent), RowGranularity.DOC, -1);
+                    return new DynamicReference(columnIdent, RowGranularity.DOC, -1);
                 }
             }
             return reference;

--- a/server/src/main/java/io/crate/analyze/RelationNames.java
+++ b/server/src/main/java/io/crate/analyze/RelationNames.java
@@ -36,7 +36,6 @@ import io.crate.expression.symbol.ScopedSymbol;
 import io.crate.expression.symbol.SelectSymbol;
 import io.crate.expression.symbol.Symbol;
 import io.crate.fdw.ForeignTableRelation;
-import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
 
 public final class RelationNames {
@@ -85,7 +84,6 @@ public final class RelationNames {
         LinkedHashSet<RelationName> relationNames = new LinkedHashSet<>();
         symbol.any(node -> {
             switch (node) {
-                case Reference ref -> relationNames.add(ref.ident().tableIdent());
                 case ScopedSymbol scoped -> relationNames.add(scoped.relation());
                 case SelectSymbol selectSymbol -> {
                     if (deep) {

--- a/server/src/main/java/io/crate/analyze/TableElementsAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/TableElementsAnalyzer.java
@@ -275,7 +275,7 @@ public class TableElementsAnalyzer implements FieldProvider<Reference> {
                 }
                 String analyzer = DataTypes.STRING.sanitizeValue(indexProperties.map(toValue).get("analyzer"));
                 ref = new IndexReference(
-                    refIdent,
+                    name,
                     rowGranularity,
                     type,
                     indexType,
@@ -293,7 +293,7 @@ public class TableElementsAnalyzer implements FieldProvider<Reference> {
                 GeoSettingsApplier.applySettings(geoMap, indexProperties.map(toValue), indexMethod);
                 Double distError = (Double) geoMap.get("distance_error_pct");
                 ref = new GeoReference(
-                    refIdent,
+                    name,
                     type,
                     indexType,
                     nullable,
@@ -308,7 +308,7 @@ public class TableElementsAnalyzer implements FieldProvider<Reference> {
                 );
             } else {
                 ref = new SimpleReference(
-                    refIdent,
+                    name,
                     rowGranularity,
                     type,
                     indexType,
@@ -367,7 +367,7 @@ public class TableElementsAnalyzer implements FieldProvider<Reference> {
             }
         }
         var columnBuilder = columns.get(columnIdent);
-        var dynamicReference = new DynamicReference(new ReferenceIdent(tableName, columnIdent), RowGranularity.DOC, -1);
+        var dynamicReference = new DynamicReference(columnIdent, RowGranularity.DOC, -1);
         if (columnBuilder == null) {
             if (resolveMissing) {
                 return dynamicReference;

--- a/server/src/main/java/io/crate/analyze/UpdateAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/UpdateAnalyzer.java
@@ -202,7 +202,7 @@ public final class UpdateAnalyzer {
 
                     SimpleReference arrayElementRefForValueNormalization =
                         new SimpleReference(
-                            targetCol.ident(),
+                            targetCol.column(),
                             targetCol.granularity(),
                             ((ArrayType<?>) targetCol.valueType()).innerType(),
                             targetCol.indexType(),

--- a/server/src/main/java/io/crate/analyze/expressions/ValueNormalizer.java
+++ b/server/src/main/java/io/crate/analyze/expressions/ValueNormalizer.java
@@ -36,6 +36,7 @@ import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.Symbols;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Reference;
+import io.crate.metadata.RelationName;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.table.TableInfo;
@@ -156,7 +157,7 @@ public final class ValueNormalizer {
             } else if (isObjectArray(nestedInfo.valueType()) && entry.getValue() instanceof List) {
                 normalizeObjectArrayValue((List<Map<String, Object>>) entry.getValue(), nestedInfo, tableInfo);
             } else {
-                entry.setValue(normalizePrimitiveValue(entry.getValue(), nestedInfo));
+                entry.setValue(normalizePrimitiveValue(tableInfo.ident(), entry.getValue(), nestedInfo));
             }
         }
     }
@@ -172,7 +173,7 @@ public final class ValueNormalizer {
         }
     }
 
-    private static Object normalizePrimitiveValue(Object primitiveValue, Reference info) {
+    private static Object normalizePrimitiveValue(RelationName table, Object primitiveValue, Reference info) {
         if (info.valueType().equals(DataTypes.STRING) && primitiveValue instanceof String) {
             return primitiveValue;
         }
@@ -181,7 +182,7 @@ public final class ValueNormalizer {
         } catch (Exception e) {
             throw new ColumnValidationException(
                 info.column().sqlFqn(),
-                info.ident().tableIdent(),
+                table,
                 String.format(Locale.ENGLISH, "Invalid %s", info.valueType().getName())
             );
         }

--- a/server/src/main/java/io/crate/analyze/relations/DocTableRelation.java
+++ b/server/src/main/java/io/crate/analyze/relations/DocTableRelation.java
@@ -52,7 +52,7 @@ public class DocTableRelation extends AbstractTableRelation<DocTableInfo> {
         super(
             tableInfo,
             List.copyOf(tableInfo.rootColumns()),
-            concat(SysColumns.forTable(tableInfo.ident()), tableInfo.indexColumns())
+            concat(SysColumns.forTable(), tableInfo.indexColumns())
         );
     }
 

--- a/server/src/main/java/io/crate/analyze/relations/QuerySplitter.java
+++ b/server/src/main/java/io/crate/analyze/relations/QuerySplitter.java
@@ -129,7 +129,7 @@ public class QuerySplitter {
 
         @Override
         public Void visitReference(Reference ref, Context ctx) {
-            ctx.parts.merge(Set.of(ref.ident().tableIdent()), ref, AndOperator::of);
+            ctx.parts.merge(Set.of(), ref, AndOperator::of);
             return null;
         }
 
@@ -139,8 +139,6 @@ public class QuerySplitter {
             for (Symbol field : matchPredicate.identBoostMap().keySet()) {
                 if (field instanceof ScopedSymbol scopedSymbol) {
                     relationNames.add(scopedSymbol.relation());
-                } else if (field instanceof Reference ref) {
-                    relationNames.add(ref.ident().tableIdent());
                 }
             }
             ctx.parts.merge(relationNames, matchPredicate, AndOperator::of);

--- a/server/src/main/java/io/crate/analyze/relations/TableFunctionRelation.java
+++ b/server/src/main/java/io/crate/analyze/relations/TableFunctionRelation.java
@@ -38,7 +38,6 @@ import io.crate.expression.symbol.format.Style;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.FunctionName;
 import io.crate.metadata.Reference;
-import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.SimpleReference;
@@ -66,7 +65,7 @@ public class TableFunctionRelation implements AnalyzedRelation, FieldResolver {
         for (int i = 0; i < rowType.numElements(); i++) {
             DataType<?> type = rowType.getFieldType(i);
             String fieldName = rowType.getFieldName(i);
-            var ref = new SimpleReference(new ReferenceIdent(relationName, fieldName), RowGranularity.DOC, type, idx, null);
+            var ref = new SimpleReference(ColumnIdent.of(fieldName), RowGranularity.DOC, type, idx, null);
             outputs.add(ref);
             idx++;
         }

--- a/server/src/main/java/io/crate/execution/dml/ArrayOfObjectIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/ArrayOfObjectIndexer.java
@@ -30,6 +30,7 @@ import org.jetbrains.annotations.NotNull;
 
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Reference;
+import io.crate.metadata.RelationName;
 
 /**
  * Specialized indexer for an array of objects, which duplicates the translog entry
@@ -41,8 +42,8 @@ import io.crate.metadata.Reference;
  */
 public class ArrayOfObjectIndexer<T> extends ArrayIndexer<T> {
 
-    ArrayOfObjectIndexer(ValueIndexer<T> innerIndexer, Function<ColumnIdent, Reference> getRef, Reference reference) {
-        super(innerIndexer, getRef, reference);
+    ArrayOfObjectIndexer(RelationName table, ValueIndexer<T> innerIndexer, Function<ColumnIdent, Reference> getRef, Reference reference) {
+        super(table, innerIndexer, getRef, reference);
     }
 
     @Override

--- a/server/src/main/java/io/crate/execution/dml/DynamicIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/DynamicIndexer.java
@@ -33,7 +33,7 @@ import io.crate.expression.reference.doc.lucene.SourceParser;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.IndexType;
 import io.crate.metadata.Reference;
-import io.crate.metadata.ReferenceIdent;
+import io.crate.metadata.RelationName;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.SimpleReference;
 import io.crate.types.ArrayType;
@@ -43,18 +43,21 @@ import io.crate.types.StorageSupport;
 
 public final class DynamicIndexer implements ValueIndexer<Object> {
 
-    private final ReferenceIdent refIdent;
+    private final ColumnIdent column;
     private final Function<ColumnIdent, Reference> getRef;
     private final int position;
     private final boolean useOids;
     private DataType<?> type = null;
     private ValueIndexer<Object> indexer;
+    private final RelationName relation;
 
-    public DynamicIndexer(ReferenceIdent refIdent,
+    public DynamicIndexer(RelationName relation,
+                          ColumnIdent column,
                           int position,
                           Function<ColumnIdent, Reference> getRef,
                           boolean useOids) {
-        this.refIdent = refIdent;
+        this.relation = relation;
+        this.column = column;
         this.getRef = getRef;
         this.position = position;
         this.useOids = useOids;
@@ -63,7 +66,7 @@ public final class DynamicIndexer implements ValueIndexer<Object> {
     /**
      * Create a new Reference based on a dynamically detected type
      */
-    public static Reference buildReference(ReferenceIdent refIdent, DataType<?> type, int position, long oid) {
+    public static Reference buildReference(ColumnIdent column, DataType<?> type, int position, long oid) {
         StorageSupport<?> storageSupport = type.storageSupport();
         if (storageSupport == null) {
             throw new IllegalArgumentException(
@@ -71,7 +74,7 @@ public final class DynamicIndexer implements ValueIndexer<Object> {
                     "Storage is not supported for this type");
         }
         return new SimpleReference(
-            refIdent,
+            column,
             RowGranularity.DOC,
             type,
             IndexType.PLAIN,
@@ -91,11 +94,11 @@ public final class DynamicIndexer implements ValueIndexer<Object> {
                                      Synthetics synthetics) throws IOException {
         if (type == null) {
             type = guessType(value);
-            Reference newColumn = buildReference(refIdent, type, position, COLUMN_OID_UNASSIGNED);
+            Reference newColumn = buildReference(column, type, position, COLUMN_OID_UNASSIGNED);
             StorageSupport<?> storageSupport = type.storageSupport();
             assert storageSupport != null; // will have already thrown in buildReference
             indexer = (ValueIndexer<Object>) storageSupport.valueIndexer(
-                refIdent.tableIdent(),
+                relation,
                 newColumn,
                 getRef
             );
@@ -122,13 +125,13 @@ public final class DynamicIndexer implements ValueIndexer<Object> {
                 "Cannot create columns of type " + type.getName() + " dynamically. " +
                     "Storage is not supported for this type");
         }
-        Reference newColumn = buildReference(refIdent, type, position, COLUMN_OID_UNASSIGNED);
+        Reference newColumn = buildReference(column, type, position, COLUMN_OID_UNASSIGNED);
         if (indexer == null) {
             // Reuse indexer if phase 1 already created one.
             // Phase 1 mutates indexer.innerTypes on new columns creation.
             // Phase 2 must be aware of all mapping updates.
             // noinspection unchecked
-            indexer = (ValueIndexer<Object>) storageSupport.valueIndexer(refIdent.tableIdent(), newColumn, getRef);
+            indexer = (ValueIndexer<Object>) storageSupport.valueIndexer(relation, newColumn, getRef);
         }
         value = type.sanitizeValue(value);
         indexer.indexValue(value, docBuilder);
@@ -137,8 +140,8 @@ public final class DynamicIndexer implements ValueIndexer<Object> {
     @Override
     public String storageIdentLeafName() {
         return useOids
-            ? SourceParser.UNKNOWN_COLUMN_PREFIX + refIdent.columnIdent().leafName()
-            : refIdent.columnIdent().leafName();
+            ? SourceParser.UNKNOWN_COLUMN_PREFIX + column.leafName()
+            : column.leafName();
     }
 
     /**

--- a/server/src/main/java/io/crate/execution/dml/Indexer.java
+++ b/server/src/main/java/io/crate/execution/dml/Indexer.java
@@ -156,7 +156,6 @@ public class Indexer {
         }
 
         @Override
-        @SuppressWarnings("unchecked")
         public CollectExpression<IndexItem, Object> getImplementation(Reference ref) {
 
             // Here be dragons: A reference can refer to:
@@ -509,7 +508,7 @@ public class Indexer {
                         table.ident()
                     ));
                 }
-                valueIndexer = new DynamicIndexer(ref.ident(), position, getRef, writeOids);
+                valueIndexer = new DynamicIndexer(table.ident(), ref.column(), position, getRef, writeOids);
                 position--;
             } else {
                 valueIndexer = ref.valueType().valueIndexer(
@@ -746,7 +745,7 @@ public class Indexer {
                 if (oldRef.equals(newRef) == false) {
                     columns.set(idx, newRef);
                     valueIndexers.set(idx, newRef.valueType().valueIndexer(
-                        newRef.ident().tableIdent(),
+                        newTable.ident(),
                         newRef,
                         getRef
                     ));
@@ -759,7 +758,7 @@ public class Indexer {
                 }
                 if (newRef.valueType().id() == ArrayType.ID) {
                     columns.set(idx, newRef);
-                    valueIndexers.set(idx, newRef.valueType().valueIndexer(newRef.ident().tableIdent(), newRef, getRef));
+                    valueIndexers.set(idx, newRef.valueType().valueIndexer(newTable.ident(), newRef, getRef));
                 }
             } else if (ArrayType.unnest(oldRef.valueType()).id() == ObjectType.ID) {
                 // object types in 'columns' may be outdated - missing newly added child types

--- a/server/src/main/java/io/crate/execution/dml/ObjectIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/ObjectIndexer.java
@@ -45,7 +45,6 @@ import io.crate.exceptions.ConversionException;
 import io.crate.expression.reference.doc.lucene.SourceParser;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Reference;
-import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.RowGranularity;
 import io.crate.sql.tree.ColumnPolicy;
@@ -274,7 +273,7 @@ public class ObjectIndexer implements ValueIndexer<Map<String, Object>> {
             }
             var type = DynamicIndexer.guessType(innerValue);
             Reference newColumn = DynamicIndexer.buildReference(
-                new ReferenceIdent(table, column.getChild(innerName)),
+                column.getChild(innerName),
                 type,
                 position,
                 COLUMN_OID_UNASSIGNED

--- a/server/src/main/java/io/crate/execution/dsl/projection/builder/InputColumns.java
+++ b/server/src/main/java/io/crate/execution/dsl/projection/builder/InputColumns.java
@@ -251,7 +251,7 @@ public final class InputColumns extends SymbolVisitor<InputColumns.SourceSymbols
         }
         InputColumn inputColumn = sourceSymbols.inputs.get(ref);
         if (inputColumn == null) {
-            Symbol subscriptOnRoot = tryCreateSubscriptOnRoot(ref.ident().tableIdent(), ref, ref.column(), sourceSymbols.inputs);
+            Symbol subscriptOnRoot = tryCreateSubscriptOnRoot(null, ref, ref.column(), sourceSymbols.inputs);
             if (subscriptOnRoot != null) {
                 return subscriptOnRoot;
             }
@@ -298,7 +298,10 @@ public final class InputColumns extends SymbolVisitor<InputColumns.SourceSymbols
     }
 
     @Nullable
-    private static Symbol tryCreateSubscriptOnRoot(RelationName relationName, Symbol symbol, ColumnIdent column, HashMap<Symbol, InputColumn> inputs) {
+    private static Symbol tryCreateSubscriptOnRoot(@Nullable RelationName relationName,
+                                                   Symbol symbol,
+                                                   ColumnIdent column,
+                                                   HashMap<Symbol, InputColumn> inputs) {
         if (column.isRoot()) {
             return null;
         }

--- a/server/src/main/java/io/crate/execution/engine/collect/DocValuesAggregates.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/DocValuesAggregates.java
@@ -167,7 +167,7 @@ public final class DocValuesAggregates {
                         // to the normal aggregation implementation
                         return null;
                     }
-                    assert reference.ident().columnIdent().fqn().startsWith(SysColumns.Names.DOC) == false :
+                    assert reference.column().fqn().startsWith(SysColumns.Names.DOC) == false :
                         "Source look-up for Reference " + reference + " is not allowed in DocValuesAggregates.";
                     aggregationReferences.add(reference);
                     literals.add(null);

--- a/server/src/main/java/io/crate/execution/engine/fetch/FetchTask.java
+++ b/server/src/main/java/io/crate/execution/engine/fetch/FetchTask.java
@@ -273,7 +273,8 @@ public class FetchTask implements Task {
         }
         Set<RelationName> tablesWithFetchRefs = new HashSet<>();
         for (Reference reference : phase.fetchRefs()) {
-            tablesWithFetchRefs.add(reference.ident().tableIdent());
+            // TODO:
+            // tablesWithFetchRefs.add(reference.ident().tableIdent());
         }
         String source = "fetch-task: " + jobId.toString() + '-' + phase.phaseId() + '-' + phase.name();
         for (Routing routing : routings) {
@@ -324,7 +325,7 @@ public class FetchTask implements Task {
             }
         }
         for (Reference reference : phase.fetchRefs()) {
-            Collection<Reference> references = toFetch.get(reference.ident().tableIdent());
+            Collection<Reference> references = List.of(); // TODO: toFetch.get(reference.ident().tableIdent());
             if (references != null) {
                 references.add(reference);
             }

--- a/server/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
+++ b/server/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
@@ -650,9 +650,10 @@ public class ProjectionToProjectorVisitor
 
         for (Map.Entry<Reference, Symbol> e : assignments.entrySet()) {
             Reference ref = e.getKey();
-            assert
-                relationName == null || relationName.equals(ref.ident().tableIdent()) : "mixed table assignments found";
-            relationName = ref.ident().tableIdent();
+            // TODO
+            // assert
+            //     relationName == null || relationName.equals(ref.ident().tableIdent()) : "mixed table assignments found";
+            // relationName = ref.ident().tableIdent();
             if (readCtx == null) {
                 StaticTableDefinition<?> tableDefinition = staticTableDefinitionGetter.apply(relationName);
                 readCtx = inputFactory.ctxForRefs(context.txnCtx, tableDefinition.getReferenceResolver());

--- a/server/src/main/java/io/crate/expression/InputFactory.java
+++ b/server/src/main/java/io/crate/expression/InputFactory.java
@@ -45,7 +45,6 @@ import io.crate.expression.symbol.SymbolVisitor;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
-import io.crate.metadata.Schemas;
 import io.crate.metadata.TransactionContext;
 
 /**
@@ -239,11 +238,7 @@ public class InputFactory {
             }
             implementation = referenceResolver.getImplementation(ref);
             if (implementation == null) {
-                String schema = ref.ident().tableIdent().schema();
-                String msg = Schemas.READ_ONLY_SYSTEM_SCHEMAS.contains(schema)
-                    ? "Column implementation not found for: " + ref + ". This can happen in mixed clusters when using " +
-                        "`SELECT *`; Declare the column list explicitly instead"
-                    : "Column implementation not found for: " + ref;
+                String msg = "Column implementation not found for: " + ref;
                 throw new IllegalArgumentException(msg);
             }
             referenceMap.put(ref, implementation);

--- a/server/src/main/java/io/crate/expression/reference/doc/blob/BlobReferenceResolver.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/blob/BlobReferenceResolver.java
@@ -28,7 +28,6 @@ import io.crate.execution.engine.collect.CollectExpression;
 import io.crate.execution.engine.collect.NestableCollectExpression;
 import io.crate.expression.reference.ReferenceResolver;
 import io.crate.metadata.Reference;
-import io.crate.metadata.blob.BlobSchemaInfo;
 
 public class BlobReferenceResolver implements ReferenceResolver<CollectExpression<File, ?>> {
 
@@ -47,8 +46,6 @@ public class BlobReferenceResolver implements ReferenceResolver<CollectExpressio
 
     @Override
     public CollectExpression<File, ?> getImplementation(Reference refInfo) {
-        assert BlobSchemaInfo.NAME.equals(refInfo.ident().tableIdent().schema()) :
-            "schema name must be 'blob";
         ExpressionBuilder builder = EXPRESSION_BUILDER.get(refInfo.column().name());
         if (builder != null) {
             return builder.create();

--- a/server/src/main/java/io/crate/expression/reference/file/SourceLineNumberExpression.java
+++ b/server/src/main/java/io/crate/expression/reference/file/SourceLineNumberExpression.java
@@ -24,7 +24,6 @@ package io.crate.expression.reference.file;
 import io.crate.execution.engine.collect.files.LineCollectorExpression;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Reference;
-import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.SimpleReference;
@@ -37,7 +36,7 @@ public class SourceLineNumberExpression extends LineCollectorExpression<Long> {
 
     public static Reference getReferenceForRelation(RelationName relationName) {
         return new SimpleReference(
-            new ReferenceIdent(relationName, COLUMN_IDENT), RowGranularity.DOC, DataTypes.LONG, 0, null
+            COLUMN_IDENT, RowGranularity.DOC, DataTypes.LONG, 0, null
         );
     }
 

--- a/server/src/main/java/io/crate/expression/reference/file/SourceParsingFailureExpression.java
+++ b/server/src/main/java/io/crate/expression/reference/file/SourceParsingFailureExpression.java
@@ -26,7 +26,6 @@ import org.jetbrains.annotations.Nullable;
 import io.crate.execution.engine.collect.files.LineCollectorExpression;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Reference;
-import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.SimpleReference;
@@ -52,7 +51,7 @@ public class SourceParsingFailureExpression extends LineCollectorExpression<Stri
 
     public static Reference getReferenceForRelation(RelationName relationName) {
         return new SimpleReference(
-            new ReferenceIdent(relationName, COLUMN_IDENT), RowGranularity.DOC, DataTypes.STRING, 0, null
+            COLUMN_IDENT, RowGranularity.DOC, DataTypes.STRING, 0, null
         );
     }
 }

--- a/server/src/main/java/io/crate/expression/reference/file/SourceUriExpression.java
+++ b/server/src/main/java/io/crate/expression/reference/file/SourceUriExpression.java
@@ -24,7 +24,6 @@ package io.crate.expression.reference.file;
 import io.crate.execution.engine.collect.files.LineCollectorExpression;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Reference;
-import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.SimpleReference;
@@ -49,7 +48,7 @@ public class SourceUriExpression extends LineCollectorExpression<String> {
 
     public static Reference getReferenceForRelation(RelationName relationName) {
         return new SimpleReference(
-            new ReferenceIdent(relationName, COLUMN_IDENT), RowGranularity.DOC, DataTypes.STRING, 0, null
+            COLUMN_IDENT, RowGranularity.DOC, DataTypes.STRING, 0, null
         );
     }
 }

--- a/server/src/main/java/io/crate/expression/reference/file/SourceUriFailureExpression.java
+++ b/server/src/main/java/io/crate/expression/reference/file/SourceUriFailureExpression.java
@@ -26,7 +26,6 @@ import org.jetbrains.annotations.Nullable;
 import io.crate.execution.engine.collect.files.LineCollectorExpression;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Reference;
-import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.SimpleReference;
@@ -52,7 +51,7 @@ public class SourceUriFailureExpression extends LineCollectorExpression<String> 
 
     public static Reference getReferenceForRelation(RelationName relationName) {
         return new SimpleReference(
-            new ReferenceIdent(relationName, COLUMN_IDENT), RowGranularity.DOC, DataTypes.STRING, 0, null
+            COLUMN_IDENT, RowGranularity.DOC, DataTypes.STRING, 0, null
         );
     }
 }

--- a/server/src/main/java/io/crate/expression/symbol/DynamicReference.java
+++ b/server/src/main/java/io/crate/expression/symbol/DynamicReference.java
@@ -25,7 +25,7 @@ import java.io.IOException;
 
 import org.elasticsearch.common.io.stream.StreamInput;
 
-import io.crate.metadata.ReferenceIdent;
+import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.SimpleReference;
 import io.crate.types.DataType;
@@ -37,8 +37,8 @@ public class DynamicReference extends SimpleReference {
         super(in);
     }
 
-    public DynamicReference(ReferenceIdent ident, RowGranularity granularity, int position) {
-        super(ident, granularity, DataTypes.UNDEFINED, position, null);
+    public DynamicReference(ColumnIdent column, RowGranularity granularity, int position) {
+        super(column, granularity, DataTypes.UNDEFINED, position, null);
     }
 
     @Override

--- a/server/src/main/java/io/crate/expression/symbol/FetchMarker.java
+++ b/server/src/main/java/io/crate/expression/symbol/FetchMarker.java
@@ -45,7 +45,7 @@ public final class FetchMarker implements Symbol {
     private final Reference fetchId;
 
     public FetchMarker(RelationName relationName, List<Reference> fetchRefs) {
-        this(relationName, fetchRefs, SysColumns.forTable(relationName, SysColumns.FETCHID));
+        this(relationName, fetchRefs, SysColumns.forTable(SysColumns.FETCHID));
     }
 
     public FetchMarker(RelationName relationName, List<Reference> fetchRefs, Reference fetchId) {

--- a/server/src/main/java/io/crate/expression/symbol/Symbols.java
+++ b/server/src/main/java/io/crate/expression/symbol/Symbols.java
@@ -70,12 +70,12 @@ public final class Symbols {
     }
 
     @Nullable
-    public static <V> V lookupValueByColumn(RelationName relationName, Map<? extends Symbol, V> valuesBySymbol, ColumnIdent column) {
+    public static <V> V lookupValueByColumn(@Nullable RelationName relationName,
+                                            Map<? extends Symbol, V> valuesBySymbol,
+                                            ColumnIdent column) {
         for (Map.Entry<? extends Symbol, V> entry : valuesBySymbol.entrySet()) {
             Symbol key = entry.getKey();
-            if (key instanceof Reference ref
-                    && ref.column().equals(column)
-                    && ref.ident().tableIdent().equals(relationName)) {
+            if (key instanceof Reference ref && ref.column().equals(column) && relationName == null) {
                 return entry.getValue();
             }
             if (key instanceof ScopedSymbol scopedSymbol
@@ -293,7 +293,6 @@ public final class Symbols {
                         break;
                     } else if (ref instanceof VoidReference
                                && t instanceof ScopedSymbol tScopedSymbol
-                               && tScopedSymbol.relation().equals(ref.ident().tableIdent())
                                && tScopedSymbol.column().equals(root)) {
                         consumer.accept(t);
                         break;

--- a/server/src/main/java/io/crate/expression/symbol/VoidReference.java
+++ b/server/src/main/java/io/crate/expression/symbol/VoidReference.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 
 import org.elasticsearch.common.io.stream.StreamInput;
 
-import io.crate.metadata.ReferenceIdent;
+import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.RowGranularity;
 
 /**
@@ -38,9 +38,8 @@ public class VoidReference extends DynamicReference {
         super(in);
     }
 
-    public VoidReference(ReferenceIdent ident,
-                         int position) {
-        super(ident, RowGranularity.DOC, position);
+    public VoidReference(ColumnIdent column, int position) {
+        super(column, RowGranularity.DOC, position);
     }
 
     @Override

--- a/server/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
+++ b/server/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
@@ -334,7 +334,7 @@ public class LuceneQueryBuilder {
                     if (ref.column().equals(SysColumns.UID)) {
                         return new Function(
                             function.signature(),
-                            List.of(SysColumns.forTable(ref.ident().tableIdent(), SysColumns.ID.COLUMN), right),
+                            List.of(SysColumns.forTable(SysColumns.ID.COLUMN), right),
                             function.valueType()
                         );
                     } else {

--- a/server/src/main/java/io/crate/metadata/DocReferences.java
+++ b/server/src/main/java/io/crate/metadata/DocReferences.java
@@ -88,14 +88,11 @@ public final class DocReferences {
     }
 
     private static Reference toDocLookup(Reference reference, Predicate<Reference> condition) {
-        ReferenceIdent ident = reference.ident();
-        if (ident.columnIdent().isSystemColumn()) {
+        if (reference.column().isSystemColumn()) {
             return reference;
         }
-        if (reference.granularity() == RowGranularity.DOC && Schemas.isDefaultOrCustomSchema(ident.tableIdent().schema())
-            && condition.test(reference)) {
-            return reference.withReferenceIdent(
-                new ReferenceIdent(ident.tableIdent(), ident.columnIdent().prepend(SysColumns.Names.DOC)));
+        if (reference.granularity() == RowGranularity.DOC && condition.test(reference)) {
+            return reference.withName(reference.column().prepend(SysColumns.Names.DOC));
         }
         return reference;
     }
@@ -103,7 +100,7 @@ public final class DocReferences {
     public static Reference docRefToRegularRef(Reference ref) {
         ColumnIdent column = ref.column();
         if (!column.isRoot() && column.name().equals(SysColumns.Names.DOC)) {
-            return ref.withReferenceIdent(new ReferenceIdent(ref.ident().tableIdent(), column.shiftRight()));
+            return ref.withName(column.shiftRight());
         }
         return ref;
     }

--- a/server/src/main/java/io/crate/metadata/GeneratedReference.java
+++ b/server/src/main/java/io/crate/metadata/GeneratedReference.java
@@ -104,7 +104,7 @@ public final class GeneratedReference implements Reference {
                 simpleRef.writeTo(out);
             } else {
                 SimpleReference simpleReference = new SimpleReference(
-                    ref.ident(),
+                    ref.column(),
                     ref.granularity(),
                     ref.valueType(),
                     ref.indexType(),
@@ -189,11 +189,6 @@ public final class GeneratedReference implements Reference {
     }
 
     @Override
-    public ReferenceIdent ident() {
-        return ref.ident();
-    }
-
-    @Override
     public ColumnIdent column() {
         return ref.column();
     }
@@ -265,9 +260,9 @@ public final class GeneratedReference implements Reference {
     }
 
     @Override
-    public Reference withReferenceIdent(ReferenceIdent referenceIdent) {
+    public Reference withName(ColumnIdent name) {
         return new GeneratedReference(
-            ref.withReferenceIdent(referenceIdent),
+            ref.withName(name),
             formattedGeneratedExpression,
             generatedExpression
         );

--- a/server/src/main/java/io/crate/metadata/GeoReference.java
+++ b/server/src/main/java/io/crate/metadata/GeoReference.java
@@ -53,7 +53,7 @@ public class GeoReference extends SimpleReference {
     @Nullable
     private final Double distanceErrorPct;
 
-    public GeoReference(ReferenceIdent ident,
+    public GeoReference(ColumnIdent column,
                         DataType<?> type,
                         IndexType indexType,
                         boolean nullable,
@@ -65,7 +65,7 @@ public class GeoReference extends SimpleReference {
                         String precision,
                         Integer treeLevels,
                         Double distanceErrorPct) {
-        super(ident,
+        super(column,
             RowGranularity.DOC, // Only primitive types columns can be used in PARTITIONED BY clause
             type,
             indexType,
@@ -159,9 +159,9 @@ public class GeoReference extends SimpleReference {
     }
 
     @Override
-    public Reference withReferenceIdent(ReferenceIdent newIdent) {
+    public Reference withName(ColumnIdent name) {
         return new GeoReference(
-            newIdent,
+            column,
             type,
             indexType,
             nullable,
@@ -184,7 +184,7 @@ public class GeoReference extends SimpleReference {
             return this;
         }
         return new GeoReference(
-            ident,
+            column,
             type,
             indexType,
             nullable,
@@ -202,7 +202,7 @@ public class GeoReference extends SimpleReference {
     @Override
     public GeoReference withValueType(DataType<?> newType) {
         return new GeoReference(
-            ident,
+            column,
             newType,
             indexType,
             nullable,

--- a/server/src/main/java/io/crate/metadata/IndexReference.java
+++ b/server/src/main/java/io/crate/metadata/IndexReference.java
@@ -46,7 +46,7 @@ import io.crate.types.DataTypes;
 public class IndexReference extends SimpleReference {
 
     public static class Builder {
-        private final ReferenceIdent ident;
+        private final ColumnIdent column;
         private IndexType indexType = IndexType.FULLTEXT;
 
         @Deprecated
@@ -60,9 +60,9 @@ public class IndexReference extends SimpleReference {
         // Temporal source names holder, real references resolved by names on build();
         private List<String> sourceNames = new ArrayList<>();
 
-        public Builder(ReferenceIdent ident) {
-            requireNonNull(ident, "ident is null");
-            this.ident = ident;
+        public Builder(ColumnIdent column) {
+            requireNonNull(column, "ident is null");
+            this.column = column;
         }
 
         public Builder indexType(IndexType indexType) {
@@ -107,7 +107,7 @@ public class IndexReference extends SimpleReference {
                 // columns is derived from copy_to which has been deprecated in 5.4.
                 // When a node is upgraded it can have shards on older nodes with outdated mapping (still having copy_to and no sources).
                 // This code handles outdated shards case.
-                return new IndexReference(position, oid, isDropped, ident, indexType, columns, analyzer);
+                return new IndexReference(position, oid, isDropped, column, indexType, columns, analyzer);
             }
             List<Reference> sources = new ArrayList<>(sourceNames.size());
             for (String sourceName : sourceNames) {
@@ -117,7 +117,7 @@ public class IndexReference extends SimpleReference {
                     .orElseThrow();
                 sources.add(ref);
             }
-            return new IndexReference(position, oid, isDropped, ident, indexType, sources, analyzer);
+            return new IndexReference(position, oid, isDropped, column, indexType, sources, analyzer);
         }
     }
 
@@ -139,17 +139,17 @@ public class IndexReference extends SimpleReference {
     public IndexReference(int position,
                           long oid,
                           boolean isDropped,
-                          ReferenceIdent ident,
+                          ColumnIdent column,
                           IndexType indexType,
                           List<Reference> columns,
                           @Nullable String analyzer) {
-        super(ident, RowGranularity.DOC, DataTypes.STRING, indexType,
+        super(column, RowGranularity.DOC, DataTypes.STRING, indexType,
               false, false, position, oid, isDropped, null);
         this.columns = columns;
         this.analyzer = analyzer;
     }
 
-    public IndexReference(ReferenceIdent ident,
+    public IndexReference(ColumnIdent column,
                           RowGranularity granularity,
                           DataType<?> type,
                           IndexType indexType,
@@ -161,7 +161,7 @@ public class IndexReference extends SimpleReference {
                           Symbol defaultExpression,
                           List<Reference> columns,
                           String analyzer) {
-        super(ident,
+        super(column,
               granularity,
               type,
               indexType,
@@ -222,9 +222,9 @@ public class IndexReference extends SimpleReference {
     }
 
     @Override
-    public Reference withReferenceIdent(ReferenceIdent newIdent) {
+    public Reference withName(ColumnIdent name) {
         return new IndexReference(
-            newIdent,
+            name,
             granularity,
             type,
             indexType,
@@ -247,7 +247,7 @@ public class IndexReference extends SimpleReference {
             return this;
         }
         return new IndexReference(
-            ident,
+            column,
             granularity,
             type,
             indexType,
@@ -265,7 +265,7 @@ public class IndexReference extends SimpleReference {
     @Override
     public Reference withDropped(boolean dropped) {
         return new IndexReference(
-            ident,
+            column,
             granularity,
             type,
             indexType,
@@ -283,7 +283,7 @@ public class IndexReference extends SimpleReference {
     @Override
     public IndexReference withValueType(DataType<?> newType) {
         return new IndexReference(
-            ident,
+            column,
             granularity,
             newType,
             indexType,
@@ -315,7 +315,7 @@ public class IndexReference extends SimpleReference {
 
     public IndexReference withColumns(List<Reference> newColumns) {
         return new IndexReference(
-                ident,
+                column,
                 granularity,
                 type,
                 indexType,

--- a/server/src/main/java/io/crate/metadata/Reference.java
+++ b/server/src/main/java/io/crate/metadata/Reference.java
@@ -62,8 +62,6 @@ public interface Reference extends Symbol {
         return -1;
     }
 
-    ReferenceIdent ident();
-
     ColumnIdent column();
 
     @Override
@@ -102,7 +100,7 @@ public interface Reference extends Symbol {
 
     boolean isGenerated();
 
-    Reference withReferenceIdent(ReferenceIdent referenceIdent);
+    Reference withName(ColumnIdent name);
 
     Reference withOidAndPosition(LongSupplier acquireOid, IntSupplier acquirePosition);
 

--- a/server/src/main/java/io/crate/metadata/SystemTable.java
+++ b/server/src/main/java/io/crate/metadata/SystemTable.java
@@ -296,7 +296,7 @@ public final class SystemTable<T> implements TableInfo {
                 refByColumns.put(
                     column.column,
                     new SimpleReference(
-                        new ReferenceIdent(name, column.column),
+                        column.column,
                         RowGranularity.DOC,
                         column.type,
                         IndexType.PLAIN,
@@ -313,7 +313,7 @@ public final class SystemTable<T> implements TableInfo {
                     final DataType<?> leafType = ((DynamicColumn<?>) column).leafType;
                     dynamicColumns.put(column.column, wanted -> {
                         var ref = new DynamicReference(
-                            new ReferenceIdent(name, wanted),
+                            wanted,
                             RowGranularity.DOC,
                             position
                         );

--- a/server/src/main/java/io/crate/metadata/blob/BlobTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/blob/BlobTableInfo.java
@@ -40,7 +40,6 @@ import org.jetbrains.annotations.Nullable;
 import io.crate.analyze.WhereClause;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Reference;
-import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.Routing;
 import io.crate.metadata.RoutingProvider;
@@ -155,7 +154,7 @@ public class BlobTableInfo implements TableInfo, ShardedTable, StoredTable {
 
     private void addColumn(String name, DataType<?> type, int position) {
         SimpleReference ref = new SimpleReference(
-            new ReferenceIdent(ident(), name, null),
+            ColumnIdent.of(name),
             RowGranularity.DOC,
             type,
             position,

--- a/server/src/main/java/io/crate/metadata/cluster/RenameTableClusterStateExecutor.java
+++ b/server/src/main/java/io/crate/metadata/cluster/RenameTableClusterStateExecutor.java
@@ -35,11 +35,9 @@ import org.elasticsearch.cluster.metadata.RelationMetadata;
 import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
 
-import io.crate.common.collections.Lists;
 import io.crate.exceptions.RelationUnknown;
 import io.crate.execution.ddl.tables.RenameTableRequest;
 import io.crate.metadata.PartitionName;
-import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.view.ViewsMetadata;
 
@@ -94,10 +92,7 @@ public class RenameTableClusterStateExecutor {
             .dropRelation(source)
             .setTable(
                 target,
-                Lists.map(
-                    table.columns(),
-                    ref -> ref.withReferenceIdent(new ReferenceIdent(target, ref.column()))
-                ),
+                table.columns(),
                 table.settings(),
                 table.routingColumn(),
                 table.columnPolicy(),

--- a/server/src/main/java/io/crate/metadata/doc/DocTableInfoFactory.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocTableInfoFactory.java
@@ -65,7 +65,6 @@ import io.crate.metadata.IndexReference;
 import io.crate.metadata.IndexType;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
-import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.SimpleReference;
@@ -393,7 +392,6 @@ public class DocTableInfoFactory implements TableInfoFactory<DocTableInfo> {
             Map<String, Object> columnProperties = (Map<String, Object>) entry.getValue();
             final DataType<?> type = getColumnDataType(columnProperties);
             ColumnIdent column = parent == null ? ColumnIdent.of(columnName) : parent.getChild(columnName);
-            ReferenceIdent refIdent = new ReferenceIdent(relationName, column);
             columnProperties = innerProperties(columnProperties);
 
             String analyzer = (String) columnProperties.get("analyzer");
@@ -434,7 +432,7 @@ public class DocTableInfoFactory implements TableInfoFactory<DocTableInfo> {
                 Integer treeLevels = (Integer) columnProperties.get("tree_levels");
                 Double distanceErrorPct = (Double) columnProperties.get("distance_error_pct");
                 Reference ref = new GeoReference(
-                    refIdent,
+                    column,
                     type,
                     IndexType.PLAIN,
                     nullable,
@@ -454,7 +452,7 @@ public class DocTableInfoFactory implements TableInfoFactory<DocTableInfo> {
                 }
             } else if (elementType.id() == ObjectType.ID) {
                 Reference ref = new SimpleReference(
-                    refIdent,
+                    column,
                     granularity,
                     type,
                     indexType,
@@ -494,7 +492,7 @@ public class DocTableInfoFactory implements TableInfoFactory<DocTableInfo> {
                     if (sources != null) {
                         IndexReference.Builder builder = indexColumns.computeIfAbsent(
                             column,
-                            k -> new IndexReference.Builder(refIdent)
+                            k -> new IndexReference.Builder(column)
                         );
                         builder.indexType(indexType)
                             .position(position)
@@ -506,7 +504,7 @@ public class DocTableInfoFactory implements TableInfoFactory<DocTableInfo> {
                     Reference ref;
                     if (analyzer == null) {
                         ref = new SimpleReference(
-                            refIdent,
+                            column,
                             granularity,
                             type,
                             indexType,
@@ -519,7 +517,7 @@ public class DocTableInfoFactory implements TableInfoFactory<DocTableInfo> {
                         );
                     } else {
                         ref = new IndexReference(
-                            refIdent,
+                            column,
                             granularity,
                             type,
                             indexType,

--- a/server/src/main/java/io/crate/metadata/doc/SysColumns.java
+++ b/server/src/main/java/io/crate/metadata/doc/SysColumns.java
@@ -36,7 +36,6 @@ import io.crate.execution.engine.fetch.FetchId;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.IndexType;
 import io.crate.metadata.Reference;
-import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.SimpleReference;
@@ -155,8 +154,8 @@ public class SysColumns {
      * Creates a Reference for a system column.
      * Don't use this for user table columns, it's not safe (e.g. Reference has no oid)
      */
-    private static Reference newInfo(RelationName table, ColumnIdent column, DataType<?> dataType, int position) {
-        return new SimpleReference(new ReferenceIdent(table, column),
+    private static Reference newInfo(ColumnIdent column, DataType<?> dataType, int position) {
+        return new SimpleReference(column,
                              RowGranularity.DOC,
                              dataType,
                              IndexType.PLAIN,
@@ -176,21 +175,21 @@ public class SysColumns {
         int position = 1;
         for (Map.Entry<ColumnIdent, DataType<?>> entry : COLUMN_IDENTS.entrySet()) {
             ColumnIdent columnIdent = entry.getKey();
-            consumer.accept(columnIdent, newInfo(relationName, columnIdent, entry.getValue(), position++));
+            consumer.accept(columnIdent, newInfo(columnIdent, entry.getValue(), position++));
         }
     }
 
-    public static List<Reference> forTable(RelationName relationName) {
+    public static List<Reference> forTable() {
         int position = 1;
         var columns = new ArrayList<Reference>();
         for (Map.Entry<ColumnIdent, DataType<?>> entry : COLUMN_IDENTS.entrySet()) {
-            columns.add(newInfo(relationName, entry.getKey(), entry.getValue(), position++));
+            columns.add(newInfo(entry.getKey(), entry.getValue(), position++));
         }
         return columns;
     }
 
-    public static Reference forTable(RelationName table, ColumnIdent column) {
-        return newInfo(table, column, COLUMN_IDENTS.get(column), 0);
+    public static Reference forTable(ColumnIdent column) {
+        return newInfo(column, COLUMN_IDENTS.get(column), 0);
     }
 
     public static String nameForLucene(ColumnIdent ident) {

--- a/server/src/main/java/io/crate/metadata/information/InformationColumnsTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/information/InformationColumnsTableInfo.java
@@ -52,8 +52,8 @@ public final class InformationColumnsTableInfo {
     private InformationColumnsTableInfo() {}
 
     public static SystemTable<ColumnContext> INSTANCE = SystemTable.<ColumnContext>builder(IDENT)
-        .addNonNull("table_schema", STRING, r -> r.ref().ident().tableIdent().schema())
-        .addNonNull("table_name", STRING, r -> r.ref().ident().tableIdent().name())
+        .addNonNull("table_schema", STRING, r -> r.relation().ident().schema())
+        .addNonNull("table_name", STRING, r -> r.relation().ident().name())
         .addNonNull("table_catalog", STRING, r -> Constants.DB_NAME)
         .addNonNull("column_name", STRING, r -> r.ref().column().sqlFqn())
         .addNonNull("ordinal_position", INTEGER, r -> r.ref().position())

--- a/server/src/main/java/io/crate/metadata/sys/TableColumn.java
+++ b/server/src/main/java/io/crate/metadata/sys/TableColumn.java
@@ -25,8 +25,6 @@ import java.util.Map;
 
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Reference;
-import io.crate.metadata.ReferenceIdent;
-import io.crate.metadata.RelationName;
 
 /**
  * A virtual column that is pointing to other columns.
@@ -49,7 +47,7 @@ public class TableColumn {
         this.columns = columns;
     }
 
-    public Reference getReference(RelationName relationName, ColumnIdent columnIdent) {
+    public Reference getReference(ColumnIdent columnIdent) {
         if (!columnIdent.isChildOf(column)) {
             return null;
         }
@@ -57,6 +55,6 @@ public class TableColumn {
         if (info == null) {
             return null;
         }
-        return info.withReferenceIdent(new ReferenceIdent(relationName, columnIdent));
+        return info.withName(columnIdent);
     }
 }

--- a/server/src/main/java/io/crate/metadata/table/TableInfo.java
+++ b/server/src/main/java/io/crate/metadata/table/TableInfo.java
@@ -71,7 +71,7 @@ public interface TableInfo extends RelationInfo {
             return ref;
         } else {
             return new SimpleReference(
-                ref.ident(),
+                ref.column(),
                 ref.granularity(),
                 readType,
                 ref.indexType(),

--- a/server/src/main/java/io/crate/metadata/view/ViewInfoFactory.java
+++ b/server/src/main/java/io/crate/metadata/view/ViewInfoFactory.java
@@ -34,7 +34,6 @@ import io.crate.analyze.relations.RelationAnalyzer;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.Reference;
-import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.SimpleReference;
@@ -80,7 +79,7 @@ public class ViewInfoFactory {
                 ColumnIdent columnIdent = field.toColumn();
                 collectedColumns.add(
                     new SimpleReference(
-                        new ReferenceIdent(ident, columnIdent.sqlFqn()),
+                        columnIdent,
                         RowGranularity.DOC,
                         field.valueType(),
                         position++,
@@ -120,7 +119,7 @@ public class ViewInfoFactory {
                 DataType<?> childType = entry.getValue();
                 subColumns.add(
                     new SimpleReference(
-                        new ReferenceIdent(ident, childColumn.sqlFqn()),
+                        childColumn,
                         RowGranularity.DOC,
                         childType,
                         position++,

--- a/server/src/main/java/io/crate/planner/operators/EquiJoinDetector.java
+++ b/server/src/main/java/io/crate/planner/operators/EquiJoinDetector.java
@@ -171,7 +171,6 @@ public final class EquiJoinDetector {
 
         @Override
         public Void visitReference(Reference ref, Context context) {
-            context.relations.add(ref.ident().tableIdent());
             return null;
         }
     }

--- a/server/src/main/java/io/crate/planner/operators/FetchRewrite.java
+++ b/server/src/main/java/io/crate/planner/operators/FetchRewrite.java
@@ -67,7 +67,7 @@ public final class FetchRewrite {
         for (int i = 0; i < outputs.size(); i++) {
             Symbol output = outputs.get(i);
             if (output instanceof FetchMarker fetchMarker) {
-                RelationName tableName = fetchMarker.fetchId().ident().tableIdent();
+                RelationName tableName = null; // TODO: fetchMarker.fetchId().ident().tableIdent();
                 FetchSource fetchSource = fetchSources.get(tableName);
                 if (fetchSource == null) {
                     fetchSource = new FetchSource();

--- a/server/src/main/java/io/crate/types/ArrayType.java
+++ b/server/src/main/java/io/crate/types/ArrayType.java
@@ -106,7 +106,7 @@ public class ArrayType<T> extends DataType<List<T>> {
                     int topMostArrayDimensions = ArrayType.dimensions(innerType) + 1;
                     assert topMostArrayDimensions == ArrayType.dimensions(ref.valueType()) :
                         "Must not retrieve value indexer of the child array of a multi dimensional array";
-                    return ArrayIndexer.of(ref, getRef);
+                    return ArrayIndexer.of(table, ref, getRef);
                 }
 
                 @Override
@@ -143,7 +143,7 @@ public class ArrayType<T> extends DataType<List<T>> {
                     int topMostArrayDimensions = ArrayType.dimensions(innerType) + 1;
                     assert topMostArrayDimensions == ArrayType.dimensions(ref.valueType()) :
                         "Must not retrieve value indexer of the child array of a multi dimensional array";
-                    return ArrayIndexer.of(ref, getRef);
+                    return ArrayIndexer.of(table, ref, getRef);
                 }
 
                 @Override

--- a/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -106,7 +106,6 @@ import io.crate.exceptions.RelationUnknown;
 import io.crate.metadata.IndexName;
 import io.crate.metadata.IndexParts;
 import io.crate.metadata.PartitionName;
-import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.doc.DocTableInfo;
 
@@ -602,10 +601,7 @@ public class RestoreService implements ClusterStateApplier {
                 mdBuilder.setTable(
                     columnOidSupplier,
                     targetName,
-                    Lists.map(
-                        table.columns(),
-                        ref -> ref.withReferenceIdent(new ReferenceIdent(targetName, ref.column()))
-                    ),
+                    table.columns(),
                     table.settings(),
                     table.routingColumn(),
                     table.columnPolicy(),
@@ -626,10 +622,7 @@ public class RestoreService implements ClusterStateApplier {
                     mdBuilder.setTable(
                         columnOidSupplier,
                         targetName,
-                        Lists.map(
-                            table.columns(),
-                            ref -> ref.withReferenceIdent(new ReferenceIdent(targetName, ref.column()))
-                        ),
+                        table.columns(),
                         table.settings(),
                         table.routingColumn(),
                         table.columnPolicy(),

--- a/server/src/test/java/io/crate/analyze/GroupByAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/GroupByAnalyzerTest.java
@@ -28,6 +28,7 @@ import static io.crate.testing.Asserts.isField;
 import static io.crate.testing.Asserts.isFunction;
 import static io.crate.testing.Asserts.isLiteral;
 import static io.crate.testing.Asserts.isReference;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
@@ -41,8 +42,8 @@ import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.expression.operator.LikeOperators;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Reference;
-import io.crate.metadata.ReferenceIdent;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 
@@ -171,9 +172,8 @@ public class GroupByAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         QueriedSelectRelation relation = analyze("select 58 as age from foo.users group by age;");
         assertThat(relation.groupBy()).isNotEmpty();
         List<Symbol> groupBySymbols = relation.groupBy();
-        ReferenceIdent groupByIdent = ((Reference) groupBySymbols.getFirst()).ident();
-        assertThat(groupByIdent.columnIdent().fqn()).isEqualTo("age");
-        assertThat(groupByIdent.tableIdent().fqn()).isEqualTo("foo.users");
+        ColumnIdent groupByIdent = ((Reference) groupBySymbols.getFirst()).column();
+        assertThat(groupByIdent).isEqualTo("age");
     }
 
     @Test
@@ -181,9 +181,8 @@ public class GroupByAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         QueriedSelectRelation relation = analyze("select age age, - age age from foo.users group by age;");
         assertThat(relation.groupBy()).isNotEmpty();
         List<Symbol> groupBySymbols = relation.groupBy();
-        ReferenceIdent groupByIdent = ((Reference) groupBySymbols.getFirst()).ident();
-        assertThat(groupByIdent.columnIdent().fqn()).isEqualTo("age");
-        assertThat(groupByIdent.tableIdent().fqn()).isEqualTo("foo.users");
+        ColumnIdent groupByIdent = ((Reference) groupBySymbols.getFirst()).column();
+        assertThat(groupByIdent).isEqualTo("age");
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/tablefunctions/AbstractTableFunctionsTest.java
+++ b/server/src/test/java/io/crate/expression/tablefunctions/AbstractTableFunctionsTest.java
@@ -42,7 +42,6 @@ import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.CoordinatorTxnCtx;
-import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.Scalar;
@@ -66,7 +65,7 @@ public abstract class AbstractTableFunctionsTest extends ESTestCase {
         RelationName relationName = new RelationName(null, "t");
         when(relation.getField(any(ColumnIdent.class), any(Operation.class), any(Boolean.class)))
             .thenReturn(new SimpleReference(
-                new ReferenceIdent(relationName, "name"),
+                ColumnIdent.of("name"),
                 RowGranularity.NODE,
                 DataTypes.STRING,
                 0,

--- a/server/src/test/java/io/crate/planner/SelectPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/SelectPlannerTest.java
@@ -671,7 +671,7 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
             .as("would require merge with more than 1 nodeIds")
             .hasSize(1);
         assertThat(((RoutedCollectPhase) collect.collectPhase()).where())
-            .isSQL("(((doc.t1.i + doc.t1.i) * 2) > 4)");
+            .isSQL("(((i + i) * 2) > 4)");
         List<Projection> projections = collect.collectPhase().projections();
         assertThat(projections).satisfiesExactly(
             p -> assertThat(p).isExactlyInstanceOf(GroupProjection.class), // parallel on shard-level
@@ -734,7 +734,7 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(nl.joinPhase().joinType()).isEqualTo(JoinType.INNER);
         Collect rightCM = (Collect) nl.right();
         assertThat(((RoutedCollectPhase) rightCM.collectPhase()).where())
-            .isSQL("((doc.users.name = 'Arthur') AND (doc.users.id > 1::bigint))");
+            .isSQL("((name = 'Arthur') AND (id > 1::bigint))");
     }
 
     @Test

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/PublicationTransportHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/PublicationTransportHandlerTests.java
@@ -66,7 +66,6 @@ import org.junit.Test;
 
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.IndexType;
-import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.SimpleReference;
@@ -161,7 +160,7 @@ public class PublicationTransportHandlerTests extends ESTestCase {
         RelationMetadata.Table table = new RelationMetadata.Table(
             relationName,
             List.of(new SimpleReference(
-                new ReferenceIdent(relationName, "x"),
+                ColumnIdent.of("x"),
                 RowGranularity.PARTITION,
                 DataTypes.STRING,
                 IndexType.PLAIN,


### PR DESCRIPTION
Relates to https://github.com/crate/crate/issues/18445

## Blockers / Open questions

- BWC handling for Reference.writeTo: Can't stream correct RelationName anymore; would need intermediate Version(s) where we're sure the older version doesn't make use of a RelationName property so we can stream a dummy value.
- SysUpdateProjection needs different representation
- FetchPhase needs different representation
- QuerySplitter/Symbols.intersectionVisitor (Maybe needs something like `ScopedReference` as specialization of `ScopedSymbol` ?)
- DocReferences.toDocLookup schema check no longer works  (Is `_doc` even still needed after recent storage changes?)
