### PR TITLE
Add the PostgreSQL license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -212,6 +212,27 @@ The ASF licenses Apache Lucene to You under the Apache License, Version 2.0
 
 -------------------------------------------------------------------------------
 
+The PostgreSQL License
+Copyright (c) 2026, CrateDB
+
+Permission to use, copy, modify, and distribute this software and its
+documentation for any purpose, without fee, and without a written agreement is
+hereby granted, provided that the above copyright notice and this paragraph and
+the following two paragraphs appear in all copies.
+
+IN NO EVENT SHALL CrateDB BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF THE
+USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF CrateDB HAS BEEN
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+CrateDB SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+THE SOFTWARE PROVIDED HEREUNDER IS ON AN “AS IS” BASIS, AND CrateDB HAS
+NO OBLIGATIONS TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR
+MODIFICATIONS.
+
+-------------------------------------------------------------------------------
+
 To get a quick overview about licenses of all bundled third-party build-time
 dependencies, please also see the "3RD-PARTY-NOTICES.md" file.
 


### PR DESCRIPTION
Allowing us to use documentation or even code from the PG code base.

License template taken from https://opensource.org/license/postgresql.