### PR TITLE
Ensure there is only a single AsyncExecutor instance

### DIFF
--- a/plugins/cr8-copy-s3/src/main/java/io/crate/copy/s3/S3CopyPlugin.java
+++ b/plugins/cr8-copy-s3/src/main/java/io/crate/copy/s3/S3CopyPlugin.java
@@ -39,7 +39,12 @@ public class S3CopyPlugin extends Plugin implements CopyPlugin {
 
     @Inject
     public S3CopyPlugin(Settings settings) {
-        this.sharedAsyncExecutor = new SharedAsyncExecutor(settings);
+        this.sharedAsyncExecutor = SharedAsyncExecutor.getInstance(settings);
+    }
+
+    @Override
+    public void close() throws IOException {
+        sharedAsyncExecutor.close();
     }
 
     public Map<String, FileInputFactory> getFileInputFactories() {
@@ -54,10 +59,5 @@ public class S3CopyPlugin extends Plugin implements CopyPlugin {
             S3FileOutputFactory.NAME,
             new S3FileOutputFactory(sharedAsyncExecutor.asyncExecutor())
         );
-    }
-
-    @Override
-    public void close() throws IOException {
-        sharedAsyncExecutor.close();
     }
 }

--- a/plugins/crate-copy-azure/src/main/java/io/crate/copy/azure/AzureCopyPlugin.java
+++ b/plugins/crate-copy-azure/src/main/java/io/crate/copy/azure/AzureCopyPlugin.java
@@ -21,6 +21,7 @@
 
 package io.crate.copy.azure;
 
+import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
@@ -52,7 +53,12 @@ public class AzureCopyPlugin extends Plugin implements CopyPlugin {
 
     @Inject
     public AzureCopyPlugin(Settings settings) {
-        this.sharedAsyncExecutor = new SharedAsyncExecutor(settings);
+        this.sharedAsyncExecutor = SharedAsyncExecutor.getInstance(settings);
+    }
+
+    @Override
+    public void close() throws IOException {
+        sharedAsyncExecutor.close();
     }
 
     public Map<String, FileInputFactory> getFileInputFactories() {

--- a/plugins/es-discovery-ec2/src/main/java/org/elasticsearch/discovery/ec2/AmazonEc2Reference.java
+++ b/plugins/es-discovery-ec2/src/main/java/org/elasticsearch/discovery/ec2/AmazonEc2Reference.java
@@ -19,10 +19,10 @@
 
 package org.elasticsearch.discovery.ec2;
 
-import com.amazonaws.services.ec2.AmazonEC2;
-
 import org.elasticsearch.common.lease.Releasable;
 import org.elasticsearch.common.util.concurrent.AbstractRefCounted;
+
+import com.amazonaws.services.ec2.AmazonEC2;
 
 /**
  * Handles the shutdown of the wrapped {@link AmazonEC2} using reference

--- a/plugins/es-repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureRepositoryPlugin.java
+++ b/plugins/es-repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureRepositoryPlugin.java
@@ -51,7 +51,7 @@ public class AzureRepositoryPlugin extends Plugin implements RepositoryPlugin {
     private SharedAsyncExecutor executor;
 
     public AzureRepositoryPlugin(Settings settings) {
-        executor = new SharedAsyncExecutor(settings);
+        executor = SharedAsyncExecutor.getInstance(settings);
     }
 
     @Override

--- a/plugins/es-repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3RepositoryPlugin.java
+++ b/plugins/es-repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3RepositoryPlugin.java
@@ -50,7 +50,12 @@ public class S3RepositoryPlugin extends Plugin implements RepositoryPlugin {
     private final SharedAsyncExecutor executor;
 
     public S3RepositoryPlugin(Settings settings) {
-        executor = new SharedAsyncExecutor(settings);
+        executor = SharedAsyncExecutor.getInstance(settings);
+    }
+
+    @Override
+    public void close() throws IOException {
+        executor.close();
     }
 
     @Override
@@ -86,10 +91,5 @@ public class S3RepositoryPlugin extends Plugin implements RepositoryPlugin {
                 }
             }
         );
-    }
-
-    @Override
-    public void close() throws IOException {
-        executor.close();
     }
 }

--- a/plugins/repository-gcs/src/main/java/io/crate/gcs/GCSRepositoryPlugin.java
+++ b/plugins/repository-gcs/src/main/java/io/crate/gcs/GCSRepositoryPlugin.java
@@ -41,15 +41,12 @@ import io.crate.analyze.repositories.TypeSettings;
 import io.crate.opendal.SharedAsyncExecutor;
 
 
-/**
- * Based on https://github.com/opensearch-project/OpenSearch/blob/main/plugins/repository-gcs/src/main/java/org/opensearch/repositories/gcs/GoogleCloudStoragePlugin.java
- */
 public class GCSRepositoryPlugin extends Plugin implements RepositoryPlugin {
 
     private final SharedAsyncExecutor executor;
 
     public GCSRepositoryPlugin(Settings settings) {
-        executor = new SharedAsyncExecutor(settings);
+        executor = SharedAsyncExecutor.getInstance(settings);
     }
 
     @Override


### PR DESCRIPTION
To avoid spawning additional threads per OpenDAL based plugin
