### PR TITLE
Remove expressions dependency from GenericFunctionQuery

### DIFF
--- a/server/src/test/java/io/crate/lucene/GenericFunctionQueryTest.java
+++ b/server/src/test/java/io/crate/lucene/GenericFunctionQueryTest.java
@@ -80,7 +80,7 @@ public class GenericFunctionQueryTest extends CrateDummyClusterServiceUnitTest {
         try (QueryTester tester = builder.build()) {
             var query = tester.toQuery("abs(a) * abs(b) = 1");
             assertThat(query).isInstanceOf(GenericFunctionQuery.class);
-            assertThat(CustomLRUQueryCache.getRamBytesUsed(query)).isEqualTo(1652L);
+            assertThat(CustomLRUQueryCache.getRamBytesUsed(query)).isEqualTo(1668L);
         }
     }
 
@@ -97,7 +97,7 @@ public class GenericFunctionQueryTest extends CrateDummyClusterServiceUnitTest {
         try (QueryTester tester = builder.build()) {
             var query = tester.toQuery("abs(a) = 1 AND abs(b) = 1");
             assertThat(query).isInstanceOf(BooleanQuery.class);
-            assertThat(CustomLRUQueryCache.getRamBytesUsed(query)).isEqualTo(1776L);
+            assertThat(CustomLRUQueryCache.getRamBytesUsed(query)).isEqualTo(1808L);
         }
     }
 }

--- a/server/src/test/java/io/crate/lucene/LikeQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/LikeQueryBuilderTest.java
@@ -30,6 +30,7 @@ import java.util.List;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.WildcardQuery;
 import org.assertj.core.api.Assertions;
@@ -191,7 +192,7 @@ public class LikeQueryBuilderTest extends LuceneQueryBuilderTest {
     }
 
     @Test
-    public void test_like_ilike_with_trailing_escape_char() {
+    public void test_like_ilike_with_trailing_escape_char() throws Exception {
         assertThatThrownBy(() -> convert("name like '\\'"))
             .isExactlyInstanceOf(IllegalArgumentException.class)
             .hasMessage("pattern '\\' must not end with escape character '\\'");
@@ -200,10 +201,17 @@ public class LikeQueryBuilderTest extends LuceneQueryBuilderTest {
             .hasMessage("pattern '\\' must not end with escape character '\\'");
 
         // no index
-        assertThatThrownBy(() -> convert("text_no_index like '\\'"))
+        Query query = convert("text_no_index like '\\'");
+        assertThat(query).isInstanceOf(GenericFunctionQuery.class);
+        GenericFunctionQuery genericFunctionQuery1 = (GenericFunctionQuery) query;
+        assertThatThrownBy(() -> genericFunctionQuery1.createWeight(null, ScoreMode.COMPLETE, 1))
             .isExactlyInstanceOf(IllegalArgumentException.class)
             .hasMessage("pattern '\\' must not end with escape character '\\'");
-        assertThatThrownBy(() -> convert("text_no_index ilike '\\'"))
+
+        query = convert("text_no_index ilike '\\'");
+        assertThat(query).isInstanceOf(GenericFunctionQuery.class);
+        GenericFunctionQuery genericFunctionQuery2 = (GenericFunctionQuery) query;
+        assertThatThrownBy(() -> genericFunctionQuery2.createWeight(null, ScoreMode.COMPLETE, 1))
             .isExactlyInstanceOf(IllegalArgumentException.class)
             .hasMessage("pattern '\\' must not end with escape character '\\'");
     }


### PR DESCRIPTION
Queries in the cache can end up retaining heavy objects,
and prevent them being garbage collected.

expressions can reference a heavy readers via `expression.setNextReader(readerContext)`,
hence we move expressions dependency out of the `GenericFunctionQuery` and re-create them per-weight.

See related discussion in https://github.com/apache/lucene/pull/15558#discussion_r2700886956 and
reproduction in https://github.com/crate/crate/pull/18913#discussion_r2703831962.

Closes https://github.com/crate/support/issues/797
