### PR TITLE
Add a hint about defaultReadAdvice setting to 6.0 release notes

### DIFF
--- a/docs/appendices/release-notes/6.0.0.rst
+++ b/docs/appendices/release-notes/6.0.0.rst
@@ -65,6 +65,12 @@ Breaking Changes
     stemmer without a character filter that already did this, they will need to
     re-index after upgrading.
 
+  - Lucene 10.2 opens files with the ``MADV_RANDOM`` advice by default on Linux
+    and Mac OS. If you experience an increase in IOPS and degraded performance,
+    especially slow recovery times on node restarts,
+    set ``CRATE_JAVA_OPTS=-Dorg.apache.lucene.store.defaultReadAdvice=NORMAL``
+    to restore previous behavior.
+
 - Removed the deprecated ``soft_deletes.enabled`` setting for ``CREATE TABLE``.
   The setting defaulted to ``true`` since 4.3.0, was deprecated in 4.5.0 and
   soft deletes became mandatory in 5.0.0.

--- a/docs/appendices/release-notes/6.1.0.rst
+++ b/docs/appendices/release-notes/6.1.0.rst
@@ -65,6 +65,12 @@ Breaking Changes
   of the available processors, improving the performance of the :ref:`optimize`
   operation on machines with more than ``15`` cores.
 
+- Lucene 10.2 opens files with the ``MADV_RANDOM`` advice by default on Linux
+  and Mac OS. If you experience an increase in IOPS and degraded performance,
+  especially slow recovery times on node restarts,
+  set ``CRATE_JAVA_OPTS=-Dorg.apache.lucene.store.defaultReadAdvice=NORMAL``
+  to restore previous behavior.
+
 Deprecations
 ============
 

--- a/docs/appendices/release-notes/6.1.3.rst
+++ b/docs/appendices/release-notes/6.1.3.rst
@@ -136,3 +136,9 @@ Fixes
     SELECT * FROM t1 WHERE NOT EXISTS
       (SELECT 1 FROM (SELECT c2 FROM t1 WHERE bool_col) AS sub0
        WHERE t1.bool_col OR t1.bool_col);
+
+- Fixed a regression introduced in :ref:`version_6.0.0` with upgrade to
+  Lucene 10.2 that caused increase in IOPS and slow recovery times on node
+  restarts. Flag mentioned in :ref:`version_6.0.0_breaking_changes` and
+  :ref:`version_6.1.0_breaking_changes` is already set to ``NORMAL`` starting
+  from this version and won't be needed at all starting from CrateDB 6.2.0.


### PR DESCRIPTION
Relates to https://github.com/crate/support/issues/806


Lucene started using `ReadAdvice.RANDOM` by default in https://github.com/apache/lucene/commit/a2676b1b26aab5a8bb655031f2ce0299e5207e00

This can cause 2 types of regressions
1. When access pattern doesn't fit `RANDOM`. For example, `RecoverySourceHandler` was meant to use READ 
    (sequential chunks) 
but in 10.0 upgrade https://github.com/crate/crate/commit/4918f3c228adf13e8e3d065cd3266f499f242b85 we started using DEFAULT
to reflect the fact that READ was replaced by DEFAULT in Lucene in https://github.com/apache/lucene/commit/32d692049fc4ea3a34ad25ef116c8148f7c055ac

However, once `RANDOM` became default, we implicitly started using not-fitting access pattern and got performance drawback on recovery, similar to https://github.com/opensearch-project/OpenSearch/issues/19156#issuecomment-3288799192

We already tried it and got better recovery/upgrade pattern

>Initial observations after changing read advice to `NORMAL` are positive. Node restarts showed quick shard recovery and no longer exhibited the slow progress we saw initially after the 6.0 upgrade.

2. If flag is set back to `NORMAL` and this is still not enough, it means `RANDOM` is used **explicitly** somewhere (and flag is not affecting it) and MGLRU is enabled in Linux kernel 
(see https://github.com/apache/lucene/issues/14408).

In this case, MGLRU can be disabled with `sudo sh -c 'echo 0 > /sys/kernel/mm/lru_gen/enabled'`

However, code where `ReadAdvice.Random` is used in 10.0 (https://github.com/apache/lucene/commit/4ea2bae1198bb3052912e08faa3a4c2cdaa67db0) was backported to 9.11.0 in https://github.com/apache/lucene/commit/bb52dcbbc24ed4acce72f6236f417e889aee2f92 

CrateDB uses this since 5.8.0 https://github.com/crate/crate/commit/de9cb2ec8fe1fe143704a8001d2a9788269a7d43 and no regressions have been reported, so not including this hint to the release notes

