### PR TITLE
Clear DFA cache on memory pressure

### DIFF
--- a/docs/appendices/release-notes/6.2.0.rst
+++ b/docs/appendices/release-notes/6.2.0.rst
@@ -122,6 +122,11 @@ None
 Performance and Resilience Improvements
 ---------------------------------------
 
+- Added heuristics to clear the SQL parsers internal cache on memory pressure.
+  This should help on clusters where users run hundreds of thousands of unique
+  SQL statements, leading to the parser cache taking up a significant amount of
+  memory.
+
 - Added an optimization rule to push down query predicates in cases where the
   child relation is using scalar sub-queries.
 

--- a/libs/sql-parser/src/test/java/io/crate/sql/parser/TestSqlParser.java
+++ b/libs/sql-parser/src/test/java/io/crate/sql/parser/TestSqlParser.java
@@ -36,6 +36,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 
+import org.antlr.v4.runtime.dfa.DFA;
 import org.junit.jupiter.api.Test;
 
 import io.crate.common.collections.Lists;
@@ -58,6 +59,27 @@ import io.crate.sql.tree.Statement;
 import io.crate.sql.tree.StringLiteral;
 
 public class TestSqlParser {
+
+    @Test
+    public void test_clear_cache_clears_entries_depending_on_cache_size() throws Exception {
+        SqlParser.createStatement("select 1");
+        DFA[] dfas = SqlParser.dfas();
+        long numEntries = 0;
+        for (var dfa : dfas) {
+            numEntries += dfa.states.size();
+        }
+        assertThat(numEntries).isGreaterThanOrEqualTo(38L);
+        assertThat(SqlParser.contextCacheSize()).isGreaterThanOrEqualTo(138);
+
+        SqlParser.clearCaches(10, 10);
+        dfas = SqlParser.dfas();
+        numEntries = 0;
+        for (var dfa : dfas) {
+            numEntries += dfa.states.size();
+        }
+        assertThat(numEntries).isEqualTo(0);
+        assertThat(SqlParser.contextCacheSize()).isEqualTo(0);
+    }
 
     @Test
     public void testComments() {

--- a/server/src/main/java/org/elasticsearch/monitor/jvm/JvmGcMonitorService.java
+++ b/server/src/main/java/org/elasticsearch/monitor/jvm/JvmGcMonitorService.java
@@ -19,18 +19,7 @@
 
 package org.elasticsearch.monitor.jvm;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.elasticsearch.common.component.AbstractLifecycleComponent;
-import org.elasticsearch.common.settings.Setting;
-import org.elasticsearch.common.settings.Setting.Property;
-import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.unit.ByteSizeValue;
-import io.crate.common.unit.TimeValue;
-import org.elasticsearch.monitor.jvm.JvmStats.GarbageCollector;
-import org.elasticsearch.threadpool.Scheduler.Cancellable;
-import org.elasticsearch.threadpool.ThreadPool;
-import org.elasticsearch.threadpool.ThreadPool.Names;
+import static java.util.Collections.unmodifiableMap;
 
 import java.util.HashMap;
 import java.util.Locale;
@@ -39,7 +28,20 @@ import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
 
-import static java.util.Collections.unmodifiableMap;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.common.component.AbstractLifecycleComponent;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Setting.Property;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.monitor.jvm.JvmStats.GarbageCollector;
+import org.elasticsearch.threadpool.Scheduler.Cancellable;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.threadpool.ThreadPool.Names;
+
+import io.crate.common.unit.TimeValue;
+import io.crate.sql.parser.SqlParser;
 
 public class JvmGcMonitorService extends AbstractLifecycleComponent {
 
@@ -205,6 +207,9 @@ public class JvmGcMonitorService extends AbstractLifecycleComponent {
 
             @Override
             void onGcOverhead(final Threshold threshold, final long current, final long elapsed, final long seq) {
+                if (threshold == Threshold.INFO || threshold == Threshold.WARN) {
+                    SqlParser.clearCaches();
+                }
                 logGcOverhead(LOGGER, threshold, current, elapsed, seq);
             }
         }, interval, Names.SAME);


### PR DESCRIPTION
The ANTLR DFA cache is unbounded and grows with new unique statements.
That could lead to OOMs or high GC activity caused by a large cache that can't be GCd.

Accounting the size of the DFA cache itself after each query would add
quite a lot of overhead - and that overhead increases with the size of
the cache.

This instead simply triggers a cache reset once high GC load is
detected. This will cause subsequent queries to parse slower but should
avoid out of memory errors.

Running sqllogic tests from crate-qa without this change on a node with 1GB heap:

<img width="1522" height="1170" alt="image" src="https://github.com/user-attachments/assets/d3c1a52b-36fb-4d8c-a373-3bd64b8e4430" />

<img width="1796" height="816" alt="image" src="https://github.com/user-attachments/assets/01064292-0699-4458-845e-f40a14b7d2f1" />


With cache clearing (but no thresholds yet), on a node with 128M heap (Lowered it to trigger GC warnings quicker):

(Note the graph is slightly misleading, the context cache size is only the number of entries, not the number of bytes)

<img width="2162" height="1620" alt="image" src="https://github.com/user-attachments/assets/20f675a3-15a6-4292-bc62-1f3f2411a289" />

With 512M heap:

<img width="1900" height="1422" alt="image" src="https://github.com/user-attachments/assets/4ea2d6fc-c3dd-42b0-bbc2-5de6847d51b7" />
