### PR TITLE
Fix nested subscript lookup on aliased function symbols

### DIFF
--- a/docs/appendices/release-notes/6.1.3.rst
+++ b/docs/appendices/release-notes/6.1.3.rst
@@ -142,3 +142,16 @@ Fixes
   restarts. Flag mentioned in :ref:`version_6.0.0_breaking_changes` and
   :ref:`version_6.1.0_breaking_changes` is already set to ``NORMAL`` starting
   from this version and won't be needed at all starting from CrateDB 6.2.0.
+
+- Fixed a regression introduced in :ref:`version_6.0.0` that caused nested path
+  accesses on ``ARRAY(OBJECT)`` columns returned by a sub-select using a
+  ``UNNEST`` function to either fail with a ``ColumnUnknownException`` or
+  return incorrect results as wrong child-columns are used. Example::
+
+    SELECT obj_arr['child_obj']['id'] AS id
+    FROM (
+      SELECT unnest(
+        [ {child_obj = { id = 'correct_id'}, id='wrong_id'} ]
+      ) AS obj_arr
+    ) AS sub1
+    --> now returns 'correct_id' instead of returning 'wrong_id'

--- a/docs/appendices/release-notes/6.2.1.rst
+++ b/docs/appendices/release-notes/6.2.1.rst
@@ -95,3 +95,17 @@ Fixes
   on reserved schemas (e.g., ``sys``, ``doc``). This was harmless; for example,
   no tables could be created in the ``sys`` schema regardless, but the
   operations are now blocked.
+
+
+- Fixed a regression introduced in :ref:`version_6.0.0` that caused nested path
+  accesses on ``ARRAY(OBJECT)`` columns returned by a sub-select using a
+  ``UNNEST`` function to either fail with a ``ColumnUnknownException`` or
+  return incorrect results as wrong child-columns are used. Example::
+
+    SELECT obj_arr['child_obj']['id'] AS id
+    FROM (
+      SELECT unnest(
+        [ {child_obj = { id = 'correct_id'}, id='wrong_id'} ]
+      ) AS obj_arr
+    ) AS sub1
+    --> now returns 'correct_id' instead of returning 'wrong_id'

--- a/server/src/test/java/io/crate/expression/scalar/SubscriptFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/SubscriptFunctionTest.java
@@ -37,6 +37,7 @@ import io.crate.exceptions.ConversionException;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.SelectSymbol;
 import io.crate.expression.symbol.Symbol;
+import io.crate.types.ArrayType;
 import io.crate.types.DataTypes;
 
 
@@ -83,7 +84,7 @@ public class SubscriptFunctionTest extends ScalarTestCase {
     public void test_subscript_can_be_used_on_subqueries_returning_objects() {
         assertNormalize(
             "(select {x=10})['x']",
-            isFunction("subscript", exactlyInstanceOf(SelectSymbol.class), isLiteral("x"))
+            isFunction("subscript_obj", exactlyInstanceOf(SelectSymbol.class), isLiteral("x"))
         );
     }
 
@@ -163,12 +164,13 @@ public class SubscriptFunctionTest extends ScalarTestCase {
     @Test
     public void test_return_type_of_subscript_on_literals() {
         assertNormalize("{a = {b = 1}}['a']['b']", isLiteral(1, DataTypes.INTEGER));
+        assertNormalize("[{a = {b = 1}}]['a']['b']", isLiteral(List.of(1), new ArrayType<>(DataTypes.INTEGER)));
         assertNormalize("subscript({a = {b = 1}}['a'], 'b')", isLiteral(1, DataTypes.INTEGER));
     }
 
     @Test
     public void test_return_type_of_subscript_on_expressions() {
         Symbol symbol = sqlExpressions.asSymbol("(obj_typed || {c=1})['a']['b']");
-        assertThat(symbol).isFunction("subscript", DataTypes.INTEGER);
+        assertThat(symbol).isFunction("subscript_obj", DataTypes.INTEGER);
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/SubSelectIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SubSelectIntegrationTest.java
@@ -26,7 +26,6 @@ import static com.carrotsearch.randomizedtesting.RandomizedTest.$$;
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
 import static io.crate.testing.Asserts.assertThat;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -865,5 +864,36 @@ public class SubSelectIntegrationTest extends IntegTestCase {
             """;
         execute(stmt);
         assertThat(response).hasRowCount(5);
+    }
+
+    @Test
+    public void test_subscript_on_subselect_using_unnest_on_subscript() {
+        execute("""
+            SELECT obj_arr['child_obj']['id'] AS id
+                    FROM (
+                       SELECT unnest([{child_obj = { id = 'correct_id'}, id='wrong_id'}]) obj_arr
+                    ) sub1
+            """);
+        assertThat(response).hasRows("correct_id");
+    }
+
+    @Test
+    public void test_subscript_with_index_on_subselect_using_unnest_on_subscript() {
+        execute("""
+            SELECT obj_arr['child_obj']['ids'][2] AS id
+                    FROM (
+                       SELECT unnest([{child_obj = { ids = ['c1', 'c2']}, ids=['w1, w2']}]) obj_arr
+                    ) sub1;
+            """);
+        assertThat(response).hasRows("c2");
+
+        // Using nested array accesses
+        execute("""
+            SELECT obj_arr['child_obj']['ids'][1][2] AS id
+            FROM (
+               SELECT unnest([{child_obj = { ids = [['c1', 'c2']]}, ids=[['w1, w2']]}]) obj_arr
+            ) sub1;
+            """);
+        assertThat(response).hasRows("c2");
     }
 }


### PR DESCRIPTION
All child parts must be used when a direct parent isn't resolvable but upper parents are, resulting in nested subscript functions. Otherwise, a wrong sub-column will be used when trying to resolve it, resulting in an unexpected `ColumnUnknownException` or even worse, resolving an existing wrong column and such wrong results.
