### PR TITLE
Fix table SWAP/DROP that corrupt Metadata in a mixed cluster

### DIFF
--- a/docs/appendices/release-notes/6.0.6.rst
+++ b/docs/appendices/release-notes/6.0.6.rst
@@ -46,4 +46,8 @@ series.
 Fixes
 =====
 
-None
+- Fixed an issue that caused :ref:`swap table <alter_cluster_swap_table>` or
+  :ref:`drop table <drop-table>` to cause temporary metadata corruption if
+  run during a rolling upgrade from 5.10.x. The corruption can be recovered by
+  restarting the upgraded nodes. Rolling upgrades from 6.0+ to 6.2.2 weren't
+  affected.

--- a/docs/appendices/release-notes/6.1.4.rst
+++ b/docs/appendices/release-notes/6.1.4.rst
@@ -46,4 +46,8 @@ series.
 Fixes
 =====
 
-None
+- Fixed an issue that caused :ref:`swap table <alter_cluster_swap_table>` or
+  :ref:`drop table <drop-table>` to cause temporary metadata corruption if
+  run during a rolling upgrade from 5.10.x. The corruption can be recovered by
+  restarting the upgraded nodes. Rolling upgrades from 6.0+ to 6.2.2 weren't
+  affected.

--- a/docs/appendices/release-notes/6.2.2.rst
+++ b/docs/appendices/release-notes/6.2.2.rst
@@ -49,4 +49,8 @@ series.
 Fixes
 =====
 
-None
+- Fixed an issue that caused :ref:`swap table <alter_cluster_swap_table>` or
+  :ref:`drop table <drop-table>` to cause temporary metadata corruption if
+  run during a rolling upgrade from 5.10.x. The corruption can be recovered by
+  restarting the upgraded nodes. Rolling upgrades from 6.0+ to 6.2.2 weren't
+  affected.


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes https://github.com/crate/crate/issues/18972.

`SWAP`/`DELETE` tables use `MetadataDiff.deletes` to stream the changes in Metadata among nodes. Since `6.0`, metadata formatting is changed.(`Metadata.schemas` added) `MetadataDiff.deletes` streamed from a node < `6.0` only holds diffs of `indices` and `templates` which must be manually applied to `Metadata.schemas` for consistency.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
