### PR TITLE
Fix release notes entry for pg_sleep

### DIFF
--- a/docs/appendices/release-notes/6.2.0.rst
+++ b/docs/appendices/release-notes/6.2.0.rst
@@ -101,7 +101,6 @@ SQL Standard and PostgreSQL Compatibility
   versions than the server supports. The client is expected to downgrade it's
   used minor version in such cases.
 
-- Added the :ref:`pg_sleep <scalar-pg_sleep>` function, which pauses a session.
 
 Data Types
 ----------

--- a/docs/appendices/release-notes/6.3.0.rst
+++ b/docs/appendices/release-notes/6.3.0.rst
@@ -64,7 +64,7 @@ None
 SQL Standard and PostgreSQL Compatibility
 -----------------------------------------
 
-None
+- Added the :ref:`pg_sleep <scalar-pg_sleep>` function, which pauses a session.
 
 Data Types
 ----------


### PR DESCRIPTION
Since master was bumped to 6.3.0, the entry should be on 6.3.0 and not 6.2.0

Follows: #18855

