### PR TITLE
debug

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -22,7 +22,7 @@
       </list>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_25" default="true" project-jdk-name="temurin-25" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_25" project-jdk-name="temurin-25" project-jdk-type="JavaSDK" />
   <component name="SuppressionsComponent">
     <option name="suppComments" value="[]" />
   </component>

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
           <!-- by default is false but is set to true by `serverTest` profile to avoid running tests
                for modules on which `server` module depends on, when running `mvn -Pserver test` -->
           <skip>${skipRunTests}</skip>
-          <argLine>@{argLine} -XX:+UseSerialGC -XX:TieredStopAtLevel=1 -XX:ReservedCodeCacheSize=512M -XX:+UseCompactObjectHeaders --add-modules jdk.incubator.vector --enable-native-access=ALL-UNNAMED --sun-misc-unsafe-memory-access=allow</argLine>
+          <argLine>@{argLine} -Xmx100m  -XX:+UseSerialGC -XX:TieredStopAtLevel=1 -XX:ReservedCodeCacheSize=512M -XX:+UseCompactObjectHeaders --add-modules jdk.incubator.vector --enable-native-access=ALL-UNNAMED --sun-misc-unsafe-memory-access=allow</argLine>
         </configuration>
       </plugin>
       <plugin>

--- a/server/src/main/java/io/crate/lucene/GenericFunctionQuery.java
+++ b/server/src/main/java/io/crate/lucene/GenericFunctionQuery.java
@@ -59,6 +59,7 @@ public class GenericFunctionQuery extends Query implements Accountable {
 
     private final Function function;
     private final LuceneCollectorExpression<?>[] expressions;
+    private String retainedDemo;
     private final Input<Boolean> condition;
     private final Runnable raiseIfKilled;
     private final long ramBytesUsed;
@@ -130,6 +131,11 @@ public class GenericFunctionQuery extends Query implements Accountable {
                         for (LuceneCollectorExpression<?> expression : expressions) {
                             expression.setNextReader(readerContext);
                         }
+                        StringBuilder sb = new StringBuilder();
+                        for (int i = 0; i < 10000; i++) {
+                            sb.append("abdadaskdjaskdjkasdjaksdjaskjdkjdaskjd");
+                        }
+                        retainedDemo = sb.toString();
                         var twoPhaseIterator = new FilteredTwoPhaseIterator(
                             context.reader(),
                             condition,
@@ -202,5 +208,9 @@ public class GenericFunctionQuery extends Query implements Accountable {
             // Arbitrary number, we don't have a way to get the cost of the condition
             return 10;
         }
+    }
+
+    public void reset() {
+        retainedDemo = null;
     }
 }

--- a/server/src/testFixtures/java/org/elasticsearch/test/IntegTestCase.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/IntegTestCase.java
@@ -997,10 +997,8 @@ public abstract class IntegTestCase extends ESTestCase {
             .put(DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_LOW_DISK_WATERMARK_SETTING.getKey(), "1b")
             .put(DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_WATERMARK_SETTING.getKey(), "1b")
             .put(DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_DISK_FLOOD_STAGE_WATERMARK_SETTING.getKey(), "1b")
-            // by default we never cache below 10k docs in a segment,
-            // bypass this limit so that caching gets some testing in
-            // integration tests that usually create few documents
-            .put(IndicesQueryCache.INDICES_QUERIES_CACHE_ALL_SEGMENTS_SETTING.getKey(), nodeOrdinal % 2 == 0)
+            // Cache small segments to trigger caching in all test cases
+            .put(IndicesQueryCache.INDICES_QUERIES_CACHE_ALL_SEGMENTS_SETTING.getKey(), true)
             // wait short time for other active shards before actually deleting, default 30s not needed in tests
             .put(IndicesStore.INDICES_STORE_DELETE_SHARD_TIMEOUT.getKey(), new TimeValue(1, TimeUnit.SECONDS))
             .putList(DISCOVERY_SEED_HOSTS_SETTING.getKey()) // empty list disables a port scan for other nodes


### PR DESCRIPTION
Relates to https://github.com/crate/support/issues/797

`uniqueQueries` is not cleared in `clearCoreCacheKey` hook, only leafCache is cleared, see [lucene code](https://github.com/sgup432/lucene/blob/main/lucene/core/src/java/org/apache/lucene/search/LRUQueryCache.java#L383).  

Queries sitting in `uniqueQueries` can exclusively retain references and `uniqueQueries` keeps growing because its computed ram usage is low and eviction is not triggered.
<img width="1920" height="1080" alt="Screenshot 2026-01-09 at 13 43 46 2" src="https://github.com/user-attachments/assets/6c712e69-717c-4cf3-94b3-84c1287d1f5c" />



