### PR TITLE
Revert "Fix: CLA GHA updated to use pull_request_target event (#18991)"

### DIFF
--- a/.github/workflows/cla-check.yml
+++ b/.github/workflows/cla-check.yml
@@ -1,6 +1,6 @@
 name: Check PR Author has signed CLA
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, unlabeled]
 jobs:
   check-author-signed-cla:


### PR DESCRIPTION
This reverts commit 6e31b1bf5dbcc10195dfbff8ca76f0dd7756b958.

Using `pull_request_target` may leak secret to user code, we should consider different solutions instead.