### PR TITLE
Ensure that refresh_stats column is queryable for unassigned shards

### DIFF
--- a/server/src/main/java/io/crate/metadata/sys/SysShardsTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/sys/SysShardsTableInfo.java
@@ -127,6 +127,7 @@ public class SysShardsTableInfo {
             entry(Columns.RETENTION_LEASES, NestedNullObjectExpression::new),
             entry(Columns.FLUSH_STATS, NestedNullObjectExpression::new),
             entry(Columns.MERGE_STATS, NestedNullObjectExpression::new),
+            entry(Columns.REFRESH_STATS, NestedNullObjectExpression::new),
             entry(Columns.LAST_WRITE_BEFORE, () -> constant(null))
         );
     }


### PR DESCRIPTION
Follow up to https://github.com/crate/crate/commit/6a7b0a3b03242636d4ee860ba657e099dcf71b85

