### PR TITLE
Fix matching on multiline content for ILIKE

### DIFF
--- a/docs/appendices/release-notes/6.1.3.rst
+++ b/docs/appendices/release-notes/6.1.3.rst
@@ -46,6 +46,9 @@ series.
 Fixes
 =====
 
+- Fixed an issue that prevented ``ILIKE`` from matching records with text
+  containing newline characters.
+
 - Fixed an issue that could lead to a ``Couldn't create executionContexts from
   [...] Can't handle Symbol`` error when running ``SELECT`` queries involving
   expressions using multiple columns like ``CASE`` and a ``LIMIT`` clause.

--- a/server/src/main/java/io/crate/expression/operator/LikeOperators.java
+++ b/server/src/main/java/io/crate/expression/operator/LikeOperators.java
@@ -116,7 +116,10 @@ public class LikeOperators {
                 if (isIndexed) {
                     String regex = patternToRegex(pattern, escapeChar);
                     Term term = new Term(fqColumn, regex);
-                    return new CrateRegexQuery(term, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE);
+                    return new CrateRegexQuery(
+                        term,
+                        Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE | Pattern.DOTALL
+                    );
                 }
                 return null;
             }

--- a/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
@@ -690,7 +690,7 @@ public class CommonQueryBuilderTest extends LuceneQueryBuilderTest {
         assertThat(query).hasToString("(name:bar name:foo)~1");
 
         query = convert("name not ilike any(['bar', null, 'foo'])");
-        assertThat(query).hasToString("+*:* -(+name:^bar$,flags:66 +name:^foo$,flags:66)");
+        assertThat(query).hasToString("+*:* -(+name:^bar$,flags:98 +name:^foo$,flags:98)");
     }
 
     @Test


### PR DESCRIPTION
`DOTALL` wasn't set for the regex pattern - because of that `%` in the
like pattern which is translated to `.*` didn't match newlines.

Closes https://github.com/crate/crate/issues/18883
