### PR TITLE
Fix handling of NOT NULL constraints on array(object) children

### DIFF
--- a/docs/appendices/release-notes/6.1.3.rst
+++ b/docs/appendices/release-notes/6.1.3.rst
@@ -46,6 +46,10 @@ series.
 Fixes
 =====
 
+- Fixed an issue that allowed inserting ``NULL`` values into child columns of
+  ``ARRAY(OBJECT)`` columns despite ``NOT NULL`` constraint on those child
+  columns if a sibling column had a value.
+
 - Fixed an issue that prevented ``ILIKE`` from matching records with text
   containing newline characters.
 

--- a/docs/appendices/release-notes/6.2.1.rst
+++ b/docs/appendices/release-notes/6.2.1.rst
@@ -49,6 +49,10 @@ series.
 Fixes
 =====
 
+- Fixed an issue that allowed inserting ``NULL`` values into child columns of
+  ``ARRAY(OBJECT)`` columns despite ``NOT NULL`` constraint on those child
+  columns if a sibling column had a value.
+
 - Fixed an issue with users being able to execute
   :ref:`user defined functions <user-defined-functions>`, even if they lacked
   privileges on the schema under which a ``UDF`` is defined. Now ``DQL``

--- a/libs/shared/src/main/java/io/crate/common/collections/Maps.java
+++ b/libs/shared/src/main/java/io/crate/common/collections/Maps.java
@@ -103,6 +103,17 @@ public final class Maps {
         return getByPath(value, path, 0);
     }
 
