### PR TITLE
Improve hash join performance for primary-key joins

### DIFF
--- a/benchmarks/src/main/java/io/crate/data/join/RowsBatchIteratorBenchmark.java
+++ b/benchmarks/src/main/java/io/crate/data/join/RowsBatchIteratorBenchmark.java
@@ -167,8 +167,8 @@ public class RowsBatchIteratorBenchmark {
             row -> Objects.hash(row.get(0)),
             row -> Objects.hash(row.get(0)),
             ignored -> 1000,
-            false
-        );
+            false,
+                false);
         while (leftJoin.moveNext()) {
             blackhole.consume(leftJoin.currentElement().get(0));
         }
@@ -191,8 +191,8 @@ public class RowsBatchIteratorBenchmark {
             },
             row -> (Integer) row.get(0) % 500,
             ignored -> 1000,
-            false
-        );
+            false,
+                false);
         while (leftJoin.moveNext()) {
             blackhole.consume(leftJoin.currentElement().get(0));
         }

--- a/docs/appendices/release-notes/6.2.0.rst
+++ b/docs/appendices/release-notes/6.2.0.rst
@@ -157,6 +157,12 @@ Performance and Resilience Improvements
   remain in ``PARTIAL`` state, with an ``ABORTED`` failure message showing in
   the :ref:`sys.snapshots <sys-snapshots>` system table.
 
+- Improved hash join performance for joins on a simple (single-column) primary
+  key::
+
+    SELECT * FROM t1 JOIN t2 ON t1.pk_col = t2.col
+
+
 Administration and Operations
 -----------------------------
 

--- a/server/src/main/java/io/crate/execution/engine/join/HashJoinOperation.java
+++ b/server/src/main/java/io/crate/execution/engine/join/HashJoinOperation.java
@@ -57,7 +57,8 @@ public class HashJoinOperation implements CompletionListenable {
                              InputFactory inputFactory,
                              CircuitBreaker circuitBreaker,
                              long estimatedRowSizeForLeft,
-                             boolean emitNullValues) {
+                             boolean emitNullValues,
+                             boolean uniqueHashPerRow) {
 
         this.resultConsumer = nlResultConsumer;
         this.leftConsumer = new CapturingRowConsumer(nlResultConsumer.requiresScroll(), nlResultConsumer.completionFuture());
@@ -87,8 +88,8 @@ public class HashJoinOperation implements CompletionListenable {
                         circuitBreaker,
                         estimatedRowSizeForLeft
                     ),
-                    emitNullValues
-                );
+                    emitNullValues,
+                    uniqueHashPerRow);
                 nlResultConsumer.accept(joinIterator, null);
             } catch (Exception e) {
                 nlResultConsumer.accept(null, e);

--- a/server/src/main/java/io/crate/execution/jobs/JobSetup.java
+++ b/server/src/main/java/io/crate/execution/jobs/JobSetup.java
@@ -970,7 +970,8 @@ public class JobSetup {
                 inputFactory,
                 breaker,
                 phase.estimatedRowSizeForLeft(),
-                phase.joinType() == JoinType.LEFT
+                phase.joinType() == JoinType.LEFT,
+                phase.isUniqueHashPerRow()
             );
             DistResultRXTask left = pageDownstreamContextForNestedLoop(
                 phase.phaseId(),

--- a/server/src/test/java/io/crate/execution/engine/join/HashInnerJoinBatchIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/join/HashInnerJoinBatchIteratorTest.java
@@ -140,8 +140,8 @@ public class HashInnerJoinBatchIteratorTest {
             getHashForLeft(),
             getHashForRight(),
             ignored -> 5,
-            false
-        );
+            false,
+                false);
         var tester = BatchIteratorTester.forRows(batchIteratorSupplier, ResultOrder.EXACT);
         tester.verifyResultAndEdgeCaseBehaviour(expectedResult);
     }
@@ -158,8 +158,8 @@ public class HashInnerJoinBatchIteratorTest {
             getHashWithCollisions(),
             getHashWithCollisions(),
             ignored -> 5,
-            false
-        );
+            false,
+                false);
         var tester = BatchIteratorTester.forRows(batchIteratorSupplier, ResultOrder.EXACT);
         tester.verifyResultAndEdgeCaseBehaviour(expectedResult);
     }
@@ -176,8 +176,8 @@ public class HashInnerJoinBatchIteratorTest {
             getHashForLeft(),
             getHashForRight(),
             ignored -> 1,
-            false
-        );
+            false,
+                false);
         var tester = BatchIteratorTester.forRows(batchIteratorSupplier, ResultOrder.EXACT);
         tester.verifyResultAndEdgeCaseBehaviour(expectedResult);
     }
@@ -194,8 +194,8 @@ public class HashInnerJoinBatchIteratorTest {
             getHashForLeft(),
             getHashForRight(),
             ignored -> 3,
-            false
-        );
+            false,
+                false);
         var tester = BatchIteratorTester.forRows(batchIteratorSupplier, ResultOrder.EXACT);
         tester.verifyResultAndEdgeCaseBehaviour(expectedResult);
     }

