### PR TITLE
Improve error message for invalid kvp config settings

### DIFF
--- a/docs/appendices/release-notes/6.1.3.rst
+++ b/docs/appendices/release-notes/6.1.3.rst
@@ -122,3 +122,9 @@ Fixes
   Now it returns ``NULL`` if :ref:`conf-session-error_on_unknown_object_key` is
   set to ``false`` and throws ``ColumnUnknownException`` if it has default
   value ``true``.
+
+- Improved error message thrown when providing empty value for configuration
+  settings, e.g.:
+
+      $> bin/crate -Cauth.host_based.enabled
+      $> bin/crate -Cauth.host_based.enabled=

--- a/docs/appendices/release-notes/6.2.1.rst
+++ b/docs/appendices/release-notes/6.2.1.rst
@@ -76,3 +76,9 @@ Fixes
   Now it returns ``NULL`` if :ref:`conf-session-error_on_unknown_object_key` is
   set to ``false`` and throws ``ColumnUnknownException`` if it has default
   value ``true``.
+
+- Improved error message thrown when providing empty value for configuration
+  settings, e.g.:
+
+      $> bin/crate -Cauth.host_based.enabled
+      $> bin/crate -Cauth.host_based.enabled=

--- a/server/src/main/java/io/crate/server/cli/EnvironmentAwareCommand.java
+++ b/server/src/main/java/io/crate/server/cli/EnvironmentAwareCommand.java
@@ -64,8 +64,8 @@ public abstract class EnvironmentAwareCommand extends Command {
     protected void execute(Terminal terminal, OptionSet options) throws Exception {
         final Map<String, String> settings = new HashMap<>();
         for (final KeyValuePair kvp : settingOption.values(options)) {
-            if (kvp.value.isEmpty()) {
-                throw new UserException(ExitCodes.USAGE, "setting [" + kvp.key + "] must not be empty");
+            if (kvp.value == null || kvp.value.isEmpty()) {
+                throw new UserException(ExitCodes.USAGE, "no value provided for setting [" + kvp.key + "]");
             }
             if (settings.containsKey(kvp.key)) {
                 final String message = String.format(

--- a/server/src/test/java/io/crate/server/cli/CrateStartupTest.java
+++ b/server/src/test/java/io/crate/server/cli/CrateStartupTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.crate.server.cli;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.elasticsearch.cli.Command;
+import org.elasticsearch.cli.Terminal;
+import org.elasticsearch.cli.UserException;
+import org.elasticsearch.env.Environment;
+import org.junit.jupiter.api.Test;
+
+import joptsimple.OptionSet;
+
+public class CrateStartupTest extends CommandTestCase {
+
+    @Test
+    public void test_invalid_config_settings_kvp() throws Exception {
+        assertThatThrownBy(() -> execute("-Cauth.host_based.enabled"))
+            .isExactlyInstanceOf(UserException.class)
+            .hasMessage("no value provided for setting [auth.host_based.enabled]");
+        assertThatThrownBy(() -> execute("-Cauth.host_based.enabled="))
+            .isExactlyInstanceOf(UserException.class)
+            .hasMessage("no value provided for setting [auth.host_based.enabled]");
+    }
+
+    @Override
+    protected Command newCommand() {
+        return new EnvironmentAwareCommand("starts CrateDB", "C", () -> { }) {
+            @Override
+            protected void execute(Terminal terminal, OptionSet options, Environment env) throws Exception {
+                execute(terminal, options);
+            }
+        };
+    }
+}


### PR DESCRIPTION
Previously, the value of a config setting was not checked for `null`, leading to an NPE exception, instead of a user friendly message.

Fixes: #18919

