### PR TITLE
Ensure updated columns + sanitized values are used for replica requests

### DIFF
--- a/server/src/main/java/io/crate/execution/dml/Indexer.java
+++ b/server/src/main/java/io/crate/execution/dml/Indexer.java
@@ -921,6 +921,8 @@ public class Indexer {
             // for insert-on-conflict columns.size() > values.length is possible to be able to process both INSERT and UPDATE rows
             if (idx >= 0 && idx < values.length) {
                 Object value = valueForInsert(ref.valueType(), values[idx]);
+                // Mutate values to ensure replica request can use the converted/sanitized value
+                values[idx] = value;
                 ColumnConstraint check = columnConstraints.get(ref.column());
                 if (check != null) {
                     check.verify(value);

--- a/server/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
+++ b/server/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
@@ -57,10 +57,10 @@ import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.jspecify.annotations.Nullable;
-import io.crate.common.annotations.VisibleForTesting;
 
 import com.carrotsearch.hppc.IntArrayList;
 
+import io.crate.common.annotations.VisibleForTesting;
 import io.crate.common.collections.Lists;
 import io.crate.common.exceptions.Exceptions;
 import io.crate.execution.ddl.tables.AddColumnRequest;
@@ -178,18 +178,6 @@ public class TransportShardUpsertAction extends TransportShardAction<
         ShardResponse shardResponse = new ShardResponse(request.returnValues());
         Translog.Location translogLocation = null;
         List<UpsertReplicaRequest.Item> replicaItems = new ArrayList<>();
-        UpsertReplicaRequest replicaRequest = new UpsertReplicaRequest(
-            request.shardId(),
-            request.jobId(),
-            request.sessionSettings(),
-            // Copy because indexer.insertColumns can be mutated during indexing
-            // to refine types. (undefined[] -> long[], with values being integer[])
-            // Using the refined types can break streaming for the replica
-            // See `test_dynamic_null_array_overridden_to_integer_becomes_null`
-            indexer.onConflictIndexer() == null ?
-                List.copyOf(indexer.insertColumns()) : List.copyOf(indexer.onConflictIndexer().insertColumns()),
-            replicaItems
-        );
         for (ShardUpsertRequest.Item item : request.items()) {
             if (shardResponse.failure() != null) {
                 // Skip all remaining items on replica
@@ -258,6 +246,18 @@ public class TransportShardUpsertAction extends TransportShardAction<
                 break;
             }
         }
+
+        // Create the replica requests with already sanitized item values and updated(guessed) insert columns
+        // It's important that the insert columns are in sync with the item values AND registered references (types),
+        // since the replica request stream reader will resolve the references from the table.
+        UpsertReplicaRequest replicaRequest = new UpsertReplicaRequest(
+            request.shardId(),
+            request.jobId(),
+            request.sessionSettings(),
+            indexer.onConflictIndexer() == null ?
+                indexer.insertColumns() : indexer.onConflictIndexer().insertColumns(),
+            replicaItems
+        );
         return new WritePrimaryResult<>(replicaRequest, shardResponse, translogLocation, indexShard);
     }
 


### PR DESCRIPTION
During dynamic insertion of sub-columns into dynamic objects, the sub-column will be registered dynamically, included it's detected type.
This changes ensures that the new sub-columns reference is used to stream the sanitized sub-columns value to the replica. This is important, as the replica request is read using the registered reference (data type).

Follow up of https://github.com/crate/crate/commit/4e136f9d9eec4496233ff6c8162119c35b62363f.

Supersede #18885.