### PR TITLE
Fix `length` function to correctly count supplementary Unicode characters

### DIFF
--- a/docs/appendices/release-notes/6.1.2.rst
+++ b/docs/appendices/release-notes/6.1.2.rst
@@ -46,6 +46,9 @@ series.
 Fixes
 =====
 
+- Fixed :ref:`length <scalar-length>` function that incorrectly returned ``2`` for
+  supplementary Unicode characters instead of ``1``.
+
 - Fixed an issue that caused ``SELECT COUNT(NULL) FROM tbl`` to return one
   record per row in the table instead of a single row with value ``0``.
 

--- a/server/src/main/java/io/crate/expression/scalar/string/LengthFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/LengthFunction.java
@@ -36,8 +36,8 @@ public final class LengthFunction {
     public static void register(Functions.Builder builder) {
         register(builder, "octet_length", x -> x.getBytes(StandardCharsets.UTF_8).length);
         register(builder, "bit_length", x -> x.getBytes(StandardCharsets.UTF_8).length * Byte.SIZE);
-        register(builder, "char_length", String::length);
-        register(builder, "length", String::length);
+        register(builder, "char_length", x -> x.codePointCount(0, x.length()));
+        register(builder, "length", x -> x.codePointCount(0, x.length()));
     }
 
     private static void register(Functions.Builder builder, String name, Function<String, Integer> func) {

--- a/server/src/test/java/io/crate/expression/scalar/LengthFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/LengthFunctionTest.java
@@ -82,6 +82,7 @@ public class LengthFunctionTest extends ScalarTestCase {
         assertEvaluate("length('')", 0);
         assertEvaluate("length('cra')", 3);
         assertEvaluate("length('©rate')", 5);
+        assertEvaluate("length('🥝')", 1);
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes https://github.com/crate/crate/issues/18801.

## Checklist

 - [ ] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
