### PR TITLE
Utilize SchemaMetadata for more efficient cache invalidation in DocSchemaInfo

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/SchemaMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/SchemaMetadata.java
@@ -90,6 +90,11 @@ public class SchemaMetadata implements Diffable<SchemaMetadata> {
         return relations.get(relation.name());
     }
 
+    @Nullable
+    public RelationMetadata get(String name) {
+        return relations.get(name);
+    }
+
     /// True if schema was created explicitly via CREATE SCHEMA
     /// Explicit schemas are not removed if the last table within a relation is dropped.
     public boolean explicit() {


### PR DESCRIPTION
For each cached table `DocSchemaInfo` created a `RelationName` instance
and looked up the `SchemaMetadata` to get the `RelationMetadata` for a
table.

This changes the logic to lookup `SchemaMetadata` only once and avoids
creating `RelationName` instances.
