### PR TITLE
Stream insert columns in ShardUpsertRequest via oid

### DIFF
--- a/server/src/main/java/io/crate/metadata/Schemas.java
+++ b/server/src/main/java/io/crate/metadata/Schemas.java
@@ -39,8 +39,11 @@ import org.apache.lucene.search.spell.LevenshteinDistance;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterStateListener;
 import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.metadata.RelationMetadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.IndexNotFoundException;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.VisibleForTesting;
@@ -262,6 +265,17 @@ public class Schemas extends AbstractLifecycleComponent implements Iterable<Sche
                3 : "When identifying schemas or tables a qualified name should not have more the 3 parts";
         List<String> parts = ident.getParts();
         return parts.get(parts.size() - 1);
+    }
+
+    /// @throws [IndexNotFoundException]
+    /// @throws [RelationUnknown]
+    public DocTableInfo getTableInfo(Index index) {
+        Metadata metadata = clusterService.state().metadata();
+        RelationMetadata relation = metadata.getRelation(index.getUUID());
+        if (relation == null) {
+            throw new IndexNotFoundException(index);
+        }
+        return getTableInfo(relation.name());
     }
 
     /**

--- a/server/src/main/java/io/crate/metadata/doc/DocTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocTableInfo.java
@@ -329,21 +329,26 @@ public class DocTableInfo implements TableInfo, ShardedTable, StoredTable {
     }
 
     @Nullable
+    public Reference getReference(long oid) {
+        for (var ref : allColumns.values()) {
+            if (ref.oid() == oid) {
+                return ref;
+            }
+        }
+        for (var ref: indexColumns.values()) {
+            if (ref.oid() == oid) {
+                return ref;
+            }
+        }
+        return null;
+    }
+
+    @Nullable
     public Reference getReference(String storageIdent) {
         long[] out = StringUtils.PARSE_LONG_BUFFER.get();
         if (StringUtils.tryParseLong(storageIdent, out)) {
             long oid = out[0];
-            for (var ref : allColumns.values()) {
-                if (ref.oid() == oid) {
-                    return ref;
-                }
-            }
-            for (var ref: indexColumns.values()) {
-                if (ref.oid() == oid) {
-                    return ref;
-                }
-            }
-            return null;
+            return getReference(oid);
         }
         return getReference(ColumnIdent.fromPath(storageIdent));
     }


### PR DESCRIPTION
Relates to https://github.com/crate/crate/issues/18445

Steams the `insertColumns` for insert requests via oid instead of via `Reference.toStream`. 
Downside of this approach is that it only applies specifically for this case, instead of general to any symbol/reference streaming - e.g. it doesn't work for reference used in the UPDATE assignment expressions.

We could generalize this by changing `Symbol.fromStream(in)` to `Symbol.fromStream(schemas, in)`. But that has a bigger blast radius as it adds a schemas dependency to more places. I plan to follow up on giving this a shot, to get an idea how bad it is. But this PR is probably a good starting point to get some feedback about the direction.

Also note in regards to the RelationMetadata on-disk serialization (https://github.com/crate/crate/issues/18445#issuecomment-3405092502). For that we can additionally pursue https://github.com/crate/crate/pull/18776 (quite a bit of effort to deal with the mentioned blockers), or a simpler but less general solution would be to introduce a `Reference.writeThin(out)` / `Reference.readThin(relationName, in)` that's specifically used in the serialization methods of `RelationMetadata`

With a benchmark derived from crate-benchmarks/specs/select/wide_table.toml. 3 nodes running on the same machine. Disk on tmpfs so serialization effects are exaggerated compared to when disk IO would be a bigger bottleneck:

```
C: 25
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |     1040.334 ±  667.399 |    183.844 |    867.940 |   1331.124 |   3578.957 |
|   V2    |     1001.709 ±  608.293 |    259.680 |    807.191 |   1259.200 |   3218.927 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -   3.78%                           -   7.25%
There is a 50.08% probability that the observed difference is not random, and the best estimate of that difference is 3.78%
The test has no statistical significance

Q: insert into wide_obj ("obj") values ($1)
C: 25
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |     1234.715 ±  977.651 |    192.895 |    879.757 |   1813.323 |   4764.148 |
|   V2    |      933.964 ±  552.337 |    271.901 |    706.748 |   1333.406 |   2573.662 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -  27.74%                           -  21.81%
There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 27.74%
The test has statistical significance
```