### PR TITLE
Fix: CLA GHA updated to use pull_request_target event

### DIFF
--- a/.github/workflows/cla-check.yml
+++ b/.github/workflows/cla-check.yml
@@ -1,6 +1,6 @@
 name: Check PR Author has signed CLA
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, unlabeled]
 jobs:
   check-author-signed-cla:


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Fix CLA check workflow for pull requests from external forks.

The `pull_request` trigger doesn't provide secrets to workflows triggered by fork PRs. Changing to `pull_request_target` runs the workflow in the base repo context, making the secrets available for the GHA. 

This has now been tested with an external by from a fork. It's unclear why this hasn't been a problem before.