### PR TITLE
Fix NPE when SWAP interleaved with INSERT on partitioned table

### DIFF
--- a/docs/appendices/release-notes/6.3.0.rst
+++ b/docs/appendices/release-notes/6.3.0.rst
@@ -130,6 +130,10 @@ Performance and Resilience Improvements
   remain in ``PARTIAL`` state, with an ``ABORTED`` failure message showing in
   the :ref:`sys.snapshots <sys-snapshots>` system table.
 
+- :ref:`INSERT INTO <sql-insert>` statements that create new partitions are no
+  longer interrupted by :ref:`SWAP <alter_cluster_swap_table>` or
+  :ref:`RENAME <sql-alter-table-rename-to>` table statements.
+
 Administration and Operations
 -----------------------------
 

--- a/server/src/main/java/io/crate/execution/engine/indexing/ColumnIndexWriterProjector.java
+++ b/server/src/main/java/io/crate/execution/engine/indexing/ColumnIndexWriterProjector.java
@@ -87,7 +87,8 @@ public class ColumnIndexWriterProjector implements Projector {
                                       boolean autoCreateIndices,
                                       List<Symbol> returnValues,
                                       UUID jobId,
-                                      long fullDocSizeEstimate
+                                      long fullDocSizeEstimate,
+                                      int tableOID
                                       ) {
         RowShardResolver rowShardResolver = new RowShardResolver(
             txnCtx, nodeCtx, primaryKeyIdents, primaryKeySymbols, clusteredByColumn, routingSymbol);
@@ -154,7 +155,8 @@ public class ColumnIndexWriterProjector implements Projector {
             targetTableNumReplicas,
             upsertResultContext,
             _ -> false,
-            UpsertResults::resultsToFailure
+            UpsertResults::resultsToFailure,
+            tableOID
         );
     }
 

--- a/server/src/main/java/io/crate/execution/engine/indexing/GroupRowsByShard.java
+++ b/server/src/main/java/io/crate/execution/engine/indexing/GroupRowsByShard.java
@@ -224,7 +224,7 @@ public final class GroupRowsByShard<TReq extends ShardRequest<TReq, TItem>, TIte
     /**
      * @throws IllegalStateException if a shardLocation still can't be resolved
      */
