### PR TITLE
Don't use columns info to resolve active execution for ANALYZE

### DIFF
--- a/server/src/main/java/io/crate/statistics/TransportAnalyzeAction.java
+++ b/server/src/main/java/io/crate/statistics/TransportAnalyzeAction.java
@@ -27,8 +27,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -66,47 +65,26 @@ public final class TransportAnalyzeAction {
     private final TransportService transportService;
     private final Schemas schemas;
     private final ClusterService clusterService;
-    private final ConcurrentHashMap<FetchSampleRequest, CompletableFuture<Samples>> analysisByRequest = new ConcurrentHashMap<>();
-    private final Executor executor;
+    private final AtomicReference<CompletableFuture<AcknowledgedResponse>> activeExecution = new AtomicReference<>();
 
     @Inject
     public TransportAnalyzeAction(TransportService transportService,
                                   ReservoirSampler reservoirSampler,
                                   NodeContext nodeContext,
                                   ClusterService clusterService,
-                                  TableStatsService tableStatsService,
-                                  ThreadPool threadPool) {
+                                  TableStatsService tableStatsService) {
         this.transportService = transportService;
         this.schemas = nodeContext.schemas();
         this.clusterService = clusterService;
-        this.executor = threadPool.executor(ThreadPool.Names.SEARCH);
 
         transportService.registerRequestHandler(
             FETCH_SAMPLES,
-            ThreadPool.Names.SAME,
+            ThreadPool.Names.SEARCH,
             FetchSampleRequest::new,
             // Explicit generic is required for eclipse JDT, otherwise it won't compile
             new NodeActionRequestHandler<FetchSampleRequest, FetchSampleResponse>(
-                req -> {
-
-                    CompletableFuture<Samples> newSamples = new CompletableFuture<>();
-                    CompletableFuture<Samples> previous = analysisByRequest.putIfAbsent(
-                        req,
-                        newSamples
-                    );
-
-                    if (previous == null) {
-                        newSamples.completeAsync(
-                            () -> reservoirSampler.getSamples(req.relation(), req.columns()),
-                            executor
-                        );
-                        return newSamples
-                            .thenApply(FetchSampleResponse::new)
-                            .whenComplete((res, err) -> analysisByRequest.remove(req));
-                    } else {
-                        return previous.thenApply(FetchSampleResponse::new);
-                    }
-                }
+                req -> completedFuture(new FetchSampleResponse(
+                    reservoirSampler.getSamples(req.relation(), req.columns())))
             )
         );
 
@@ -125,28 +103,35 @@ public final class TransportAnalyzeAction {
     }
 
     public CompletableFuture<AcknowledgedResponse> fetchSamplesThenGenerateAndPublishStats() {
-        LOGGER.info("ANALYZE: Start collecting samples to update table statistics");
-        HashMap<RelationName, Stats> entries = new HashMap<>();
-        CompletableFuture<Void> currentFetch = CompletableFuture.completedFuture(null);
-        for (SchemaInfo schema : schemas) {
-            if (!(schema instanceof DocSchemaInfo)) {
-                continue;
-            }
-            for (TableInfo table : schema.getTables()) {
-                List<Reference> primitiveColumns = StreamSupport.stream(table.spliterator(), false)
-                    .filter(x -> !x.column().isSystemColumn())
-                    .filter(x -> DataTypes.isPrimitive(x.valueType()))
-                    .map(x -> table.getReadReference(x.column()))
-                    .toList();
+        return activeExecution.updateAndGet(
+            current -> {
+                if (current == null) {
+                    LOGGER.info("ANALYZE: Start collecting samples to update table statistics");
+                    HashMap<RelationName, Stats> entries = new HashMap<>();
+                    CompletableFuture<Void> currentFetch = CompletableFuture.completedFuture(null);
+                    for (SchemaInfo schema : schemas) {
+                        if (!(schema instanceof DocSchemaInfo)) {
+                            continue;
+                        }
+                        for (TableInfo table : schema.getTables()) {
+                            List<Reference> primitiveColumns = StreamSupport.stream(table.spliterator(), false)
+                                .filter(x -> !x.column().isSystemColumn())
+                                .filter(x -> DataTypes.isPrimitive(x.valueType()))
+                                .map(x -> table.getReadReference(x.column()))
+                                .toList();
 
-                currentFetch = currentFetch
-                    .thenCompose(ignored -> fetchSamples(table.ident(), primitiveColumns))
-                    .thenAccept(samples -> {
-                        entries.put(table.ident(), samples.createTableStats(primitiveColumns));
-                    });
-            }
-        }
-        return currentFetch.thenCompose(ignored -> publishTableStats(entries));
+                            currentFetch = currentFetch
+                                .thenCompose(ignored -> fetchSamples(table.ident(), primitiveColumns))
+                                .thenAccept(samples -> {
+                                    entries.put(table.ident(), samples.createTableStats(primitiveColumns));
+                                });
+                        }
+                    }
+                    return currentFetch.thenCompose(ignored -> publishTableStats(entries));
+                }
+                return current;
+            })
+            .whenComplete((r, t) -> activeExecution.set(null));
     }
 
     private CompletableFuture<AcknowledgedResponse> publishTableStats(Map<RelationName, Stats> newTableStats) {

--- a/server/src/test/java/io/crate/statistics/TransportAnalyzeActionTest.java
+++ b/server/src/test/java/io/crate/statistics/TransportAnalyzeActionTest.java
@@ -22,23 +22,58 @@
 package io.crate.statistics;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import java.util.Collections;
 import java.util.List;
 
-import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.Version;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.network.NetworkService;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.PageCacheRecycler;
+import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
+import org.elasticsearch.test.transport.MockTransportService;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.transport.netty4.Netty4Transport;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
+import io.crate.auth.AlwaysOKAuthentication;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.SimpleReference;
 import io.crate.metadata.doc.DocSchemaInfo;
+import io.crate.netty.NettyBootstrap;
+import io.crate.protocols.ssl.SslContextProvider;
+import io.crate.role.Role;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.SQLExecutor;
 import io.crate.types.ArrayType;
 import io.crate.types.DataTypes;
 
+public class TransportAnalyzeActionTest extends CrateDummyClusterServiceUnitTest {
 
-public class TransportAnalyzeActionTest extends ESTestCase {
+    private NettyBootstrap nettyBootstrap;
+
+    @Before
+    public void setupNetty() {
+        nettyBootstrap = new NettyBootstrap(Settings.EMPTY);
+        nettyBootstrap.start();
+    }
+
+    @After
+    public void teardownNetty() {
+        nettyBootstrap.close();
+    }
 
     @Test
     public void test_create_stats_for_tables_with_array_columns_with_nulls() {
@@ -64,5 +99,64 @@ public class TransportAnalyzeActionTest extends ESTestCase {
         );
         var stats = samples.createTableStats(references);
         assertThat(stats.numDocs()).isEqualTo(2L);
+    }
+
+    @Test
+    public void test_existing_run_reused_when_second_analyze_is_run() throws Exception {
+        SQLExecutor executor = SQLExecutor.of(clusterService)
+            .addTable(
+                """
+                create table doc.t (
+                    a int
+                )
+                """
+            );
+        ReservoirSampler mockSampler = mock(ReservoirSampler.class);
+        when(mockSampler.getSamples(any(), anyList())).thenAnswer(_ -> {
+            // Sleep a bit to be sure that second request always arrives when first is still running.
+            Thread.sleep(100);
+            return Samples.EMPTY;
+        });
+
+        try (TransportService service = createTransportService()) {
+            TransportAnalyzeAction transportAnalyzeAction = new TransportAnalyzeAction(
+                service,
+                mockSampler,
+                executor.nodeCtx,
+                clusterService,
+                null // TableStatsService won't be used, is irrelevant for this test.
+            );
+
+            transportAnalyzeAction.fetchSamplesThenGenerateAndPublishStats();
+
+            transportAnalyzeAction.fetchSamplesThenGenerateAndPublishStats();
+            // assertBusy because of the sleep.
+            assertBusy(() -> verify(mockSampler, times(1)).getSamples(any(), anyList()));
+        }
+    }
+
+    private TransportService createTransportService() {
+        var transport = new Netty4Transport(
+            Settings.EMPTY,
+            Version.CURRENT,
+            THREAD_POOL,
+            new NetworkService(Collections.emptyList()),
+            PageCacheRecycler.NON_RECYCLING_INSTANCE,
+            new NamedWriteableRegistry(Collections.emptyList()),
+            new NoneCircuitBreakerService(),
+            nettyBootstrap,
+            new AlwaysOKAuthentication(() -> List.of(Role.CRATE_USER)),
+            new SslContextProvider(Settings.EMPTY)
+        );
+        TransportService transportService = new MockTransportService(
+            Settings.EMPTY,
+            transport,
+            THREAD_POOL,
+            _ -> clusterService.localNode(),
+            clusterService.getClusterSettings()
+        );
+        transportService.start();
+        transportService.acceptIncomingRequests();
+        return transportService;
     }
 }


### PR DESCRIPTION
In https://github.com/crate/crate/commit/e1cc214cafe59a7dd0160658269b75ea76482540, we added future-per-table in request handler to track active samplings in order to re-use them.

Originally it was done as a follow up to https://github.com/crate/crate/commit/7f03ad64d5df3a077c80149c49643476757775ad but it differes from it in a way that automatic `ANALYZE` doesn't care about tables state, it doesn't run until previous is done.

With schema changes in between, manual run can start collecting samples even if we had already running, which defeats the idea of having only one active `ANALYZE`. 

Also, it affects memory footprint of clusters with thousands of tables (some of them having thousands of columns)

Auto `ANALYZE` also hits this code, so has 2 layers of "is already running" check
I thought we can have an issue on versions with not persisted stats and dynamic mapping updates (see edit) but I was wrong. 

This change is mainly about manual/manual or manual/scheduled, not about scheduled/scheduled + reduces footprint for big clusters