--- a/server/src/test/java/io/crate/execution/engine/join/HashJoinBatchIteratorBehaviouralTest.java
+++ b/server/src/test/java/io/crate/execution/engine/join/HashJoinBatchIteratorBehaviouralTest.java
@@ -73,8 +73,8 @@ public class HashJoinBatchIteratorBehaviouralTest {
             row -> Objects.hash(row.get(0)),
             row -> Objects.hash(row.get(0)),
             ignored -> 2,
-            false
-        );
+            false,
+                false);
 
         TestingRowConsumer consumer = new TestingRowConsumer();
         consumer.accept(batchIterator, null);
@@ -105,8 +105,8 @@ public class HashJoinBatchIteratorBehaviouralTest {
             row -> Objects.hash(row.get(0)),
             row -> Objects.hash(row.get(0)),
             ignored -> 500000,
-            false
-        );
+            false,
+                false);
 
         TestingRowConsumer consumer = new TestingRowConsumer();
         consumer.accept(batchIterator, null);
@@ -131,8 +131,8 @@ public class HashJoinBatchIteratorBehaviouralTest {
             row -> Objects.hash(row.get(0)),
             row -> Objects.hash(row.get(0)),
             ignored -> 2,
-            true
-        );
+            true,
+                false);
 
         TestingRowConsumer consumer = new TestingRowConsumer();
         consumer.accept(batchIterator, null);
@@ -167,8 +167,8 @@ public class HashJoinBatchIteratorBehaviouralTest {
             row -> Objects.hash(row.get(0)),
             row -> Objects.hash(row.get(0)),
             ignored -> 500000,
-            true
-        );
+            true,
+                false);
 
         TestingRowConsumer consumer = new TestingRowConsumer();
         consumer.accept(batchIterator, null);

--- a/server/src/test/java/io/crate/execution/engine/join/HashJoinBatchIteratorMemoryTest.java
+++ b/server/src/test/java/io/crate/execution/engine/join/HashJoinBatchIteratorMemoryTest.java
@@ -83,8 +83,8 @@ public class HashJoinBatchIteratorMemoryTest {
             getHashForLeft(),
             getHashForRight(),
             ignored -> 2,
-            false
-        );
+            false,
+                false);
         TestingRowConsumer consumer = new TestingRowConsumer();
         consumer.accept(it, null);
         consumer.getResult();
@@ -116,8 +116,8 @@ public class HashJoinBatchIteratorMemoryTest {
             getHashForLeft(),
             getHashForRight(),
             ignored -> 2,
-            true
-        );
+            true,
+                false);
         TestingRowConsumer consumer = new TestingRowConsumer();
         consumer.accept(it, null);
         consumer.getResult();

--- a/server/src/test/java/io/crate/execution/engine/join/LeftOuterHashJoinBatchIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/join/LeftOuterHashJoinBatchIteratorTest.java
@@ -125,8 +125,8 @@ public class LeftOuterHashJoinBatchIteratorTest {
             getHashForLeft(),
             getHashForRight(),
             ignored -> 5,
-            true
-        );
+            true,
+                false);
         var tester = BatchIteratorTester.forRows(batchIteratorSupplier, ResultOrder.ANY);
         tester.verifyResultAndEdgeCaseBehaviour(expectedResult);
     }
@@ -143,8 +143,8 @@ public class LeftOuterHashJoinBatchIteratorTest {
             getHashForLeft(),
             getHashForRight(),
             ignored -> 1,
-            true
-        );
+            true,
+                false);
         var tester = BatchIteratorTester.forRows(batchIteratorSupplier, ResultOrder.ANY);
         tester.verifyResultAndEdgeCaseBehaviour(expectedResult);
     }
@@ -161,8 +161,8 @@ public class LeftOuterHashJoinBatchIteratorTest {
             getHashForLeft(),
             getHashForRight(),
             ignored -> 3,
-            true
-        );
+            true,
+                false);
         var tester = BatchIteratorTester.forRows(batchIteratorSupplier, ResultOrder.ANY);
         tester.verifyResultAndEdgeCaseBehaviour(expectedResult);
     }
@@ -179,8 +179,8 @@ public class LeftOuterHashJoinBatchIteratorTest {
             getHashWithCollisions(),
             getHashWithCollisions(),
             ignored -> 3,
-            true
-        );
+            true,
+                false);
         var tester = BatchIteratorTester.forRows(batchIteratorSupplier, ResultOrder.ANY);
         tester.verifyResultAndEdgeCaseBehaviour(expectedResult);
     }

--- a/server/src/test/java/io/crate/planner/node/dql/JoinPhaseTest.java
+++ b/server/src/test/java/io/crate/planner/node/dql/JoinPhaseTest.java
@@ -151,8 +151,8 @@ public class JoinPhaseTest extends ESTestCase {
             List.of(Literal.of("testRight"), Literal.of(20)),
             List.of(DataTypes.STRING, DataTypes.INTEGER),
             111,
-            JoinType.INNER
-        );
+            JoinType.INNER,
+                false);
 
         BytesStreamOutput output = new BytesStreamOutput();
         node.writeTo(output);


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Follows https://github.com/crate/crate/pull/18754#issuecomment-3608848325.

