### PR TITLE
Fix unreleased memory when query circuit breaker trips in TransportShardAction

### DIFF
--- a/server/src/test/java/io/crate/execution/dml/TransportShardActionTest.java
+++ b/server/src/test/java/io/crate/execution/dml/TransportShardActionTest.java
@@ -84,7 +84,7 @@ public class TransportShardActionTest extends CrateDummyClusterServiceUnitTest {
                 public Object call() throws Exception {
                     return null;
                 }
-            }))
+            }, true))
             .isExactlyInstanceOf(CircuitBreakingException.class)
             .hasMessage("broken");
         assertThat(circuitBreaker.getUsed()).isEqualTo(oldUsed);


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Originated by @BaurzhanSakhariev https://github.com/crate/crate/pull/18828#discussion_r2627172655
> org.opentest4j.AssertionFailedError: [Query breaker not reset to 0 on node: node_sd2] 
> expected: 0L
>  but was: 504L
> Expected :0L
> Actual   :504L
> ```
> 
> which is not good, circuit breakers must be reset (other wise we will keep getting false positive CBE-s)
> 
> Fix: Move `addEstimateBytesAndMaybeBreak` under `try`, because `finally` is already releasing the breaker This a regression introduced in 5.10.11 with [40a432b](https://github.com/crate/crate/commit/40a432bf84dc786964c694270425009c343d35e8)

## Checklist

 - [ ] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
