### PR TITLE
Extend ram accounting hierarchy

### DIFF
--- a/server/src/main/java/io/crate/execution/jobs/CountTask.java
+++ b/server/src/main/java/io/crate/execution/jobs/CountTask.java
@@ -25,6 +25,7 @@ import static io.crate.data.SentinelRow.SENTINEL;
 
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.LongSupplier;
 
 import com.carrotsearch.hppc.IntIndexedContainer;
 
@@ -42,6 +43,7 @@ public class CountTask extends AbstractTask {
     private final CountOperation countOperation;
     private final RowConsumer consumer;
     private final Map<String, IntIndexedContainer> indexShardMap;
+    private final LongSupplier bytesUsed;
     private CompletableFuture<Long> countFuture;
     private volatile Throwable killReason;
 
@@ -49,13 +51,15 @@ public class CountTask extends AbstractTask {
               TransactionContext txnCtx,
               CountOperation countOperation,
               RowConsumer consumer,
-              Map<String, IntIndexedContainer> indexShardMap) {
+              Map<String, IntIndexedContainer> indexShardMap,
+              LongSupplier bytesUsed) {
         super(countPhase.phaseId());
         this.countPhase = countPhase;
         this.txnCtx = txnCtx;
         this.countOperation = countOperation;
         this.consumer = consumer;
         this.indexShardMap = indexShardMap;
+        this.bytesUsed = bytesUsed;
     }
 
     @Override
@@ -97,6 +101,6 @@ public class CountTask extends AbstractTask {
 
     @Override
     public long bytesUsed() {
-        return -1;
+        return bytesUsed.getAsLong();
     }
 }

--- a/server/src/test/java/io/crate/execution/engine/collect/collectors/RemoteCollectorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/collectors/RemoteCollectorTest.java
@@ -37,6 +37,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 import org.elasticsearch.transport.TransportService;
 import org.junit.Before;
 import org.junit.Test;
@@ -97,6 +98,7 @@ public class RemoteCollectorTest extends CrateDummyClusterServiceUnitTest {
         TasksService tasksService = new TasksService(
             clusterService,
             mock(TransportService.class),
+            new NoneCircuitBreakerService(),
             new JobsLogs(() -> true));
         numBroadcastCalls = new AtomicInteger(0);
         transportKillJobsNodeAction = new TransportKillJobsNodeAction(

--- a/server/src/test/java/io/crate/execution/engine/distribution/TransportDistributedResultActionTest.java
+++ b/server/src/test/java/io/crate/execution/engine/distribution/TransportDistributedResultActionTest.java
@@ -31,6 +31,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.bulk.BackoffPolicy;
+import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 import org.elasticsearch.transport.TransportService;
 import org.junit.Test;
 
@@ -51,7 +52,12 @@ public class TransportDistributedResultActionTest extends CrateDummyClusterServi
     @Test
     public void testKillIsInvokedIfContextIsNotFound() throws Exception {
         TransportService transportService = mock(TransportService.class);
-        TasksService tasksService = new TasksService(clusterService, transportService, new JobsLogs(() -> false));
+        TasksService tasksService = new TasksService(
+            clusterService,
+            transportService,
+            new NoneCircuitBreakerService(),
+            new JobsLogs(() -> false)
+        );
         AtomicInteger numBroadcasts = new AtomicInteger(0);
         TransportKillJobsNodeAction killJobsAction = new TransportKillJobsNodeAction(
             tasksService,

--- a/server/src/test/java/io/crate/execution/jobs/CountTaskTest.java
+++ b/server/src/test/java/io/crate/execution/jobs/CountTaskTest.java
@@ -64,7 +64,14 @@ public class CountTaskTest extends ESTestCase {
         CountOperation countOperation = mock(CountOperation.class);
         when(countOperation.count(eq(txnCtx), any(), any(Symbol.class), eq(false))).thenReturn(future);
 
-        final CountTask countTask1 = new CountTask(countPhaseWithId(1), txnCtx, countOperation, new TestingRowConsumer(), null);
+        final CountTask countTask1 = new CountTask(
+            countPhaseWithId(1),
+            txnCtx,
+            countOperation,
+            new TestingRowConsumer(),
+            null,
+            () -> -1
+        );
         countTask1.start();
         future.complete(1L);
         assertThat(countTask1.isClosed()).isTrue();
@@ -75,8 +82,14 @@ public class CountTaskTest extends ESTestCase {
         future = new CompletableFuture<>();
         when(countOperation.count(eq(txnCtx), any(), any(Symbol.class), eq(false))).thenReturn(future);
 
-        final CountTask countTask2 =
-            new CountTask(countPhaseWithId(2), txnCtx, countOperation, new TestingRowConsumer(), null);
+        final CountTask countTask2 = new CountTask(
+            countPhaseWithId(2),
+            txnCtx,
+            countOperation,
+            new TestingRowConsumer(),
+            null,
+            () -> -1
+        );
         countTask2.start();
         future.completeExceptionally(new UnhandledServerException("dummy"));
         assertThat(countTask2.isClosed()).isTrue();
@@ -92,7 +105,14 @@ public class CountTaskTest extends ESTestCase {
         CountOperation countOperation = mock(CountOperation.class);
         when(countOperation.count(any(), any(), any(), eq(false))).thenReturn(future);
 
-        CountTask countTask = new CountTask(countPhaseWithId(1), txnCtx, countOperation, new TestingRowConsumer(), null);
+        CountTask countTask = new CountTask(
+            countPhaseWithId(1),
+            txnCtx,
+            countOperation,
+            new TestingRowConsumer(),
+            null,
+            () -> -1
+        );
 
         countTask.start();
         countTask.kill(JobKilledException.of("dummy"));

--- a/server/src/test/java/io/crate/execution/jobs/RootTaskTest.java
+++ b/server/src/test/java/io/crate/execution/jobs/RootTaskTest.java
@@ -38,6 +38,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -65,8 +67,16 @@ public class RootTaskTest extends ESTestCase {
 
     @Test
     public void testKillPropagatesToSubContexts() throws Exception {
-        RootTask.Builder builder =
-            new RootTask.Builder(logger, UUID.randomUUID(), "dummy-user", coordinatorNode, Collections.emptySet(), mock(JobsLogs.class));
+        RootTask.Builder builder = new RootTask.Builder(
+            logger,
+            UUID.randomUUID(),
+            "dummy-user",
+            coordinatorNode,
+            Collections.emptySet(),
+            new NoopCircuitBreaker(CircuitBreaker.QUERY),
+            -1,
+            mock(JobsLogs.class)
+        );
 
 
         AbstractTaskTest.TestingTask ctx1 = new AbstractTaskTest.TestingTask(1);
@@ -86,8 +96,16 @@ public class RootTaskTest extends ESTestCase {
     @Test
     public void testErrorMessageIsIncludedInStatsTableOnFailure() throws Throwable {
         JobsLogs jobsLogs = mock(JobsLogs.class);
-        RootTask.Builder builder =
-            new RootTask.Builder(logger, UUID.randomUUID(), "dummy-user", coordinatorNode, Collections.emptySet(), jobsLogs);
+        RootTask.Builder builder = new RootTask.Builder(
+            logger,
+            UUID.randomUUID(),
+            "dummy-user",
+            coordinatorNode,
+            Collections.emptySet(),
+            new NoopCircuitBreaker(CircuitBreaker.QUERY),
+            -1,
+            jobsLogs
+        );
 
         Task task = new AbstractTask(0) {
             @Override
@@ -119,8 +137,16 @@ public class RootTaskTest extends ESTestCase {
         when(collectPhase.routing()).thenReturn(routing);
         when(collectPhase.maxRowGranularity()).thenReturn(RowGranularity.DOC);
 
-        RootTask.Builder builder =
-            new RootTask.Builder(logger, UUID.randomUUID(), "dummy-user", coordinatorNode, Collections.emptySet(), mock(JobsLogs.class));
+        RootTask.Builder builder = new RootTask.Builder(
+            logger,
+            UUID.randomUUID(),
+            "dummy-user",
+            coordinatorNode,
+            Collections.emptySet(),
+            new NoopCircuitBreaker(CircuitBreaker.QUERY),
+            -1,
+            mock(JobsLogs.class)
+        );
 
         CollectTask collectChildTask = new CollectTask(
             collectPhase,
@@ -165,8 +191,16 @@ public class RootTaskTest extends ESTestCase {
 
     @Test
     public void testEnablingProfilingGathersExecutionTimes() throws Throwable {
-        RootTask.Builder builder =
-            new RootTask.Builder(logger, UUID.randomUUID(), "dummy-user", coordinatorNode, Collections.emptySet(), mock(JobsLogs.class));
+        RootTask.Builder builder = new RootTask.Builder(
+            logger,
+            UUID.randomUUID(),
+            "dummy-user",
+            coordinatorNode,
+            Collections.emptySet(),
+            new NoopCircuitBreaker(CircuitBreaker.QUERY),
+            -1,
+            mock(JobsLogs.class)
+        );
         ProfilingContext profilingContext = new ProfilingContext(Map.of(), ClusterState.EMPTY_STATE);
         builder.profilingContext(profilingContext);
 

--- a/server/src/test/java/io/crate/execution/jobs/TasksServiceTest.java
+++ b/server/src/test/java/io/crate/execution/jobs/TasksServiceTest.java
@@ -37,6 +37,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.elasticsearch.action.NoSuchNodeException;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 import org.elasticsearch.transport.Transport.Connection;
 import org.elasticsearch.transport.TransportService;
 import org.junit.After;
@@ -58,7 +59,12 @@ public class TasksServiceTest extends CrateDummyClusterServiceUnitTest {
     @Before
     public void prepare() {
         JobsLogs jobsLogs = new JobsLogs(() -> true);
-        tasksService = new TasksService(clusterService, Mockito.mock(TransportService.class), jobsLogs);
+        tasksService = new TasksService(
+            clusterService,
+            Mockito.mock(TransportService.class),
+            new NoneCircuitBreakerService(),
+            jobsLogs
+        );
     }
 
     @After

--- a/server/src/test/java/io/crate/planner/node/ddl/AlterTablePlanTest.java
+++ b/server/src/test/java/io/crate/planner/node/ddl/AlterTablePlanTest.java
@@ -35,6 +35,7 @@ import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.settings.IndexScopedSettings;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 import org.elasticsearch.transport.TransportService;
 import org.junit.Before;
 import org.junit.Test;
@@ -76,6 +77,7 @@ public class AlterTablePlanTest extends CrateDummyClusterServiceUnitTest {
         tasksService = new TasksService(
             clusterService,
             mock(TransportService.class),
+            new NoneCircuitBreakerService(),
             new JobsLogs(() -> false)
         );
     }

--- a/server/src/test/java/io/crate/planner/node/management/KillPlanTest.java
+++ b/server/src/test/java/io/crate/planner/node/management/KillPlanTest.java
@@ -28,6 +28,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 import org.elasticsearch.transport.TransportService;
 import org.junit.Test;
 
@@ -46,7 +47,12 @@ public class KillPlanTest extends CrateDummyClusterServiceUnitTest {
     public void testKillTaskCallsBroadcastOnTransportKillAllNodeAction() {
         AtomicInteger broadcastCalls = new AtomicInteger(0);
         AtomicInteger nodeOperationCalls = new AtomicInteger(0);
-        TasksService tasksService = new TasksService(clusterService, mock(TransportService.class), new JobsLogs(() -> false));
+        TasksService tasksService = new TasksService(
+            clusterService,
+            mock(TransportService.class),
+            new NoneCircuitBreakerService(),
+            new JobsLogs(() -> false)
+        );
         TransportKillAllNodeAction killAllNodeAction = new TransportKillAllNodeAction(
             tasksService,
             clusterService,


### PR DESCRIPTION
So far we had a accounting hierarchy with parent breaker, query breaker
and then typically N RamAccounting instances - one per leaf task.
Depending on if parts were executed parallel either with
ConcurrentRamAccounting instances or BlockBasedRamAccounting.

This changes the hierarchy to always have a `ConcurrentRamAccounting`
instance at the root task level which is then used by the sub-tasks.

This will allow us to improve memory usage reporting and to rework the
circuit breaker mechanism to break the query consuming the most memory -
or other similar policies.