+    @Nullable
+    public static Object getByPath(Object value, List<String> path) {
+        if (value instanceof Map<?, ?> map) {
+            return getByPath(map, path);
+        } else if (value instanceof List<?> list) {
+            return getByPath(list, path, -1);
+        } else {
+            return null;
+        }
+    }
+
     private static Object getByPath(Map<?, ?> value, List<String> path, int startIndex) {
         assert path instanceof RandomAccess : "Path must support random access for fast iteration";
         Map<?, ?> map = value;

--- a/libs/shared/src/test/java/io/crate/common/collections/MapsTest.java
+++ b/libs/shared/src/test/java/io/crate/common/collections/MapsTest.java
@@ -56,6 +56,19 @@ class MapsTest {
     }
 
     @Test
+    void test_get_by_path_on_list_of_maps() {
+        List<Map<String, Integer>> rootObjects = List.of(Map.of("x", 1), Map.of("x", 2));
+        Object actual = Maps.getByPath(rootObjects, List.of("x"));
+        assertThat(actual).isEqualTo(List.of(1, 2));
+
+        actual = Maps.getByPath(rootObjects, List.of());
+        assertThat(actual).isEqualTo(rootObjects);
+
+        actual = Maps.getByPath(List.of(Map.of("x", Map.of("x1", 1))), List.of("x", "x1"));
+        assertThat(actual).isEqualTo(List.of(1));
+    }
+
+    @Test
     public void testExtractValueFromNestedObject() {
         Map<String, Map<String, Integer>> map = Map.of("x", Map.of("y", 10));
         Object o = Maps.getByPath(map, Arrays.asList("x", "y"));

--- a/server/src/main/java/io/crate/execution/dml/Indexer.java
+++ b/server/src/main/java/io/crate/execution/dml/Indexer.java
@@ -46,9 +46,9 @@ import org.apache.lucene.document.Field;
 import org.elasticsearch.Version;
 import org.elasticsearch.index.mapper.ParsedDocument;
 import org.jspecify.annotations.Nullable;
-import io.crate.common.annotations.VisibleForTesting;
 
 import io.crate.analyze.SymbolEvaluator;
+import io.crate.common.annotations.VisibleForTesting;
 import io.crate.common.collections.Maps;
 import io.crate.data.Input;
 import io.crate.data.Row;
@@ -239,11 +239,7 @@ public class Indexer {
                 return NestableCollectExpression.constant(null);
             }
             Function<IndexItem, Object> getValue = item -> {
-                Object val = item.insertValues()[rootIndex];
-                if (val instanceof Map<?, ?> m) {
-                    List<String> path = column.path();
-                    val = Maps.getByPath(m, path);
-                }
+                Object val = Maps.getByPath(item.insertValues()[rootIndex], column.path());
                 if (val == null) {
                     Symbol defaultExpression = ref.defaultExpression();
                     if (defaultExpression != null) {
@@ -328,13 +324,25 @@ public class Indexer {
         void verify(Object[] values);
     }
 
-    record NotNullTableConstraint(ColumnIdent column, Input<?> input) implements TableConstraint {
+    record NotNullTableConstraint(int dimensions, ColumnIdent column, Input<?> input) implements TableConstraint {
 
         @Override
         public void verify(Object[] values) {
-            Object value = input.value();
+            verify(input.value(), 0);
+        }
+
+        private void verify(Object value, int dimension) {
             if (value == null) {
                 throw new IllegalArgumentException("\"" + column + "\" must not be null");
+            } else if (dimension < dimensions) {
+                if (value instanceof Iterable<?> values) {
+                    int newDimension = dimension + 1;
+                    for (Object v : values) {
+                        verify(v, newDimension);
+                    }
+                } else {
+                    assert false : "Expected an Iterable value but got: " + value;
+                }
             }
         }
     }
@@ -805,15 +813,17 @@ public class Indexer {
                                               Context<CollectExpression<IndexItem, Object>> ctxForRefs) {
         for (var column : table.notNullColumns()) {
             Reference ref = table.getReference(column);
+            DataType<?> readType = table.getReadType(column);
+            int arrayProjectionDimensions = ArrayType.dimensions(readType) - ArrayType.dimensions(ref.valueType());
             assert ref != null : "Column in #notNullColumns must be available via table.getReference";
             if (targetColumns.contains(ref)) {
                 columnConstraints.merge(ref.column(), new NotNull(column), MultiCheck::merge);
             } else if (ref instanceof GeneratedReference generated) {
                 Input<?> input = ctxForRefs.add(generated.generatedExpression());
-                tableConstraints.add(new NotNullTableConstraint(column, input));
+                tableConstraints.add(new NotNullTableConstraint(arrayProjectionDimensions, column, input));
             } else {
                 Input<?> input = ctxForRefs.add(ref);
-                tableConstraints.add(new NotNullTableConstraint(column, input));
+                tableConstraints.add(new NotNullTableConstraint(arrayProjectionDimensions, column, input));
             }
         }
     }

--- a/server/src/test/java/io/crate/execution/dml/IndexerTest.java
+++ b/server/src/test/java/io/crate/execution/dml/IndexerTest.java
@@ -1753,6 +1753,51 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
             .hasMessage("'aa' is too long for the text type of length: 1");
     }
 
+    @Test
+    public void test_not_null_constraint_on_array_object_children() throws Exception {
+        SQLExecutor executor = SQLExecutor.of(clusterService)
+            .addTable(
+                """
+                create table t (
+                    points array(object(strict) as (
+                        x int not null,
+                        y int not null
+                    ))
+                )
+                """
+            );
+        DocTableInfo table = executor.resolveTableInfo("t");
+        Indexer insertIndexer = new Indexer(
+            List.of(),
+            table,
+            Version.CURRENT,
+            new CoordinatorTxnCtx(executor.getSessionSettings()),
+            executor.nodeCtx,
+            List.of(table.getReference(ColumnIdent.of("points"))),
+            null,
+            null
+        );
+
+        assertThatThrownBy(() -> insertIndexer.index(item(List.of(Map.of("x", 1)))))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("\"points['y']\" must not be null");
+
+        Indexer updateIndexer = new Indexer(
+            List.of(),
+            table,
+            Version.CURRENT,
+            new CoordinatorTxnCtx(executor.getSessionSettings()),
+            executor.nodeCtx,
+            List.of(),
+            new String[] { "points" },
+            null
+        );
+
+        assertThatThrownBy(() -> updateIndexer.index(item(List.of(Map.of("x", 1)))))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("\"points['y']\" must not be null");
+    }
+
     public static void assertTranslogParses(ParsedDocument doc, DocTableInfo info) {
         assertTranslogParses(doc, info, Version.CURRENT);
     }


### PR DESCRIPTION
Closes https://github.com/crate/crate/issues/18918

The not null validation didn't consider array projections.
`input.value()` for children of object arrays returned the list value of
the parent array object instead of being projected and the `not null`
constraint implementations couldn't handle projected values (lists) either.
