### PR TITLE
Include column name to the UndefinedType indexing error

### DIFF
--- a/server/src/main/java/io/crate/types/UndefinedType.java
+++ b/server/src/main/java/io/crate/types/UndefinedType.java
@@ -127,7 +127,7 @@ public class UndefinedType extends DataType<Object> implements Streamer<Object> 
                 return new ValueIndexer<>() {
                     @Override
                     public void indexValue(Object value, IndexDocumentBuilder docBuilder) {
-                        throw new UnsupportedOperationException("Cannot index values for type `undefined`");
+                        throw new UnsupportedOperationException("Cannot index values of column " + ref.column() + " with type `undefined`");
                     }
 
                     @Override


### PR DESCRIPTION
Example from another local branch where I'm using this for debugging
``
java.lang.UnsupportedOperationException: Cannot index values of column offices['description'] with type `undefined
``

