### PR TITLE
Don't propagate added undefined type to parent column inner types

### DIFF
--- a/docs/appendices/release-notes/6.1.3.rst
+++ b/docs/appendices/release-notes/6.1.3.rst
@@ -155,3 +155,8 @@ Fixes
       ) AS obj_arr
     ) AS sub1
     --> now returns 'correct_id' instead of returning 'wrong_id'
+
+- Fixed an issue that caused inserts to fail with a
+  ``UnsupportedFeatureException`` error if a sub-column of a ``OBJECT`` typed
+  column, previously created with a ``NULL`` value, is then inserted using a
+  non-NULL value and such using a concrete data type.

--- a/docs/appendices/release-notes/6.2.1.rst
+++ b/docs/appendices/release-notes/6.2.1.rst
@@ -109,3 +109,8 @@ Fixes
       ) AS obj_arr
     ) AS sub1
     --> now returns 'correct_id' instead of returning 'wrong_id'
+
+- Fixed a regression introduced in ref:`version_6.2.0` that caused inserts to
+  fail with a ``UnsupportedFeatureException`` error if a sub-column of a
+  ``OBJECT`` typed column, previously created with a ``NULL`` value, is then
+  inserted using a non-NULL value and such using a concrete data type.


### PR DESCRIPTION
Closes https://github.com/crate/crate/issues/18955

Fixes a regression introduced in 6.2.0.

We started adding `UndefinedType` sub-columns for null values in https://github.com/crate/crate/commit/5ec34b24285d113c079d07471458cab937255380

This needs to be taken into account in child type propagation that was introduced in https://github.com/crate/crate/commit/d7b27a2107e360b08185fb6df81597b39470e3dc

Undefined type must not overwrite a concrete type on schema updates, it's handled by `DocTableInfo.staleUndefined`

Propagation of `UndefinedType` cancels outs logic to do nothing on `staleUndefined`. 

As a consequence, dynamic mapping update with `subcol:null` can put an `UndefinedType` 
instead of existing concrete type to the cluster state. 

That broken state can arrive to another item that just collected schema updates and was waiting for blocking result of `AddColumnRequest`. That item is then indexed with incorrect `UndefinedType` and throw `UnsupportedFeatureException`