### PR TITLE
debug: lower MaxDirectMemorySize, use same args as in prod

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
           <!-- by default is false but is set to true by `serverTest` profile to avoid running tests
                for modules on which `server` module depends on, when running `mvn -Pserver test` -->
           <skip>${skipRunTests}</skip>
-          <argLine>@{argLine} -XX:MaxDirectMemorySize=1k -XX:+DisableExplicitGC  -XX:+UseG1GC -XX:G1ReservePercent=25 -XX:InitiatingHeapOccupancyPercent=30 -XX:+UseCompactObjectHeaders --add-modules jdk.incubator.vector --enable-native-access=ALL-UNNAMED --sun-misc-unsafe-memory-access=allow</argLine>
+          <argLine>@{argLine} -XX:+DisableExplicitGC  -XX:+UseG1GC -XX:G1ReservePercent=25 -XX:InitiatingHeapOccupancyPercent=30 -XX:+UseCompactObjectHeaders --add-modules jdk.incubator.vector --enable-native-access=ALL-UNNAMED --sun-misc-unsafe-memory-access=allow</argLine>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
See https://github.com/elastic/elasticsearch/pull/25759 and https://github.com/apache/pulsar/issues/13737 as an alternative

I can't reproduce OOM with a code snippet shared in https://bugs.openjdk.org/browse/JDK-8142537
I can only reproduce when explicitly using pooled buffers(that's what I saw in logs)
```
ByteBufAllocator allocator = PooledByteBufAllocator.DEFAULT;
while(true) {
    ByteBuf buf =  allocator.directBuffer(10000);
    //  buf.release();
}
```
        
But I also get leak warn that `release` is not called. 
If I uncomment release, I don't see OOM even with `DisableExplicitGC`

So porting https://github.com/elastic/elasticsearch/pull/25759  would be rather fixing a symptom and instead we need to find a buffer leak (?)

We had a leak(?) in https://tools.cr8.net/grafana/goto/4rCCETZvg?orgId=1 (https://github.com/crate/support/issues/744) but it was on 5.10.12 and on 6.0 we use Netty 4.2 with AdaptiveByteBufAllocator

Idea of this PR is to run/debug tests with low direct memory limit and use JVM flags that are _actually used_ in production
Will play around more with MaxDirectMemorySize/DisableExplicitGC and allocating pooled buffers