### PR TITLE
Fix flaky PrivilegesIntegrationTest

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/PrivilegesIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/PrivilegesIntegrationTest.java
@@ -29,6 +29,7 @@ import static io.crate.testing.TestingHelpers.printedTable;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
 import static io.netty.handler.codec.http.HttpResponseStatus.UNAUTHORIZED;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.After;
 import org.junit.Before;
@@ -95,6 +96,7 @@ public class PrivilegesIntegrationTest extends BaseRolesIntegrationTest {
     @After
     public void dropDbObjects() {
         executeAsSuperuser("drop view if exists v1, my_schema.v2, other_schema.v3");
+        executeAsSuperuser("drop function if exists my_schema.foo(bigint)");
     }
 
     @Test


### PR DESCRIPTION
Became flaky with https://github.com/crate/crate/pull/18827 due to two
test methods creating the same function without drop function in the
teardown:

    org.postgresql.util.PSQLException:
    ERROR: User defined Function 'my_schema.foo(bigint)' already exists.
      Where: io.crate.expression.udf.UserDefinedFunctionService.putFunction(UserDefinedFunctionService.java:181)
    io.crate.expression.udf.UserDefinedFunctionService$1.execute(UserDefinedFunctionService.java:102)
    org.elasticsearch.cluster.ClusterStateUpdateTask.execute(ClusterStateUpdateTask.java:45)
    org.elasticsearch.cluster.service.MasterService.executeTasks(MasterService.java:664)
    org.elasticsearch.cluster.service.MasterService.calculateTaskOutputs(MasterService.java:281)
    org.elasticsearch.cluster.service.MasterService.runTasks(MasterService.java:176)
    org.elasticsearch.cluster.service.MasterService.lambda$doStart$0(MasterService.java:122)
    org.elasticsearch.cluster.service.TaskBatcher.runIfNotProcessed(TaskBatcher.java:170)
    org.elasticsearch.cluster.service.BatchedTask.run(BatchedTask.java:71)
    org.elasticsearch.common.util.concurrent.PrioritizedEsThreadPoolExecutor$TieBreakingPrioritizedRunnable.runAndClean(PrioritizedEsThreadPoolExecutor.java:208)
    org.elasticsearch.common.util.concurrent.PrioritizedEsThreadPoolExecutor$TieBreakingPrioritizedRunnable.run(PrioritizedEsThreadPoolExecutor.java:171)
    java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
    java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
    java.lang.Thread.run(Thread.java:1474)
    	at __randomizedtesting.SeedInfo.seed([9A2F090BD8464E65:9F196E470CC6AA77]:0)
