### PR TITLE
Add warn log when ANALYZE can't resolve a table

### DIFF
--- a/server/src/main/java/io/crate/statistics/ReservoirSampler.java
+++ b/server/src/main/java/io/crate/statistics/ReservoirSampler.java
@@ -137,6 +137,9 @@ public final class ReservoirSampler {
         try {
             table = schemas.getTableInfo(relationName);
         } catch (RelationUnknown e) {
+            if (LOGGER.isWarnEnabled()) {
+                LOGGER.warn("ANALYZE couldn't find table {}", relationName, e);
+            }
             return Samples.EMPTY;
         }
         if (!(table instanceof DocTableInfo docTable)) {

--- a/server/src/main/java/io/crate/statistics/TransportAnalyzeAction.java
+++ b/server/src/main/java/io/crate/statistics/TransportAnalyzeAction.java
@@ -105,6 +105,9 @@ public final class TransportAnalyzeAction {
                             .thenApply(FetchSampleResponse::new)
                             .whenComplete((res, err) -> analysisByRequest.remove(req));
                     } else {
+                        if (LOGGER.isDebugEnabled()) {
+                            LOGGER.debug("ANALYZE is already running, re-using its result");
+                        }
                         return previous.thenApply(FetchSampleResponse::new);
                     }
                 }


### PR DESCRIPTION
Also, add a debug log entry when prev run is re-used.

Relates to https://github.com/crate/support/issues/768