### PR TITLE
Introduce table OID

### DIFF
--- a/plugins/es-repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureRepositoryAnalyzerTest.java
+++ b/plugins/es-repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureRepositoryAnalyzerTest.java
@@ -45,8 +45,7 @@ public class AzureRepositoryAnalyzerTest extends CrateDummyClusterServiceUnitTes
                     Settings.builder().put("location", "/tmp/my_repo").build()
                 )));
         ClusterState clusterState = ClusterState.builder(new ClusterName("testing"))
-            .metadata(Metadata.builder()
-                          .putCustom(RepositoriesMetadata.TYPE, repositoriesMetadata))
+            .metadata(new Metadata.Builder(Metadata.OID_UNASSIGNED).putCustom(RepositoriesMetadata.TYPE, repositoriesMetadata))
             .build();
         ClusterServiceUtils.setState(clusterService, clusterState);
         e = SQLExecutor.builder(clusterService).build();

--- a/plugins/es-repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3RepositoryPluginAnalyzerTest.java
+++ b/plugins/es-repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3RepositoryPluginAnalyzerTest.java
@@ -69,7 +69,7 @@ public class S3RepositoryPluginAnalyzerTest extends CrateDummyClusterServiceUnit
                     Settings.builder().put("location", "/tmp/my_repo").build()
                 )));
         ClusterState clusterState = ClusterState.builder(new ClusterName("testing"))
