### PR TITLE
Exclude guava from jwks-rsa

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -405,6 +405,12 @@
             <groupId>com.auth0</groupId>
             <artifactId>jwks-rsa</artifactId>
             <version>${versions.jwks-rsa}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>


### PR DESCRIPTION
See https://github.com/auth0/jwks-rsa-java/pull/121
jwks-rsa only uses guava for the `GuavaCachedJwkProvider`

We use our own `CachingJwkProvider` instead
Together with https://github.com/crate/crate/pull/18997 this means we
won't need guava on the classpath anymore