Below is a temporary benchmark simulating joining on primary key columns(resulting in HashGroup size=1 always):
```
[setup]
statements = [
	"create table t (a int);",
	"insert into t select * from generate_series(1, 500000);",
	"create table t2 (a int);",
	"insert into t2 select * from generate_series(1, 500000, 1000);",
	"refresh table t, t2"
]

[[queries]]

statement = """
select * from t left join t2 on t.a = t2.a limit 3000;
"""
iterations = 500
```

And below benchmark results show 17% faster execution and ~10GB less memory allocations.
```
# Results (server side duration in ms)
V1: 6.2.0-d31bd126c49b8283fa5a28b6ec90099024bedef1
V2: 6.2.0-072ab66acb6479f68cf6092a6650e4dfd8ba522c

Q: select * from t left join t2 on t.a = t2.a limit 3000;

C: 1
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |      114.119 ±   65.476 |     53.549 |    103.018 |    128.479 |    396.360 |
|   V2    |       96.130 ±   63.073 |     43.887 |     78.586 |    105.646 |    430.291 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -  17.11%                           -  26.91%   
There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 17.11%
The test has statistical significance


System/JVM Metrics (durations in ms, byte-values in MB)
    |    YOUNG GC            |       OLD GC           |      HEAP         |     ALLOC     
    |  cnt      avg      max |  cnt      avg      max |  initial     used |     rate      total
 V1 |  256    75.98    50.19 |   74   117.30    65.51 |      268      535 |   906.10      52090
 V2 |  210    81.29   176.63 |   60   106.74   151.00 |      268     1501 |   878.18      42453
    
Top allocation frames
  V1
    ArrayList.grow(int) total=15035855859, count=4514
    HashJoinBatchIterator$HashGroup.<init>(boolean) total=9100159737, count=2834
    IntObjectHashMap.rehash(int) total=8132539745, count=1704
    BitSet.initWords(int) total=5363876952, count=1460
    HashJoinBatchIterator.addToBuffer(...) total=4267156448, count=1018
    Row.materialize() total=4029087368, count=1011
    Integer.valueOf(int) total=3160390448, count=936
    AbstractQueuedSynchronizer$ConditionObject.newConditionNode() total=1592524944, count=63
    HashJoinOperation.lambda$new$0(...) total=1174500600, count=51
    Collections$UnmodifiableCollection.iterator() total=111811048, count=18
  V2
    HashJoinBatchIterator$HashGroup.<init>(boolean) total=10172177040, count=3483
    IntObjectHashMap.rehash(int) total=8425304303, count=1741
    BitSet.initWords(int) total=5478642336, count=1724
    ArrayList.<init>(int) total=4018418489, count=1168
    Integer.valueOf(int) total=3904941344, count=1036
    Row.materialize() total=3669985904, count=1126
    HashJoinBatchIterator.addToBuffer(...) total=3456525832, count=1196
    AbstractQueuedSynchronizer$ConditionObject.newConditionNode() total=1681472256, count=53
    HashJoinOperation.lambda$new$0(...) total=1330573856, count=57
    HashJoinBatchIterator$HashGroup.iterator() total=130572088, count=10

Top frames (by count)
  V1
    ArrayList.grow(int) total=15035855859, count=4514
    HashJoinBatchIterator$HashGroup.<init>(boolean) total=9100159737, count=2834
    IntObjectHashMap.rehash(int) total=8132539745, count=1704
    BitSet.initWords(int) total=5363876952, count=1460
    HashJoinBatchIterator.addToBuffer(...) total=4267156448, count=1018
    Row.materialize() total=4029087368, count=1011
    Integer.valueOf(int) total=3160390448, count=936
    HashJoinOperation.lambda$getHashBuilderFromSymbols$0(...) total=912, count=912
    IntObjectHashMap.put(...) total=502, count=502
    HashJoinBatchIterator.buildBufferAndMatchRight() total=168, count=168
  V2
    HashJoinBatchIterator$HashGroup.<init>(boolean) total=10172177040, count=3483
    IntObjectHashMap.rehash(int) total=8425304303, count=1741
    BitSet.initWords(int) total=5478642336, count=1724
    HashJoinBatchIterator.addToBuffer(...) total=3456525832, count=1196
    ArrayList.<init>(int) total=4018418489, count=1168
    Row.materialize() total=3669985904, count=1126
    Integer.valueOf(int) total=3904941344, count=1036
    HashJoinOperation.lambda$getHashBuilderFromSymbols$0(...) total=620, count=620
    IntObjectHashMap.put(...) total=474, count=474
    HashJoinBatchIterator.buildBufferAndMatchRight() total=247, count=247
```

## Checklist

 - [ ] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
