### PR TITLE
Fix `SWAP TABLE` IllegalStateException due to duplicate table aliases

### DIFF
--- a/docs/appendices/release-notes/6.0.6.rst
+++ b/docs/appendices/release-notes/6.0.6.rst
@@ -51,3 +51,8 @@ Fixes
   run during a rolling upgrade from 5.10.x. The corruption can be recovered by
   restarting the upgraded nodes. Rolling upgrades from 6.0+ to 6.2.2 weren't
   affected.
+
+- Fixed an issue that caused :ref:`swap table <alter_cluster_swap_table>` on
+  partitioned tables to be rejected with ``IllegalStateException`` due to wrong
+  version upgrade migration logic. Only tables created on or before 5.10.x are
+  affected.

--- a/docs/appendices/release-notes/6.1.4.rst
+++ b/docs/appendices/release-notes/6.1.4.rst
@@ -51,3 +51,8 @@ Fixes
   run during a rolling upgrade from 5.10.x. The corruption can be recovered by
   restarting the upgraded nodes. Rolling upgrades from 6.0+ to 6.2.2 weren't
   affected.
+
+- Fixed an issue that caused :ref:`swap table <alter_cluster_swap_table>` on
+  partitioned tables to be rejected with ``IllegalStateException`` due to wrong
+  version upgrade migration logic. Only tables created on or before 5.10.x are
+  affected.

--- a/docs/appendices/release-notes/6.2.2.rst
+++ b/docs/appendices/release-notes/6.2.2.rst
@@ -54,3 +54,8 @@ Fixes
   run during a rolling upgrade from 5.10.x. The corruption can be recovered by
   restarting the upgraded nodes. Rolling upgrades from 6.0+ to 6.2.2 weren't
   affected.
+
+- Fixed an issue that caused :ref:`swap table <alter_cluster_swap_table>` on
+  partitioned tables to be rejected with ``IllegalStateException`` due to wrong
+  version upgrade migration logic. Only tables created on or before 5.10.x are
+  affected.

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -1013,6 +1013,9 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata> {
             final Set<String> duplicateAliasesIndices = new HashSet<>();
             for (ObjectCursor<IndexMetadata> cursor : indices.values()) {
                 final IndexMetadata indexMetadata = cursor.value;
+                if (indexMetadata.getUpgradedVersion().onOrAfter(Version.V_6_0_0)) {
+                    continue;
+                }
                 final String uuid = indexMetadata.getIndex().getUUID();
                 boolean added = allIndices.add(uuid);
                 assert added : "double index named [" + uuid + "]";
@@ -1086,7 +1089,7 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata> {
             SortedMap<String, AliasOrIndex> aliasAndIndexLookup = new TreeMap<>();
             for (ObjectCursor<IndexMetadata> cursor : indices.values()) {
                 IndexMetadata indexMetadata = cursor.value;
-                if (indexMetadata.getCreationVersion().onOrAfter(Version.V_6_0_0)) {
+                if (indexMetadata.getUpgradedVersion().onOrAfter(Version.V_6_0_0)) {
                     // aliases are deprecated and only needed to be built for old indices, aliases will be removed once
                     // the metadata is fully migrated/upgraded to schemas/relations.
                     continue;


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
`swap table` [fails](https://github.com/crate/crate-qa/pull/391) when executed during a rolling upgrade from `5.0.x` to `6.0.x` with the following exception:
```
crate.client.exceptions.ProgrammingError: IllegalStateException[index and alias names need to be unique, but the following duplicates were found [parted (alias of [.partitioned.t1.041j2c0/cNM-qMBvR8u8vWW1u-YW7Q]), parted (alias of [.partitioned.t1.04132/6ZSeqvBuSK-Yt-TC0j6bfA])]]
java.lang.IllegalStateException: index and alias names need to be unique, but the following duplicates were found [parted (alias of [.partitioned.t1.041j2c0/cNM-qMBvR8u8vWW1u-YW7Q]), parted (alias of [.partitioned.t1.04132/6ZSeqvBuSK-Yt-TC0j6bfA])]
```
thrown from
https://github.com/crate/crate/blob/d0427daf78e60302331e62ca8be802860cc3030b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java#L1021-L1034

The exception is thrown because aliases are not properly swapped but aliases are not swapped by intention because it is deprecated starting 6.0 (the logic was removed [here](https://github.com/crate/crate/commit/ccdb23604a992badc37cf8c60c6be611aae4d5c1#diff-53150a47bfae7155c2e5bb1d22d569d63422c57136670c0d28b4bfeb79972d7aL102-L236)).

Also fixes https://github.com/crate/crate/issues/18972#issuecomment-3838256033.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
