### PR TITLE
Update release notes to reflect cast function change/backport

### DIFF
--- a/docs/appendices/release-notes/6.2.0.rst
+++ b/docs/appendices/release-notes/6.2.0.rst
@@ -21,7 +21,10 @@ Version 6.2.0 - Unreleased
     We recommend that you upgrade to the latest 6.1 release before moving to
     6.2.0.
 
-    A rolling upgrade from >= 6.1.0 to 6.2.0 is supported.
+    A rolling upgrade from >= 6.1.2 to 6.2.0 is supported. Doing a rolling
+    upgrade from an earlier version than 6.1.2 can cause runtime errors when
+    executing statements relying on implicit casts.
+
     Before upgrading, you should `back up your data`_.
 
 .. WARNING::
@@ -118,8 +121,6 @@ None
 
 Performance and Resilience Improvements
 ---------------------------------------
-
-- Improved the performance of implicit type casts
 
 - Added an optimization rule to push down query predicates in cases where the
   child relation is using scalar sub-queries.


### PR DESCRIPTION
Relates to https://github.com/crate/crate/pull/18759
It removed the second argument for cast functions. That would lead to
function lookup failures in mixed clusters.

https://github.com/crate/crate/pull/18774 backported the cast function
registration change, to ensure 6.1.2+ nodes will be able to handle cast
functions sent from 6.2.0 nodes.

It also included the performance improvement. This changes the release
notes to reflect both changes.
