### PR TITLE
Replace Stack in WhereClauseValidator with ArrayDeque

### DIFF
--- a/server/src/main/java/io/crate/analyze/where/WhereClauseValidator.java
+++ b/server/src/main/java/io/crate/analyze/where/WhereClauseValidator.java
@@ -22,9 +22,9 @@
 package io.crate.analyze.where;
 
 
+import java.util.ArrayDeque;
 import java.util.Locale;
 import java.util.Set;
-import java.util.Stack;
 import java.util.function.Supplier;
 
 import io.crate.exceptions.VersioningValidationException;
@@ -51,17 +51,10 @@ public final class WhereClauseValidator {
     private WhereClauseValidator() {}
 
     public static void validate(Symbol query) {
-        query.accept(VISITOR, new Visitor.Context());
+        query.accept(VISITOR, new ArrayDeque<>());
     }
 
-    private static class Visitor extends SymbolVisitor<Visitor.Context, Symbol> {
-
-        static class Context {
-
-            private final Stack<Function> functions = new Stack<>();
-
-            private Context() {}
-        }
+    private static class Visitor extends SymbolVisitor<ArrayDeque<Function>, Symbol> {
 
         private static final String SCORE = "_score";
         private static final Set<String> SCORE_ALLOWED_COMPARISONS = Set.of(GteOperator.NAME);
@@ -77,41 +70,37 @@ public final class WhereClauseValidator {
                                                                 SCORE, ComparisonExpression.Type.GREATER_THAN_OR_EQUAL.getValue());
 
         @Override
-        public Symbol visitField(ScopedSymbol field, Context context) {
-            validateSysReference(context, field.column().sqlFqn());
-            return super.visitField(field, context);
+        public Symbol visitField(ScopedSymbol field, ArrayDeque<Function> functions) {
+            validateSysReference(functions, field.column().sqlFqn());
+            return super.visitField(field, functions);
         }
 
         @Override
-        public Symbol visitReference(Reference symbol, Context context) {
-            validateSysReference(context, symbol.column().name());
-            return super.visitReference(symbol, context);
+        public Symbol visitReference(Reference symbol, ArrayDeque<Function> functions) {
+            validateSysReference(functions, symbol.column().name());
+            return super.visitReference(symbol, functions);
         }
 
         @Override
-        public Symbol visitFunction(Function function, Context context) {
-            context.functions.push(function);
+        public Symbol visitFunction(Function function, ArrayDeque<Function> functions) {
+            functions.push(function);
             if (function.signature().getType().equals(FunctionType.TABLE)) {
                 throw new UnsupportedOperationException("Table functions are not allowed in WHERE");
             }
-            continueTraversal(function, context);
-            context.functions.pop();
+            for (Symbol argument : function.arguments()) {
+                argument.accept(this, functions);
+            }
+            functions.pop();
             return function;
         }
 
         @Override
-        public Symbol visitWindowFunction(WindowFunction symbol, Context context) {
+        public Symbol visitWindowFunction(WindowFunction symbol, ArrayDeque<Function> functions) {
             throw new IllegalArgumentException("Window functions are not allowed in WHERE");
         }
 
-        private void continueTraversal(Function symbol, Context context) {
-            for (Symbol argument : symbol.arguments()) {
-                argument.accept(this, context);
-            }
-        }
-
-        private static boolean insideNotPredicate(Context context) {
-            for (Function function : context.functions) {
+        private static boolean insideNotPredicate(ArrayDeque<Function> functions) {
+            for (Function function : functions) {
                 if (function.name().equals(NotPredicate.NAME)) {
                     return true;
                 }
@@ -119,13 +108,14 @@ public final class WhereClauseValidator {
             return false;
         }
 
-        private static boolean insideCastComparedWithLiteral(Context context, Set<String> requiredFunctionNames) {
-            var numFunctions = context.functions.size();
+        private static boolean insideCastComparedWithLiteral(ArrayDeque<Function> functions, Set<String> requiredFunctionNames) {
+            var numFunctions = functions.size();
             if (numFunctions < 2) {
                 return false;
             }
-            var lastFunction = context.functions.get(numFunctions - 1);
-            var parentFunction = context.functions.get(numFunctions - 2);
+            var lastFunction = functions.pollFirst();
+            var parentFunction = functions.peekFirst();
+            functions.push(lastFunction);
 
             if (lastFunction.isCast()
                 && parentFunction.name().startsWith(Operator.PREFIX)
@@ -136,26 +126,26 @@ public final class WhereClauseValidator {
             return false;
         }
 
-        private void validateSysReference(Context context, String columnName) {
+        private void validateSysReference(ArrayDeque<Function> functions, String columnName) {
             if (columnName.equalsIgnoreCase(VERSION)) {
-                validateSysReference(context, VERSIONING_ALLOWED_COMPARISONS, VersioningValidationException::versionInvalidUsage);
+                validateSysReference(functions, VERSIONING_ALLOWED_COMPARISONS, VersioningValidationException::versionInvalidUsage);
             } else if (columnName.equalsIgnoreCase(SEQ_NO) || columnName.equalsIgnoreCase(PRIMARY_TERM)) {
-                validateSysReference(context, VERSIONING_ALLOWED_COMPARISONS, VersioningValidationException::seqNoAndPrimaryTermUsage);
+                validateSysReference(functions, VERSIONING_ALLOWED_COMPARISONS, VersioningValidationException::seqNoAndPrimaryTermUsage);
             } else if (columnName.equalsIgnoreCase(SCORE)) {
-                validateSysReference(context, SCORE_ALLOWED_COMPARISONS, () -> new UnsupportedOperationException(SCORE_ERROR));
+                validateSysReference(functions, SCORE_ALLOWED_COMPARISONS, () -> new UnsupportedOperationException(SCORE_ERROR));
             } else if (columnName.equalsIgnoreCase(SysColumns.RAW.name())) {
                 throw new UnsupportedOperationException("The _raw column is not searchable and cannot be used inside a query");
             }
         }
 
-        private static void validateSysReference(Context context, Set<String> requiredFunctionNames, Supplier<RuntimeException> error) {
-            if (context.functions.isEmpty()) {
+        private static void validateSysReference(ArrayDeque<Function> functions, Set<String> requiredFunctionNames, Supplier<RuntimeException> error) {
+            if (functions.isEmpty()) {
                 throw error.get();
             }
-            Function function = context.functions.lastElement();
-            if ((!insideCastComparedWithLiteral(context, requiredFunctionNames)
+            Function function = functions.peekFirst();
+            if ((!insideCastComparedWithLiteral(functions, requiredFunctionNames)
                 && !requiredFunctionNames.contains(function.name().toLowerCase(Locale.ENGLISH)))
-                || insideNotPredicate(context)) {
+                || insideNotPredicate(functions)) {
                 throw error.get();
             }
             if (function.arguments().size() > 1) {


### PR DESCRIPTION
`Stack` is synchronized and `ArrayDeque` is generally the recommended
replacement for a stack use case.

Also removes the `Context` wrapper.
