### PR TITLE
Add `regexp_count` scalar function

### DIFF
--- a/docs/appendices/release-notes/6.3.0.rst
+++ b/docs/appendices/release-notes/6.3.0.rst
@@ -102,6 +102,9 @@ Scalar and Aggregation Functions
 - `Dhruv Patel <https://github.com/DHRUV6029>`_ added support for ``interval``
   type to the :ref:`percentile <aggregation-percentile>` aggregation function.
 
+- Added the :ref:`regexp_count <scalar-regexp_count>` scalar function to count
+  regular expression matches, with optional ``start`` and ``flags`` arguments.
+
 Performance and Resilience Improvements
 ---------------------------------------
 

--- a/docs/general/builtins/scalar-functions.rst
+++ b/docs/general/builtins/scalar-functions.rst
@@ -2706,6 +2706,62 @@ See the API documentation for more details.
     operator <sql_dql_regexp>` uses `Lucene Regular Expressions`_.
 
 
+.. _scalar-regexp_count:
+
+``regexp_count(text, pattern [, start [, flags]])``
+---------------------------------------------------
+
+Counts the number of non-overlapping occurrences of ``pattern`` in ``text``.
+``start`` is an optional 1-based index to start searching from. If ``start``
+is less than ``1``, an error is raised. If ``start`` is beyond the length of
+``text``, the result is ``0``. Returns ``NULL`` if any of the parameters is
+``NULL``.
+
+Returns: ``integer``
+
+``pattern`` is a Java regular expression. For details on the regexp syntax, see
+`Java Regular Expressions`_.
+
+``flags`` is a string containing any of the characters listed in
+:ref:`regexp_replace flags <scalar-regexp_replace-flags>` except for the
+``g`` flag which only makes sense for replacements.
+
+Examples
+........
+
+::
+
+    cr> select regexp_count('foobarbequebaz', 'ba(r|z)') AS count;
+    +-------+
+    | count |
+    +-------+
+    |     2 |
+    +-------+
+    SELECT 1 row in set (... sec)
+
+::
+
+    cr> select regexp_count('AaA', 'a+', 1, 'i') AS count;
+    +-------+
+    | count |
+    +-------+
+    |     1 |
+    +-------+
+    SELECT 1 row in set (... sec)
+
+Or with ``start`` and ``flags`` (``i`` for case-insensitive matching):
+
+::
+
+    cr> select regexp_count('a-A-a', 'a+', 2, 'i') AS count;
+    +-------+
+    | count |
+    +-------+
+    |     2 |
+    +-------+
+    SELECT 1 row in set (... sec)
+
+
 .. _scalar-regexp_replace:
 
 ``regexp_replace(source, pattern, replacement [, flags])``

--- a/server/src/main/java/io/crate/expression/scalar/ScalarFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/ScalarFunctions.java
@@ -67,6 +67,7 @@ import io.crate.expression.scalar.postgres.PgGetUserByIdFunction;
 import io.crate.expression.scalar.postgres.PgPostmasterStartTime;
 import io.crate.expression.scalar.postgres.PgSleepFunction;
 import io.crate.expression.scalar.postgres.PgTableIsVisibleFunction;
+import io.crate.expression.scalar.regex.RegexpCountFunction;
 import io.crate.expression.scalar.regex.RegexpReplaceFunction;
 import io.crate.expression.scalar.string.AsciiFunction;
 import io.crate.expression.scalar.string.ChrFunction;
@@ -122,6 +123,7 @@ public class ScalarFunctions implements FunctionsProvider {
         NumericCollectionAverageFunction.register(builder);
         FormatFunction.register(builder);
         SubstrFunction.register(builder);
+        RegexpCountFunction.register(builder);
         RegexpReplaceFunction.register(builder);
 
         ArithmeticFunctions.register(builder);

--- a/server/src/main/java/io/crate/expression/scalar/regex/RegexpCountFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/regex/RegexpCountFunction.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.expression.scalar.regex;
+
+import static io.crate.expression.RegexpFlags.isGlobal;
+import static io.crate.expression.RegexpFlags.parseFlags;
+
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.jspecify.annotations.Nullable;
+
+import io.crate.data.Input;
+import io.crate.expression.symbol.Function;
+import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.FunctionType;
+import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.Scalar;
+import io.crate.metadata.TransactionContext;
+import io.crate.metadata.functions.BoundSignature;
+import io.crate.metadata.functions.Signature;
+import io.crate.role.Roles;
+import io.crate.types.DataTypes;
+import io.crate.types.TypeSignature;
+
+public final class RegexpCountFunction extends Scalar<Integer, Object> {
+
+    public static final String NAME = "regexp_count";
+
+    public static void register(Functions.Builder builder) {
+        TypeSignature stringType = DataTypes.STRING.getTypeSignature();
+        TypeSignature intType = DataTypes.INTEGER.getTypeSignature();
+        builder.add(
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(stringType, stringType)
+                .returnType(intType)
+                .features(Feature.DETERMINISTIC, Feature.STRICTNULL)
+                .build(),
+            RegexpCountFunction::new
+        );
+        builder.add(
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(stringType, stringType, intType)
+                .returnType(intType)
+                .features(Feature.DETERMINISTIC, Feature.STRICTNULL)
+                .build(),
+            RegexpCountFunction::new
+        );
+        builder.add(
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(stringType, stringType, intType, stringType)
+                .returnType(intType)
+                .features(Feature.DETERMINISTIC, Feature.STRICTNULL)
+                .build(),
+            RegexpCountFunction::new
+        );
+    }
+
+    @Nullable
+    private final Pattern pattern;
+
+    private RegexpCountFunction(Signature signature, BoundSignature boundSignature) {
+        this(signature, boundSignature, null);
+    }
+
+    private RegexpCountFunction(Signature signature, BoundSignature boundSignature, @Nullable Pattern pattern) {
+        super(signature, boundSignature);
+        this.pattern = pattern;
+    }
+
+    @Override
+    public Symbol normalizeSymbol(Function symbol, TransactionContext txnCtx, NodeContext nodeCtx) {
+        return evaluateIfLiterals(this, txnCtx, nodeCtx, symbol);
+    }
+
+    @Override
+    public Scalar<Integer, Object> compile(List<Symbol> arguments, String currentUser, Roles roles) {
+        assert arguments.size() >= 2 : "number of arguments must be >= 2";
+        Symbol patternSymbol = arguments.get(1);
+        if (patternSymbol instanceof Input<?> input) {
+            String pattern = (String) input.value();
+            if (pattern == null) {
+                return this;
+            }
+            if (arguments.size() == 4) {
+                Symbol flagsSymbol = arguments.get(3);
+                if (flagsSymbol instanceof Input<?> flagsInput) {
+                    String flags = (String) flagsInput.value();
+                    if (flags == null) {
+                        return this;
+                    }
+                    if (isGlobal(flags)) {
+                        throw new IllegalArgumentException("The regular expression flag is unknown: g");
+                    }
+                    return new RegexpCountFunction(signature, boundSignature, Pattern.compile(pattern, parseFlags(flags)));
+                }
+                return this;
+            }
+            return new RegexpCountFunction(signature, boundSignature, Pattern.compile(pattern));
+        }
+        return this;
+    }
+
+    @Override
+    public Integer evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Object>[] args) {
+        assert args.length >= 2 && args.length <= 4 : "number of args must be 2 to 4";
+        String value = (String) args[0].value();
+        String patternStr = (String) args[1].value();
+        if (value == null || patternStr == null) {
+            return null;
+        }
+
+        int startIndex = 0;
+        if (args.length >= 3) {
+            Number start = (Number) args[2].value();
+            if (start == null) {
+                return null;
+            }
+            int startValue = start.intValue();
+            if (startValue < 1) {
+                throw new IllegalArgumentException("`start` must be greater than or equal to 1");
+            }
+            startIndex = startValue - 1;
+        }
+        if (startIndex >= value.length()) {
+            return 0;
+        }
+
+        String flags = null;
+        if (args.length == 4) {
+            flags = (String) args[3].value();
+            if (flags == null) {
+                return null;
+            }
+            if (isGlobal(flags)) {
+                throw new IllegalArgumentException("The regular expression flag is unknown: g");
+            }
+        }
+
+        Pattern pattern;
+        if (this.pattern == null) {
+            pattern = Pattern.compile(patternStr, parseFlags(flags));
+        } else {
+            pattern = this.pattern;
+        }
+
+        Matcher matcher = pattern.matcher(value);
+        matcher.region(startIndex, value.length());
+        int count = 0;
+        while (matcher.find()) {
+            count++;
+        }
+        return count;
+    }
+}

--- a/server/src/test/java/io/crate/expression/scalar/regex/RegexpCountFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/regex/RegexpCountFunctionTest.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.expression.scalar.regex;
+
+import static io.crate.testing.Asserts.isLiteral;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.Test;
+
+import io.crate.exceptions.UnsupportedFunctionException;
+import io.crate.expression.scalar.ScalarTestCase;
+import io.crate.expression.symbol.Literal;
+
+public class RegexpCountFunctionTest extends ScalarTestCase {
+
+    @Test
+    public void test_count_no_match() {
+        assertEvaluate("regexp_count(name, 'crate')", 0, Literal.of("foobarbequebaz"));
+    }
+
+    @Test
+    public void test_count_basic() {
+        assertEvaluate("regexp_count(name, 'ba(?:r|z)')", 2, Literal.of("foobarbequebaz"));
+    }
+
+    @Test
+    public void test_count_non_overlapping() {
+        assertEvaluate("regexp_count('aaaa', 'a{2}')", 2);
+    }
+
+    @Test
+    public void test_count_with_start() {
+        assertEvaluate("regexp_count('abcabc', 'abc', 2)", 1);
+        assertEvaluate("regexp_count('abcabc', 'abc', 1)", 2);
+        assertEvaluate("regexp_count('aaaa', 'aa', 2)", 1);
+    }
+
+    @Test
+    public void test_count_start_beyond_length() {
+        assertEvaluate("regexp_count('abc', 'a', 5)", 0);
+    }
+
+    @Test
+    public void test_count_start_zero_or_negative_throws_error() {
+        assertThatThrownBy(() -> assertEvaluate("regexp_count('abcabc', 'abc', 0)", 2))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("`start` must be greater than or equal to 1");
+        assertThatThrownBy(() -> assertEvaluate("regexp_count('abcabc', 'abc', -2)", 2))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("`start` must be greater than or equal to 1");
+        assertThatThrownBy(() -> assertEvaluate("regexp_count('abc', 'a', -2147483648)", 1))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("`start` must be greater than or equal to 1");
+    }
+
+    @Test
+    public void test_count_with_flags() {
+        assertEvaluate("regexp_count('AaA', 'a', 1, 'i')", 3);
+    }
+
+    @Test
+    public void test_g_flag_is_rejected() {
+        assertThatThrownBy(() -> assertNormalize("regexp_count('aba', 'a', 1, 'g')", isLiteral(0)))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("The regular expression flag is unknown: g");
+    }
+
+    @Test
+    public void test_g_flag_is_rejected_during_compile() {
+        assertThatThrownBy(() -> assertCompile("regexp_count(name, 'a', 1, 'g')", ignored -> ignored2 -> {
+        }))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("The regular expression flag is unknown: g");
+    }
+
+    @Test
+    public void test_nulls() {
+        assertEvaluateNull("regexp_count(null, 'a')");
+        assertEvaluateNull("regexp_count('abc', null)");
+        assertEvaluateNull("regexp_count('abc', 'a', null)");
+        assertEvaluateNull("regexp_count('aaa', 'a', 1, null)");
+    }
+
+    @Test
+    public void test_normalize_symbol() {
+        assertNormalize("regexp_count('AbA', 'a', 1, 'i')", isLiteral(2));
+    }
+
+    @Test
+    public void test_invalid_flags() {
+        assertThatThrownBy(() -> assertNormalize("regexp_count('foobar', 'foo', 1, 'n')", isLiteral(0)))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("The regular expression flag is unknown: n");
+    }
+
+    @Test
+    public void test_invalid_number_of_arguments() {
+        assertThatThrownBy(() -> assertEvaluateNull("regexp_count('foobar')"))
+            .isExactlyInstanceOf(UnsupportedFunctionException.class);
+        assertThatThrownBy(() -> assertCompile("regexp_count('foobar')", ignored -> ignored2 -> {
+        }))
+            .isExactlyInstanceOf(UnsupportedFunctionException.class);
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Adds the `regexp_count(text, pattern [, start [, flags]])` scalar function to count non-overlapping regex matches with optional 1-based start and flags. This completes the regex scalar set and aligns behavior with existing regex functions (flag parsing, literal precompilation,
null semantics). 

Closes #18983.

## Checklist

 - [ ] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
