### PR TITLE
Fix `SWAP`/`RENAME` on a table with on going `INSERT`

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/indexing/GroupRowsByShard.java
+++ b/server/src/main/java/io/crate/execution/engine/indexing/GroupRowsByShard.java
@@ -241,6 +241,12 @@ public final class GroupRowsByShard<TReq extends ShardRequest<TReq, TItem>, TIte
                     true,
                     x -> x
                 );
+                if (indexMetadata == null) {
+                    // indexMetadata may not be found if the table is renamed/swapped.
+                    // However, renamed/swapped tables' indexMetadata.index still holds the previous names which can
+                    // be used here.
+                    indexMetadata = metadata.getIndexByName(partitionName.asIndexName());
+                }
                 ShardLocation shardLocation = getShardLocation(
                     state,
                     indexMetadata,


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Fixes below scenario:
```
cr> create table t (a int) clustered into 1 shards partitioned by (a) with (number_of_replicas=1);
CREATE OK, 1 row affected (0.278 sec)
cr> create table t3 (a int) ;
CREATE OK, 1 row affected (2.977 sec)
```
Run `swap` on a table being inserted:
```
cr> insert into t select * from generate_series (1, 40);

cr> alter cluster swap table t to t3;
ALTER OK, 1 row affected (1.893 sec)
```
Then an NPE will be thrown from the ongoing insert query:
```
cr> insert into t select * from generate_series (1, 40);
NullPointerException[Cannot invoke "org.elasticsearch.cluster.metadata.IndexMetadata.isRoutingPartitionedIndex()" because "indexMetadata" is null]
```

On top of the NPE, `t3` has 10 rows
```
cr> select * from t3;
+----+
|  a |
+----+
|  7 |
|  2 |
| 10 |
|  9 |
|  5 |
|  8 |
|  3 |
|  6 |
|  1 |
|  4 |
+----+
SELECT 10 rows in set (0.005 sec)
```

but it has 30 partitions

```
cr> select values from information_schema.table_partitions where table_name = 't3';
+-----------+
| values    |
+-----------+
| {"a": 4}  |
| {"a": 2}  |
| {"a": 3}  |
| {"a": 5}  |
| {"a": 1}  |
| {"a": 8}  |
| {"a": 9}  |
| {"a": 6}  |
| {"a": 7}  |
| {"a": 10} |
| {"a": 19} |
| {"a": 16} |
| {"a": 18} |
| {"a": 17} |
| {"a": 20} |
| {"a": 15} |
| {"a": 12} |
| {"a": 11} |
| {"a": 14} |
| {"a": 13} |
| {"a": 25} |
| {"a": 22} |
| {"a": 21} |
| {"a": 24} |
| {"a": 23} |
| {"a": 30} |
| {"a": 29} |
| {"a": 26} |
| {"a": 28} |
| {"a": 27} |
+-----------+
SELECT 30 rows in set (0.003 sec)
```
which is wrong, `t3` is partitioned by `a` so the number of partitions must match the number of unique values of `a` (but 10 != 30).

I think the cause is that `insert` query that implicitly creates partitions is a two step process, 1) create partition 2) insert values to the partitions; two cluster state updates. But `swap`/`rename` queries can be interleaved and 2) can fail because the new name is not known(and `reResolveShardLocations()` fails):

https://github.com/crate/crate/blob/e4503a462f713f69b728699f3f203189602ced61/server/src/main/java/io/crate/execution/engine/indexing/ShardingUpsertExecutor.java#L169-L176

**update**: due to the logic that limits the number of shards created per node, above could run multiple times. If so, create partition logic must also be able to obtain the latest `RelationName`.

## Checklist

 - [ ] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