-    void reResolveShardLocations(ShardedRequests<TReq, TItem> requests) {
+    void reResolveShardLocations(ShardedRequests<TReq, TItem> requests, int tableOID) {
         var entryIt = requests.itemsByMissingPartition.entrySet().iterator();
         ClusterState state = clusterService.state();
         Metadata metadata = state.metadata();
@@ -236,7 +236,7 @@ public final class GroupRowsByShard<TReq extends ShardRequest<TReq, TItem>, TIte
             while (it.hasNext()) {
                 ShardedRequests.ItemAndRoutingAndSourceInfo<TItem> itemAndRoutingAndSourceInfo = it.next();
                 IndexMetadata indexMetadata = metadata.getIndex(
-                    partitionName.relationName(),
+                    metadata.getRelationName(tableOID),
                     partitionName.values(),
                     true,
                     x -> x

--- a/server/src/main/java/io/crate/execution/engine/indexing/IndexWriterProjector.java
+++ b/server/src/main/java/io/crate/execution/engine/indexing/IndexWriterProjector.java
@@ -95,7 +95,8 @@ public class IndexWriterProjector implements Projector {
                                 boolean overwriteDuplicates,
                                 UUID jobId,
                                 UpsertResultContext upsertResultContext,
-                                boolean failFast) {
+                                boolean failFast,
+                                int tableOID) {
         Input<String> source;
         if (excludes == null) {
             //noinspection unchecked
@@ -151,7 +152,8 @@ public class IndexWriterProjector implements Projector {
             targetTableNumReplicas,
             upsertResultContext,
             earlyTerminationCondition,
-            earlyTerminationExceptionGenerator
+            earlyTerminationExceptionGenerator,
+            tableOID
         );
     }
 

--- a/server/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
+++ b/server/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
@@ -455,7 +455,8 @@ public class ProjectionToProjectorVisitor
             projection.overwriteDuplicates(),
             context.jobId,
             upsertResultContext,
-            projection.failFast()
+            projection.failFast(),
+            tableInfo.tableOID()
         );
     }
 
@@ -519,7 +520,8 @@ public class ProjectionToProjectorVisitor
             projection.autoCreateIndices(),
             projection.returnValues(),
             context.jobId,
-            projection.fullDocSizeEstimate()
+            projection.fullDocSizeEstimate(),
+            tableInfo.tableOID()
         );
     }
 

--- a/server/src/main/java/io/crate/planner/operators/InsertFromValues.java
+++ b/server/src/main/java/io/crate/planner/operators/InsertFromValues.java
@@ -754,7 +754,7 @@ public class InsertFromValues implements LogicalPlan {
         if (partitionsToCreate.isEmpty()) {
             return CompletableFuture.completedFuture(new AcknowledgedResponse(true));
         }
-        return client.execute(TransportCreatePartitions.ACTION, CreatePartitionsRequest.of(partitionsToCreate));
+        return client.execute(TransportCreatePartitions.ACTION, CreatePartitionsRequest.of(tableInfo.tableOID(), partitionsToCreate));
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/create/CreatePartitionsRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/create/CreatePartitionsRequest.java
@@ -28,6 +28,7 @@ import java.util.List;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
+import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
@@ -37,25 +38,27 @@ import io.crate.metadata.RelationName;
 
 public class CreatePartitionsRequest extends AcknowledgedRequest<CreatePartitionsRequest> {
 
+    private final int tableOID;
     private final RelationName relationName;
     private final List<List<String>> partitionValuesList;
 
     /**
      * @param partitions partitions to create. Limited to one unique relation
      **/
-    public static CreatePartitionsRequest of(Collection<PartitionName> partitions) {
+    public static CreatePartitionsRequest of(int tableOID, Collection<PartitionName> partitions) {
         List<RelationName> relations = partitions.stream()
             .map(PartitionName::relationName)
             .distinct()
             .toList();
         return switch (relations.size()) {
             case 0 -> throw new IllegalArgumentException("Must create at least one partition");
-            case 1 -> new CreatePartitionsRequest(relations.get(0), Lists.map(partitions, p -> p.ident().isEmpty() ? List.of() : p.values()));
+            case 1 -> new CreatePartitionsRequest(tableOID, relations.get(0), Lists.map(partitions, p -> p.ident().isEmpty() ? List.of() : p.values()));
             default -> throw new IllegalArgumentException("Cannot create partitions for more than one table in the same request: " + relations);
         };
     }
 
-    public CreatePartitionsRequest(RelationName relationName, List<List<String>> partitionValuesList) {
+    public CreatePartitionsRequest(int tableOID, RelationName relationName, List<List<String>> partitionValuesList) {
+        this.tableOID = tableOID;
         this.relationName = relationName;
         this.partitionValuesList = partitionValuesList;
     }
@@ -73,6 +76,10 @@ public class CreatePartitionsRequest extends AcknowledgedRequest<CreatePartition
      **/
     public List<String> indexNames() {
         return Lists.map(partitionValuesList, values -> new PartitionName(relationName, values).asIndexName());
+    }
+
+    public int tableOID() {
+        return tableOID;
     }
 
     public CreatePartitionsRequest(StreamInput in) throws IOException {
@@ -108,6 +115,11 @@ public class CreatePartitionsRequest extends AcknowledgedRequest<CreatePartition
             }
             this.relationName = relation;
         }
+        if (in.getVersion().onOrAfter(Version.V_6_3_0)) {
+            this.tableOID = in.readInt();
+        } else {
+            this.tableOID = Metadata.OID_UNASSIGNED;
+        }
     }
 
     @Override
@@ -136,6 +148,9 @@ public class CreatePartitionsRequest extends AcknowledgedRequest<CreatePartition
                 String indexName = new PartitionName(relationName, partitionValues).asIndexName();
                 out.writeString(indexName);
             }
+        }
+        if (out.getVersion().onOrAfter(Version.V_6_3_0)) {
+            out.writeInt(tableOID);
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/create/TransportCreatePartitions.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/create/TransportCreatePartitions.java
@@ -74,7 +74,6 @@ import io.crate.exceptions.RelationUnknown;
 import io.crate.execution.ddl.tables.MappingUtil;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.PartitionName;
-import io.crate.metadata.RelationName;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.doc.DocTableInfoFactory;
 
@@ -139,23 +138,24 @@ public class TransportCreatePartitions extends TransportMasterNodeAction<CreateP
     protected void masterOperation(final CreatePartitionsRequest request,
                                    final ClusterState state,
                                    final ActionListener<AcknowledgedResponse> listener) throws ElasticsearchException {
+        final CreatePartitionsRequest upgradedRequest = upgradeCreatePartitionsRequest(request, state.metadata());
         createIndices(request, ActionListener.wrap(response -> {
             if (response.isAcknowledged()) {
-                final String[] indices = request.partitionValuesList().stream()
-                    .map(partitionValues -> clusterService.state().metadata()
-                        .getIndex(request.relationName(), partitionValues, false, IndexMetadata::getIndexUUID))
+                Metadata metadata = clusterService.state().metadata();
+                final String[] indices = upgradedRequest.partitionValuesList().stream()
+                    .map(partitionValues -> metadata
+                        .getIndex(metadata.getRelationName(upgradedRequest.tableOID()), partitionValues, false, IndexMetadata::getIndexUUID))
                     .toArray(String[]::new);
-                activeShardsObserver.waitForActiveShards(indices, ActiveShardCount.DEFAULT, request.ackTimeout(),
+                activeShardsObserver.waitForActiveShards(indices, ActiveShardCount.DEFAULT, upgradedRequest.ackTimeout(),
                     shardsAcked -> {
                         if (!shardsAcked && logger.isInfoEnabled()) {
-                            RelationName relationName = request.relationName();
-                            RelationMetadata.Table table = state.metadata().getRelation(relationName);
+                            RelationMetadata.Table table = state.metadata().getRelation(upgradedRequest.tableOID());
                             assert table != null : "table should be present in the cluster state";
 
                             logger.info("[{}] Table partitions created, but the operation timed out while waiting for " +
                                          "enough shards to be started. Timeout={}, wait_for_active_shards={}. " +
                                          "Consider decreasing the 'number_of_shards' table setting (currently: {}) or adding nodes to the cluster.",
-                                relationName, request.timeout(),
+                                upgradedRequest.relationName(), upgradedRequest.timeout(),
                                 SETTING_WAIT_FOR_ACTIVE_SHARDS.get(table.settings()),
                                 INDEX_NUMBER_OF_SHARDS_SETTING.get(table.settings()));
                         }
@@ -173,10 +173,10 @@ public class TransportCreatePartitions extends TransportMasterNodeAction<CreateP
      * This code is more or less the same as the stuff in {@link MetadataCreateIndexService}
      * but optimized for bulk operation without separate mapping/alias/index settings.
      */
-    public ClusterState executeCreateIndices(ClusterState currentState,
-                                             RelationMetadata.Table table,
-                                             DocTableInfo docTableInfo,
-                                             CreatePartitionsRequest request) throws Exception {
+    private ClusterState executeCreateIndices(ClusterState currentState,
+                                              RelationMetadata.Table table,
+                                              DocTableInfo docTableInfo,
+                                              CreatePartitionsRequest request) throws Exception {
         String removalReason = null;
         Index testIndex = null;
         try {
@@ -317,7 +317,7 @@ public class TransportCreatePartitions extends TransportMasterNodeAction<CreateP
                 ClusterStateTaskExecutor.ClusterTasksResult.Builder<CreatePartitionsRequest> builder = ClusterStateTaskExecutor.ClusterTasksResult.builder();
                 for (CreatePartitionsRequest request1 : tasks) {
                     try {
-                        RelationMetadata.Table table = currentState.metadata().getRelation(request1.relationName());
+                        RelationMetadata.Table table = currentState.metadata().getRelation(request1.tableOID());
                         if (table == null) {
                             throw new RelationUnknown(request1.relationName());
                         }
@@ -333,7 +333,7 @@ public class TransportCreatePartitions extends TransportMasterNodeAction<CreateP
             new AckedClusterStateUpdateTask<>(request, listener) {
                 @Override
                 public ClusterState execute(ClusterState currentState) throws Exception {
-                    RelationMetadata.Table table = currentState.metadata().getRelation(request.relationName());
+                    RelationMetadata.Table table = currentState.metadata().getRelation(request.tableOID());
                     if (table == null) {
                         throw new RelationUnknown(request.relationName());
                     }
@@ -354,9 +354,9 @@ public class TransportCreatePartitions extends TransportMasterNodeAction<CreateP
         ArrayList<PartitionName> partitions = new ArrayList<>(request.partitionValuesList().size());
         for (List<String> partitionValues : request.partitionValuesList()) {
             // Don't be strict, it should not fail if the partition already exists
-            List<IndexMetadata> indices = metadata.getIndices(request.relationName(), partitionValues, false, imd -> imd);
+            List<IndexMetadata> indices = metadata.getIndices(metadata.getRelationName(request.tableOID()), partitionValues, false, imd -> imd);
             if (indices.isEmpty()) {
-                PartitionName partition = new PartitionName(request.relationName(), partitionValues);
+                PartitionName partition = new PartitionName(metadata.getRelation(request.tableOID()).name(), partitionValues);
                 partitions.add(partition);
             }
             // else: exists already
@@ -384,5 +384,19 @@ public class TransportCreatePartitions extends TransportMasterNodeAction<CreateP
             ClusterBlockLevel.METADATA_WRITE,
             request.indexNames().toArray(String[]::new)
         );
+    }
+
+    /**
+     * Upgrades CreatePartitionsRequest instance from a node < 6.3 which contains invalid table OID.
+     */
+    private static CreatePartitionsRequest upgradeCreatePartitionsRequest(CreatePartitionsRequest createPartitionsRequest, Metadata metadata) {
+        if (createPartitionsRequest.tableOID() == Metadata.OID_UNASSIGNED) {
+            RelationMetadata relationMetadata = metadata.getRelation(createPartitionsRequest.relationName());
+            return new CreatePartitionsRequest(
+                relationMetadata.oid(),
+                createPartitionsRequest.relationName(),
+                createPartitionsRequest.partitionValuesList());
+        }
+        return createPartitionsRequest;
     }
 }

--- a/server/src/test/java/io/crate/execution/engine/indexing/IndexWriterProjectorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/indexing/IndexWriterProjectorTest.java
@@ -113,7 +113,8 @@ public class IndexWriterProjectorTest extends IntegTestCase {
             false,
             UUID.randomUUID(),
             UpsertResultContext.forRowCount(),
-            false
+            false,
+            table.tableOID()
         );
 
         BatchIterator<Row> rowsIterator = InMemoryBatchIterator.of(IntStream.range(0, 100)

--- a/server/src/test/java/io/crate/execution/engine/indexing/IndexWriterProjectorUnitTest.java
+++ b/server/src/test/java/io/crate/execution/engine/indexing/IndexWriterProjectorUnitTest.java
@@ -36,6 +36,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
@@ -125,7 +126,8 @@ public class IndexWriterProjectorUnitTest extends CrateDummyClusterServiceUnitTe
             false,
             UUID.randomUUID(),
             UpsertResultContext.forRowCount(),
-            false
+            false,
+            Metadata.OID_UNASSIGNED
         );
 
         RowN rowN = new RowN(new Object[]{new BytesRef("{\"y\": \"x\"}"), null});

--- a/server/src/test/java/io/crate/execution/engine/indexing/ShardUpsertExecutorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/indexing/ShardUpsertExecutorTest.java
@@ -148,7 +148,8 @@ public class ShardUpsertExecutorTest extends IntegTestCase {
             NumberOfReplicas.effectiveNumReplicas(table.parameters(), state.nodes()),
             UpsertResultContext.forRowCount(),
             UpsertResults::containsErrors,
-            UpsertResults::resultsToFailure
+            UpsertResults::resultsToFailure,
+            table.tableOID()
         );
 
         BatchIterator<Row> rowsIterator = InMemoryBatchIterator.of(IntStream.range(0, 10_000)

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/create/CreatePartitionsRequestTest.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/create/CreatePartitionsRequestTest.java
@@ -25,6 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 
+import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.junit.Test;
 
@@ -36,7 +37,7 @@ public class CreatePartitionsRequestTest {
     @Test
     public void testSerialization() throws Exception {
         RelationName tbl = new RelationName("doc", "tbl");
-        CreatePartitionsRequest request = new CreatePartitionsRequest(tbl, List.of(List.of("1"), List.of("2")));
+        CreatePartitionsRequest request = new CreatePartitionsRequest(Metadata.OID_UNASSIGNED, tbl, List.of(List.of("1"), List.of("2")));
         BytesStreamOutput out = new BytesStreamOutput();
         request.writeTo(out);
         CreatePartitionsRequest requestDeserialized = new CreatePartitionsRequest(out.bytes().streamInput());

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/create/TransportCreatePartitionsTest.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/create/TransportCreatePartitionsTest.java
@@ -139,7 +139,7 @@ public class TransportCreatePartitionsTest extends IntegTestCase {
 
     @Test
     public void testEmpty() throws Exception {
-        assertThatThrownBy(() -> CreatePartitionsRequest.of(List.of()))
+        assertThatThrownBy(() -> CreatePartitionsRequest.of(Metadata.OID_UNASSIGNED, List.of()))
             .hasMessage("Must create at least one partition");
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes below scenario:

```
cr> create table t (a int) clustered into 1 shards partitioned by (a) with (number_of_replicas=1);
CREATE OK, 1 row affected (0.278 sec)
cr> create table t3 (a int) ;
CREATE OK, 1 row affected (2.977 sec)
```
Run `swap` on a table being inserted:
```
cr> insert into t select * from generate_series (1, 40);

cr> alter cluster swap table t to t3;
ALTER OK, 1 row affected (1.893 sec)
```
Then an NPE will be thrown from the ongoing insert query:
```
cr> insert into t select * from generate_series (1, 40);
NullPointerException[Cannot invoke "org.elasticsearch.cluster.metadata.IndexMetadata.isRoutingPartitionedIndex()" because "indexMetadata" is null]
```

The main issue is that an insert query on a partitioned table is a two-step process: it creates partitions(and shards) first, then resolves the shard locations to insert data.

Because shard resolution is done by the table name (which is mutable), a `swap table` operation can interleave between these steps. The ongoing insert then fails because it tries to resolve shards using a name that is now assigned to a different table.

We can address this by adding table OID(immutable) in `ShardingUpsertExecutor` and use it to resolve shards.

Cannot backport because this fix depends on #18954.

---

**Follow up:** https://github.com/crate/crate/pull/19029#discussion_r2820771766

## Checklist

 - [ ] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
