### PR TITLE
TEMP: Validate on Sphinx 9

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,7 +6,7 @@ version: 2
 build:
   os: "ubuntu-22.04"
   tools:
-    python: "3.13"
+    python: "3.14"
 
   jobs:
 
@@ -17,7 +17,7 @@ build:
       - asdf global uv latest
       - uv venv
     install:
-      - uv pip install -r docs/requirements.txt
+      - uv pip install --upgrade -r docs/requirements.txt
 
     # Invoke the build using `uv`.
     build:

--- a/blackbox/requirements.txt
+++ b/blackbox/requirements.txt
@@ -15,7 +15,7 @@ pyjnius
 dnslib
 
 # Documentation
-crate-docs-theme>=0.42.0
+crate-docs-theme>=0.47.1.dev5
 sphinx-csv-filter==0.4.2
 
 # docutils 0.21 currently has problems with the `sphinx-csv-filter` addon.
@@ -26,4 +26,4 @@ sphinx-csv-filter==0.4.2
 docutils<0.21
 
 # Documentation: local development
-sphinx-autobuild<2024
+sphinx-autobuild>=2024

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 # packages for RTD to pick up (not used for local dev)
-crate-docs-theme>=0.35.0
-sphinx-csv-filter==0.4.0
+crate-docs-theme>=0.47.1.dev5
+sphinx-csv-filter==0.4.2
 Pygments>=2.7.4,<3


### PR DESCRIPTION
## About
Validate documentation build using Sphinx 9.

## Preview
https://crate--18932.org.readthedocs.build/en/18932/

> Running Sphinx v9.1.0 ([ref](https://app.readthedocs.org/projects/crate/builds/31084048/?utm_source=crate&utm_content=notification#302719715--1))

## References
- https://github.com/crate/crate-docs-theme/pull/671