### PR TITLE
Fix `NullPointerException` thrown when swap/rename on a table being inserted

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/indexing/GroupRowsByShard.java
+++ b/server/src/main/java/io/crate/execution/engine/indexing/GroupRowsByShard.java
@@ -46,6 +46,7 @@ import org.jspecify.annotations.Nullable;
 import io.crate.data.Input;
 import io.crate.data.Row;
 import io.crate.data.UnsafeArrayRow;
+import io.crate.exceptions.RelationUnknown;
 import io.crate.execution.dml.IndexItem;
 import io.crate.execution.dml.ShardRequest;
 import io.crate.execution.engine.collect.CollectExpression;
@@ -241,6 +242,9 @@ public final class GroupRowsByShard<TReq extends ShardRequest<TReq, TItem>, TIte
                     true,
                     x -> x
                 );
+                if (indexMetadata == null) {
+                    throw new RelationUnknown(partitionName.relationName());
+                }
                 ShardLocation shardLocation = getShardLocation(
                     state,
                     indexMetadata,


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Fixes below scenario:
```
cr> create table t (a int) clustered into 1 shards partitioned by (a) with (number_of_replicas=1);
CREATE OK, 1 row affected (0.278 sec)
cr> create table t3 (a int) ;
CREATE OK, 1 row affected (2.977 sec)
```
Run `swap` on a table being inserted:
```
cr> insert into t select * from generate_series (1, 40);

cr> alter cluster swap table t to t3;
ALTER OK, 1 row affected (1.893 sec)
```
Then an NPE will be thrown from the ongoing insert query:
```
cr> insert into t select * from generate_series (1, 40);
NullPointerException[Cannot invoke "org.elasticsearch.cluster.metadata.IndexMetadata.isRoutingPartitionedIndex()" because "indexMetadata" is null]
```

## Checklist

 - [ ] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
