### PR TITLE
Re-add handling of UndefinedType to the SubscriptFunction

### DIFF
--- a/docs/appendices/release-notes/6.1.3.rst
+++ b/docs/appendices/release-notes/6.1.3.rst
@@ -107,3 +107,12 @@ Fixes
 - Fixed an issue that caused under-accounting of memory usage of some queries
   stored in cache. It affected cache eviction that is depending on query memory
   usage, potentially leading to an ``OutOfMemoryError``.
+
+- Fixed a regression introduced in :ref:`version_6.0.0` that caused statements
+  ``SELECT unnest(obj['arr'])['subcol']`` to fail with a ``ClassCastException``
+  if ``obj`` column had a type :ref:`IGNORED <type-object-columns-ignored>`
+  and ``subcol`` was missing in the record. Error was thrown regardless of the
+  value specified in :ref:`conf-session-error_on_unknown_object_key`.
+  Now it returns ``NULL`` if :ref:`conf-session-error_on_unknown_object_key` is
+  set to ``false`` and throws ``ColumnUnknownException`` if it has default
+  value ``true``.

--- a/docs/appendices/release-notes/6.2.1.rst
+++ b/docs/appendices/release-notes/6.2.1.rst
@@ -61,3 +61,12 @@ Fixes
 - Fixed an issue that caused under-accounting of memory usage of some queries
   stored in cache. It affected cache eviction that is depending on query memory
   usage, potentially leading to an ``OutOfMemoryError``.
+
+- Fixed a regression introduced in :ref:`version_6.0.0` that caused statements
+  ``SELECT unnest(obj['arr'])['subcol']`` to fail with a ``ClassCastException``
+  if ``obj`` column had a type :ref:`IGNORED <type-object-columns-ignored>`
+  and ``subcol`` was missing in the record. Error was thrown regardless of the
+  value specified in :ref:`conf-session-error_on_unknown_object_key`.
+  Now it returns ``NULL`` if :ref:`conf-session-error_on_unknown_object_key` is
+  set to ``false`` and throws ``ColumnUnknownException`` if it has default
+  value ``true``.

--- a/server/src/main/java/io/crate/expression/scalar/SubscriptFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/SubscriptFunction.java
@@ -224,13 +224,13 @@ public class SubscriptFunction extends Scalar<Object, Object> {
         } else if (base instanceof Map<?, ?> map) {
             Object value = map.get(name);
             ColumnPolicy columnPolicy = baseType.columnPolicy();
-            if (value == null) {
-                assert baseType instanceof ObjectType;
-                ObjectType objType = (ObjectType) baseType;
-                if (columnPolicy == ColumnPolicy.IGNORED
-                    || (columnPolicy == ColumnPolicy.DYNAMIC && !errorOnUnknownObjectKey)
-                    || (objType.innerTypes().containsKey(name))) {
-                    return null;
+            if (value == null && errorOnUnknownObjectKey) {
+                // Type could also be "undefined"
+                if (baseType instanceof ObjectType objType) {
+                    if (columnPolicy == ColumnPolicy.IGNORED
+                        || objType.innerTypes().containsKey(name)) {
+                        return null;
+                    }
                 }
                 throw ColumnUnknownException.ofUnknownRelation("The object `" + base + "` does not contain the key `" + name + "`");
             }


### PR DESCRIPTION
Fixes a regression introduced with https://github.com/crate/crate/commit/88e23272403a17f70d7625019cc923674c4a287e

Closes https://github.com/crate/support/issues/805.

I also checked that this PR fixes scenario in the original issue for both scenarios: flag being true/false.
