### PR TITLE
Fix COUNT(null) returning one row per record instead of only one row

### DIFF
--- a/docs/appendices/release-notes/6.1.2.rst
+++ b/docs/appendices/release-notes/6.1.2.rst
@@ -46,4 +46,5 @@ series.
 Fixes
 =====
 
-None
+- Fixed an issue that caused ``SELECT COUNT(NULL) FROM tbl`` to return one
+  record per row in the table instead of a single row with value ``0``.

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/CountAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/CountAggregation.java
@@ -153,7 +153,7 @@ public class CountAggregation extends AggregationFunction<MutableLong, Long> {
             Symbol arg = function.arguments().get(0);
             if (arg instanceof Input<?> input) {
                 if (input.value() == null) {
-                    return Literal.of(0L);
+                    return function;
                 } else {
                     return new Function(COUNT_STAR_SIGNATURE, List.of(), DataTypes.LONG);
                 }

--- a/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -481,12 +481,13 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     }
 
     @Test
-    public void testRewriteCountNull() {
+    public void test_count_on_null_literal_is_preserved() {
         var executor = SQLExecutor.of(clusterService);
         AnalyzedRelation relation = executor.analyze("select count(null) from sys.nodes");
         List<Symbol> outputSymbols = relation.outputs();
-        assertThat(outputSymbols).hasSize(1);
-        assertThat(outputSymbols.getFirst()).isLiteral(0L);
+        assertThat(outputSymbols).satisfiesExactly(
+            x -> assertThat(x).isFunction("count", arg -> assertThat(arg).isLiteral(null))
+        );
     }
 
     @Test

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/CountAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/CountAggregationTest.java
@@ -22,6 +22,7 @@
 package io.crate.execution.engine.aggregation.impl;
 
 import static io.crate.testing.Asserts.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -435,8 +436,8 @@ public class CountAggregationTest extends AggregationTestCase {
 
     @Test
     public void testNormalizeWithNullLiteral() {
-        assertThat(normalize("count", null, DataTypes.STRING)).isLiteral(0L);
-        assertThat(normalize("count", null, DataTypes.UNDEFINED)). isLiteral(0L);
+        assertThat(normalize("count", null, DataTypes.STRING)).isFunction("count");
+        assertThat(normalize("count", null, DataTypes.UNDEFINED)).isFunction("count");
     }
 
     @Test


### PR DESCRIPTION
`COUNT(NULL)` got normalized to a literal `0` with https://github.com/crate/crate/pull/464
That transformed the aggregation `count` into a scalar literal - meaning
that the query was no longer executed with an aggregation
projection/count plan, but a collect plan which returned `0` per row in
the table.

Found this enabling aggregate tests in the crate-qa sqllogic tests
