### PR TITLE
Account for direct buffers when constructing an http result set

### DIFF
--- a/docs/appendices/release-notes/6.1.3.rst
+++ b/docs/appendices/release-notes/6.1.3.rst
@@ -52,3 +52,7 @@ Fixes
 
 - Fixed an issue causing memory leaks if requests to the ``HTTP`` endpoint
   failed due to a missing :ref:`HBA <admin_hba>` entry or wrong credentials.
+
+- Fixed an issue that caused direct memory under-accounting, potentially leading
+  to an ``OutOfMemoryError`` when a large result set was returned by the
+  ``HTTP`` endpoint.

--- a/server/src/test/java/io/crate/netty/AccountedByteBufTest.java
+++ b/server/src/test/java/io/crate/netty/AccountedByteBufTest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.netty;
+
+import static io.crate.netty.AccountedByteBuf.SINGLE_DIRECT_BUF_LIMIT;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.nio.charset.StandardCharsets;
+
+import org.elasticsearch.common.breaker.CircuitBreakingException;
+import org.junit.Test;
+
+import io.crate.data.breaker.RamAccounting;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.netty.buffer.ByteBuf;
+
+public class AccountedByteBufTest extends CrateDummyClusterServiceUnitTest {
+
+    @Test
+    public void test_delegate_direct_buffer_throws_cbe_on_OOM() {
+        // It's hard and expensive to trigger real OOM.
+        // When not specified in JVM args, direct memory is similar to XMX (equal to Runtime.getRuntime().maxMemory()).
+        // We would need to write small buffer to bypass SINGLE_DIRECT_BUF_LIMIT check
+        // and also allocate many large direct buffers (concurrently to write) to imitate direct buffer saturation.
+        // It's not feasible and can be flaky, hence using mocks.
+        ByteBuf delegate = mock(ByteBuf.class);
+        when(delegate.isDirect()).thenReturn(true);
+        byte[] data = "test".getBytes(StandardCharsets.UTF_8);
+        when(delegate.writeBytes(eq(data), eq(0), eq(data.length))).thenThrow(new OutOfMemoryError("dummy"));
+
+        ByteBuf buf = AccountedByteBuf.of(delegate, RamAccounting.NO_ACCOUNTING);
+
+        assertThatThrownBy(() -> buf.writeBytes(data, 0, data.length))
+            .isExactlyInstanceOf(CircuitBreakingException.class);
+    }
+
+    @Test
+    public void test_single_buffer_cant_exceed_given_threshold() {
+        // When not specified in JVM args, direct memory is similar to XMX (equal to Runtime.getRuntime().maxMemory()).
+        // Using mock to avoid allocating 60% of Runtime.getRuntime().maxMemory().
+        // Writing bytes is not important for this test, it only checks increment of usedBytes + eventual trigger of CBE.
+        ByteBuf delegate = mock(ByteBuf.class);
+        when(delegate.isDirect()).thenReturn(true);
+
+        ByteBuf buf = AccountedByteBuf.of(delegate, RamAccounting.NO_ACCOUNTING);
+
+        // If CI runs on a large heap, 60% of heap/direct memory can be > Integer.MAX_VALUE
+        // length in writeBytes is int, so we increment usedBytes to the point when it's about to reach the limit.
+        int iters = (int) (SINGLE_DIRECT_BUF_LIMIT / Integer.MAX_VALUE);
+        for (int i = 0; i < iters; i++) {
+            // Cheap, writeBytes is not doing anything, only incrementing "written" bytes.
+            buf.writeBytes(new byte[] {}, 0, Integer.MAX_VALUE);
+        }
+
+        int minToThrow = (int) (SINGLE_DIRECT_BUF_LIMIT % Integer.MAX_VALUE) + 1;
+        assertThatThrownBy(() -> buf.writeBytes(new byte[] {}, 0, minToThrow))
+            .isExactlyInstanceOf(CircuitBreakingException.class);
+    }
+
+}


### PR DESCRIPTION
Fixes https://github.com/crate/support/issues/785

In https://github.com/crate/crate/pull/18534 we switched to direct buffers from on heap buffers

We replaced `Netty4Utils.toByteBuf(BytesReference.bytes(result))` with `ByteBuf resultBuffer = ctx.alloc().buffer()`
and the former used to be on heap - `result` was `RamAccountingOutputStream` (resize accounted), `toByteBuf` created unpooled wrapped buffers
```
while ((slice = iterator.next()) != null) {
    buffers.add(Unpooled.wrappedBuffer(slice.bytes, slice.offset, slice.length));
}
```

Possible solutions: 
1) Revert https://github.com/crate/crate/pull/18534/ (opted out from it as we still want to avoid copying result)
2) Account for direct buffers? See https://github.com/crate/crate/pull/18534#discussion_r2444487723 - if we do it properly, we should do it like on heap circuit breakers -  add circuit breaker limits for direct memory, expose it with JMX metrics, sounds like a feature
3) Use on heap buffer and such make result sets protected by existing circuit breakers, ie use `Unpooled.buffer` instead of `ctx.alloc().buffer()`. 
Currently still facing OOM, I think I was lucky enough to also reproduce "resize can be big". 
We probably need to tweak `AccountedByteBuf` and do smth like https://github.com/crate/crate/pull/18531/ on it