### PR TITLE
Avoid quadratic outputNames evaluation

### DIFF
--- a/server/src/main/java/io/crate/analyze/relations/AliasedAnalyzedRelation.java
+++ b/server/src/main/java/io/crate/analyze/relations/AliasedAnalyzedRelation.java
@@ -61,11 +61,12 @@ public class AliasedAnalyzedRelation implements AnalyzedRelation, FieldResolver 
         aliasToColumnMapping = HashMap.newHashMap(columnAliases.size());
         this.outputs = new ArrayList<>(relation.outputs().size());
         this.scopedSymbols = new ArrayList<>(relation.outputs().size());
+        List<String> outputNames = relation.outputNames();
         for (int i = 0; i < relation.outputs().size(); i++) {
             Symbol childOutput = relation.outputs().get(i);
             ColumnIdent childColumn = childOutput.toColumn();
-            ColumnIdent columnAlias = relation.outputNames() != null
-                ? ColumnIdent.of(relation.outputNames().get(i))
+            ColumnIdent columnAlias = outputNames != null
+                ? ColumnIdent.of(outputNames.get(i))
                 : childColumn;
             if (i < columnAliases.size()) {
                 columnAlias = ColumnIdent.of(columnAliases.get(i));

--- a/server/src/main/java/io/crate/analyze/relations/select/SelectAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/relations/select/SelectAnalyzer.java
@@ -120,10 +120,11 @@ public final class SelectAnalyzer {
 
         private static void addAllFieldsFromRelation(SelectAnalysis context, AnalyzedRelation relation) {
             int i = 0;
+            List<String> outputNames = relation.outputNames();
             for (Symbol field : relation.outputs()) {
                 var columnIdent = field.toColumn();
                 if (!columnIdent.isSystemColumn()) {
-                    context.add(field.toColumn(), field, relation.outputNames() != null ? relation.outputNames().get(i) : null);
+                    context.add(field.toColumn(), field, outputNames != null ? outputNames.get(i) : null);
                 }
                 i++;
             }


### PR DESCRIPTION
`AnalyzedStatement.outputNames` generates a new list on each access. For
`SELECT *` and for aliased relations this was called twice per column,
instead of only once for all columns.

Also seen in the flamegraph posted in https://github.com/crate/crate/issues/18787