-            .metadata(Metadata.builder()
+            .metadata(new Metadata.Builder(Metadata.OID_UNASSIGNED)
                           .putCustom(RepositoriesMetadata.TYPE, repositoriesMetadata))
             .build();
         ClusterServiceUtils.setState(clusterService, clusterState);

--- a/server/src/main/java/io/crate/analyze/TableElementsAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/TableElementsAnalyzer.java
@@ -21,7 +21,7 @@
 
 package io.crate.analyze;
 
-import static org.elasticsearch.cluster.metadata.Metadata.COLUMN_OID_UNASSIGNED;
+import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -281,7 +281,7 @@ public class TableElementsAnalyzer implements FieldProvider<Reference> {
                     nullable,
                     hasDocValues,
                     position,
-                    COLUMN_OID_UNASSIGNED,
+                    OID_UNASSIGNED,
                     false,
                     defaultExpression,
                     sources,
@@ -298,7 +298,7 @@ public class TableElementsAnalyzer implements FieldProvider<Reference> {
                     indexType,
                     nullable,
                     position,
-                    COLUMN_OID_UNASSIGNED,
+                    OID_UNASSIGNED,
                     false,
                     defaultExpression,
                     indexMethod,
@@ -316,7 +316,7 @@ public class TableElementsAnalyzer implements FieldProvider<Reference> {
                     nullable,
                     hasDocValues,
                     position,
-                    COLUMN_OID_UNASSIGNED,
+                    OID_UNASSIGNED,
                     false,
                     defaultExpression
                 );

--- a/server/src/main/java/io/crate/execution/ddl/SwapRelationsOperation.java
+++ b/server/src/main/java/io/crate/execution/ddl/SwapRelationsOperation.java
@@ -147,7 +147,8 @@ public class SwapRelationsOperation {
                     sourceRelation.partitionedBy(),
                     sourceRelation.state(),
                     sourceRelation.indexUUIDs(),
-                    sourceRelation.tableVersion() + 1
+                    sourceRelation.tableVersion() + 1,
+                    sourceRelation.oid()
                 )
                 .setTable(
                     source,
@@ -164,7 +165,8 @@ public class SwapRelationsOperation {
                     targetRelation.partitionedBy(),
                     targetRelation.state(),
                     targetRelation.indexUUIDs(),
-                    targetRelation.tableVersion() + 1
+                    targetRelation.tableVersion() + 1,
+                    targetRelation.oid()
                 );
         }
 

--- a/server/src/main/java/io/crate/execution/ddl/tables/MappingUtil.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/MappingUtil.java
@@ -22,7 +22,7 @@
 package io.crate.execution.ddl.tables;
 
 import static io.crate.metadata.Reference.buildTree;
-import static org.elasticsearch.cluster.metadata.Metadata.COLUMN_OID_UNASSIGNED;
+import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -201,7 +201,7 @@ public final class MappingUtil {
 
     private static String mappingKey(Reference reference) {
         if (reference.isDropped()) {
-            assert reference.oid() != COLUMN_OID_UNASSIGNED : "Only columns with assigned OID-s can be dropped";
+            assert reference.oid() != OID_UNASSIGNED : "Only columns with assigned OID-s can be dropped";
             return DROPPED_COLUMN_NAME_PREFIX + reference.oid();
         } else {
             return reference.column().leafName();

--- a/server/src/main/java/io/crate/execution/ddl/tables/TransportCloseTable.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/TransportCloseTable.java
@@ -173,7 +173,8 @@ public final class TransportCloseTable extends TransportMasterNodeAction<CloseTa
                 table.partitionedBy(),
                 State.CLOSE,
                 table.indexUUIDs(),
-                table.tableVersion() + 1
+                table.tableVersion() + 1,
+                table.oid()
             );
         } else {
             PartitionName partitionName = new PartitionName(target.table(), partitionValues);

--- a/server/src/main/java/io/crate/execution/ddl/tables/TransportCreateTable.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/TransportCreateTable.java
@@ -170,7 +170,8 @@ public class TransportCreateTable extends TransportMasterNodeAction<CreateTableR
 
                 ClusterState newState = ClusterState.builder(currentState).build();
                 List<String> newIndexUUIDs = isPartitioned ? List.of() : List.of(UUIDs.randomBase64UUID());
-                Metadata newMetadata = Metadata.builder(newState.metadata())
+                var mdBuilder = Metadata.builder(newState.metadata());
+                Metadata newMetadata = mdBuilder
                     .setTable(
                         relationName,
                         request.references(),
@@ -183,7 +184,8 @@ public class TransportCreateTable extends TransportMasterNodeAction<CreateTableR
                         request.partitionedBy(),
                         State.OPEN,
                         newIndexUUIDs,
-                        0
+                        0,
+                        mdBuilder.tableOidSupplier().nextOid()
                     ).build();
                 table = newMetadata.getRelation(relationName);
                 assert table != null : "table must not be null";

--- a/server/src/main/java/io/crate/execution/dml/DynamicIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/DynamicIndexer.java
@@ -21,7 +21,7 @@
 
 package io.crate.execution.dml;
 
-import static org.elasticsearch.cluster.metadata.Metadata.COLUMN_OID_UNASSIGNED;
+import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
 
 import java.io.IOException;
 import java.util.function.Consumer;
@@ -97,7 +97,7 @@ public final class DynamicIndexer implements ValueIndexer<Object> {
                                      Synthetics synthetics) throws IOException {
         if (type == null) {
             type = guessType(value);
-            Reference newColumn = buildReference(relation, column, type, position, COLUMN_OID_UNASSIGNED);
+            Reference newColumn = buildReference(relation, column, type, position, OID_UNASSIGNED);
             StorageSupport<?> storageSupport = type.storageSupport();
             assert storageSupport != null; // will have already thrown in buildReference
             indexer = (ValueIndexer<Object>) storageSupport.valueIndexer(
@@ -128,7 +128,7 @@ public final class DynamicIndexer implements ValueIndexer<Object> {
                 "Cannot create columns of type " + type.getName() + " dynamically. " +
                     "Storage is not supported for this type");
         }
-        Reference newColumn = buildReference(relation, column, type, position, COLUMN_OID_UNASSIGNED);
+        Reference newColumn = buildReference(relation, column, type, position, OID_UNASSIGNED);
         if (indexer == null) {
             // Reuse indexer if phase 1 already created one.
             // Phase 1 mutates indexer.innerTypes on new columns creation.

--- a/server/src/main/java/io/crate/execution/dml/Indexer.java
+++ b/server/src/main/java/io/crate/execution/dml/Indexer.java
@@ -22,7 +22,7 @@
 
 package io.crate.execution.dml;
 
-import static org.elasticsearch.cluster.metadata.Metadata.COLUMN_OID_UNASSIGNED;
+import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -740,7 +740,7 @@ public class Indexer {
         var idx = 0;
         while (it.hasNext()) {
             var oldRef = it.next();
-            if (oldRef.oid() == COLUMN_OID_UNASSIGNED) {
+            if (oldRef.oid() == OID_UNASSIGNED) {
                 // try to resolve the column again, new reference may have been added to or dropped of the table or
                 // the reference may be invalid
                 Reference newRef = getRef.apply(oldRef.column());

--- a/server/src/main/java/io/crate/execution/dml/ObjectIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/ObjectIndexer.java
@@ -21,7 +21,7 @@
 
 package io.crate.execution.dml;
 
-import static org.elasticsearch.cluster.metadata.Metadata.COLUMN_OID_UNASSIGNED;
+import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -74,7 +74,7 @@ public class ObjectIndexer implements ValueIndexer<Map<String, Object>> {
         this.table = table;
         this.ref = ref;
         this.getRef = getRef;
-        this.unknownColumnPrefix = ref.oid() != COLUMN_OID_UNASSIGNED ? SourceParser.UNKNOWN_COLUMN_PREFIX : "";
+        this.unknownColumnPrefix = ref.oid() != OID_UNASSIGNED ? SourceParser.UNKNOWN_COLUMN_PREFIX : "";
         this.column = ref.column();
         ObjectType objectType = (ObjectType) ArrayType.unnest(ref.valueType());
         for (var entry : objectType.innerTypes().entrySet()) {
@@ -287,7 +287,7 @@ public class ObjectIndexer implements ValueIndexer<Map<String, Object>> {
                 column.getChild(innerName),
                 type,
                 position,
-                COLUMN_OID_UNASSIGNED
+                OID_UNASSIGNED
             );
             position--;
             onDynamicColumn.accept(newColumn);

--- a/server/src/main/java/io/crate/execution/dml/UpsertReplicaRequest.java
+++ b/server/src/main/java/io/crate/execution/dml/UpsertReplicaRequest.java
@@ -86,7 +86,7 @@ public class UpsertReplicaRequest extends ShardRequest<UpsertReplicaRequest, Ups
             this.columns = new ArrayList<>(numColumns);
             for (int i = 0; i < numColumns; i++) {
                 long oid = in.readLong();
-                Reference column = oid == Metadata.COLUMN_OID_UNASSIGNED
+                Reference column = oid == Metadata.OID_UNASSIGNED
                     ? Reference.fromStream(in)
                     : table.getReference(oid);
                 if (column == null) {
@@ -143,7 +143,7 @@ public class UpsertReplicaRequest extends ShardRequest<UpsertReplicaRequest, Ups
             out.writeVInt(columns.size());
             for (Reference column : columns) {
                 out.writeLong(column.oid());
-                if (column.oid() == Metadata.COLUMN_OID_UNASSIGNED) {
+                if (column.oid() == Metadata.OID_UNASSIGNED) {
                     Reference.toStream(out, column);
                 }
             }

--- a/server/src/main/java/io/crate/execution/dml/upsert/ShardUpsertRequest.java
+++ b/server/src/main/java/io/crate/execution/dml/upsert/ShardUpsertRequest.java
@@ -121,7 +121,7 @@ public final class ShardUpsertRequest extends ShardRequest<ShardUpsertRequest, S
             if (in.getVersion().onOrAfter(Version.V_6_2_0)) {
                 for (int i = 0; i < missingAssignmentsColumnsSize; i++) {
                     long oid = in.readLong();
-                    Reference ref = oid == Metadata.COLUMN_OID_UNASSIGNED
+                    Reference ref = oid == Metadata.OID_UNASSIGNED
                         ? Reference.fromStream(in)
                         : tableInfo.getReference(oid);
                     if (ref == null) {
@@ -178,7 +178,7 @@ public final class ShardUpsertRequest extends ShardRequest<ShardUpsertRequest, S
             if (out.getVersion().onOrAfter(Version.V_6_2_0)) {
                 for (Reference reference : insertColumns) {
                     out.writeLong(reference.oid());
-                    if (reference.oid() == Metadata.COLUMN_OID_UNASSIGNED) {
+                    if (reference.oid() == Metadata.OID_UNASSIGNED) {
                         Reference.toStream(out, reference);
                     }
                 }

--- a/server/src/main/java/io/crate/metadata/GeoReference.java
+++ b/server/src/main/java/io/crate/metadata/GeoReference.java
@@ -23,7 +23,7 @@ package io.crate.metadata;
 
 import static io.crate.types.GeoShapeType.Names.TREE_BKD;
 import static io.crate.types.GeoShapeType.Names.TREE_GEOHASH;
-import static org.elasticsearch.cluster.metadata.Metadata.COLUMN_OID_UNASSIGNED;
+import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
 
 import java.io.IOException;
 import java.util.Map;
@@ -201,7 +201,7 @@ public class GeoReference extends SimpleReference {
 
     @Override
     public Reference withOidAndPosition(LongSupplier acquireOid, IntSupplier acquirePosition) {
-        long newOid = oid == COLUMN_OID_UNASSIGNED ? acquireOid.getAsLong() : oid;
+        long newOid = oid == OID_UNASSIGNED ? acquireOid.getAsLong() : oid;
         int newPosition = position < 0 ? acquirePosition.getAsInt() : position;
         if (newOid == oid && newPosition == position) {
             return this;

--- a/server/src/main/java/io/crate/metadata/IndexReference.java
+++ b/server/src/main/java/io/crate/metadata/IndexReference.java
@@ -21,7 +21,7 @@
 
 package io.crate.metadata;
 
-import static org.elasticsearch.cluster.metadata.Metadata.COLUMN_OID_UNASSIGNED;
+import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -272,7 +272,7 @@ public class IndexReference extends SimpleReference {
 
     @Override
     public Reference withOidAndPosition(LongSupplier acquireOid, IntSupplier acquirePosition) {
-        long newOid = oid == COLUMN_OID_UNASSIGNED ? acquireOid.getAsLong() : oid;
+        long newOid = oid == OID_UNASSIGNED ? acquireOid.getAsLong() : oid;
         int newPosition = position < 0 ? acquirePosition.getAsInt() : position;
         if (newOid == oid && newPosition == position) {
             return this;

--- a/server/src/main/java/io/crate/metadata/Reference.java
+++ b/server/src/main/java/io/crate/metadata/Reference.java
@@ -21,7 +21,7 @@
 
 package io.crate.metadata;
 
-import static org.elasticsearch.cluster.metadata.Metadata.COLUMN_OID_UNASSIGNED;
+import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -114,7 +114,7 @@ public interface Reference extends Symbol, ScopedColumn {
      */
     default String storageIdent() {
         long oid = oid();
-        if (oid == COLUMN_OID_UNASSIGNED) {
+        if (oid == OID_UNASSIGNED) {
             ColumnIdent column = column();
             if (column.isRoot() == false && column.name().equals(SysColumns.Names.DOC)) {
                 column = column.shiftRight();
@@ -131,7 +131,7 @@ public interface Reference extends Symbol, ScopedColumn {
      * if no OID is assigned.
      */
     default String storageIdentLeafName() {
-        return oid() == COLUMN_OID_UNASSIGNED ? column().leafName() : Long.toString(oid());
+        return oid() == OID_UNASSIGNED ? column().leafName() : Long.toString(oid());
     }
 
     /**

--- a/server/src/main/java/io/crate/metadata/RelationInfo.java
+++ b/server/src/main/java/io/crate/metadata/RelationInfo.java
@@ -21,7 +21,7 @@
 
 package io.crate.metadata;
 
-import static org.elasticsearch.cluster.metadata.Metadata.COLUMN_OID_UNASSIGNED;
+import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
 
 import java.util.Collection;
 import java.util.List;
@@ -93,7 +93,7 @@ public interface RelationInfo extends Iterable<Reference> {
             .filter(ref -> !ref.column().isSystemColumn())
             .mapToLong(Reference::oid)
             .max()
-            .orElse(COLUMN_OID_UNASSIGNED);
+            .orElse(OID_UNASSIGNED);
     }
 
     RowGranularity rowGranularity();

--- a/server/src/main/java/io/crate/metadata/SimpleReference.java
+++ b/server/src/main/java/io/crate/metadata/SimpleReference.java
@@ -21,7 +21,7 @@
 
 package io.crate.metadata;
 
-import static org.elasticsearch.cluster.metadata.Metadata.COLUMN_OID_UNASSIGNED;
+import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -83,7 +83,7 @@ public class SimpleReference implements Reference {
              true,
              false,
              position,
-             COLUMN_OID_UNASSIGNED,
+            OID_UNASSIGNED,
              false,
              defaultExpression);
     }
@@ -129,7 +129,7 @@ public class SimpleReference implements Reference {
             oid = in.readLong();
             isDropped = in.readBoolean();
         } else {
-            oid = COLUMN_OID_UNASSIGNED;
+            oid = OID_UNASSIGNED;
             isDropped = false;
         }
         type = DataTypes.fromStream(in);
@@ -219,7 +219,7 @@ public class SimpleReference implements Reference {
 
     @Override
     public Reference withOidAndPosition(LongSupplier acquireOid, IntSupplier acquirePosition) {
-        long newOid = oid == COLUMN_OID_UNASSIGNED ? acquireOid.getAsLong() : oid;
+        long newOid = oid == OID_UNASSIGNED ? acquireOid.getAsLong() : oid;
         int newPosition = position < 0 ? acquirePosition.getAsInt() : position;
         if (newOid == oid && newPosition == position) {
             return this;
@@ -363,7 +363,7 @@ public class SimpleReference implements Reference {
         Map<String, Object> mapping = new HashMap<>();
         mapping.put("type", DataTypes.esMappingNameFrom(innerType.id()));
         mapping.put("position", position);
-        if (oid != COLUMN_OID_UNASSIGNED) {
+        if (oid != OID_UNASSIGNED) {
             mapping.put("oid", oid);
         }
         if (isDropped) {

--- a/server/src/main/java/io/crate/metadata/SystemTable.java
+++ b/server/src/main/java/io/crate/metadata/SystemTable.java
@@ -21,7 +21,7 @@
 
 package io.crate.metadata;
 
-import static org.elasticsearch.cluster.metadata.Metadata.COLUMN_OID_UNASSIGNED;
+import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -302,7 +302,7 @@ public final class SystemTable<T> implements TableInfo {
                         column.isNullable,
                         false,
                         position,
-                        COLUMN_OID_UNASSIGNED, // No oid for system tables
+                        OID_UNASSIGNED, // No oid for system tables
                         false, // Columns cannot be dropped from system tables
                         null
                     )

--- a/server/src/main/java/io/crate/metadata/cluster/AlterTableClusterStateExecutor.java
+++ b/server/src/main/java/io/crate/metadata/cluster/AlterTableClusterStateExecutor.java
@@ -105,7 +105,8 @@ public class AlterTableClusterStateExecutor extends DDLClusterStateTaskExecutor<
                 table.partitionedBy(),
                 table.state(),
                 table.indexUUIDs(),
-                table.tableVersion() + 1
+                table.tableVersion() + 1,
+                table.oid()
             );
             currentState = ClusterState.builder(currentState)
                 .metadata(newMetadata)

--- a/server/src/main/java/io/crate/metadata/cluster/OpenTableClusterStateTaskExecutor.java
+++ b/server/src/main/java/io/crate/metadata/cluster/OpenTableClusterStateTaskExecutor.java
@@ -82,7 +82,8 @@ public class OpenTableClusterStateTaskExecutor extends DDLClusterStateTaskExecut
                 table.partitionedBy(),
                 State.OPEN,
                 table.indexUUIDs(),
-                table.tableVersion() + 1
+                table.tableVersion() + 1,
+                table.oid()
             );
         } else if (closedIndices.isEmpty()) {
             return currentState;

--- a/server/src/main/java/io/crate/metadata/cluster/RenameTableClusterStateExecutor.java
+++ b/server/src/main/java/io/crate/metadata/cluster/RenameTableClusterStateExecutor.java
@@ -106,7 +106,8 @@ public class RenameTableClusterStateExecutor {
                 table.partitionedBy(),
                 table.state(),
                 table.indexUUIDs(),
-                table.tableVersion() + 1
+                table.tableVersion() + 1,
+                table.oid()
             );
 
         boolean needIndexAndRoutingUpdate = currentState.nodes().getSmallestNonClientNodeVersion().before(Version.V_6_1_0);

--- a/server/src/main/java/io/crate/metadata/cluster/SwapAndDropIndexExecutor.java
+++ b/server/src/main/java/io/crate/metadata/cluster/SwapAndDropIndexExecutor.java
@@ -101,7 +101,8 @@ public class SwapAndDropIndexExecutor extends DDLClusterStateTaskExecutor<SwapAn
                 table.partitionedBy(),
                 table.state(),
                 newUUIDs,
-                table.tableVersion() + 1
+                table.tableVersion() + 1,
+                table.oid()
             );
         }
 

--- a/server/src/main/java/io/crate/metadata/doc/SysColumns.java
+++ b/server/src/main/java/io/crate/metadata/doc/SysColumns.java
@@ -21,7 +21,7 @@
 
 package io.crate.metadata.doc;
 
-import static org.elasticsearch.cluster.metadata.Metadata.COLUMN_OID_UNASSIGNED;
+import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -164,7 +164,7 @@ public class SysColumns {
             false,
             false,
             position,
-            COLUMN_OID_UNASSIGNED,
+            OID_UNASSIGNED,
             false,
             null
         );

--- a/server/src/main/java/io/crate/metadata/upgrade/MetadataIndexUpgrader.java
+++ b/server/src/main/java/io/crate/metadata/upgrade/MetadataIndexUpgrader.java
@@ -22,7 +22,7 @@
 package io.crate.metadata.upgrade;
 
 import static io.crate.execution.ddl.tables.MappingUtil.DROPPED_COLUMN_NAME_PREFIX;
-import static org.elasticsearch.cluster.metadata.Metadata.COLUMN_OID_UNASSIGNED;
+import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -162,7 +162,7 @@ public class MetadataIndexUpgrader {
     public static boolean removeInvalidPropertyGeneratedByDroppingSysCols(Map<String, Object> defaultMapping) {
         Map<String, Object> properties = Maps.get(defaultMapping, "properties");
         if (properties != null) {
-            String droppedUnassigned = DROPPED_COLUMN_NAME_PREFIX + COLUMN_OID_UNASSIGNED;
+            String droppedUnassigned = DROPPED_COLUMN_NAME_PREFIX + OID_UNASSIGNED;
             if (properties.containsKey(droppedUnassigned)) {
                 properties.remove(droppedUnassigned);
                 return true;

--- a/server/src/main/java/io/crate/replication/logical/MetadataTracker.java
+++ b/server/src/main/java/io/crate/replication/logical/MetadataTracker.java
@@ -385,7 +385,8 @@ public final class MetadataTracker implements Closeable {
                     publisherTable.partitionedBy(),
                     subscriberTable.state(),
                     subscriberTable.indexUUIDs(),
-                    publisherTable.tableVersion()
+                    publisherTable.tableVersion(),
+                    subscriberTable.oid()
                 );
                 updateClusterState = true;
             }

--- a/server/src/main/java/io/crate/replication/logical/action/DropSubscriptionAction.java
+++ b/server/src/main/java/io/crate/replication/logical/action/DropSubscriptionAction.java
@@ -103,7 +103,8 @@ public class DropSubscriptionAction extends ActionType<AcknowledgedResponse> {
                     table.partitionedBy(),
                     table.state(),
                     table.indexUUIDs(),
-                    table.tableVersion() + 1
+                    table.tableVersion() + 1,
+                    table.oid()
                 );
             }
         }

--- a/server/src/main/java/io/crate/replication/logical/action/PublicationsStateAction.java
+++ b/server/src/main/java/io/crate/replication/logical/action/PublicationsStateAction.java
@@ -130,7 +130,7 @@ public class PublicationsStateAction extends ActionType<PublicationsStateAction.
                 throw new IllegalStateException("Cannot build publication state, no publications found");
             }
 
-            Metadata.Builder metadataBuilder = Metadata.builder();
+            Metadata.Builder metadataBuilder = Metadata.builder(state.metadata().currentMaxTableOid());
             List<String> unknownPublications = new ArrayList<>();
             for (var publicationName : request.publications()) {
                 var publication = publicationsMetadata.publications().get(publicationName);
@@ -217,7 +217,7 @@ public class PublicationsStateAction extends ActionType<PublicationsStateAction.
             if (in.getVersion().before(Version.V_6_0_0)) {
                 Map<RelationName, RelationMetadata> relationsInPublications = in.readMap(RelationName::new, RelationMetadata::new);
                 this.relationsInPublications = relationsInPublications;
-                Metadata.Builder mdBuilder = Metadata.builder();
+                Metadata.Builder mdBuilder = Metadata.builder(Metadata.OID_UNASSIGNED);
                 for (Map.Entry<RelationName, RelationMetadata> entry : relationsInPublications.entrySet()) {
                     RelationMetadata relationMetadata = entry.getValue();
                     for (IndexMetadata indexMetadata : relationMetadata.indices()) {

--- a/server/src/main/java/io/crate/replication/logical/repository/LogicalReplicationRepository.java
+++ b/server/src/main/java/io/crate/replication/logical/repository/LogicalReplicationRepository.java
@@ -199,7 +199,8 @@ public class LogicalReplicationRepository extends AbstractLifecycleComponent imp
                         table.partitionedBy(),
                         table.state(),
                         table.indexUUIDs(),
-                        table.tableVersion()
+                        table.tableVersion(),
+                        table.oid()
                     );
                 }
                 return metadataBuilder.build();

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/state/TransportClusterState.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/state/TransportClusterState.java
@@ -187,7 +187,7 @@ public class TransportClusterState extends TransportMasterNodeReadAction<Cluster
             builder.blocks(currentState.blocks());
         }
 
-        Metadata.Builder mdBuilder = Metadata.builder();
+        Metadata.Builder mdBuilder = Metadata.builder(currentState.metadata().currentMaxTableOid());
         mdBuilder.clusterUUID(currentState.metadata().clusterUUID());
 
         if (request.metadata()) {
@@ -209,7 +209,8 @@ public class TransportClusterState extends TransportMasterNodeReadAction<Cluster
                             table.partitionedBy(),
                             table.state(),
                             table.indexUUIDs(),
-                            table.tableVersion()
+                            table.tableVersion(),
+                            table.oid()
                         );
                         for (String indexUUID : table.indexUUIDs()) {
                             IndexMetadata indexMetadata = currentState.metadata().index(indexUUID);

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
@@ -281,8 +281,8 @@ public class MetadataCreateIndexService {
                 .build();
 
             return indicesService.withTempIndexService(indexMetadata, indexService -> {
-                Metadata.Builder mdBuilder = Metadata.builder(currentState.metadata())
-                    .setBlobTable(relationName, indexUUID, settings, State.OPEN);
+                Metadata.Builder mdBuilder = Metadata.builder(currentState.metadata());
+                mdBuilder.setBlobTable(relationName, indexUUID, settings, State.OPEN);
                 ClusterState updatedState = addIndex(
                     allocationService,
                     indexService,
@@ -465,7 +465,8 @@ public class MetadataCreateIndexService {
                     table.partitionedBy(),
                     table.state(),
                     table.indexUUIDs(),
-                    table.tableVersion() + 1
+                    table.tableVersion() + 1,
+                    table.oid()
                 );
             }
 

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataDeleteIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataDeleteIndexService.java
@@ -124,7 +124,8 @@ public class MetadataDeleteIndexService {
                 table.partitionedBy(),
                 table.state(),
                 newIndexUUIDs,
-                table.tableVersion() + 1
+                table.tableVersion() + 1,
+                table.oid()
             );
         }
 

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/RelationMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/RelationMetadata.java
@@ -48,7 +48,11 @@ public sealed interface RelationMetadata extends Diffable<RelationMetadata> perm
 
     static RelValueSerializer<String> VALUE_SERIALIZER = new RelValueSerializer<>();
 
+    int oid();
+
     short ord();
+
+    Settings settings();
 
     RelationName name();
 
@@ -150,7 +154,8 @@ public sealed interface RelationMetadata extends Diffable<RelationMetadata> perm
 
     RelationMetadata withIndexUUIDs(List<String> indexUUIDs);
 
-    record BlobTable(RelationName name,
+    record BlobTable(int oid,
+                     RelationName name,
                      String indexUUID,
                      Settings settings,
                      IndexMetadata.State state) implements RelationMetadata {
@@ -158,19 +163,38 @@ public sealed interface RelationMetadata extends Diffable<RelationMetadata> perm
         private static final short ORD = 0;
 
         static BlobTable of(StreamInput in) throws IOException {
+            int tableOID;
+            if (in.getVersion().onOrAfter(Version.V_6_3_0)) {
+                tableOID = in.readInt();
+            } else {
+                tableOID = Metadata.OID_UNASSIGNED;
+            }
             RelationName name = new RelationName(in);
             String indexUUID = in.readString();
             Settings settings = Settings.readSettingsFromStream(in);
             IndexMetadata.State state = in.readEnum(IndexMetadata.State.class);
-            return new BlobTable(name, indexUUID, settings, state);
+            return new BlobTable(tableOID, name, indexUUID, settings, state);
         }
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
+            if (out.getVersion().onOrAfter(Version.V_6_3_0)) {
+                out.writeInt(oid);
+            }
             name.writeTo(out);
             out.writeString(indexUUID);
             Settings.writeSettingsToStream(out, settings);
             out.writeEnum(state);
+        }
+
+        @Override
+        public int oid() {
+            return oid;
+        }
+
+        @Override
+        public Settings settings() {
+            return settings;
         }
 
         @Override
@@ -187,15 +211,16 @@ public sealed interface RelationMetadata extends Diffable<RelationMetadata> perm
         public RelationMetadata withIndexUUIDs(List<String> indexUUIDs) {
             assert indexUUIDs.size() == 1 : "Must have exactly one index linked with blob table";
             return new BlobTable(
+                oid,
                 name,
                 indexUUIDs.getFirst(),
                 settings,
-                state
-            );
+                state);
         }
     }
 
-    record Table(RelationName name,
+    record Table(int oid,
+                 RelationName name,
                  List<Reference> columns,
                  Settings settings,
                  @Nullable ColumnIdent routingColumn,
@@ -220,11 +245,27 @@ public sealed interface RelationMetadata extends Diffable<RelationMetadata> perm
         private static final short ORD = 1;
 
         @Override
+        public int oid() {
+            return oid;
+        }
+
+        @Override
+        public Settings settings() {
+            return settings;
+        }
+
+        @Override
         public short ord() {
             return ORD;
         }
 
         public static Table of(StreamInput in) throws IOException {
+            int tableOID;
+            if (in.getVersion().onOrAfter(Version.V_6_3_0)) {
+                tableOID = in.readInt();
+            } else {
+                tableOID = Metadata.OID_UNASSIGNED;
+            }
             RelationName name = new RelationName(in);
             List<Reference> columns = in.readList(Reference::fromStream);
             Settings settings = Settings.readSettingsFromStream(in);
@@ -239,6 +280,7 @@ public sealed interface RelationMetadata extends Diffable<RelationMetadata> perm
             List<String> indexUUIDs = in.readStringList();
             long tableVersion = in.readLong();
             return new Table(
+                tableOID,
                 name,
                 columns,
                 settings,
@@ -250,12 +292,14 @@ public sealed interface RelationMetadata extends Diffable<RelationMetadata> perm
                 partitionedBy,
                 state,
                 indexUUIDs,
-                tableVersion
-            );
+                tableVersion);
         }
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
+            if (out.getVersion().onOrAfter(Version.V_6_3_0)) {
+                out.writeInt(oid);
+            }
             name.writeTo(out);
             out.writeCollection(columns, Reference::toStream);
             Settings.writeSettingsToStream(out, settings);
@@ -273,6 +317,7 @@ public sealed interface RelationMetadata extends Diffable<RelationMetadata> perm
         @Override
         public RelationMetadata withIndexUUIDs(List<String> indexUUIDs) {
             return new Table(
+                oid,
                 name,
                 columns,
                 settings,
@@ -284,8 +329,7 @@ public sealed interface RelationMetadata extends Diffable<RelationMetadata> perm
                 partitionedBy,
                 state,
                 indexUUIDs,
-                tableVersion
-            );
+                tableVersion);
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/gateway/ClusterStateUpdaters.java
+++ b/server/src/main/java/org/elasticsearch/gateway/ClusterStateUpdaters.java
@@ -127,7 +127,7 @@ public final class ClusterStateUpdaters {
             for (IndexMetadata indexMetadata: state.metadata()) {
                 blocks.removeIndexBlocks(indexMetadata.getIndex().getUUID());
             }
-            final Metadata metadata = Metadata.builder()
+            final Metadata metadata = Metadata.builder(state.metadata().currentMaxTableOid())
                     .clusterUUID(state.metadata().clusterUUID())
                     .coordinationMetadata(state.metadata().coordinationMetadata())
                     .build();

--- a/server/src/main/java/org/elasticsearch/gateway/MetaStateService.java
+++ b/server/src/main/java/org/elasticsearch/gateway/MetaStateService.java
@@ -81,7 +81,7 @@ public class MetaStateService {
 
         final Metadata.Builder metadataBuilder;
         if (manifest.isGlobalGenerationMissing()) {
-            metadataBuilder = Metadata.builder();
+            metadataBuilder = Metadata.builder(Metadata.OID_UNASSIGNED);
         } else {
             final Metadata globalMetadata = METADATA_FORMAT.loadGeneration(
                 LOGGER,
@@ -135,7 +135,7 @@ public class MetaStateService {
             // TODO https://github.com/elastic/elasticsearch/issues/38556
             // assert Version.CURRENT.major < 8 : "failed to find manifest file, which is mandatory staring with Elasticsearch version 8.0";
         } else {
-            metadataBuilder = Metadata.builder();
+            metadataBuilder = Metadata.builder(Metadata.OID_UNASSIGNED);
         }
 
         for (String indexFolderName : nodeEnv.availableIndexFolders()) {

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -73,6 +73,7 @@ import org.elasticsearch.action.admin.indices.forcemerge.ForceMergeRequest;
 import org.elasticsearch.action.support.replication.PendingReplicationActions;
 import org.elasticsearch.action.support.replication.ReplicationResponse;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
 import org.elasticsearch.cluster.routing.RecoverySource;
 import org.elasticsearch.cluster.routing.RecoverySource.SnapshotRecoverySource;
@@ -1748,7 +1749,7 @@ public class IndexShard extends AbstractIndexShardComponent {
             // we are the first primary, recover from the gateway
             // if its post api allocation, the index should exists
             assert shardRouting.primary() : "recover from local shards only makes sense if the shard is a primary shard";
-            StoreRecovery storeRecovery = new StoreRecovery(shardId, logger, tableFactory::create);
+            StoreRecovery storeRecovery = new StoreRecovery(shardId, logger, indexMetadata -> tableFactory.create(indexMetadata, Metadata.OID_UNASSIGNED));
             storeRecovery.recoverFromLocalShards(this, snapshots, recoveryListener);
             success = true;
         } finally {
@@ -1763,7 +1764,7 @@ public class IndexShard extends AbstractIndexShardComponent {
         // if its post api allocation, the index should exists
         assert shardRouting.primary() : "recover from store only makes sense if the shard is a primary shard";
         assert shardRouting.initializing() : "can only start recovery on initializing shard";
-        StoreRecovery storeRecovery = new StoreRecovery(shardId, logger, tableFactory::create);
+        StoreRecovery storeRecovery = new StoreRecovery(shardId, logger, indexMetadata -> tableFactory.create(indexMetadata, Metadata.OID_UNASSIGNED));
         storeRecovery.recoverFromStore(this, listener);
     }
 
@@ -1772,7 +1773,7 @@ public class IndexShard extends AbstractIndexShardComponent {
             assert shardRouting.primary() : "recover from store only makes sense if the shard is a primary shard";
             assert recoveryState.getRecoverySource().getType() == RecoverySource.Type.SNAPSHOT : "invalid recovery type: " +
                 recoveryState.getRecoverySource();
-            StoreRecovery storeRecovery = new StoreRecovery(shardId, logger, tableFactory::create);
+            StoreRecovery storeRecovery = new StoreRecovery(shardId, logger, indexMetadata -> tableFactory.create(indexMetadata, Metadata.OID_UNASSIGNED));
             storeRecovery.recoverFromRepository(this, repository, listener);
         } catch (Exception e) {
             listener.onFailure(e);

--- a/server/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -64,6 +64,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.bulk.BackoffPolicy;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.routing.RoutingNode;
 import org.elasticsearch.cluster.routing.ShardRouting;
@@ -501,7 +502,7 @@ public class IndicesService extends AbstractLifecycleComponent
             );
             closeables.add(() -> service.close("metadata verification", false));
             if (metadata.equals(metadataUpdate) == false) {
-                tableFactory.create(metadataUpdate);
+                tableFactory.create(metadataUpdate, Metadata.OID_UNASSIGNED);
                 service.updateMetadata(metadata, metadataUpdate);
             }
         } finally {

--- a/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -614,7 +614,8 @@ public class RestoreService implements ClusterStateApplier {
                     table.partitionedBy(),
                     table.state(),
                     Lists.concatUnique(existingTable.indexUUIDs(), indexUUIDs),
-                    table.tableVersion()
+                    table.tableVersion(),
+                    mdBuilder.tableOidSupplier().nextOid()
                 );
             } else if (existingRelation == null) {
                 if (snapshotRelation instanceof RelationMetadata.Table table) {
@@ -638,7 +639,8 @@ public class RestoreService implements ClusterStateApplier {
                         table.partitionedBy(),
                         table.state(),
                         indexUUIDs,
-                        table.tableVersion()
+                        table.tableVersion(),
+                        mdBuilder.tableOidSupplier().nextOid()
                     );
                 }
             } else {

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -448,7 +448,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
         final Metadata.Builder builder;
         if (snapshot.includeGlobalState() == false) {
             // Remove global state from the cluster state
-            builder = Metadata.builder();
+            builder = Metadata.builder(metadata.currentMaxTableOid());
             List<String> allIndexUUIDs = new ArrayList<>();
             for (IndexId index : snapshot.indices()) {
                 IndexMetadata indexMetadata = metadata.getIndexByName(index.getName());

--- a/server/src/test/java/io/crate/analyze/AlterTableRenameTableAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/AlterTableRenameTableAnalyzerTest.java
@@ -93,7 +93,7 @@ public class AlterTableRenameTableAnalyzerTest extends CrateDummyClusterServiceU
     private ClusterService clusterServiceWithPublicationMetadata(boolean allTablesPublished, RelationName... tables) {
         var publications = Map.of("pub1", new Publication("user1", allTablesPublished, Arrays.asList(tables)));
         var publicationsMetadata = new PublicationsMetadata(publications);
-        var metadata = new Metadata.Builder().putCustom(PublicationsMetadata.TYPE, publicationsMetadata).build();
+        var metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED).putCustom(PublicationsMetadata.TYPE, publicationsMetadata).build();
         return createClusterService(additionalClusterSettings(), metadata, Version.CURRENT);
     }
 }

--- a/server/src/test/java/io/crate/analyze/CreateAlterPartitionedTableAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/CreateAlterPartitionedTableAnalyzerTest.java
@@ -69,7 +69,7 @@ public class CreateAlterPartitionedTableAnalyzerTest extends CrateDummyClusterSe
     public void prepare() throws IOException {
         String analyzerSettings = FulltextAnalyzerResolver.encodeSettings(
             Settings.builder().put("search", "foobar").build()).utf8ToString();
-        Metadata metadata = Metadata.builder()
+        Metadata metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED)
             .persistentSettings(
                 Settings.builder()
                     .put(ANALYZER.buildSettingName("ft_search"), analyzerSettings)

--- a/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
@@ -96,7 +96,7 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
     public void prepare() throws IOException {
         String analyzerSettings = FulltextAnalyzerResolver.encodeSettings(
             Settings.builder().put("search", "foobar").build()).utf8ToString();
-        Metadata metadata = Metadata.builder()
+        Metadata metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED)
             .persistentSettings(
                 Settings.builder().put(ANALYZER.buildSettingName("ft_search"), analyzerSettings).build())
             .build();

--- a/server/src/test/java/io/crate/analyze/CreateDropRepositoryAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/CreateDropRepositoryAnalyzerTest.java
@@ -66,7 +66,7 @@ public class CreateDropRepositoryAnalyzerTest extends CrateDummyClusterServiceUn
                     Settings.builder().put("location", "/tmp/my_repo").build()
                 )));
         ClusterState clusterState = ClusterState.builder(new ClusterName("testing"))
-            .metadata(Metadata.builder()
+            .metadata(new Metadata.Builder(Metadata.OID_UNASSIGNED)
                           .putCustom(RepositoriesMetadata.TYPE, repositoriesMetadata))
             .build();
         ClusterServiceUtils.setState(clusterService, clusterState);

--- a/server/src/test/java/io/crate/analyze/RestoreSnapshotAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/RestoreSnapshotAnalyzerTest.java
@@ -79,7 +79,7 @@ public class RestoreSnapshotAnalyzerTest extends CrateDummyClusterServiceUnitTes
                     Settings.builder().put("location", "/tmp/my_repo").build()
             )));
         ClusterState clusterState = ClusterState.builder(new ClusterName("testing"))
-            .metadata(Metadata.builder()
+            .metadata(new Metadata.Builder(Metadata.OID_UNASSIGNED)
                 .putCustom(RepositoriesMetadata.TYPE, repositoriesMetadata))
             .build();
         ClusterServiceUtils.setState(clusterService, clusterState);

--- a/server/src/test/java/io/crate/cluster/commands/FixCorruptedMetadataCommandTest.java
+++ b/server/src/test/java/io/crate/cluster/commands/FixCorruptedMetadataCommandTest.java
@@ -60,7 +60,7 @@ public class FixCorruptedMetadataCommandTest {
 
         ImmutableOpenMap.Builder<String, IndexTemplateMetadata> mapBuilder = ImmutableOpenMap.builder();
         mapBuilder.put(corruptedName, corrupted);
-        Metadata.Builder fixedMetadata = new Metadata.Builder();
+        Metadata.Builder fixedMetadata = new Metadata.Builder(Metadata.OID_UNASSIGNED);
         fixNameOfTemplateMetadata(mapBuilder.build(), fixedMetadata);
 
         // only the name of the corrupted template is fixed
@@ -95,7 +95,7 @@ public class FixCorruptedMetadataCommandTest {
         ImmutableOpenMap.Builder<String, IndexTemplateMetadata> mapBuilder = ImmutableOpenMap.builder();
         mapBuilder.put(corruptedName, corrupted);
         mapBuilder.put(nameOfExistingTemplate, existingTemplate);
-        Metadata.Builder fixedMetadata = new Metadata.Builder();
+        Metadata.Builder fixedMetadata = new Metadata.Builder(Metadata.OID_UNASSIGNED);
         fixNameOfTemplateMetadata(mapBuilder.build(), fixedMetadata);
 
         // only the name of the corrupted template is fixed
@@ -138,7 +138,7 @@ public class FixCorruptedMetadataCommandTest {
         mapBuilder.put(corruptedName, corrupted);
         mapBuilder.put(dummyName, dummy);
         mapBuilder.put(nameOfExistingTemplate, existingTemplate);
-        Metadata.Builder fixedMetadata = new Metadata.Builder();
+        Metadata.Builder fixedMetadata = new Metadata.Builder(Metadata.OID_UNASSIGNED);
         fixNameOfTemplateMetadata(mapBuilder.build(), fixedMetadata);
 
         // only the name of the corrupted template is fixed
@@ -200,7 +200,7 @@ public class FixCorruptedMetadataCommandTest {
 
         IndexMetadata corruptedMetadata = corruptedBuilder.build();
 
-        Metadata.Builder upgradedMetadata = Metadata.builder();
+        Metadata.Builder upgradedMetadata = new Metadata.Builder(Metadata.OID_UNASSIGNED);
         upgradedMetadata.put(IndexMetadata.builder(corruptedMetadata));
 
         fixInconsistencyBetweenIndexAndTemplates(corruptedMetadata, upgradedMetadata);
@@ -240,7 +240,7 @@ public class FixCorruptedMetadataCommandTest {
 
         IndexMetadata corruptedMetadata = corruptedBuilder.build();
 
-        Metadata.Builder upgradedMetadata = Metadata.builder();
+        Metadata.Builder upgradedMetadata = new Metadata.Builder(Metadata.OID_UNASSIGNED);
         upgradedMetadata.put(IndexMetadata.builder(corruptedMetadata));
 
         // an existing template that will conflict with the template to be created.
@@ -286,7 +286,7 @@ public class FixCorruptedMetadataCommandTest {
 
         IndexMetadata nonPartitioned = nonPartitionedBuilder.build();
 
-        Metadata.Builder fixedMetadata = Metadata.builder();
+        Metadata.Builder fixedMetadata = new Metadata.Builder(Metadata.OID_UNASSIGNED);
         fixedMetadata.put(IndexMetadata.builder(nonPartitioned));
 
         // to be removed

--- a/server/src/test/java/io/crate/execution/ddl/RepositoryServiceTest.java
+++ b/server/src/test/java/io/crate/execution/ddl/RepositoryServiceTest.java
@@ -92,7 +92,7 @@ public class RepositoryServiceTest extends CrateDummyClusterServiceUnitTest {
         // add repo to cluster service so that it exists..
         RepositoriesMetadata repos = new RepositoriesMetadata(Collections.singletonList(new RepositoryMetadata("repo1", "fs", Settings.EMPTY)));
         ClusterState state = ClusterState.builder(new ClusterName("dummy")).metadata(
-                Metadata.builder().putCustom(RepositoriesMetadata.TYPE, repos)).build();
+                new Metadata.Builder(Metadata.OID_UNASSIGNED).putCustom(RepositoriesMetadata.TYPE, repos)).build();
         ClusterServiceUtils.setState(clusterService, state);
 
 

--- a/server/src/test/java/io/crate/execution/ddl/tables/AddColumnTaskTest.java
+++ b/server/src/test/java/io/crate/execution/ddl/tables/AddColumnTaskTest.java
@@ -24,7 +24,7 @@ package io.crate.execution.ddl.tables;
 import static io.crate.testing.Asserts.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.elasticsearch.cluster.metadata.Metadata.COLUMN_OID_UNASSIGNED;
+import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
 
 import java.util.List;
 import java.util.Map;
@@ -73,7 +73,7 @@ public class AddColumnTaskTest extends CrateDummyClusterServiceUnitTest {
             true,
             true,
             3,
-            COLUMN_OID_UNASSIGNED,
+            OID_UNASSIGNED,
             false,
             null
         );
@@ -122,7 +122,7 @@ public class AddColumnTaskTest extends CrateDummyClusterServiceUnitTest {
             IndexType.PLAIN,
             true,
             2,
-            COLUMN_OID_UNASSIGNED,
+            OID_UNASSIGNED,
             false,
             null,
             null,
@@ -139,7 +139,7 @@ public class AddColumnTaskTest extends CrateDummyClusterServiceUnitTest {
             IndexType.PLAIN,
             true,
             3,
-            COLUMN_OID_UNASSIGNED,
+            OID_UNASSIGNED,
             false,
             null,
             null,
@@ -289,7 +289,7 @@ public class AddColumnTaskTest extends CrateDummyClusterServiceUnitTest {
         DocTableInfo newTable = new DocTableInfoFactory(e.nodeCtx).create(tbl.ident(), newState.metadata());
 
         Reference addedColumn = newTable.getReference(colToAdd.column());
-        assertThat(addedColumn).hasOid(COLUMN_OID_UNASSIGNED);
+        assertThat(addedColumn).hasOid(OID_UNASSIGNED);
     }
 
     @Test

--- a/server/src/test/java/io/crate/execution/dml/IndexerTest.java
+++ b/server/src/test/java/io/crate/execution/dml/IndexerTest.java
@@ -32,7 +32,7 @@ import static io.crate.types.GeoShapeType.Names.TREE_LEGACY_QUADTREE;
 import static io.crate.types.GeoShapeType.Names.TREE_QUADTREE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.elasticsearch.cluster.metadata.Metadata.COLUMN_OID_UNASSIGNED;
+import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -1394,7 +1394,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
     public void test_ignored_object_child_columns_are_not_prefixed_on_tables_created_less_5_5() throws Exception {
         SQLExecutor e = SQLExecutor.of(clusterService)
             // old tables created with CrateDB < 5.5.0 do not assign any OID, fake it here
-            .setColumnOidSupplier(() -> COLUMN_OID_UNASSIGNED)
+            .setColumnOidSupplier(() -> OID_UNASSIGNED)
             .addTable("create table tbl (o object (ignored) as (i int))",
                 Settings.builder().put(IndexMetadata.SETTING_INDEX_VERSION_CREATED.getKey(), Version.V_5_4_0).build()
             );

--- a/server/src/test/java/io/crate/execution/dsl/projection/SourceIndexWriterProjectionSerializationTest.java
+++ b/server/src/test/java/io/crate/execution/dsl/projection/SourceIndexWriterProjectionSerializationTest.java
@@ -23,7 +23,7 @@
 package io.crate.execution.dsl.projection;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.elasticsearch.cluster.metadata.Metadata.COLUMN_OID_UNASSIGNED;
+import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
 
 import java.io.IOException;
 import java.util.List;
@@ -61,7 +61,7 @@ public class SourceIndexWriterProjectionSerializationTest {
             false,
             true,
             0,
-            COLUMN_OID_UNASSIGNED,
+            OID_UNASSIGNED,
             false,
             Literal.of(dataType, List.of(Map.of("f", 10))
             )

--- a/server/src/test/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIteratorTest.java
@@ -27,7 +27,7 @@ import static io.crate.operation.aggregation.AggregationTestCase.createCollectTa
 import static io.crate.operation.aggregation.AggregationTestCase.newStartedPrimaryShard;
 import static io.crate.testing.TestingHelpers.createNodeContext;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.elasticsearch.cluster.metadata.Metadata.COLUMN_OID_UNASSIGNED;
+import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
 import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
@@ -134,7 +134,7 @@ public class DocValuesGroupByOptimizedIteratorTest extends CrateDummyClusterServ
                 true,
                 true,
                 0,
-                COLUMN_OID_UNASSIGNED,
+                OID_UNASSIGNED,
                 false,
                 null)
             ),
@@ -155,7 +155,7 @@ public class DocValuesGroupByOptimizedIteratorTest extends CrateDummyClusterServ
                 true,
                 true,
                 0,
-                COLUMN_OID_UNASSIGNED,
+                OID_UNASSIGNED,
                 false,
                 null
             ),
@@ -195,7 +195,7 @@ public class DocValuesGroupByOptimizedIteratorTest extends CrateDummyClusterServ
                 true,
                 true,
                 0,
-                COLUMN_OID_UNASSIGNED,
+                OID_UNASSIGNED,
                 false,
                 null)
             ),

--- a/server/src/test/java/io/crate/execution/engine/collect/collectors/OptimizeQueryForSearchAfterTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/collectors/OptimizeQueryForSearchAfterTest.java
@@ -23,7 +23,7 @@
 package io.crate.execution.engine.collect.collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.elasticsearch.cluster.metadata.Metadata.COLUMN_OID_UNASSIGNED;
+import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
 
 import java.util.List;
 
@@ -73,7 +73,7 @@ public class OptimizeQueryForSearchAfterTest {
     public void test_short_range_query_with_and_without_docvalues() {
         OrderBy orderBy = new OrderBy(List.of(
             new SimpleReference(relationName, ColumnIdent.of("x"), RowGranularity.DOC, DataTypes.SHORT,
-                    IndexType.PLAIN, true, true, 1, COLUMN_OID_UNASSIGNED, false, null)
+                    IndexType.PLAIN, true, true, 1, OID_UNASSIGNED, false, null)
         ));
         var optimize = new OptimizeQueryForSearchAfter(orderBy);
         FieldDoc lastCollected = new FieldDoc(1, 1.0f, new Object[] { (short) 10 });
@@ -87,7 +87,7 @@ public class OptimizeQueryForSearchAfterTest {
 
         orderBy = new OrderBy(List.of(
                 new SimpleReference(relationName, ColumnIdent.of("x"), RowGranularity.DOC, DataTypes.SHORT,
-                                    IndexType.PLAIN, true, false, 1, COLUMN_OID_UNASSIGNED, false, null)
+                                    IndexType.PLAIN, true, false, 1, OID_UNASSIGNED, false, null)
         ));
         optimize = new OptimizeQueryForSearchAfter(orderBy);
         lastCollected = new FieldDoc(1, 1.0f, new Object[] { (short) 10 });
@@ -115,7 +115,7 @@ public class OptimizeQueryForSearchAfterTest {
                             true,
                             false,
                             1,
-                            COLUMN_OID_UNASSIGNED,
+                            OID_UNASSIGNED,
                             false,
                             null)),
                     new boolean[]{reverseFlag},

--- a/server/src/test/java/io/crate/execution/engine/fetch/FetchTaskTest.java
+++ b/server/src/test/java/io/crate/execution/engine/fetch/FetchTaskTest.java
@@ -95,7 +95,7 @@ public class FetchTaskTest extends CrateDummyClusterServiceUnitTest {
         Map<RelationName, Collection<String>> tableIndices = new HashMap<>();
         tableIndices.put(new RelationName(DocSchemaInfo.NAME, "i1"), List.of("i1"));
 
-        Metadata metadata = Metadata.builder()
+        Metadata metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED)
             .put(IndexMetadata.builder("i1")
                      .settings(Settings.builder()
                                    .put(SETTING_NUMBER_OF_SHARDS, 1)

--- a/server/src/test/java/io/crate/expression/reference/sys/check/node/SysNodeChecksTest.java
+++ b/server/src/test/java/io/crate/expression/reference/sys/check/node/SysNodeChecksTest.java
@@ -382,7 +382,7 @@ public class SysNodeChecksTest extends CrateDummyClusterServiceUnitTest {
         var routingTable = RoutingTable.builder().add(indexRoutingTableBuilder).build();
         var meta = IndexMetadata.builder(index.getUUID()).settings(settings(Version.CURRENT)).numberOfShards(numberOfShards).numberOfReplicas(0);
         var clusterState = ClusterState.builder(new ClusterName("crate")).version(1L)
-            .metadata(Metadata.builder().put(meta)).routingTable(routingTable).nodes(discoveryNodes).build();
+            .metadata(new Metadata.Builder(Metadata.OID_UNASSIGNED).put(meta)).routingTable(routingTable).nodes(discoveryNodes).build();
 
         // Validate that with `cluster.max_shards_per_node = 100` and 85 shards the check passes
         var setting = Settings.builder().put(ShardLimitValidator.SETTING_CLUSTER_MAX_SHARDS_PER_NODE.getKey(), 100).build();

--- a/server/src/test/java/io/crate/metadata/ReferenceTest.java
+++ b/server/src/test/java/io/crate/metadata/ReferenceTest.java
@@ -23,7 +23,7 @@ package io.crate.metadata;
 
 import static io.crate.testing.Asserts.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.elasticsearch.cluster.metadata.Metadata.COLUMN_OID_UNASSIGNED;
+import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
 
 import java.io.IOException;
 import java.util.List;
@@ -124,7 +124,7 @@ public class ReferenceTest extends CrateDummyClusterServiceUnitTest {
             false,
             true,
             0,
-            COLUMN_OID_UNASSIGNED,
+            OID_UNASSIGNED,
             false,
             Literal.of(dataType, List.of(Map.of("f", 10))
             )
@@ -213,7 +213,7 @@ public class ReferenceTest extends CrateDummyClusterServiceUnitTest {
             false,
             true,
             0,
-            COLUMN_OID_UNASSIGNED,
+            OID_UNASSIGNED,
             false,
             null
         );
@@ -267,7 +267,7 @@ public class ReferenceTest extends CrateDummyClusterServiceUnitTest {
             false,
             true,
             0,
-            COLUMN_OID_UNASSIGNED,  // important! with an oid the storageIdent is the oid itself
+            OID_UNASSIGNED,  // important! with an oid the storageIdent is the oid itself
             false,
             null
         );

--- a/server/src/test/java/io/crate/metadata/SchemasTest.java
+++ b/server/src/test/java/io/crate/metadata/SchemasTest.java
@@ -93,7 +93,7 @@ public class SchemasTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testSchemasFromUDF() {
-        Metadata metadata = Metadata.builder()
+        Metadata metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED)
             .putCustom(
                 UserDefinedFunctionsMetadata.TYPE,
                 UserDefinedFunctionsMetadata.of(
@@ -106,7 +106,7 @@ public class SchemasTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testSchemasFromViews() {
-        Metadata metadata = Metadata.builder()
+        Metadata metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED)
             .putCustom(
                 ViewsMetadata.TYPE,
                 ViewsMetadataTest.createMetadata()
@@ -117,7 +117,7 @@ public class SchemasTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testCurrentSchemas() throws Exception {
-        Metadata metadata = Metadata.builder()
+        Metadata metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED)
             .put(IndexMetadata.builder(UUIDs.randomBase64UUID())
                 .state(IndexMetadata.State.OPEN)
                 .settings(Settings.builder()

--- a/server/src/test/java/io/crate/metadata/doc/DocSchemaInfoTest.java
+++ b/server/src/test/java/io/crate/metadata/doc/DocSchemaInfoTest.java
@@ -69,7 +69,7 @@ public class DocSchemaInfoTest extends CrateDummyClusterServiceUnitTest {
     public void testNoNPEIfDeletedIndicesNotInPreviousClusterState() throws Exception {
         // sometimes on startup it occurs that a ClusterChangedEvent contains deleted indices
         // which are not in the previousState.
-        Metadata metadata = new Metadata.Builder().build();
+        Metadata metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED).build();
         docSchemaInfo.invalidateFromIndex(new Index("my_index", "asdf"), metadata);
     }
 
@@ -176,6 +176,7 @@ public class DocSchemaInfoTest extends CrateDummyClusterServiceUnitTest {
 
     private DocTableInfo docTableInfo(String name) {
         return new DocTableInfo(
+            Metadata.OID_UNASSIGNED,
             new RelationName(DocSchemaInfo.NAME, name),
             Map.of(),
             Map.of(),

--- a/server/src/test/java/io/crate/metadata/doc/DocTableInfoFactoryTest.java
+++ b/server/src/test/java/io/crate/metadata/doc/DocTableInfoFactoryTest.java
@@ -95,7 +95,7 @@ public class DocTableInfoFactoryTest extends ESTestCase {
                 "    }" +
                 "  }" +
                 "}");
-        Metadata metadata = Metadata.builder()
+        Metadata metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED)
                 .put(indexMetadataBuilder)
                 .build();
 
@@ -157,7 +157,7 @@ public class DocTableInfoFactoryTest extends ESTestCase {
             .numberOfShards(5)
             .putMapping(
                 mapping);
-        Metadata metadata = Metadata.builder()
+        Metadata metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED)
                 .put(indexMetadataBuilder)
                 .put(template)
                 .build();
@@ -204,7 +204,7 @@ public class DocTableInfoFactoryTest extends ESTestCase {
             .putMapping(mapping)
             .putAlias(new AliasMetadata(tbl.indexNameOrAlias()))
             .build();
-        Metadata metadata = Metadata.builder()
+        Metadata metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED)
                 .put(template)
                 .build();
         metadata = metadataUpgradeService.upgradeMetadata(metadata);
@@ -265,7 +265,7 @@ public class DocTableInfoFactoryTest extends ESTestCase {
             .numberOfShards(5)
             .putMapping(mapping);
 
-        Metadata metadata = Metadata.builder()
+        Metadata metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED)
             .put(indexMetadataBuilder)
             .build();
         metadata = metadataUpgradeService.upgradeMetadata(metadata);

--- a/server/src/test/java/io/crate/metadata/doc/DocTableInfoTest.java
+++ b/server/src/test/java/io/crate/metadata/doc/DocTableInfoTest.java
@@ -24,7 +24,7 @@ package io.crate.metadata.doc;
 import static io.crate.testing.Asserts.assertThat;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.elasticsearch.cluster.metadata.Metadata.COLUMN_OID_UNASSIGNED;
+import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -77,7 +77,7 @@ public class DocTableInfoTest extends CrateDummyClusterServiceUnitTest {
 
         ColumnIdent columnIdent = ColumnIdent.of("o", List.of());
         DocTableInfo info = new DocTableInfo(
-            relationName,
+                Metadata.OID_UNASSIGNED, relationName,
             Map.of(
                 columnIdent,
                 new SimpleReference(
@@ -144,7 +144,7 @@ public class DocTableInfoTest extends CrateDummyClusterServiceUnitTest {
             true,
             false,
             1,
-            COLUMN_OID_UNASSIGNED,
+            OID_UNASSIGNED,
             false,
             null
         );
@@ -152,7 +152,7 @@ public class DocTableInfoTest extends CrateDummyClusterServiceUnitTest {
         Map<ColumnIdent, Reference> references = Map.of(column, strictParent);
 
         DocTableInfo info = new DocTableInfo(
-            dummy,
+                Metadata.OID_UNASSIGNED, dummy,
             references,
             Map.of(),
             Set.of(),
@@ -260,7 +260,7 @@ public class DocTableInfoTest extends CrateDummyClusterServiceUnitTest {
             true,
             false,
             1,
-            COLUMN_OID_UNASSIGNED,
+            OID_UNASSIGNED,
             false,
             null
         );
@@ -278,7 +278,7 @@ public class DocTableInfoTest extends CrateDummyClusterServiceUnitTest {
             null
         );
         DocTableInfo docTableInfo = new DocTableInfo(
-            relationName,
+                Metadata.OID_UNASSIGNED, relationName,
             Map.of(
                 withoutOid.column(), withoutOid,
                 withOid.column(), withOid
@@ -337,7 +337,7 @@ public class DocTableInfoTest extends CrateDummyClusterServiceUnitTest {
             null
         );
         DocTableInfo info = new DocTableInfo(
-            relationName,
+                Metadata.OID_UNASSIGNED, relationName,
             Map.of(a, refa, b, refb),
             Map.of(),
             Set.of(refb),
@@ -790,8 +790,8 @@ public class DocTableInfoTest extends CrateDummyClusterServiceUnitTest {
             table.partitionedBy(),
             table.state(),
             table.indexUUIDs(),
-            table.tableVersion() + 1
-        );
+            table.tableVersion() + 1,
+            table.oid());
 
         var newMetadata = metadataBuilder.build();
 

--- a/server/src/test/java/io/crate/metadata/view/ViewInfoFactoryTest.java
+++ b/server/src/test/java/io/crate/metadata/view/ViewInfoFactoryTest.java
@@ -51,7 +51,7 @@ public class ViewInfoFactoryTest {
         ViewsMetadata views = new ViewsMetadata(Map.of(ident.fqn(), viewMetadata));
 
         ClusterState state = ClusterState.builder(ClusterState.EMPTY_STATE)
-            .metadata(Metadata.builder().putCustom(ViewsMetadata.TYPE, views)).build();
+            .metadata(new Metadata.Builder(Metadata.OID_UNASSIGNED).putCustom(ViewsMetadata.TYPE, views)).build();
 
         // `definition` col includes a hint about an error in the view's query
         ViewInfo viewInfo = factory.create(ident, state);

--- a/server/src/test/java/io/crate/replication/logical/LogicalReplicationSettingsTest.java
+++ b/server/src/test/java/io/crate/replication/logical/LogicalReplicationSettingsTest.java
@@ -44,7 +44,7 @@ public class LogicalReplicationSettingsTest extends CrateDummyClusterServiceUnit
         var replicationSettings = new LogicalReplicationSettings(Settings.EMPTY, clusterService);
 
         ClusterState newState = ClusterState.builder(clusterService.state())
-            .metadata(Metadata.builder().transientSettings(
+            .metadata(new Metadata.Builder(Metadata.OID_UNASSIGNED).transientSettings(
                 Settings.builder()
                     .put(REPLICATION_CHANGE_BATCH_SIZE.getKey(), 20)
                     .put(REPLICATION_READ_POLL_DURATION.getKey(), "1s")

--- a/server/src/test/java/io/crate/replication/logical/action/PublicationsStateActionTest.java
+++ b/server/src/test/java/io/crate/replication/logical/action/PublicationsStateActionTest.java
@@ -106,7 +106,7 @@ public class PublicationsStateActionTest extends CrateDummyClusterServiceUnitTes
             .startShards("doc.t1", "doc.t3");
         var publication = new Publication("publisher", true, List.of());
 
-        Metadata.Builder metadataBuilder = Metadata.builder();
+        Metadata.Builder metadataBuilder = Metadata.builder(clusterService.state().metadata().currentMaxTableOid());
         publication.resolveCurrentRelations(
             clusterService.state(),
             roles,
@@ -151,7 +151,7 @@ public class PublicationsStateActionTest extends CrateDummyClusterServiceUnitTes
             .startShards("doc.t1", "doc.t2");
         var publication = new Publication("publisher", true, List.of());
 
-        Metadata.Builder metadataBuilder = Metadata.builder();
+        Metadata.Builder metadataBuilder = Metadata.builder(clusterService.state().metadata().currentMaxTableOid());
         publication.resolveCurrentRelations(
             clusterService.state(),
             roles,
@@ -200,7 +200,7 @@ public class PublicationsStateActionTest extends CrateDummyClusterServiceUnitTes
             )
         );
 
-        Metadata.Builder metadataBuilder = Metadata.builder();
+        Metadata.Builder metadataBuilder = Metadata.builder(clusterService.state().metadata().currentMaxTableOid());
         publication.resolveCurrentRelations(
             clusterService.state(),
             roles,
@@ -238,7 +238,7 @@ public class PublicationsStateActionTest extends CrateDummyClusterServiceUnitTes
             .startShards("doc.t1");      // <- only t1 has active primary shards;
         var publication = new Publication("some_user", true, List.of());
 
-        Metadata.Builder metadataBuilder = Metadata.builder();
+        Metadata.Builder metadataBuilder = Metadata.builder(clusterService.state().metadata().currentMaxTableOid());
         publication.resolveCurrentRelations(
             clusterService.state(),
             roles,
@@ -281,7 +281,7 @@ public class PublicationsStateActionTest extends CrateDummyClusterServiceUnitTes
             List.of(RelationName.fromIndexName("t1"), RelationName.fromIndexName("doc.t2"))
         );
 
-        Metadata.Builder metadataBuilder = Metadata.builder();
+        Metadata.Builder metadataBuilder = Metadata.builder(clusterService.state().metadata().currentMaxTableOid());
         publication.resolveCurrentRelations(
             clusterService.state(),
             roles,
@@ -323,7 +323,7 @@ public class PublicationsStateActionTest extends CrateDummyClusterServiceUnitTes
             );
         var publication = new Publication("some_user", true, List.of());
 
-        Metadata.Builder metadataBuilder = Metadata.builder();
+        Metadata.Builder metadataBuilder = Metadata.builder(clusterService.state().metadata().currentMaxTableOid());
         publication.resolveCurrentRelations(
             clusterService.state(),
             roles,
@@ -365,7 +365,7 @@ public class PublicationsStateActionTest extends CrateDummyClusterServiceUnitTes
             List.of(RelationName.fromIndexName("p1"))
         );
 
-        Metadata.Builder metadataBuilder = Metadata.builder();
+        Metadata.Builder metadataBuilder = Metadata.builder(clusterService.state().metadata().currentMaxTableOid());
         publication.resolveCurrentRelations(
             clusterService.state(),
             roles,
@@ -409,7 +409,7 @@ public class PublicationsStateActionTest extends CrateDummyClusterServiceUnitTes
             .startShards("doc.t1", "doc.t2");
         var publication = new Publication("publisher", true, List.of());
 
-        Metadata.Builder metadataBuilder = Metadata.builder();
+        Metadata.Builder metadataBuilder = Metadata.builder(clusterService.state().metadata().currentMaxTableOid());
         publication.resolveCurrentRelations(
             clusterService.state(),
             roles,

--- a/server/src/test/java/io/crate/replication/logical/action/TransportAlterPublicationTest.java
+++ b/server/src/test/java/io/crate/replication/logical/action/TransportAlterPublicationTest.java
@@ -61,7 +61,7 @@ public class TransportAlterPublicationTest extends CrateDummyClusterServiceUnitT
     @Test
     public void test_unknown_table_raises_exception() {
         var pub = new Publication("owner", false, List.of());
-        var metadata = Metadata.builder().build();
+        var metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED).build();
         var request = new TransportAlterPublication.Request(
             "pub1",
             AlterPublication.Operation.SET,
@@ -75,7 +75,7 @@ public class TransportAlterPublicationTest extends CrateDummyClusterServiceUnitT
     @Test
     public void test_set_tables_on_existing_publication() {
         var oldPublication = new Publication("owner", false, List.of(RelationName.fromIndexName("t1")));
-        var metadata = Metadata.builder()
+        var metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED)
             .put(IndexMetadata.builder("t2")
                 .settings(settings(Version.CURRENT))
                 .numberOfShards(1)
@@ -99,7 +99,7 @@ public class TransportAlterPublicationTest extends CrateDummyClusterServiceUnitT
     @Test
     public void test_add_table_on_existing_publication() {
         var oldPublication = new Publication("owner", false, List.of(RelationName.fromIndexName("t1")));
-        var metadata = Metadata.builder()
+        var metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED)
             .put(IndexMetadata.builder("t2")
                 .settings(settings(Version.CURRENT))
                 .numberOfShards(1)
@@ -128,7 +128,7 @@ public class TransportAlterPublicationTest extends CrateDummyClusterServiceUnitT
             false,
             List.of(RelationName.fromIndexName("t1"), RelationName.fromIndexName("t2"))
         );
-        var metadata = Metadata.builder()
+        var metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED)
             .put(IndexMetadata.builder("t2")
                 .settings(settings(Version.CURRENT))
                 .numberOfShards(1)

--- a/server/src/test/java/io/crate/replication/logical/action/TransportCreateSubscriptionTest.java
+++ b/server/src/test/java/io/crate/replication/logical/action/TransportCreateSubscriptionTest.java
@@ -135,7 +135,8 @@ public class TransportCreateSubscriptionTest {
             indexSettings.put(IndexMetadata.SETTING_VERSION_CREATED, internalVersionId);
         }
 
-        Metadata publisherMetadata = Metadata.builder()
+        var mdBuilder = Metadata.builder(clusterState.metadata().currentMaxTableOid());
+        Metadata publisherMetadata = mdBuilder
             .setTable(
                 relationName,
                 List.of(),
@@ -148,8 +149,8 @@ public class TransportCreateSubscriptionTest {
                 List.of(),
                 IndexMetadata.State.OPEN,
                 List.of(indexUUID),
-                0L
-                )
+                0L,
+                mdBuilder.tableOidSupplier().nextOid())
             .put(IndexMetadata.builder(indexUUID).indexName(relationName.indexNameOrAlias()).settings(indexSettings))
             .build();
 

--- a/server/src/test/java/io/crate/replication/logical/repository/LogicalReplicationRepositoryTest.java
+++ b/server/src/test/java/io/crate/replication/logical/repository/LogicalReplicationRepositoryTest.java
@@ -57,7 +57,7 @@ public class LogicalReplicationRepositoryTest {
     public void test_getRemoteClusterState_upgrades_indexMetadata() throws Exception {
         // This test basically checks RelationMetadata was created based on IndexMetadata, where RelationMetadata
         // was introduced to 6.0, which implicitly verifies the upgrade.
-        Metadata metadata = Metadata.builder()
+        Metadata metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED)
             .put(IndexMetadata.builder("test")
                 .settings(settings(Version.V_5_10_0))
                 .numberOfShards(1)

--- a/server/src/test/java/io/crate/role/PrivilegesModifierTest.java
+++ b/server/src/test/java/io/crate/role/PrivilegesModifierTest.java
@@ -222,7 +222,7 @@ public class PrivilegesModifierTest {
 
     @Test
     public void testDropTablePrivileges() {
-        var mdBuilder = Metadata.builder();
+        var mdBuilder = new Metadata.Builder(Metadata.OID_UNASSIGNED);
         long affectedPrivileges = PrivilegesModifier.dropTableOrViewPrivileges(mdBuilder, rolesMetadata, GRANT_TABLE_DQL.subject().ident());
         assertThat(affectedPrivileges).isEqualTo(1L);
 
@@ -246,7 +246,7 @@ public class PrivilegesModifierTest {
 
     @Test
     public void testDropViewPrivileges() {
-        var mdBuilder = Metadata.builder();
+        var mdBuilder = new Metadata.Builder(Metadata.OID_UNASSIGNED);
         long affectedPrivileges = PrivilegesModifier.dropTableOrViewPrivileges(mdBuilder, rolesMetadata, GRANT_VIEW_DQL.subject().ident());
         assertThat(affectedPrivileges).isEqualTo(1L);
 

--- a/server/src/test/java/io/crate/role/RoleManagerDDLModifierTest.java
+++ b/server/src/test/java/io/crate/role/RoleManagerDDLModifierTest.java
@@ -46,7 +46,7 @@ public class RoleManagerDDLModifierTest extends ESTestCase {
     public void test_transferTablePrivileges_from_old_users_and_privileges_metadata() {
         // given
         Privilege oldGrantDQL = new Privilege(Policy.GRANT, Permission.DQL, Securable.SCHEMA, "mySchema", "crate");
-        Metadata.Builder mdBuilder = Metadata.builder();
+        Metadata.Builder mdBuilder = new Metadata.Builder(Metadata.OID_UNASSIGNED);
         Map<String, Role> rolesMap = new HashMap<>();
         rolesMap.put("Ford", userOf("Ford", Set.of(oldGrantDQL), null));
 

--- a/server/src/test/java/io/crate/role/TransportPrivilegesTest.java
+++ b/server/src/test/java/io/crate/role/TransportPrivilegesTest.java
@@ -54,7 +54,7 @@ public class TransportPrivilegesTest extends ESTestCase {
     @Test
     public void testApplyPrivilegesCreatesNewPrivilegesInstance() {
         // given
-        Metadata.Builder mdBuilder = Metadata.builder();
+        Metadata.Builder mdBuilder = new Metadata.Builder(Metadata.OID_UNASSIGNED);
         Map<String, Role> rolesMap = new HashMap<>();
         rolesMap.put("Ford", userOf("Ford", new HashSet<>(PRIVILEGES), null));
 
@@ -96,7 +96,7 @@ public class TransportPrivilegesTest extends ESTestCase {
 
     @Test
     public void test_validate_response_when_roles_do_not_exist() {
-        Metadata.Builder mdBuilder = Metadata.builder();
+        Metadata.Builder mdBuilder = new Metadata.Builder(Metadata.OID_UNASSIGNED);
         var rolesMetadata = new RolesMetadata(DUMMY_USERS_AND_ROLES);
         mdBuilder.putCustom(RolesMetadata.TYPE, rolesMetadata);
 
@@ -117,7 +117,7 @@ public class TransportPrivilegesTest extends ESTestCase {
 
     @Test
     public void test_grant_revoke_user_to_another_user_is_not_allowed() {
-        var mdBuilder = Metadata.builder();
+        var mdBuilder = new Metadata.Builder(Metadata.OID_UNASSIGNED);
         var rolesMetadata = new RolesMetadata(DUMMY_USERS_AND_ROLES);
         mdBuilder.putCustom(RolesMetadata.TYPE, rolesMetadata);
 

--- a/server/src/test/java/io/crate/role/TransportRoleTest.java
+++ b/server/src/test/java/io/crate/role/TransportRoleTest.java
@@ -61,7 +61,7 @@ public class TransportRoleTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testCreateFirstUser() throws Exception {
-        Metadata.Builder mdBuilder = new Metadata.Builder();
+        Metadata.Builder mdBuilder = new Metadata.Builder(Metadata.OID_UNASSIGNED);
         TransportCreateRole.putRole(mdBuilder,
             "root",
             true,
@@ -81,7 +81,7 @@ public class TransportRoleTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void test_create_user_with_matching_jwt_props_exists() throws Exception {
         // Users have different "aud" property values - still clashing as only iss/username matters.
-        Metadata.Builder mdBuilder = new Metadata.Builder();
+        Metadata.Builder mdBuilder = new Metadata.Builder(Metadata.OID_UNASSIGNED);
         TransportCreateRole.putRole(mdBuilder,
             "user1",
             true,
@@ -101,7 +101,7 @@ public class TransportRoleTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void test_create_user_with_existing_name_but_different_jwt_props() throws Exception {
-        Metadata.Builder mdBuilder = new Metadata.Builder();
+        Metadata.Builder mdBuilder = new Metadata.Builder(Metadata.OID_UNASSIGNED);
         TransportCreateRole.putRole(mdBuilder,
             "user1",
             true,
@@ -120,14 +120,14 @@ public class TransportRoleTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testCreateUserAlreadyExists() throws Exception {
-        Metadata.Builder mdBuilder = new Metadata.Builder()
+        Metadata.Builder mdBuilder = new Metadata.Builder(Metadata.OID_UNASSIGNED)
             .putCustom(RolesMetadata.TYPE, new RolesMetadata(SINGLE_USER_ONLY));
         assertThat(TransportCreateRole.putRole(mdBuilder, "Arthur", true, null, null, Map.of())).isTrue();
     }
 
     @Test
     public void testCreateUser() throws Exception {
-        Metadata.Builder mdBuilder = new Metadata.Builder()
+        Metadata.Builder mdBuilder = new Metadata.Builder(Metadata.OID_UNASSIGNED)
             .putCustom(RolesMetadata.TYPE, new RolesMetadata(SINGLE_USER_ONLY));
         TransportCreateRole.putRole(mdBuilder, "Trillian", true, null, null, Map.of());
         RolesMetadata newMetadata = (RolesMetadata) mdBuilder.getCustom(RolesMetadata.TYPE);
@@ -138,7 +138,7 @@ public class TransportRoleTest extends CrateDummyClusterServiceUnitTest {
     public void test_create_user_with_old_users_metadata() throws Exception {
         var oldUsersMetadata = usersMetadataOf(DUMMY_USERS);
         var oldRolesMetadata = new RolesMetadata(DUMMY_USERS_AND_ROLES);
-        Metadata.Builder mdBuilder = Metadata.builder()
+        Metadata.Builder mdBuilder = new Metadata.Builder(Metadata.OID_UNASSIGNED)
             .putCustom(UsersMetadata.TYPE, oldUsersMetadata)
             .putCustom(RolesMetadata.TYPE, oldRolesMetadata);
         boolean res = TransportCreateRole.putRole(mdBuilder, "RoleFoo", false, null, null, Map.of());
@@ -154,7 +154,7 @@ public class TransportRoleTest extends CrateDummyClusterServiceUnitTest {
         var oldUsersMetadata = usersMetadataOf(DUMMY_USERS_WITHOUT_PASSWORD);
         var oldUsersPrivilegesMetadata = new UsersPrivilegesMetadata(OLD_DUMMY_USERS_PRIVILEGES);
         var oldRolesMetadata = new RolesMetadata(DUMMY_USERS_AND_ROLES_WITHOUT_PASSWORD);
-        Metadata.Builder mdBuilder = Metadata.builder()
+        Metadata.Builder mdBuilder = new Metadata.Builder(Metadata.OID_UNASSIGNED)
             .putCustom(UsersMetadata.TYPE, oldUsersMetadata)
             .putCustom(UsersPrivilegesMetadata.TYPE, oldUsersPrivilegesMetadata)
             .putCustom(RolesMetadata.TYPE, oldRolesMetadata);
@@ -181,13 +181,13 @@ public class TransportRoleTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testDropUserNoUsersAtAll() throws Exception {
-        assertThat(DropRoleTask.dropRole(Metadata.builder(), "root")).isFalse();
+        assertThat(DropRoleTask.dropRole(new Metadata.Builder(Metadata.OID_UNASSIGNED), "root")).isFalse();
     }
 
     @Test
     public void testDropNonExistingUser() throws Exception {
         boolean res = DropRoleTask.dropRole(
-                Metadata.builder().putCustom(RolesMetadata.TYPE, new RolesMetadata(SINGLE_USER_ONLY)),
+                new Metadata.Builder(Metadata.OID_UNASSIGNED).putCustom(RolesMetadata.TYPE, new RolesMetadata(SINGLE_USER_ONLY)),
                 "trillian"
         );
         assertThat(res).isFalse();
@@ -196,7 +196,7 @@ public class TransportRoleTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testDropUser() throws Exception {
         RolesMetadata metadata = new RolesMetadata(DUMMY_USERS);
-        Metadata.Builder mdBuilder = Metadata.builder().putCustom(RolesMetadata.TYPE, metadata);
+        Metadata.Builder mdBuilder = new Metadata.Builder(Metadata.OID_UNASSIGNED).putCustom(RolesMetadata.TYPE, metadata);
         boolean res = DropRoleTask.dropRole(mdBuilder, "Arthur");
         assertThat(roles(mdBuilder)).containsExactlyEntriesOf(Map.of("Ford", DUMMY_USERS.get("Ford")));
         assertThat(res).isTrue();
@@ -213,7 +213,7 @@ public class TransportRoleTest extends CrateDummyClusterServiceUnitTest {
             "role3", role3
         );
         RolesMetadata metadata = new RolesMetadata(roles);
-        Metadata.Builder mdBuilder = Metadata.builder().putCustom(RolesMetadata.TYPE, metadata);
+        Metadata.Builder mdBuilder = new Metadata.Builder(Metadata.OID_UNASSIGNED).putCustom(RolesMetadata.TYPE, metadata);
         assertThatThrownBy(() -> DropRoleTask.dropRole(mdBuilder, "role2"))
             .isExactlyInstanceOf(IllegalArgumentException.class)
             .hasMessage("Cannot drop ROLE: role2 as it is granted on role: role3");
@@ -223,7 +223,7 @@ public class TransportRoleTest extends CrateDummyClusterServiceUnitTest {
     public void test_drop_user_with_old_users_metadata() throws Exception {
         var oldUsersMetadata = usersMetadataOf(DUMMY_USERS);
         var oldRolesMetadata = new RolesMetadata(DUMMY_USERS_AND_ROLES);
-        Metadata.Builder mdBuilder = Metadata.builder()
+        Metadata.Builder mdBuilder = new Metadata.Builder(Metadata.OID_UNASSIGNED)
             .putCustom(UsersMetadata.TYPE, oldUsersMetadata)
             .putCustom(RolesMetadata.TYPE, oldRolesMetadata);
         boolean res = DropRoleTask.dropRole(mdBuilder, "Arthur");
@@ -237,7 +237,7 @@ public class TransportRoleTest extends CrateDummyClusterServiceUnitTest {
             "role1", RolesHelper.roleOf("role1")
         );
         RolesMetadata rolesMetadata = new RolesMetadata(roles);
-        Metadata metadata = Metadata.builder()
+        Metadata metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED)
             .putCustom(RolesMetadata.TYPE, rolesMetadata)
             .build();
         ClusterState clusterState = ClusterState.builder(clusterService.state()).metadata(metadata).build();
@@ -261,7 +261,7 @@ public class TransportRoleTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void test_alter_user_cannot_set_password_to_role() throws Exception {
         var oldRolesMetadata = new RolesMetadata(DUMMY_USERS_AND_ROLES_WITHOUT_PASSWORD);
-        Metadata.Builder mdBuilder = Metadata.builder()
+        Metadata.Builder mdBuilder = new Metadata.Builder(Metadata.OID_UNASSIGNED)
             .putCustom(RolesMetadata.TYPE, oldRolesMetadata);
         // Set new password
         assertThatThrownBy(() -> TransportAlterRole.alterRole(
@@ -291,7 +291,7 @@ public class TransportRoleTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void test_alter_user_cannot_set_jwt_to_role() throws Exception {
         var oldRolesMetadata = new RolesMetadata(DUMMY_USERS_AND_ROLES_WITHOUT_PASSWORD);
-        Metadata.Builder mdBuilder = Metadata.builder()
+        Metadata.Builder mdBuilder = new Metadata.Builder(Metadata.OID_UNASSIGNED)
             .putCustom(RolesMetadata.TYPE, oldRolesMetadata);
         // Set new jwt
         assertThatThrownBy(() -> TransportAlterRole.alterRole(
@@ -330,7 +330,7 @@ public class TransportRoleTest extends CrateDummyClusterServiceUnitTest {
             new JwtProperties("https:dummy.org", "test", null))
         );
         var oldRolesMetadata = new RolesMetadata(roleWithJwtAndPassword);
-        Metadata.Builder mdBuilder = Metadata.builder()
+        Metadata.Builder mdBuilder = new Metadata.Builder(Metadata.OID_UNASSIGNED)
             .putCustom(RolesMetadata.TYPE, oldRolesMetadata);
         boolean exists = TransportAlterRole.alterRole(
             mdBuilder,
@@ -366,7 +366,7 @@ public class TransportRoleTest extends CrateDummyClusterServiceUnitTest {
            )
         );
         var oldRolesMetadata = new RolesMetadata(roleWithJwtAndPassword);
-        Metadata.Builder mdBuilder = Metadata.builder()
+        Metadata.Builder mdBuilder = new Metadata.Builder(Metadata.OID_UNASSIGNED)
             .putCustom(RolesMetadata.TYPE, oldRolesMetadata);
         var newPwd = getSecureHash("new-pwd");
 
@@ -425,7 +425,7 @@ public class TransportRoleTest extends CrateDummyClusterServiceUnitTest {
             new JwtProperties("https:dummy.org", "test", null))
         );
         var oldRolesMetadata = new RolesMetadata(roleWithJwtAndPassword);
-        Metadata.Builder mdBuilder = Metadata.builder()
+        Metadata.Builder mdBuilder = new Metadata.Builder(Metadata.OID_UNASSIGNED)
             .putCustom(RolesMetadata.TYPE, oldRolesMetadata);
         boolean exists = TransportAlterRole.alterRole(
             mdBuilder,
@@ -468,7 +468,7 @@ public class TransportRoleTest extends CrateDummyClusterServiceUnitTest {
             new JwtProperties("john's valid iss", "john's valid username", "aud2"))
         );
         var oldRolesMetadata = new RolesMetadata(roleWithJwtAndPassword);
-        Metadata.Builder mdBuilder = Metadata.builder()
+        Metadata.Builder mdBuilder = new Metadata.Builder(Metadata.OID_UNASSIGNED)
             .putCustom(RolesMetadata.TYPE, oldRolesMetadata);
         assertThatThrownBy(() -> TransportAlterRole.alterRole(
             mdBuilder,
@@ -492,7 +492,7 @@ public class TransportRoleTest extends CrateDummyClusterServiceUnitTest {
             Map.of("search_path", "my_schema"))
         );
         var oldRolesMetadata = new RolesMetadata(role);
-        Metadata.Builder mdBuilder = Metadata.builder()
+        Metadata.Builder mdBuilder = new Metadata.Builder(Metadata.OID_UNASSIGNED)
             .putCustom(RolesMetadata.TYPE, oldRolesMetadata);
         boolean exists = TransportAlterRole.alterRole(
             mdBuilder,
@@ -524,7 +524,7 @@ public class TransportRoleTest extends CrateDummyClusterServiceUnitTest {
             Map.of("search_path", "my_schema"))
         );
         var oldRolesMetadata = new RolesMetadata(role);
-        Metadata.Builder mdBuilder = Metadata.builder()
+        Metadata.Builder mdBuilder = new Metadata.Builder(Metadata.OID_UNASSIGNED)
             .putCustom(RolesMetadata.TYPE, oldRolesMetadata);
         boolean exists = TransportAlterRole.alterRole(
             mdBuilder,
@@ -556,7 +556,7 @@ public class TransportRoleTest extends CrateDummyClusterServiceUnitTest {
             Map.of("search_path", "my_schema", "enable_hashjoin", false))
         );
         var oldRolesMetadata = new RolesMetadata(role);
-        Metadata.Builder mdBuilder = Metadata.builder()
+        Metadata.Builder mdBuilder = new Metadata.Builder(Metadata.OID_UNASSIGNED)
             .putCustom(RolesMetadata.TYPE, oldRolesMetadata);
         boolean exists = TransportAlterRole.alterRole(
             mdBuilder,
@@ -588,7 +588,7 @@ public class TransportRoleTest extends CrateDummyClusterServiceUnitTest {
             Map.of("search_path", "my_schema", "enable_hashjoin", false))
         );
         var oldRolesMetadata = new RolesMetadata(role);
-        Metadata.Builder mdBuilder = Metadata.builder()
+        Metadata.Builder mdBuilder = new Metadata.Builder(Metadata.OID_UNASSIGNED)
             .putCustom(RolesMetadata.TYPE, oldRolesMetadata);
         boolean exists = TransportAlterRole.alterRole(
             mdBuilder,
@@ -613,7 +613,7 @@ public class TransportRoleTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void test_cannot_set_session_settings_to_a_role() throws Exception {
         var oldRolesMetadata = new RolesMetadata(DUMMY_USERS_AND_ROLES_WITHOUT_PASSWORD);
-        Metadata.Builder mdBuilder = Metadata.builder()
+        Metadata.Builder mdBuilder = new Metadata.Builder(Metadata.OID_UNASSIGNED)
             .putCustom(RolesMetadata.TYPE, oldRolesMetadata);
         assertThatThrownBy(() -> TransportAlterRole.alterRole(
             mdBuilder,
@@ -630,7 +630,7 @@ public class TransportRoleTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void test_cannot_reset_session_settings_to_a_role() throws Exception {
         var oldRolesMetadata = new RolesMetadata(DUMMY_USERS_AND_ROLES_WITHOUT_PASSWORD);
-        Metadata.Builder mdBuilder = Metadata.builder()
+        Metadata.Builder mdBuilder = new Metadata.Builder(Metadata.OID_UNASSIGNED)
             .putCustom(RolesMetadata.TYPE, oldRolesMetadata);
         // Reset ALL
         assertThatThrownBy(() -> TransportAlterRole.alterRole(

--- a/server/src/test/java/io/crate/role/metadata/RolesMetadataTest.java
+++ b/server/src/test/java/io/crate/role/metadata/RolesMetadataTest.java
@@ -127,7 +127,7 @@ public class RolesMetadataTest extends ESTestCase {
         var oldUsersMetadata = usersMetadataOf(DUMMY_USERS);
         var oldUserPrivilegesMetadata = new UsersPrivilegesMetadata(OLD_DUMMY_USERS_PRIVILEGES);
         var oldRolesMetadata = new RolesMetadata(DUMMY_USERS_AND_ROLES);
-        Metadata.Builder mdBuilder = new Metadata.Builder()
+        Metadata.Builder mdBuilder = new Metadata.Builder(Metadata.OID_UNASSIGNED)
             .putCustom(UsersMetadata.TYPE, oldUsersMetadata)
             .putCustom(RolesMetadata.TYPE, oldRolesMetadata);
         var newRolesMetadata = RolesMetadata.of(mdBuilder, oldUsersMetadata, oldUserPrivilegesMetadata, oldRolesMetadata);

--- a/server/src/test/java/io/crate/statistics/TableStatsTest.java
+++ b/server/src/test/java/io/crate/statistics/TableStatsTest.java
@@ -29,6 +29,7 @@ import java.util.Set;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Test;
@@ -54,7 +55,7 @@ public class TableStatsTest extends ESTestCase {
         1,
         null);
     private final DocTableInfo docTableInfo = new DocTableInfo(
-        testRelation,
+            Metadata.OID_UNASSIGNED, testRelation,
         Map.of(idRef.column(), idRef),
         Map.of(),
         Set.of(),

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/configuration/AddVotingConfigExclusionsRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/configuration/AddVotingConfigExclusionsRequestTests.java
@@ -290,7 +290,7 @@ public class AddVotingConfigExclusionsRequestTests extends ESTestCase {
 
         final VotingConfigExclusion existingVotingConfigExclusion = new VotingConfigExclusion(node1);
 
-        Metadata metadata = Metadata.builder()
+        Metadata metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED)
                                     .coordinationMetadata(CoordinationMetadata.builder()
                                         .addVotingConfigExclusion(existingVotingConfigExclusion).build())
                                     .build();
@@ -330,7 +330,7 @@ public class AddVotingConfigExclusionsRequestTests extends ESTestCase {
 
         final ClusterState.Builder builder = ClusterState.builder(new ClusterName("cluster")).nodes(new Builder()
             .add(localNode).add(otherNode1).add(otherNode2).localNodeId(localNode.getId()));
-        builder.metadata(Metadata.builder()
+        builder.metadata(new Metadata.Builder(Metadata.OID_UNASSIGNED)
                 .coordinationMetadata(CoordinationMetadata.builder().addVotingConfigExclusion(otherNode1Exclusion).build()));
         final ClusterState clusterState = builder.build();
 

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/configuration/TransportAddVotingConfigExclusionsTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/configuration/TransportAddVotingConfigExclusionsTests.java
@@ -133,7 +133,7 @@ public class TransportAddVotingConfigExclusionsTests extends ESTestCase {
         setState(clusterService, builder(new ClusterName("cluster"))
             .nodes(new Builder().add(localNode).add(otherNode1).add(otherNode2).add(otherDataNode)
                 .localNodeId(localNode.getId()).masterNodeId(localNode.getId()))
-            .metadata(Metadata.builder()
+            .metadata(new Metadata.Builder(Metadata.OID_UNASSIGNED)
                 .coordinationMetadata(CoordinationMetadata.builder().lastAcceptedConfiguration(allNodesConfig)
                     .lastCommittedConfiguration(allNodesConfig).build())));
 

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/configuration/TransportClearVotingConfigExclusionsTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/configuration/TransportClearVotingConfigExclusionsTests.java
@@ -105,7 +105,7 @@ public class TransportClearVotingConfigExclusionsTests extends ESTestCase {
         final ClusterState.Builder builder = builder(new ClusterName("cluster"))
             .nodes(new Builder().add(localNode).add(otherNode1).add(otherNode2)
                 .localNodeId(localNode.getId()).masterNodeId(localNode.getId()));
-        builder.metadata(Metadata.builder()
+        builder.metadata(new Metadata.Builder(Metadata.OID_UNASSIGNED)
                 .coordinationMetadata(CoordinationMetadata.builder()
                         .addVotingConfigExclusion(otherNode1Exclusion)
                         .addVotingConfigExclusion(otherNode2Exclusion)

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/state/TransportClusterStateTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/state/TransportClusterStateTests.java
@@ -65,8 +65,10 @@ public class TransportClusterStateTests extends ESTestCase {
         var indexUUID1 = UUIDs.randomBase64UUID();
         var indexUUID2 = UUIDs.randomBase64UUID();
         var relationName2 = new RelationName("doc", "t2");
+        var tableOidSupplier = new Metadata.TableOidSupplier(Metadata.OID_UNASSIGNED);
+        var mdBuilder = Metadata.builder(Metadata.OID_UNASSIGNED);
         clusterState = ClusterState.builder(new ClusterName("test"))
-            .metadata(Metadata.builder()
+            .metadata(mdBuilder
                 .persistentSettings(Settings.builder().put("setting1", "bar").build())
                 .setTable(
                     relationName1,
@@ -83,8 +85,9 @@ public class TransportClusterStateTests extends ESTestCase {
                     List.of(),
                     IndexMetadata.State.OPEN,
                     List.of(indexUUID1),
-                    0
-                )
+                    0,
+                    mdBuilder.tableOidSupplier().nextOid()
+                    )
                 .setTable(
                     relationName2,
                     List.of(),
@@ -100,8 +103,8 @@ public class TransportClusterStateTests extends ESTestCase {
                     List.of(ColumnIdent.of("parted")),
                     IndexMetadata.State.OPEN,
                     List.of(indexUUID2),
-                    0
-                )
+                    0,
+                    mdBuilder.tableOidSupplier().nextOid())
                 .put(IndexMetadata.builder(indexUUID1)
                         .settings(settings(Version.CURRENT)
                             .put(SETTING_INDEX_UUID, indexUUID1))

--- a/server/src/test/java/org/elasticsearch/action/support/replication/ClusterStateCreationUtils.java
+++ b/server/src/test/java/org/elasticsearch/action/support/replication/ClusterStateCreationUtils.java
@@ -153,7 +153,7 @@ public class ClusterStateCreationUtils {
 
         ClusterState.Builder state = ClusterState.builder(new ClusterName("test"));
         state.nodes(discoBuilder);
-        state.metadata(Metadata.builder().put(indexMetadataBuilder.build(), false).generateClusterUuidIfNeeded());
+        state.metadata(new Metadata.Builder(Metadata.OID_UNASSIGNED).put(indexMetadataBuilder.build(), false).generateClusterUuidIfNeeded());
         state.routingTable(RoutingTable.builder().add(IndexRoutingTable.builder(indexMetadata.getIndex())
                                                           .addIndexShard(indexShardRoutingTable)).build());
         return state.build();
@@ -192,7 +192,7 @@ public class ClusterStateCreationUtils {
 
         ClusterState.Builder state = ClusterState.builder(new ClusterName("test"));
         state.nodes(discoBuilder);
-        state.metadata(Metadata.builder().put(indexMetadata, false).generateClusterUuidIfNeeded());
+        state.metadata(new Metadata.Builder(Metadata.OID_UNASSIGNED).put(indexMetadata, false).generateClusterUuidIfNeeded());
         state.routingTable(RoutingTable.builder().add(indexRoutingTable).build());
         return state.build();
     }
@@ -212,7 +212,7 @@ public class ClusterStateCreationUtils {
         }
         discoBuilder.localNodeId(newNode(0).getId());
         discoBuilder.masterNodeId(newNode(0).getId());
-        Metadata.Builder metadata = Metadata.builder();
+        Metadata.Builder metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED);
         RoutingTable.Builder routingTable = RoutingTable.builder();
         List<String> nodesList = new ArrayList<>(nodes);
         int currentNodeToAssign = 0;
@@ -303,7 +303,7 @@ public class ClusterStateCreationUtils {
 
         ClusterState.Builder state = ClusterState.builder(new ClusterName("test"));
         state.nodes(discoBuilder);
-        state.metadata(Metadata.builder().generateClusterUuidIfNeeded());
+        state.metadata(new Metadata.Builder(Metadata.OID_UNASSIGNED).generateClusterUuidIfNeeded());
         return state.build();
     }
 

--- a/server/src/test/java/org/elasticsearch/action/support/replication/TransportReplicationAllPermitsAcquisitionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/replication/TransportReplicationAllPermitsAcquisitionTests.java
@@ -39,7 +39,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutionException;
@@ -157,7 +156,7 @@ public class TransportReplicationAllPermitsAcquisitionTests extends IndexShardTe
             indexDoc(primary, id, "{\"value\":" + id + "}");
         }
 
-        state.metadata(Metadata.builder().put(indexMetadata, false).generateClusterUuidIfNeeded());
+        state.metadata(new Metadata.Builder(Metadata.OID_UNASSIGNED).put(indexMetadata, false).generateClusterUuidIfNeeded());
 
         replica = newShard(primary.shardId(), false, node2.getId(), indexMetadata, null);
         recoverReplica(replica, primary, true);

--- a/server/src/test/java/org/elasticsearch/cluster/ClusterStateTest.java
+++ b/server/src/test/java/org/elasticsearch/cluster/ClusterStateTest.java
@@ -73,7 +73,7 @@ public class ClusterStateTest extends CrateDummyClusterServiceUnitTest {
         indicesRouting.put(indexMetadata.getIndex().getName(), indexRouting);
 
         ClusterState clusterState = ClusterState.builder(new ClusterName("test"))
-            .metadata(Metadata.builder()
+            .metadata(new Metadata.Builder(Metadata.OID_UNASSIGNED)
                 .put(indexMetadata, false)
                 .build())
             .routingTable(routingTableBuilder.build())

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/ClusterFormationFailureHelperTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/ClusterFormationFailureHelperTests.java
@@ -189,7 +189,7 @@ public class ClusterFormationFailureHelperTests extends ESTestCase {
         final DiscoveryNode localNode = new DiscoveryNode("local", buildNewFakeTransportAddress(), Version.CURRENT);
         final ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT)
             .version(7L)
-            .metadata(Metadata.builder().coordinationMetadata(CoordinationMetadata.builder().term(4L).build()))
+            .metadata(new Metadata.Builder(Metadata.OID_UNASSIGNED).coordinationMetadata(CoordinationMetadata.builder().term(4L).build()))
             .nodes(DiscoveryNodes.builder().add(localNode).localNodeId(localNode.getId())).build();
 
 
@@ -240,7 +240,7 @@ public class ClusterFormationFailureHelperTests extends ESTestCase {
     private static ClusterState state(DiscoveryNode localNode, String[] acceptedConfig, String[] committedConfig) {
         return ClusterState.builder(ClusterName.DEFAULT)
             .nodes(DiscoveryNodes.builder().add(localNode).localNodeId(localNode.getId()))
-            .metadata(Metadata.builder().coordinationMetadata(CoordinationMetadata.builder()
+            .metadata(new Metadata.Builder(Metadata.OID_UNASSIGNED).coordinationMetadata(CoordinationMetadata.builder()
                 .lastAcceptedConfiguration(config(acceptedConfig))
                 .lastCommittedConfiguration(config(committedConfig)).build())).build();
     }
@@ -390,7 +390,7 @@ public class ClusterFormationFailureHelperTests extends ESTestCase {
         String[] configNodeIds = new String[]{"n1", "n2"};
         final ClusterState stateWithOtherNodes = ClusterState.builder(ClusterName.DEFAULT)
             .nodes(DiscoveryNodes.builder().add(localNode).localNodeId(localNode.getId()).add(otherMasterNode).add(otherNonMasterNode))
-            .metadata(Metadata.builder().coordinationMetadata(CoordinationMetadata.builder()
+            .metadata(new Metadata.Builder(Metadata.OID_UNASSIGNED).coordinationMetadata(CoordinationMetadata.builder()
                 .lastAcceptedConfiguration(config(configNodeIds))
                 .lastCommittedConfiguration(config(configNodeIds)).build())).build();
 

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinationStateTestCluster.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinationStateTestCluster.java
@@ -58,7 +58,7 @@ public class CoordinationStateTestCluster {
         return setValue(ClusterState.builder(ClusterName.DEFAULT)
                             .version(version)
                             .nodes(discoveryNodes)
-                            .metadata(Metadata.builder()
+                            .metadata(new Metadata.Builder(Metadata.OID_UNASSIGNED)
                                           .clusterUUID(UUIDs.randomBase64UUID(random())) // generate cluster UUID deterministically for repeatable tests
                                           .coordinationMetadata(CoordinationMetadata.builder()
                                                                     .term(term)
@@ -106,7 +106,7 @@ public class CoordinationStateTestCluster {
 
         void setInitialState(CoordinationMetadata.VotingConfiguration initialConfig, long initialValue) {
             final ClusterState.Builder builder = ClusterState.builder(state.getLastAcceptedState());
-            builder.metadata(Metadata.builder()
+            builder.metadata(new Metadata.Builder(Metadata.OID_UNASSIGNED)
                                  .coordinationMetadata(CoordinationMetadata.builder()
                                                            .lastAcceptedConfiguration(initialConfig)
                                                            .lastCommittedConfiguration(initialConfig)

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinationStateTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinationStateTests.java
@@ -811,7 +811,7 @@ public class CoordinationStateTests extends ESTestCase {
         return setValue(ClusterState.builder(ClusterName.DEFAULT)
             .version(version)
             .nodes(discoveryNodes)
-            .metadata(Metadata.builder()
+            .metadata(new Metadata.Builder(Metadata.OID_UNASSIGNED)
                 .clusterUUID(UUIDs.randomBase64UUID(random())) // generate cluster UUID deterministically for repeatable tests
                 .coordinationMetadata(CoordinationMetadata.builder()
                         .term(term)
@@ -856,7 +856,7 @@ public class CoordinationStateTests extends ESTestCase {
 
         void setInitialState(VotingConfiguration initialConfig, long initialValue) {
             final ClusterState.Builder builder = ClusterState.builder(state.getLastAcceptedState());
-            builder.metadata(Metadata.builder()
+            builder.metadata(new Metadata.Builder(Metadata.OID_UNASSIGNED)
                     .coordinationMetadata(CoordinationMetadata.builder()
                         .lastAcceptedConfiguration(initialConfig)
                         .lastCommittedConfiguration(initialConfig)

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/JoinHelperTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/JoinHelperTests.java
@@ -159,7 +159,7 @@ public class JoinHelperTests extends ESTestCase {
         MockTransport mockTransport = new MockTransport();
         DiscoveryNode localNode = new DiscoveryNode("node0", buildNewFakeTransportAddress(), Version.CURRENT);
 
-        final ClusterState localClusterState = ClusterState.builder(ClusterName.DEFAULT).metadata(Metadata.builder()
+        final ClusterState localClusterState = ClusterState.builder(ClusterName.DEFAULT).metadata(new Metadata.Builder(Metadata.OID_UNASSIGNED)
             .generateClusterUuidIfNeeded().clusterUUIDCommitted(true)).build();
 
         TransportService transportService = mockTransport.createTransportService(Settings.EMPTY,
@@ -170,7 +170,7 @@ public class JoinHelperTests extends ESTestCase {
         transportService.start();
         transportService.acceptIncomingRequests();
 
-        final ClusterState otherClusterState = ClusterState.builder(ClusterName.DEFAULT).metadata(Metadata.builder()
+        final ClusterState otherClusterState = ClusterState.builder(ClusterName.DEFAULT).metadata(new Metadata.Builder(Metadata.OID_UNASSIGNED)
             .generateClusterUuidIfNeeded()).build();
 
         final PlainFuture<TransportResponse.Empty> future = new PlainFuture<>();

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/JoinTaskExecutorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/JoinTaskExecutorTests.java
@@ -47,7 +47,7 @@ public class JoinTaskExecutorTests extends ESTestCase {
 
     public void testPreventJoinClusterWithNewerIndices() {
         Settings.builder().build();
-        Metadata.Builder metaBuilder = Metadata.builder();
+        Metadata.Builder metaBuilder = new Metadata.Builder(Metadata.OID_UNASSIGNED);
         IndexMetadata indexMetadata = IndexMetadata.builder("test")
             .settings(settings(Version.CURRENT))
             .numberOfShards(1)
@@ -62,7 +62,7 @@ public class JoinTaskExecutorTests extends ESTestCase {
 
     public void testSuccess() {
         Settings.builder().build();
-        Metadata.Builder metaBuilder = Metadata.builder();
+        Metadata.Builder metaBuilder = new Metadata.Builder(Metadata.OID_UNASSIGNED);
         IndexMetadata indexMetadata = IndexMetadata.builder("test")
             .settings(settings(VersionUtils.randomVersionBetween(random(),
                 Version.CURRENT.minimumIndexCompatibilityVersion(), Version.CURRENT)))
@@ -83,7 +83,7 @@ public class JoinTaskExecutorTests extends ESTestCase {
     @Test
     public void test_nodes_with_same_major_and_minor_version_can_join() {
         Settings.builder().build();
-        Metadata.Builder metaBuilder = Metadata.builder();
+        Metadata.Builder metaBuilder = new Metadata.Builder(Metadata.OID_UNASSIGNED);
         IndexMetadata indexMetadata = IndexMetadata.builder("test")
             .settings(settings(Version.V_5_3_3))
             .numberOfShards(1)

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/NodeJoinTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/NodeJoinTests.java
@@ -114,7 +114,7 @@ public class NodeJoinTests extends ESTestCase {
             .nodes(DiscoveryNodes.builder()
                 .add(localNode)
                 .localNodeId(localNode.getId()))
-            .metadata(Metadata.builder()
+            .metadata(new Metadata.Builder(Metadata.OID_UNASSIGNED)
                     .coordinationMetadata(
                         CoordinationMetadata.builder()
                         .term(term)

--- a/server/src/test/java/org/elasticsearch/cluster/health/ClusterHealthAllocationTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/health/ClusterHealthAllocationTests.java
@@ -44,7 +44,7 @@ public class ClusterHealthAllocationTests extends ESAllocationTestCase {
         }
         assertThat(getClusterHealthStatus(clusterState)).isEqualTo(Health.GREEN);
 
-        Metadata metadata = Metadata.builder()
+        Metadata metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED)
             .put(IndexMetadata.builder("test")
                 .settings(settings(Version.CURRENT).put(AutoExpandReplicas.SETTING.getKey(), false))
                 .numberOfShards(2)

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataUpgradeServiceTest.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataUpgradeServiceTest.java
@@ -241,7 +241,7 @@ public class MetadataUpgradeServiceTest extends CrateDummyClusterServiceUnitTest
             "dummy",
             "def foo(): return 1"
         ));
-        Metadata metadata = Metadata.builder()
+        Metadata metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED)
             .put(indexMetadata, false)
             .put(indexTemplateMetadata)
             .putCustom(UserDefinedFunctionsMetadata.TYPE, udfs)
@@ -292,7 +292,7 @@ public class MetadataUpgradeServiceTest extends CrateDummyClusterServiceUnitTest
             "dummy",
             "def foo(): return 1"
         ));
-        Metadata metadata = Metadata.builder()
+        Metadata metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED)
             .putCustom(UserDefinedFunctionsMetadata.TYPE, udfs)
             .put(template)
             .build();
@@ -369,7 +369,7 @@ public class MetadataUpgradeServiceTest extends CrateDummyClusterServiceUnitTest
             .numberOfShards(1)
             .numberOfReplicas(1)
             .build();
-        Metadata metadata = Metadata.builder()
+        Metadata metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED)
             .put(indexMetadata, false)
             .put(indexMetadataAlreadyUpgraded, false)
             .put(indexMetadataCreatedOnCurrentVersion, false)
@@ -397,7 +397,8 @@ public class MetadataUpgradeServiceTest extends CrateDummyClusterServiceUnitTest
             .build();
 
         RelationName tblName = new RelationName("doc", "tbl");
-        Metadata metadata = Metadata.builder()
+        var mdBuilder = Metadata.builder(Metadata.OID_UNASSIGNED);
+        Metadata metadata = mdBuilder
             .put(indexMetadata, false)
             .setTable(
                 tblName,
@@ -411,8 +412,8 @@ public class MetadataUpgradeServiceTest extends CrateDummyClusterServiceUnitTest
                 List.of(),
                 State.OPEN,
                 List.of(indexMetadata.getIndexUUID()),
-                1
-            )
+                1,
+                mdBuilder.tableOidSupplier().nextOid())
             .build();
 
         Metadata upgraded = metadataUpgradeService.upgradeMetadata(metadata);
@@ -432,7 +433,7 @@ public class MetadataUpgradeServiceTest extends CrateDummyClusterServiceUnitTest
             .numberOfReplicas(1)
             .build();
 
-        Metadata metadata = Metadata.builder()
+        Metadata metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED)
             .put(indexMetadata, false)
             .build();
 
@@ -465,7 +466,7 @@ public class MetadataUpgradeServiceTest extends CrateDummyClusterServiceUnitTest
     }
 
     public static Metadata randomMetadata(boolean withRelationMetadata, TestCustomMetadata... customMetadatas) {
-        Metadata.Builder builder = Metadata.builder();
+        Metadata.Builder builder = Metadata.builder(Metadata.OID_UNASSIGNED);
         for (TestCustomMetadata customMetadata : customMetadatas) {
             builder.putCustom(customMetadata.getWriteableName(), customMetadata);
         }
@@ -492,8 +493,9 @@ public class MetadataUpgradeServiceTest extends CrateDummyClusterServiceUnitTest
                     List.of(),
                     IndexMetadata.State.OPEN,
                     List.of(indexUUID),
-                    0
-                );
+                    0,
+                    builder.tableOidSupplier().nextOid()
+                    );
             }
         }
         return builder.build();

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/SchemaMetadataTest.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/SchemaMetadataTest.java
@@ -41,25 +41,25 @@ public class SchemaMetadataTest extends ESTestCase {
 
     RelationName t1 = new RelationName("blob", "t1");
     RelationMetadata.BlobTable relT1 = new RelationMetadata.BlobTable(
-        t1,
-        UUIDs.randomBase64UUID(),
-        Settings.EMPTY,
-        State.OPEN
-    );
+            Metadata.OID_UNASSIGNED,
+            t1,
+            UUIDs.randomBase64UUID(),
+            Settings.EMPTY,
+            State.OPEN);
     RelationName t2 = new RelationName("blob", "t2");
     RelationMetadata.BlobTable relT2 = new RelationMetadata.BlobTable(
-        t2,
-        UUIDs.randomBase64UUID(),
-        Settings.EMPTY,
-        State.OPEN
-    );
+            Metadata.OID_UNASSIGNED,
+            t2,
+            UUIDs.randomBase64UUID(),
+            Settings.EMPTY,
+            State.OPEN);
     RelationName t3 = new RelationName("blob", "t3");
     RelationMetadata.BlobTable relT3 = new RelationMetadata.BlobTable(
-        t3,
-        UUIDs.randomBase64UUID(),
-        Settings.EMPTY,
-        State.OPEN
-    );
+            Metadata.OID_UNASSIGNED,
+            t3,
+            UUIDs.randomBase64UUID(),
+            Settings.EMPTY,
+            State.OPEN);
 
     private void assertRelations(int expected, SchemaMetadata schemaMetadata) {
         ArrayList<RelationMetadata> actualRelations = new ArrayList<>();

--- a/server/src/test/java/org/elasticsearch/cluster/routing/PrimaryTermsTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/PrimaryTermsTests.java
@@ -65,7 +65,7 @@ public class PrimaryTermsTests extends ESAllocationTestCase {
         this.numberOfReplicas = randomIntBetween(0, 5);
         logger.info("Setup test with {} shards and {} replicas.", this.numberOfShards, this.numberOfReplicas);
         this.primaryTermsPerIndex.clear();
-        Metadata metadata = Metadata.builder()
+        Metadata metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED)
             .put(createIndexMetadata(TEST_INDEX_1))
             .put(createIndexMetadata(TEST_INDEX_2))
             .build();

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/AllocationCommandsTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/AllocationCommandsTests.java
@@ -86,7 +86,7 @@ public class AllocationCommandsTests extends ESAllocationTestCase {
             .put("cluster.routing.allocation.node_concurrent_recoveries", 10).build());
 
         logger.info("creating an index with 1 shard, no replica");
-        Metadata metadata = Metadata.builder()
+        Metadata metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED)
             .put(IndexMetadata.builder("test").settings(
                 Settings.builder()
                     .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
@@ -151,7 +151,7 @@ public class AllocationCommandsTests extends ESAllocationTestCase {
         final String index = "test";
 
         logger.info("--> building initial routing table");
-        Metadata metadata = Metadata.builder()
+        Metadata metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED)
                 .put(IndexMetadata.builder(index).settings(settings(Version.CURRENT)).numberOfShards(1).numberOfReplicas(1)
                     .putInSyncAllocationIds(0, Collections.singleton("asdf"))
                     .putInSyncAllocationIds(1, Collections.singleton("qwertz")))
@@ -286,7 +286,7 @@ public class AllocationCommandsTests extends ESAllocationTestCase {
         final String index = "test";
 
         logger.info("--> building initial routing table");
-        Metadata metadata = Metadata.builder()
+        Metadata metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED)
             .put(IndexMetadata.builder(index).settings(settings(Version.CURRENT)).numberOfShards(1).numberOfReplicas(1)
                 .putInSyncAllocationIds(0, Collections.singleton("asdf")).putInSyncAllocationIds(1, Collections.singleton("qwertz")))
             .build();
@@ -336,7 +336,7 @@ public class AllocationCommandsTests extends ESAllocationTestCase {
                 .build());
 
         logger.info("--> building initial routing table");
-        Metadata metadata = Metadata.builder()
+        Metadata metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED)
                 .put(IndexMetadata.builder("test").settings(settings(Version.CURRENT)).numberOfShards(1).numberOfReplicas(1))
                 .build();
         RoutingTable routingTable = RoutingTable.builder()
@@ -578,7 +578,7 @@ public class AllocationCommandsTests extends ESAllocationTestCase {
 
         logger.info("creating an index with 1 shard, no replica");
         String indexUUID = UUIDs.randomBase64UUID();
-        Metadata metadata = Metadata.builder()
+        Metadata metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED)
             .put(IndexMetadata.builder(indexUUID).settings(settings(Version.CURRENT)).numberOfShards(1).numberOfReplicas(0).indexName("test"))
             .build();
         RoutingTable routingTable = RoutingTable.builder()
@@ -620,7 +620,7 @@ public class AllocationCommandsTests extends ESAllocationTestCase {
             .put("cluster.routing.allocation.node_concurrent_recoveries", 10).build());
 
         logger.info("creating an index with 1 shard, no replica");
-        Metadata metadata = Metadata.builder()
+        Metadata metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED)
             .put(IndexMetadata.builder("test").settings(settings(Version.CURRENT)).numberOfShards(1).numberOfReplicas(0))
             .build();
         RoutingTable routingTable = RoutingTable.builder()
@@ -667,7 +667,7 @@ public class AllocationCommandsTests extends ESAllocationTestCase {
         final String index2 = "test2";
         final String index3 = "test3";
         logger.info("--> building initial routing table");
-        Metadata metadata = Metadata.builder()
+        Metadata metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED)
             .put(IndexMetadata.builder(index1).settings(
                 Settings.builder()
                     .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/AllocationServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/AllocationServiceTests.java
@@ -101,7 +101,7 @@ public class AllocationServiceTests extends ESTestCase {
         nodesBuilder.add(new DiscoveryNode("node1", buildNewFakeTransportAddress(), Version.CURRENT));
         nodesBuilder.add(new DiscoveryNode("node2", buildNewFakeTransportAddress(), Version.CURRENT));
 
-        final Metadata.Builder metadata = Metadata.builder().put(indexMetadata("index", Settings.builder()
+        final Metadata.Builder metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED).put(indexMetadata("index", Settings.builder()
             .put(ExistingShardsAllocator.EXISTING_SHARDS_ALLOCATOR_SETTING.getKey(), "unknown")));
 
         final RoutingTable.Builder routingTableBuilder = RoutingTable.builder().addAsRecovery(metadata.get("index"));

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/DeadNodesAllocationTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/DeadNodesAllocationTests.java
@@ -48,7 +48,7 @@ public class DeadNodesAllocationTests extends ESAllocationTestCase {
                                                                    .build());
 
         logger.info("--> building initial routing table");
-        Metadata metadata = Metadata.builder()
+        Metadata metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED)
             .put(IndexMetadata.builder("test").settings(settings(Version.CURRENT)).numberOfShards(1).numberOfReplicas(1))
             .build();
         RoutingTable routingTable = RoutingTable.builder()
@@ -96,7 +96,7 @@ public class DeadNodesAllocationTests extends ESAllocationTestCase {
                                                                    .build());
 
         logger.info("--> building initial routing table");
-        Metadata metadata = Metadata.builder()
+        Metadata metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED)
             .put(IndexMetadata.builder("test").settings(settings(Version.CURRENT)).numberOfShards(1).numberOfReplicas(1))
             .build();
         RoutingTable routingTable = RoutingTable.builder()
@@ -166,7 +166,7 @@ public class DeadNodesAllocationTests extends ESAllocationTestCase {
                                                                    .build());
 
         logger.info("--> building initial routing table");
-        Metadata metadata = Metadata.builder()
+        Metadata metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED)
             .put(IndexMetadata.builder("test").settings(settings(Version.CURRENT)).numberOfShards(1).numberOfReplicas(1))
             .build();
         RoutingTable routingTable = RoutingTable.builder()

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/DecisionsImpactOnClusterHealthTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/DecisionsImpactOnClusterHealthTests.java
@@ -115,7 +115,7 @@ public class DecisionsImpactOnClusterHealthTests extends ESAllocationTestCase {
 
         logger.info("Building initial routing table");
         final int numShards = randomIntBetween(1, 5);
-        Metadata metadata = Metadata.builder()
+        Metadata metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED)
                                 .put(IndexMetadata.builder(indexName)
                                          .settings(settings(Version.CURRENT))
                                          .numberOfShards(numShards)

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/IndexBalanceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/IndexBalanceTests.java
@@ -62,7 +62,7 @@ public class IndexBalanceTests extends ESAllocationTestCase {
 
         logger.info("Building initial routing table");
 
-        Metadata metadata = Metadata.builder()
+        Metadata metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED)
             .put(IndexMetadata.builder("test")
                 .settings(indexSettings())
                 .numberOfShards(3)
@@ -187,7 +187,7 @@ public class IndexBalanceTests extends ESAllocationTestCase {
 
         logger.info("Building initial routing table");
 
-        Metadata metadata = Metadata.builder()
+        Metadata metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED)
             .put(IndexMetadata.builder("test")
                 .settings(indexSettings())
                 .numberOfShards(3)
@@ -336,7 +336,7 @@ public class IndexBalanceTests extends ESAllocationTestCase {
 
         logger.info("Building initial routing table");
 
-        Metadata metadata = Metadata.builder()
+        Metadata metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED)
             .put(IndexMetadata.builder("test")
                 .settings(indexSettings())
                 .numberOfShards(3)

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/NodeVersionAllocationDeciderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/NodeVersionAllocationDeciderTests.java
@@ -93,7 +93,7 @@ public class NodeVersionAllocationDeciderTests extends ESAllocationTestCase {
 
         logger.info("Building initial routing table");
 
-        Metadata metadata = Metadata.builder()
+        Metadata metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED)
             .put(IndexMetadata.builder("test")
                      .settings(settings(Version.CURRENT).put(AutoExpandReplicas.SETTING.getKey(), false))
                      .numberOfShards(5)
@@ -190,7 +190,7 @@ public class NodeVersionAllocationDeciderTests extends ESAllocationTestCase {
                                                                 .build());
 
         logger.info("Building initial routing table");
-        Metadata.Builder builder = Metadata.builder();
+        Metadata.Builder builder = new Metadata.Builder(Metadata.OID_UNASSIGNED);
         RoutingTable.Builder rtBuilder = RoutingTable.builder();
         int numIndices = between(1, 20);
         for (int i = 0; i < numIndices; i++) {
@@ -245,7 +245,7 @@ public class NodeVersionAllocationDeciderTests extends ESAllocationTestCase {
 
         logger.info("Building initial routing table");
 
-        Metadata metadata = Metadata.builder()
+        Metadata metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED)
             .put(IndexMetadata.builder("test")
                      .settings(settings(Version.CURRENT).put(AutoExpandReplicas.SETTING.getKey(), false))
                      .numberOfShards(5)
@@ -319,7 +319,7 @@ public class NodeVersionAllocationDeciderTests extends ESAllocationTestCase {
         AllocationId allocationId1R = AllocationId.newInitializing();
         AllocationId allocationId2P = AllocationId.newInitializing();
         AllocationId allocationId2R = AllocationId.newInitializing();
-        Metadata metadata = Metadata.builder()
+        Metadata metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED)
             .put(IndexMetadata.builder(shard1.getIndexUUID()).settings(settings(Version.CURRENT).put(Settings.EMPTY)).numberOfShards(1)
                      .numberOfReplicas(1).putInSyncAllocationIds(0, Set.of(allocationId1P.getId(), allocationId1R.getId())))
             .put(IndexMetadata.builder(shard2.getIndexUUID()).settings(settings(Version.CURRENT).put(Settings.EMPTY)).numberOfShards(1)
@@ -382,7 +382,7 @@ public class NodeVersionAllocationDeciderTests extends ESAllocationTestCase {
         for (int i = 0; i < numberOfShards; i++) {
             indexMetadata.putInSyncAllocationIds(i, Collections.singleton("_test_"));
         }
-        Metadata metadata = Metadata.builder().put(indexMetadata).build();
+        Metadata metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED).put(indexMetadata).build();
 
         final ImmutableOpenMap.Builder<InternalSnapshotsInfoService.SnapshotShard, Long> snapshotShardSizes =
             ImmutableOpenMap.builder(numberOfShards);
@@ -472,7 +472,7 @@ public class NodeVersionAllocationDeciderTests extends ESAllocationTestCase {
 
     public void testMessages() {
 
-        Metadata metadata = Metadata.builder()
+        Metadata metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED)
             .put(IndexMetadata.builder("test").settings(settings(Version.CURRENT)).numberOfShards(1).numberOfReplicas(1))
             .build();
 
@@ -569,7 +569,7 @@ public class NodeVersionAllocationDeciderTests extends ESAllocationTestCase {
                                                          MASTER_DATA_ROLES, Version.V_4_4_1);
         AllocationId allocationId1P = AllocationId.newInitializing();
         AllocationId allocationId1R = AllocationId.newInitializing();
-        Metadata metadata = Metadata.builder()
+        Metadata metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED)
             .put(IndexMetadata.builder(shard1.getIndexUUID())
                 .settings(settings(Version.CURRENT)
                     .put(AutoExpandReplicas.SETTING.getKey(), "false")

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/RetryFailedAllocationTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/RetryFailedAllocationTests.java
@@ -50,7 +50,7 @@ public class RetryFailedAllocationTests extends ESAllocationTestCase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        Metadata metadata = Metadata.builder().put(
+        Metadata metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED).put(
             IndexMetadata.builder(INDEX_UUID)
                 .settings(settings(Version.CURRENT))
                 .numberOfShards(1)

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/TrackFailedAllocationNodesTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/TrackFailedAllocationNodesTests.java
@@ -43,7 +43,7 @@ public class TrackFailedAllocationNodesTests extends ESAllocationTestCase {
     public void testTrackFailedNodes() {
         int maxRetries = MaxRetryAllocationDecider.SETTING_ALLOCATION_MAX_RETRY.get(Settings.EMPTY);
         AllocationService allocationService = createAllocationService();
-        Metadata metadata = Metadata.builder()
+        Metadata metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED)
             .put(IndexMetadata.builder("idx").settings(
                 Settings.builder()
                     .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderTests.java
@@ -106,7 +106,7 @@ public class DiskThresholdDeciderTests extends ESAllocationTestCase {
         AllocationService strategy = new AllocationService(deciders,
                 new TestGatewayAllocator(), new BalancedShardsAllocator(Settings.EMPTY), cis, EmptySnapshotsInfoService.INSTANCE);
 
-        Metadata metadata = Metadata.builder()
+        Metadata metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED)
             .put(IndexMetadata.builder("test").settings(
                 Settings.builder()
                     .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
@@ -291,7 +291,7 @@ public class DiskThresholdDeciderTests extends ESAllocationTestCase {
         AllocationService strategy = new AllocationService(deciders, new TestGatewayAllocator(),
                 new BalancedShardsAllocator(Settings.EMPTY), cis, EmptySnapshotsInfoService.INSTANCE);
 
-        Metadata metadata = Metadata.builder()
+        Metadata metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED)
             .put(IndexMetadata.builder("test").settings(
                 Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
                     .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
@@ -535,7 +535,7 @@ public class DiskThresholdDeciderTests extends ESAllocationTestCase {
         AllocationService strategy = new AllocationService(deciders, new TestGatewayAllocator(),
                 new BalancedShardsAllocator(Settings.EMPTY), cis, EmptySnapshotsInfoService.INSTANCE);
 
-        Metadata metadata = Metadata.builder()
+        Metadata metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED)
             .put(IndexMetadata.builder("test").settings(
                 Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
                     .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
@@ -604,7 +604,7 @@ public class DiskThresholdDeciderTests extends ESAllocationTestCase {
         AllocationService strategy = new AllocationService(deciders, new TestGatewayAllocator(),
                 new BalancedShardsAllocator(Settings.EMPTY), cis, EmptySnapshotsInfoService.INSTANCE);
 
-        Metadata metadata = Metadata.builder()
+        Metadata metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED)
             .put(IndexMetadata.builder("test").settings(
                 Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
                     .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
@@ -697,7 +697,7 @@ public class DiskThresholdDeciderTests extends ESAllocationTestCase {
         final ClusterInfo clusterInfo = new DevNullClusterInfo(usages, usages, shardSizes);
 
         DiskThresholdDecider diskThresholdDecider = makeDecider(diskSettings);
-        Metadata metadata = Metadata.builder()
+        Metadata metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED)
             .put(IndexMetadata.builder("test").settings(
                 Settings.builder()
                     .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
@@ -831,7 +831,7 @@ public class DiskThresholdDeciderTests extends ESAllocationTestCase {
         final ClusterInfo clusterInfo = new DevNullClusterInfo(usages, usages, shardSizes.build());
 
         DiskThresholdDecider diskThresholdDecider = makeDecider(diskSettings);
-        Metadata metadata = Metadata.builder()
+        Metadata metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED)
             .put(IndexMetadata.builder("test").settings(settings(Version.CURRENT)).numberOfShards(1).numberOfReplicas(0))
             .build();
         RoutingTable initialRoutingTable = RoutingTable.builder()

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderUnitTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderUnitTests.java
@@ -66,7 +66,7 @@ public class DiskThresholdDeciderUnitTests extends ESAllocationTestCase {
         ClusterSettings nss = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
         DiskThresholdDecider decider = new DiskThresholdDecider(Settings.EMPTY, nss);
 
-        Metadata metadata = Metadata.builder()
+        Metadata metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED)
             .put(IndexMetadata.builder("test").settings(settings(Version.CURRENT)).numberOfShards(1).numberOfReplicas(1))
             .build();
 
@@ -125,7 +125,7 @@ public class DiskThresholdDeciderUnitTests extends ESAllocationTestCase {
         ClusterSettings nss = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
         DiskThresholdDecider decider = new DiskThresholdDecider(Settings.EMPTY, nss);
 
-        Metadata metadata = Metadata.builder()
+        Metadata metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED)
             .put(IndexMetadata.builder("test").settings(settings(Version.CURRENT)).numberOfShards(1).numberOfReplicas(1))
             .build();
 
@@ -188,7 +188,7 @@ public class DiskThresholdDeciderUnitTests extends ESAllocationTestCase {
         DiscoveryNode node_1 = new DiscoveryNode("node_1", buildNewFakeTransportAddress(), Collections.emptyMap(),
                 new HashSet<>(DiscoveryNodeRole.BUILT_IN_ROLES), Version.CURRENT);
 
-        Metadata metadata = Metadata.builder()
+        Metadata metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED)
             .put(IndexMetadata.builder("test").settings(settings(Version.CURRENT)).numberOfShards(1).numberOfReplicas(1))
             .build();
         final IndexMetadata indexMetadata = metadata.index("test");
@@ -291,7 +291,7 @@ public class DiskThresholdDeciderUnitTests extends ESAllocationTestCase {
         shardSizes.put("[test/1234][2][r]", 1000L);
         shardSizes.put("[other/5678][0][p]", 10000L);
         ClusterInfo info = new DevNullClusterInfo(ImmutableOpenMap.of(), ImmutableOpenMap.of(), shardSizes.build());
-        Metadata.Builder metaBuilder = Metadata.builder();
+        Metadata.Builder metaBuilder = new Metadata.Builder(Metadata.OID_UNASSIGNED);
         metaBuilder.put(IndexMetadata.builder("1234")
             .settings(settings(Version.CURRENT)
                 .put("index.uuid", "1234"))
@@ -404,7 +404,7 @@ public class DiskThresholdDeciderUnitTests extends ESAllocationTestCase {
 
         // Setting the creation date is important here as shards of newer indices are allocated first, see PriorityComparator
         // Shards of the source index must be allocated first, so set the highest creation date
-        Metadata.Builder metaBuilder = Metadata.builder();
+        Metadata.Builder metaBuilder = new Metadata.Builder(Metadata.OID_UNASSIGNED);
         metaBuilder.put(IndexMetadata.builder(index.getUUID())
             .settings(settings(Version.CURRENT)
                 .put("index.uuid", index.getUUID())

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/EnableAllocationShortCircuitTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/EnableAllocationShortCircuitTests.java
@@ -63,7 +63,7 @@ public class EnableAllocationShortCircuitTests extends ESAllocationTestCase {
             discoveryNodesBuilder.add(newNode("node" + i));
         }
 
-        final Metadata.Builder metadataBuilder = Metadata.builder();
+        final Metadata.Builder metadataBuilder = new Metadata.Builder(Metadata.OID_UNASSIGNED);
         final RoutingTable.Builder routingTableBuilder = RoutingTable.builder();
         for (int i = randomIntBetween(1, 10); i >= 0; i--) {
             final IndexMetadata indexMetadata = IndexMetadata.builder("test" + i)
@@ -157,7 +157,7 @@ public class EnableAllocationShortCircuitTests extends ESAllocationTestCase {
                 .put(CLUSTER_ROUTING_ALLOCATION_ENABLE_SETTING.getKey(), EnableAllocationDecider.Allocation.NONE.name()),
             plugin);
 
-        Metadata metadata = Metadata.builder()
+        Metadata metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED)
             .put(IndexMetadata.builder("test").settings(settings(Version.CURRENT)).numberOfShards(1).numberOfReplicas(0))
             .build();
 

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/FilterAllocationDeciderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/FilterAllocationDeciderTests.java
@@ -199,7 +199,7 @@ public class FilterAllocationDeciderTests extends ESAllocationTestCase {
 
 
     private static ClusterState buildClusterState(Settings.Builder indexSettings) {
-        Metadata.Builder metadata = Metadata.builder();
+        Metadata.Builder metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED);
         metadata.persistentSettings(Settings.EMPTY);
 
         final IndexMetadata.Builder indexMetadataBuilder = IndexMetadata.builder("t1")

--- a/server/src/test/java/org/elasticsearch/env/NodeRepurposeCommandTests.java
+++ b/server/src/test/java/org/elasticsearch/env/NodeRepurposeCommandTests.java
@@ -248,7 +248,7 @@ public class NodeRepurposeCommandTests extends ESTestCase {
                 try (PersistedClusterStateService.Writer writer =
                          ElasticsearchNodeCommand.createPersistedClusterStateService(Settings.EMPTY, env.nodeDataPaths()).createWriter()) {
                     writer.writeFullStateAndCommit(1L, ClusterState.builder(ClusterName.DEFAULT)
-                        .metadata(Metadata.builder().put(IndexMetadata.builder(INDEX.getUUID())
+                        .metadata(new Metadata.Builder(Metadata.OID_UNASSIGNED).put(IndexMetadata.builder(INDEX.getUUID())
                             .settings(Settings.builder().put("index.version.created", Version.CURRENT)
                                 .put(IndexMetadata.SETTING_INDEX_UUID, INDEX.getUUID()))
                             .indexName(INDEX.getName())

--- a/server/src/test/java/org/elasticsearch/env/OverrideNodeVersionCommandTests.java
+++ b/server/src/test/java/org/elasticsearch/env/OverrideNodeVersionCommandTests.java
@@ -60,7 +60,7 @@ public class OverrideNodeVersionCommandTests extends ESTestCase {
             try (PersistedClusterStateService.Writer writer = new PersistedClusterStateService(nodePaths, nodeId,
                 xContentRegistry(), writableRegistry(), BigArrays.NON_RECYCLING_INSTANCE,
                 new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS), () -> 0L, true).createWriter()) {
-                writer.writeFullStateAndCommit(1L, ClusterState.builder(ClusterName.DEFAULT).metadata(Metadata.builder()
+                writer.writeFullStateAndCommit(1L, ClusterState.builder(ClusterName.DEFAULT).metadata(new Metadata.Builder(Metadata.OID_UNASSIGNED)
                     .persistentSettings(Settings.builder().put(Metadata.SETTING_READ_ONLY_SETTING.getKey(), true).build()).build())
                     .build());
             }

--- a/server/src/test/java/org/elasticsearch/gateway/DanglingIndicesStateTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/DanglingIndicesStateTests.java
@@ -65,7 +65,7 @@ public class DanglingIndicesStateTests extends ESTestCase {
             DanglingIndicesState danglingState = createDanglingIndicesState(env, metaStateService);
 
             assertThat(danglingState.getDanglingIndices().isEmpty()).isTrue();
-            Metadata metadata = Metadata.builder().build();
+            Metadata metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED).build();
             danglingState.cleanupAllocatedDangledIndices(metadata);
             assertThat(danglingState.getDanglingIndices().isEmpty()).isTrue();
         }
@@ -77,13 +77,13 @@ public class DanglingIndicesStateTests extends ESTestCase {
             MetaStateService metaStateService = new MetaStateService(env, writableRegistry(), xContentRegistry());
             DanglingIndicesState danglingState = createDanglingIndicesState(env, metaStateService);
             assertThat(danglingState.getDanglingIndices().isEmpty()).isTrue();
-            Metadata metadata = Metadata.builder().build();
+            Metadata metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED).build();
             final Settings.Builder settings = Settings.builder().put(INDEX_SETTINGS).put(IndexMetadata.SETTING_INDEX_UUID, "test1UUID");
             IndexMetadata dangledIndex = IndexMetadata.builder("test1UUID").settings(settings).indexName("test1").build();
             metaStateService.writeIndex("test_write", dangledIndex);
             Map<Index, IndexMetadata> newDanglingIndices = danglingState.findNewDanglingIndices(metadata);
             assertThat(newDanglingIndices.containsKey(dangledIndex.getIndex())).isTrue();
-            metadata = Metadata.builder().put(dangledIndex, false).build();
+            metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED).put(dangledIndex, false).build();
             newDanglingIndices = danglingState.findNewDanglingIndices(metadata);
             assertThat(newDanglingIndices.containsKey(dangledIndex.getIndex())).isFalse();
         }
@@ -95,7 +95,7 @@ public class DanglingIndicesStateTests extends ESTestCase {
             MetaStateService metaStateService = new MetaStateService(env, writableRegistry(), xContentRegistry());
             DanglingIndicesState danglingState = createDanglingIndicesState(env, metaStateService);
 
-            Metadata metadata = Metadata.builder().build();
+            Metadata metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED).build();
             final String uuid = "test1UUID";
             final Settings.Builder settings = Settings.builder().put(INDEX_SETTINGS).put(IndexMetadata.SETTING_INDEX_UUID, uuid);
             IndexMetadata dangledIndex = IndexMetadata.builder(uuid).settings(settings).indexName("test1").build();
@@ -120,7 +120,7 @@ public class DanglingIndicesStateTests extends ESTestCase {
             MetaStateService metaStateService = new MetaStateService(env, writableRegistry(), xContentRegistry());
             DanglingIndicesState danglingState = createDanglingIndicesState(env, metaStateService);
 
-            Metadata metadata = Metadata.builder().build();
+            Metadata metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED).build();
 
             final Settings.Builder settings = Settings.builder().put(INDEX_SETTINGS).put(IndexMetadata.SETTING_INDEX_UUID, "test1UUID");
             IndexMetadata dangledIndex = IndexMetadata.builder("test1UUID").settings(settings).indexName("test1").build();
@@ -167,7 +167,7 @@ public class DanglingIndicesStateTests extends ESTestCase {
             metaStateService.writeIndex("test_write", dangledIndex);
 
             final IndexGraveyard graveyard = IndexGraveyard.builder().addTombstone(dangledIndex.getIndex()).build();
-            final Metadata metadata = Metadata.builder().indexGraveyard(graveyard).build();
+            final Metadata metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED).indexGraveyard(graveyard).build();
             assertThat(danglingState.findNewDanglingIndices(metadata)).hasSize(0);
         }
     }
@@ -215,7 +215,7 @@ public class DanglingIndicesStateTests extends ESTestCase {
             IndexMetadata dangledIndex = IndexMetadata.builder("test1UUID").settings(settings).indexName("test1").build();
             metaStateService.writeIndex("test_write", dangledIndex);
 
-            danglingIndicesState.findNewAndAddDanglingIndices(Metadata.builder().build());
+            danglingIndicesState.findNewAndAddDanglingIndices(new Metadata.Builder(Metadata.OID_UNASSIGNED).build());
 
             danglingIndicesState.allocateDanglingIndices();
 

--- a/server/src/test/java/org/elasticsearch/gateway/GatewayMetaStatePersistedStateTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/GatewayMetaStatePersistedStateTests.java
@@ -194,7 +194,7 @@ public class GatewayMetaStatePersistedStateTests extends ESTestCase {
                 final long version = randomNonNegativeLong();
                 final String indexName = randomAlphaOfLength(10);
                 final IndexMetadata indexMetadata = createIndexMetadata(indexName, randomIntBetween(1, 5), randomNonNegativeLong());
-                final Metadata metadata = Metadata.builder().
+                final Metadata metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED).
                     persistentSettings(Settings.builder().put(randomAlphaOfLength(10), randomAlphaOfLength(10)).build()).
                     coordinationMetadata(createCoordinationMetadata(term)).
                     put(indexMetadata, false).
@@ -224,7 +224,7 @@ public class GatewayMetaStatePersistedStateTests extends ESTestCase {
             final long term = randomValueOtherThan(Long.MAX_VALUE, ESTestCase::randomNonNegativeLong);
             final IndexMetadata indexMetadata = createIndexMetadata(indexName, numberOfShards, version);
             final ClusterState state = createClusterState(randomNonNegativeLong(),
-                                                          Metadata.builder().coordinationMetadata(createCoordinationMetadata(term)).put(indexMetadata, false).build());
+                                                          new Metadata.Builder(Metadata.OID_UNASSIGNED).coordinationMetadata(createCoordinationMetadata(term)).put(indexMetadata, false).build());
             gateway.setLastAcceptedState(state);
 
             gateway = maybeNew(gateway);
@@ -232,7 +232,7 @@ public class GatewayMetaStatePersistedStateTests extends ESTestCase {
             final int newNumberOfShards = randomValueOtherThan(numberOfShards, () -> randomIntBetween(1, 5));
             final IndexMetadata newIndexMetadata = createIndexMetadata(indexName, newNumberOfShards, version);
             final ClusterState newClusterState = createClusterState(randomNonNegativeLong(),
-                                                                    Metadata.builder().coordinationMetadata(createCoordinationMetadata(newTerm)).put(newIndexMetadata, false).build());
+                                                                    new Metadata.Builder(Metadata.OID_UNASSIGNED).coordinationMetadata(createCoordinationMetadata(newTerm)).put(newIndexMetadata, false).build());
             gateway.setLastAcceptedState(newClusterState);
 
             gateway = maybeNew(gateway);
@@ -252,7 +252,7 @@ public class GatewayMetaStatePersistedStateTests extends ESTestCase {
 
             gateway.setCurrentTerm(currentTerm);
             gateway.setLastAcceptedState(createClusterState(randomNonNegativeLong(),
-                                                            Metadata.builder().coordinationMetadata(CoordinationMetadata.builder().term(term).build()).build()));
+                                                            new Metadata.Builder(Metadata.OID_UNASSIGNED).coordinationMetadata(CoordinationMetadata.builder().term(term).build()).build()));
 
             gateway = maybeNew(gateway);
             assertThat(gateway.getCurrentTerm()).isEqualTo(currentTerm);
@@ -275,7 +275,7 @@ public class GatewayMetaStatePersistedStateTests extends ESTestCase {
             } while (coordinationMetadata.getLastAcceptedConfiguration().equals(coordinationMetadata.getLastCommittedConfiguration()));
 
             ClusterState state = createClusterState(randomNonNegativeLong(),
-                                                    Metadata.builder().coordinationMetadata(coordinationMetadata)
+                                                    new Metadata.Builder(Metadata.OID_UNASSIGNED).coordinationMetadata(coordinationMetadata)
                                                         .clusterUUID(randomAlphaOfLength(10)).build());
             gateway.setLastAcceptedState(state);
 
@@ -286,7 +286,7 @@ public class GatewayMetaStatePersistedStateTests extends ESTestCase {
             CoordinationMetadata expectedCoordinationMetadata = CoordinationMetadata.builder(coordinationMetadata)
                 .lastCommittedConfiguration(coordinationMetadata.getLastAcceptedConfiguration()).build();
             ClusterState expectedClusterState =
-                ClusterState.builder(state).metadata(Metadata.builder().coordinationMetadata(expectedCoordinationMetadata)
+                ClusterState.builder(state).metadata(new Metadata.Builder(Metadata.OID_UNASSIGNED).coordinationMetadata(expectedCoordinationMetadata)
                                                          .clusterUUID(state.metadata().clusterUUID()).clusterUUIDCommitted(true).build()).build();
 
             gateway = maybeNew(gateway);
@@ -307,7 +307,7 @@ public class GatewayMetaStatePersistedStateTests extends ESTestCase {
             new PersistedClusterStateService(nodeEnvironment, xContentRegistry(), writableRegistry(), getBigArrays(),
                 new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS), () -> 0L);
         final ClusterState state = createClusterState(randomNonNegativeLong(),
-                                                      Metadata.builder().clusterUUID(randomAlphaOfLength(10)).build());
+                                                      new Metadata.Builder(Metadata.OID_UNASSIGNED).clusterUUID(randomAlphaOfLength(10)).build());
         try (GatewayMetaState.LucenePersistedState ignored = new GatewayMetaState.LucenePersistedState(
             persistedClusterStateService, 42L, state)) {
 
@@ -370,7 +370,7 @@ public class GatewayMetaStatePersistedStateTests extends ESTestCase {
         } while (coordinationMetadata.getLastAcceptedConfiguration().equals(coordinationMetadata.getLastCommittedConfiguration()));
 
         ClusterState state = createClusterState(randomNonNegativeLong(),
-                                                Metadata.builder().coordinationMetadata(coordinationMetadata)
+                                                new Metadata.Builder(Metadata.OID_UNASSIGNED).coordinationMetadata(coordinationMetadata)
                                                     .clusterUUID(randomAlphaOfLength(10)).build());
         persistedState.setLastAcceptedState(state);
         assertBusy(() -> assertThat(gateway.allPendingAsyncStatesWritten()).isTrue());
@@ -387,7 +387,7 @@ public class GatewayMetaStatePersistedStateTests extends ESTestCase {
         CoordinationMetadata expectedCoordinationMetadata = CoordinationMetadata.builder(coordinationMetadata)
             .lastCommittedConfiguration(coordinationMetadata.getLastAcceptedConfiguration()).build();
         ClusterState expectedClusterState =
-            ClusterState.builder(state).metadata(Metadata.builder().coordinationMetadata(expectedCoordinationMetadata)
+            ClusterState.builder(state).metadata(new Metadata.Builder(Metadata.OID_UNASSIGNED).coordinationMetadata(expectedCoordinationMetadata)
                                                      .clusterUUID(state.metadata().clusterUUID()).clusterUUIDCommitted(true).build()).build();
 
         assertClusterStateEqual(expectedClusterState, persistedState.getLastAcceptedState());
@@ -410,7 +410,7 @@ public class GatewayMetaStatePersistedStateTests extends ESTestCase {
                 final long term = Math.min(state.term() + (rarely() ? randomIntBetween(1, 5) : 0L), currentTerm);
                 final IndexMetadata indexMetadata = createIndexMetadata(indexName, numberOfShards, i);
                 state = createClusterState(state.version() + 1,
-                                           Metadata.builder().coordinationMetadata(createCoordinationMetadata(term)).put(indexMetadata, false).build());
+                                           new Metadata.Builder(Metadata.OID_UNASSIGNED).coordinationMetadata(createCoordinationMetadata(term)).put(indexMetadata, false).build());
                 persistedState.setLastAcceptedState(state);
             }
         }
@@ -448,7 +448,7 @@ public class GatewayMetaStatePersistedStateTests extends ESTestCase {
                 }
             };
         ClusterState state = createClusterState(randomNonNegativeLong(),
-                                                Metadata.builder().clusterUUID(randomAlphaOfLength(10)).build());
+                                                new Metadata.Builder(Metadata.OID_UNASSIGNED).clusterUUID(randomAlphaOfLength(10)).build());
         long currentTerm = 42L;
         try (GatewayMetaState.LucenePersistedState persistedState = new GatewayMetaState.LucenePersistedState(
             persistedClusterStateService, currentTerm, state)) {
@@ -456,7 +456,7 @@ public class GatewayMetaStatePersistedStateTests extends ESTestCase {
             try {
                 if (randomBoolean()) {
                     final ClusterState newState = createClusterState(randomNonNegativeLong(),
-                                                                     Metadata.builder().clusterUUID(randomAlphaOfLength(10)).build());
+                                                                     new Metadata.Builder(Metadata.OID_UNASSIGNED).clusterUUID(randomAlphaOfLength(10)).build());
                     persistedState.setLastAcceptedState(newState);
                     state = newState;
                 } else {
@@ -479,7 +479,7 @@ public class GatewayMetaStatePersistedStateTests extends ESTestCase {
                     final long version = randomNonNegativeLong();
                     final String indexName = randomAlphaOfLength(10);
                     final IndexMetadata indexMetadata = createIndexMetadata(indexName, randomIntBetween(1, 5), randomNonNegativeLong());
-                    final Metadata metadata = Metadata.builder().
+                    final Metadata metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED).
                         persistentSettings(Settings.builder().put(randomAlphaOfLength(10), randomAlphaOfLength(10)).build()).
                         coordinationMetadata(createCoordinationMetadata(1L)).
                         put(indexMetadata, false).

--- a/server/src/test/java/org/elasticsearch/gateway/IncrementalClusterStateWriterTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/IncrementalClusterStateWriterTests.java
@@ -76,7 +76,7 @@ import io.crate.common.collections.Tuple;
 public class IncrementalClusterStateWriterTests extends ESAllocationTestCase {
 
     private ClusterState clusterStateWithUnassignedIndex(IndexMetadata indexMetadata, boolean masterEligible) {
-        Metadata metadata = Metadata.builder()
+        Metadata metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED)
             .put(indexMetadata, false)
             .build();
 
@@ -102,7 +102,7 @@ public class IncrementalClusterStateWriterTests extends ESAllocationTestCase {
         ClusterState oldClusterState = clusterStateWithUnassignedIndex(indexMetadata, masterEligible);
         RoutingTable routingTable = strategy.reroute(oldClusterState, "reroute").routingTable();
 
-        Metadata metadataNewClusterState = Metadata.builder()
+        Metadata metadataNewClusterState = new Metadata.Builder(Metadata.OID_UNASSIGNED)
             .put(oldClusterState.metadata().index("test"), false)
             .build();
 
@@ -113,7 +113,7 @@ public class IncrementalClusterStateWriterTests extends ESAllocationTestCase {
     private ClusterState clusterStateWithNonReplicatedClosedIndex(IndexMetadata indexMetadata, boolean masterEligible) {
         ClusterState oldClusterState = clusterStateWithAssignedIndex(indexMetadata, masterEligible);
 
-        Metadata metadataNewClusterState = Metadata.builder()
+        Metadata metadataNewClusterState = new Metadata.Builder(Metadata.OID_UNASSIGNED)
             .put(
                 IndexMetadata.builder("test").settings(settings(Version.CURRENT)
                     .put(IndexMetadata.SETTING_INDEX_UUID, indexMetadata.getIndexUUID())
@@ -135,7 +135,7 @@ public class IncrementalClusterStateWriterTests extends ESAllocationTestCase {
     private ClusterState clusterStateWithReplicatedClosedIndex(IndexMetadata indexMetadata, boolean masterEligible, boolean assigned) {
         ClusterState oldClusterState = clusterStateWithAssignedIndex(indexMetadata, masterEligible);
 
-        Metadata metadataNewClusterState = Metadata.builder()
+        Metadata metadataNewClusterState = new Metadata.Builder(Metadata.OID_UNASSIGNED)
             .put(
                 IndexMetadata.builder("test").settings(settings(Version.CURRENT)
                 .put(IndexMetadata.VERIFIED_BEFORE_CLOSE_SETTING.getKey(), true)
@@ -248,13 +248,13 @@ public class IncrementalClusterStateWriterTests extends ESAllocationTestCase {
         IndexMetadata newIndex = createIndexMetadata("new_index");
         relevantIndices.add(newIndex.getIndex());
 
-        Metadata oldMetadata = Metadata.builder()
+        Metadata oldMetadata = new Metadata.Builder(Metadata.OID_UNASSIGNED)
             .put(removedIndex, false)
             .put(versionChangedIndex, false)
             .put(notChangedIndex, false)
             .build();
 
-        Metadata newMetadata = Metadata.builder()
+        Metadata newMetadata = new Metadata.Builder(Metadata.OID_UNASSIGNED)
             .put(versionChangedIndex, true)
             .put(notChangedIndex, false)
             .put(newIndex, false)
@@ -383,7 +383,7 @@ public class IncrementalClusterStateWriterTests extends ESAllocationTestCase {
 
     private static Metadata randomMetadataForTx() {
         int settingNo = randomIntBetween(0, 10);
-        Metadata.Builder builder = Metadata.builder()
+        Metadata.Builder builder = new Metadata.Builder(Metadata.OID_UNASSIGNED)
             .persistentSettings(Settings.builder().put("setting" + settingNo, randomAlphaOfLength(5)).build());
         int numOfIndices = randomIntBetween(0, 3);
 

--- a/server/src/test/java/org/elasticsearch/gateway/MockGatewayMetaState.java
+++ b/server/src/test/java/org/elasticsearch/gateway/MockGatewayMetaState.java
@@ -76,7 +76,7 @@ public class MockGatewayMetaState extends GatewayMetaState {
             .thenReturn(new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS));
         final MetaStateService metaStateService = mock(MetaStateService.class);
         try {
-            when(metaStateService.loadFullState()).thenReturn(new Tuple<>(Manifest.empty(), Metadata.builder().build()));
+            when(metaStateService.loadFullState()).thenReturn(new Tuple<>(Manifest.empty(), new Metadata.Builder(Metadata.OID_UNASSIGNED).build()));
         } catch (IOException e) {
             throw new AssertionError(e);
         }

--- a/server/src/test/java/org/elasticsearch/gateway/PrimaryShardAllocatorTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/PrimaryShardAllocatorTests.java
@@ -422,7 +422,7 @@ public class PrimaryShardAllocatorTests extends ESAllocationTestCase {
     }
 
     private RoutingAllocation getRestoreRoutingAllocation(AllocationDeciders allocationDeciders, Long shardSize, String... allocIds) {
-        Metadata metadata = Metadata.builder()
+        Metadata metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED)
             .put(IndexMetadata.builder(shardId.getIndexUUID()).settings(settings(Version.CURRENT)).numberOfShards(1).numberOfReplicas(0)
                 .putInSyncAllocationIds(0, Set.of(allocIds)))
             .build();
@@ -448,7 +448,7 @@ public class PrimaryShardAllocatorTests extends ESAllocationTestCase {
 
     private RoutingAllocation routingAllocationWithOnePrimaryNoReplicas(AllocationDeciders deciders, UnassignedInfo.Reason reason,
                                                                         String... activeAllocationIds) {
-        Metadata metadata = Metadata.builder()
+        Metadata metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED)
                 .put(IndexMetadata.builder(shardId.getIndexUUID()).settings(settings(Version.CURRENT))
                     .numberOfShards(1).numberOfReplicas(0).putInSyncAllocationIds(shardId.id(), Set.of(activeAllocationIds)))
                 .build();

--- a/server/src/test/java/org/elasticsearch/gateway/ReplicaShardAllocatorTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/ReplicaShardAllocatorTests.java
@@ -467,7 +467,7 @@ public class ReplicaShardAllocatorTests extends ESAllocationTestCase {
             .settings(settings(Version.CURRENT).put(settings))
             .numberOfShards(1).numberOfReplicas(1)
             .putInSyncAllocationIds(0, Set.of(primaryShard.allocationId().getId()));
-        Metadata metaData = Metadata.builder().put(indexMetadata).build();
+        Metadata metaData = new Metadata.Builder(Metadata.OID_UNASSIGNED).put(indexMetadata).build();
         // mark shard as delayed if reason is NODE_LEFT
         boolean delayed = reason == UnassignedInfo.Reason.NODE_LEFT &&
             UnassignedInfo.INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING.get(settings).nanos() > 0;
@@ -494,7 +494,7 @@ public class ReplicaShardAllocatorTests extends ESAllocationTestCase {
 
     private RoutingAllocation onePrimaryOnNode1And1ReplicaRecovering(AllocationDeciders deciders, UnassignedInfo unassignedInfo) {
         ShardRouting primaryShard = TestShardRouting.newShardRouting(shardId, node1.getId(), true, ShardRoutingState.STARTED);
-        Metadata metaData = Metadata.builder()
+        Metadata metaData = new Metadata.Builder(Metadata.OID_UNASSIGNED)
                 .put(IndexMetadata.builder(shardId.getIndexUUID()).settings(settings(Version.CURRENT))
                     .numberOfShards(1).numberOfReplicas(1)
                     .putInSyncAllocationIds(0, Set.of(primaryShard.allocationId().getId())))

--- a/server/src/test/java/org/elasticsearch/indices/ShardLimitValidatorTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/ShardLimitValidatorTests.java
@@ -94,7 +94,7 @@ public class ShardLimitValidatorTests extends CrateDummyClusterServiceUnitTest {
             .creationDate(randomLong())
             .numberOfShards(shardsInIndex)
             .numberOfReplicas(replicas);
-        Metadata.Builder metadata = Metadata.builder().put(indexMetadata);
+        Metadata.Builder metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED).put(indexMetadata);
         return ClusterState.builder(ClusterName.DEFAULT)
             .metadata(metadata)
             .nodes(nodes)

--- a/server/src/test/java/org/elasticsearch/repositories/blobstore/BlobStoreRepositoryRestoreTests.java
+++ b/server/src/test/java/org/elasticsearch/repositories/blobstore/BlobStoreRepositoryRestoreTests.java
@@ -178,7 +178,7 @@ public class BlobStoreRepositoryRestoreTests extends IndexShardTestCase {
                 createNodeContext(), IndexScopedSettings.DEFAULT_SCOPED_SETTINGS, null
             );
             Metadata metadata = metadataUpgradeService.upgradeMetadata(
-                Metadata.builder().put(shard.indexSettings().getIndexMetadata(), false).build()
+                new Metadata.Builder(Metadata.OID_UNASSIGNED).put(shard.indexSettings().getIndexMetadata(), false).build()
             );
 
             // snapshot the shard

--- a/server/src/testFixtures/java/io/crate/operation/aggregation/AggregationTestCase.java
+++ b/server/src/testFixtures/java/io/crate/operation/aggregation/AggregationTestCase.java
@@ -24,7 +24,7 @@ package io.crate.operation.aggregation;
 import static io.crate.testing.TestingHelpers.createNodeContext;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
-import static org.elasticsearch.cluster.metadata.Metadata.COLUMN_OID_UNASSIGNED;
+import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
 import static org.elasticsearch.index.shard.IndexShardTestCase.EMPTY_EVENT_LISTENER;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -43,6 +43,7 @@ import java.util.stream.Collectors;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
@@ -338,7 +339,7 @@ public abstract class AggregationTestCase extends ESTestCase {
                     true,
                     true,
                     i + 1,
-                    COLUMN_OID_UNASSIGNED,
+                    OID_UNASSIGNED,
                     false,
                     null
                 )
@@ -379,7 +380,7 @@ public abstract class AggregationTestCase extends ESTestCase {
                                      Object[][] data,
                                      List<Reference> targetColumns) throws IOException {
         DocTableInfo table = new DocTableInfo(
-            PARTITION_NAME.relationName(),
+                Metadata.OID_UNASSIGNED, PARTITION_NAME.relationName(),
             targetColumns.stream().collect(Collectors.toMap(Reference::column, r -> r)),
             Map.of(),
             Set.of(),
@@ -636,7 +637,7 @@ public abstract class AggregationTestCase extends ESTestCase {
                     true,
                     storageSupport.docValuesDefault(),
                     i + 1,
-                    COLUMN_OID_UNASSIGNED,
+                    OID_UNASSIGNED,
                     false,
                     null)
             );

--- a/server/src/testFixtures/java/io/crate/testing/QueryTester.java
+++ b/server/src/testFixtures/java/io/crate/testing/QueryTester.java
@@ -22,7 +22,7 @@
 package io.crate.testing;
 
 import static java.util.Objects.requireNonNull;
-import static org.elasticsearch.cluster.metadata.Metadata.COLUMN_OID_UNASSIGNED;
+import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -95,7 +95,7 @@ public final class QueryTester implements AutoCloseable {
                 createTableStmt,
                 // Disable OID generation for columns/references in order to be able to compare the query outcome with
                 // expected ones.
-                () -> COLUMN_OID_UNASSIGNED);
+                () -> OID_UNASSIGNED);
         }
 
         public Builder(ThreadPool threadPool,

--- a/server/src/testFixtures/java/io/crate/testing/SQLExecutor.java
+++ b/server/src/testFixtures/java/io/crate/testing/SQLExecutor.java
@@ -798,7 +798,8 @@ public class SQLExecutor {
             Lists.map(boundCreateTable.partitionedBy(), Reference::toColumn),
             State.OPEN,
             indexUUIDs,
-            0
+            0,
+            mdBuilder.tableOidSupplier().nextOid()
         );
         ClusterState newState = ClusterState.builder(prevState)
             .metadata(mdBuilder.build())
@@ -864,8 +865,8 @@ public class SQLExecutor {
                 table.partitionedBy(),
                 State.CLOSE,
                 table.indexUUIDs(),
-                table.tableVersion()
-            );
+                table.tableVersion(),
+                table.oid());
         }
         ClusterBlocks.Builder blocksBuilder = ClusterBlocks.builder()
             .blocks(clusterService.state().blocks());
@@ -967,7 +968,8 @@ public class SQLExecutor {
             prevState.nodes().getSmallestNonClientNodeVersion()
         ).build();
 
-        Metadata.Builder mdBuilder = Metadata.builder(prevState.metadata())
+        Metadata.Builder mdBuilder = Metadata.builder(prevState.metadata());
+        mdBuilder
             .setBlobTable(relationName, indexMetadata.getIndexUUID(), settings, State.OPEN)
             .put(indexMetadata, true);
         ClusterState state = ClusterState.builder(prevState)

--- a/server/src/testFixtures/java/org/elasticsearch/index/engine/TranslogHandler.java
+++ b/server/src/testFixtures/java/org/elasticsearch/index/engine/TranslogHandler.java
@@ -66,11 +66,11 @@ public class TranslogHandler implements Engine.TranslogRecoveryRunner {
             false,
             true,
             0,
-            Metadata.COLUMN_OID_UNASSIGNED,
+            Metadata.OID_UNASSIGNED,
             false,
             null);
         DocTableInfo table = new DocTableInfo(
-            relation,
+                Metadata.OID_UNASSIGNED, relation,
             Map.of(ColumnIdent.of("value"), column),
             Map.of(),
             Set.of(),

--- a/server/src/testFixtures/java/org/elasticsearch/index/shard/IndexShardTestCase.java
+++ b/server/src/testFixtures/java/org/elasticsearch/index/shard/IndexShardTestCase.java
@@ -47,6 +47,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.support.PlainFuture;
 import org.elasticsearch.action.support.replication.TransportReplicationAction;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
@@ -242,7 +243,7 @@ public abstract class IndexShardTestCase extends ESTestCase {
         NodeContext nodeCtx = createNodeContext();
         DocTableInfoFactory tableFactory = new DocTableInfoFactory(nodeCtx);
         IndexMetadata indexMetadata = getIndexMetadata.get();
-        return tableFactory.create(indexMetadata);
+        return tableFactory.create(indexMetadata, Metadata.OID_UNASSIGNED);
     }
 
     protected void assertDocCount(IndexShard shard, int docDount) throws IOException {

--- a/server/src/testFixtures/java/org/elasticsearch/repositories/blobstore/BlobStoreTestUtil.java
+++ b/server/src/testFixtures/java/org/elasticsearch/repositories/blobstore/BlobStoreTestUtil.java
@@ -283,7 +283,7 @@ public final class BlobStoreTestUtil {
      */
     public static ClusterService mockClusterService(RepositoryMetadata metadata) {
         return mockClusterService(ClusterState.builder(ClusterState.EMPTY_STATE).metadata(
-            Metadata.builder().putCustom(RepositoriesMetadata.TYPE,
+            new Metadata.Builder(Metadata.OID_UNASSIGNED).putCustom(RepositoriesMetadata.TYPE,
                                          new RepositoriesMetadata(Collections.singletonList(metadata))).build()).build());
     }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This PR introduces OIDs to tables which allows identifying relations by `OID` instead of s`chema + name`. This is a pre-requisite to make sure concurrent operations like table swaps or renames don't break queries that are already running.


Key changes:
- Added an int `tableOID` field to `RelationMetadata`, `DocTableInfo` to uniquely identify tables.
- Added a `Metadata.currentMaxTableOid`, `Metadata.Builder.currentMaxTableOid`, and `Metadata.Builder.tableOidSupplier` to transfer the current max table oid when building a new `Metadata`.


`Metadata` exposes `Metadata.Builder` with two factory methods. Updated them to make sure the `OidSupplier` is in sync:
- `builder(Metadata metadata)`: This is for normal updates. It just carries over the current supplier to the new `Metadata`.
- `builder()`: This has more complex uses:
  - bootstrapping
  - loading from disk
  - logical replication communication
  - restoring snapshot
  

To make sure that `builder()` keeps the consistency of the OIDs, it has been updated to accept `currentMaxTableOid` parameter, then added an assert in `Metadata.Builder.build()`, it checks:
- all assigned tableOIDs are unique.
- All assigned tableOIDs are <= tableOidSupplier

**Exception**: There is an exception for restoring old Metadata. The restore process creates Metadata twice (once to restore, once to upgrade). The restored one might fail the assert until the upgrade is finished. This is only for version >= 6 where RelationMetadata was first introduced.

Follow ups:
- update relation lookups to actually use these OIDs instead of names.
- add the actual logic to handle concurrent table swaps and renames.
- https://github.com/crate/crate/pull/18954#discussion_r2742325630 - could also be a separate FR.
## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
