### PR TITLE
Add streaming support to ColumnUnknownException

### DIFF
--- a/server/src/main/java/org/elasticsearch/ElasticsearchException.java
+++ b/server/src/main/java/org/elasticsearch/ElasticsearchException.java
@@ -44,6 +44,7 @@ import org.elasticsearch.transport.TcpTransport;
 
 import io.crate.common.CheckedFunction;
 import io.crate.exceptions.ArrayViaDocValuesUnsupportedException;
+import io.crate.exceptions.ColumnUnknownException;
 import io.crate.exceptions.DependentObjectsExists;
 import io.crate.exceptions.RoleUnknownException;
 import io.crate.exceptions.SQLExceptions;
@@ -755,6 +756,12 @@ public class ElasticsearchException extends RuntimeException implements Writeabl
             DependentObjectsExists::new,
             185,
             Version.V_6_2_0
+        ),
+        COLUMN_UNKNOWN(
+            ColumnUnknownException.class,
+            ColumnUnknownException::new,
+            186,
+            Version.V_6_3_0
         );
 
         final Class<? extends ElasticsearchException> exceptionClass;


### PR DESCRIPTION
Relates to https://github.com/crate/crate/pull/18934#discussion_r2711771666

No tests because we don't add explicit tests for "make exception streamable" (at least it was like this in past commits), afaik it's covered by itests with distributed execution.

In this particular case, it's covered by the `test_subscript_of_missing_column_when_object_type_cannot_be_inferred`.
I even spot and fixed a bug because test was flaky (had NPE in streaming due to null `relationName`) and updated the test to use jdbc as well.

This is not a fix, just an improvement of an error shown to users. 

Otherwise it sometimes can look like
`org.elasticsearch.common.io.stream.NotSerializableExceptionWrapper: ColumnUnknownException: The object... does not contain the key...`