### PR TITLE
Add `region` option support for s3 repositories

### DIFF
--- a/docs/appendices/release-notes/6.3.0.rst
+++ b/docs/appendices/release-notes/6.3.0.rst
@@ -98,6 +98,10 @@ Performance and Resilience Improvements
 Administration and Operations
 -----------------------------
 
+- Added a ``region`` option to repositories of type ``s3`` for compatibility
+  with alternative s3 implementations like `Garage
+  <https://garagehq.deuxfleurs.fr/>`_.
+
 - Repositories of type ``s3`` now use path style access by default instead of
   virtual host style when building the URI.
 

--- a/docs/sql/statements/create-repository.rst
+++ b/docs/sql/statements/create-repository.rst
@@ -265,6 +265,12 @@ Parameters
       You can specify a `regional endpoint`_ to force the use of a specific
       `AWS region`_.
 
+**region**
+  | *Type:*    ``text``
+  | *Default:* Inferred from the endpoint if possible or us-east-1.
+
+  The region to use.
+
 .. _sql-create-repo-s3-protocol:
 
 **protocol**

--- a/plugins/es-repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
+++ b/plugins/es-repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
@@ -88,6 +88,7 @@ public class S3Repository extends BlobStoreRepository {
                        SERVER_SIDE_ENCRYPTION_SETTING,
                        // client specific settings
                        ENDPOINT_SETTING,
+                       S3RepositorySettings.REGION,
                        PROTOCOL_SETTING,
                        MAX_RETRIES_SETTING,
                        USE_THROTTLE_RETRIES_SETTING,
@@ -173,7 +174,10 @@ public class S3Repository extends BlobStoreRepository {
             endpoint = protocol + "://" + endpoint;
         }
         boolean usePathStyle = S3RepositorySettings.USE_PATH_STYLE_ACCESS.get(settings);
-        String region = S3.getRegion(endpoint, bucket);
+        String region = S3RepositorySettings.REGION.getOrNull(settings);
+        if (region == null) {
+            region = S3.getRegion(endpoint, bucket);
+        }
         var configBuilder = ServiceConfig.S3.builder()
             .bucket(bucket)
             .endpoint(endpoint)

--- a/plugins/es-repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3RepositorySettings.java
+++ b/plugins/es-repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3RepositorySettings.java
@@ -145,6 +145,8 @@ class S3RepositorySettings {
         DataTypes.STRING,
         Setting.Property.NodeScope);
 
+    static final Setting<String> REGION = Setting.simpleString("region", Setting.Property.NodeScope);
+
     /**
      * The protocol to use to connect to s3.
      */


### PR DESCRIPTION
Required to use alternative s3 implementations like https://garagehq.deuxfleurs.fr/
