### PR TITLE
Ensure that JoinGraph adds only edges for equi-join conditions

### DIFF
--- a/docs/appendices/release-notes/6.1.3.rst
+++ b/docs/appendices/release-notes/6.1.3.rst
@@ -56,3 +56,12 @@ Fixes
 - Fixed an issue that caused direct memory under-accounting, potentially leading
   to an ``OutOfMemoryError`` when a large result set was returned by the
   ``HTTP`` endpoint.
+
+- Fixed a regression introduced with :ref:`version_6.0.0` that led to wrong
+  results when mixing ``CROSS JOIN`` and ``INNER JOIN`` on a condition with a
+  :ref:`CASE<scalar-case-when-then-end>` referring to one of the cross joined
+  tables. e.g.::
+
+    SELECT * FROM t1, t0
+    INNER JOIN (SELECT 1 AS col0) AS sub0
+    ON (CASE sub0.col0 WHEN sub0.col0 THEN t0.c0 ELSE false END)

--- a/server/src/main/java/io/crate/planner/optimizer/joinorder/JoinGraph.java
+++ b/server/src/main/java/io/crate/planner/optimizer/joinorder/JoinGraph.java
@@ -21,6 +21,8 @@
 
 package io.crate.planner.optimizer.joinorder;
 
+import static io.crate.planner.operators.EquiJoinDetector.isEquiJoin;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -189,7 +191,7 @@ public record JoinGraph(List<LogicalPlan> nodes,
                     // (a,b) -> (a.x = b.y) and we can ignore any other
                     // filters. Therefore, we only want entries where we have
                     // two keys.
-                    if (entry.getKey().size() == 2) {
+                    if (entry.getKey().size() == 2 && isEquiJoin(entry.getValue())) {
                         entry.getValue().accept(edgeCollector, context);
                     } else {
                         filters.add(entry.getValue());


### PR DESCRIPTION
Fixes https://github.com/crate/crate/issues/18860

Fixes a regression, introduced with https://github.com/crate/crate/commit/1ece4b40e51ea2b95af0ac8894318cba5359bbda
Mitigation: `SET optimizer_eliminate_cross_join = false`

In fact, referenced commit only revealed issue with join graphs construction as it enabled rule being applied for (sometimes) broken graphs.

The root cause is `JoinGraph` not fulfilling the contract declared in it
>  we are only interested in equi-join conditions

Solution is to use existing `isEquiJoin` check before adding an edge. 
`EquiJoinDetector` can handle exactly the same JOIN ON CASE condition, it was done in https://github.com/crate/crate/commit/d85eba28a369253079aca3676f102996e75fbc96

With an empty graph,
`EliminateCrossJoin` hits `joinGraph.edges().isEmpty()` check and gets short-circuited

