### PR TITLE
bp: Use RamUsageEstimator instead of defaulting to 1024 bytes for non-accountable query size

### DIFF
--- a/server/src/main/java/org/elasticsearch/indices/IndicesQueryCache.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesQueryCache.java
@@ -21,12 +21,13 @@ package org.elasticsearch.indices;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.lucene.search.LRUQueryCache;
 import org.apache.lucene.search.QueryCache;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
+
+import io.crate.lucene.CustomLRUQueryCache;
 
 public final class IndicesQueryCache {
 
@@ -51,9 +52,9 @@ public final class IndicesQueryCache {
         LOGGER.debug("using [node] query cache with size [{}] max filter count [{}]",
                 size, count);
         if (INDICES_QUERIES_CACHE_ALL_SEGMENTS_SETTING.get(settings)) {
-            return new LRUQueryCache(count, size.getBytes(), context -> true, 1f);
+            return new CustomLRUQueryCache(count, size.getBytes(), context -> true, 1f);
         } else {
-            return new LRUQueryCache(count, size.getBytes());
+            return new CustomLRUQueryCache(count, size.getBytes());
         }
     }
 }

--- a/server/src/test/java/io/crate/lucene/CustomLRUQueryCacheTest.java
+++ b/server/src/test/java/io/crate/lucene/CustomLRUQueryCacheTest.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.crate.lucene;
+
+import static io.crate.testing.Asserts.assertThat;
+import static org.apache.lucene.tests.util.LuceneTestCase.newSearcher;
+import static org.apache.lucene.util.RamUsageEstimator.LINKED_HASHTABLE_RAM_BYTES_PER_ENTRY;
+import static org.apache.lucene.util.RamUsageEstimator.QUERY_DEFAULT_RAM_BYTES_USED;
+
+import java.io.IOException;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.ConstantScoreQuery;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.QueryCachingPolicy;
+import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.index.RandomIndexWriter;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.junit.Test;
+
+public class CustomLRUQueryCacheTest extends CrateLuceneTestCase {
+
+    private static final QueryCachingPolicy ALWAYS_CACHE =
+        new QueryCachingPolicy() {
+
+            @Override
+            public void onUse(Query query) {}
+
+            @Override
+            public boolean shouldCache(Query query) throws IOException {
+                return true;
+            }
+        };
+
+    @Test
+    public void testQuerySizeBytesAreCached() throws IOException {
+        try (Directory dir = newDirectory();
+             RandomIndexWriter w = new RandomIndexWriter(random(), dir)) {
+            Document doc = new Document();
+            doc.add(new StringField("foo", "bar", Field.Store.YES));
+            doc.add(new StringField("foo", "quux", Field.Store.YES));
+            w.addDocument(doc);
+            w.commit();
+            final IndexReader reader = w.getReader();
+            final IndexSearcher searcher = newSearcher(reader);
+            final CustomLRUQueryCache queryCache =
+                new CustomLRUQueryCache(1000000, 10000000, _ -> true, Float.POSITIVE_INFINITY);
+            searcher.setQueryCache(queryCache);
+            searcher.setQueryCachingPolicy(ALWAYS_CACHE);
+            StringBuilder sb = new StringBuilder();
+            sb.append("a".repeat(100));
+            String term = sb.toString();
+            TermQuery termQuery = new TermQuery(new Term("foo", term));
+            long expectedQueryInBytes =
+                LINKED_HASHTABLE_RAM_BYTES_PER_ENTRY + RamUsageEstimator.sizeOf(termQuery, 32);
+            searcher.search(new ConstantScoreQuery(termQuery), 1);
+
+            assertThat(queryCache.getUniqueQueries().size()).isEqualTo(1);
+            assertThat(queryCache.getUniqueQueries().get(termQuery).queryRamBytesUsed()).isEqualTo(expectedQueryInBytes);
+            reader.close();
+        }
+    }
+
+    public void testCacheRamBytesWithALargeTermQuery() throws IOException {
+        try (Directory dir = newDirectory();
+             RandomIndexWriter w = new RandomIndexWriter(random(), dir)) {
+            Document doc = new Document();
+            doc.add(new StringField("foo", "bar", Field.Store.YES));
+            doc.add(new StringField("foo", "quux", Field.Store.YES));
+            w.addDocument(doc);
+            w.commit();
+            final IndexReader reader = w.getReader();
+            final IndexSearcher searcher = newSearcher(reader);
+            final CustomLRUQueryCache queryCache =
+                new CustomLRUQueryCache(1000000, 10000000, _ -> true, Float.POSITIVE_INFINITY);
+            searcher.setQueryCache(queryCache);
+            searcher.setQueryCachingPolicy(ALWAYS_CACHE);
+            StringBuilder sb = new StringBuilder();
+            // Create a large string for the field value so it certainly exceeds the default query size we
+            // use ie 1024 bytes.
+            sb.append("a".repeat(1200));
+            String longTerm = sb.toString();
+            TermQuery must = new TermQuery(new Term("foo", longTerm));
+            long queryInBytes = RamUsageEstimator.sizeOf(must, 32);
+            assertThat(queryInBytes).isGreaterThan(QUERY_DEFAULT_RAM_BYTES_USED);
+            searcher.search(new ConstantScoreQuery(must), 1);
+
+            assertThat(queryCache.cachedQueries().size()).isEqualTo(1);
+            assertThat(queryCache.ramBytesUsed()).isGreaterThanOrEqualTo(queryInBytes);
+            reader.close();
+        }
+    }
+
+}


### PR DESCRIPTION
Porting https://github.com/apache/lucene/commit/e706267b893576cd334a783e6dfa8b4008cdc7b2

We have seen heap dumps with large `BooleanQuery` instances, taking much more RAM then default 10%. 
Similar to what is described in https://github.com/apache/lucene/issues/15097.

In our case memory is mainly taken by `GenericFunctionQuery` with heavy dependencies.
We don't expose cache size, so 10% is permanent limit and in the screenshot we have 63% RAM taken by cache.
<img width="1920" height="1080" alt="Screenshot 2026-01-09 at 13 43 46 2" src="https://github.com/user-attachments/assets/03520c36-4883-4b84-9c64-323866b219b0" />


This is general improvement for Queries that don't implement `Accountable` and it also prepares ground to plug in future changes in `GenericFunctionQuery` to the custom cache.

Relates to https://github.com/crate/support/issues/797 but doesn't fix it, I will follow up with `GenericFunctionQuery` change and prepare a relevant test for it. 


