### PR TITLE
Assess performance benefit of introducing `Metadata.oidsRelations` map

### DIFF
--- a/benchmarks/src/main/java/io/crate/common/TableLookupByOidBenchmark.java
+++ b/benchmarks/src/main/java/io/crate/common/TableLookupByOidBenchmark.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.common;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.metadata.RelationMetadata;
+import org.elasticsearch.common.settings.Settings;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import io.crate.metadata.RelationName;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Thread)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(1)
+public class TableLookupByOidBenchmark {
+
+    @Param({"1", "10", "50"})
+    public int numSchemas;
+
+    public Metadata metadata;
+    public List<Integer> allTableOids;
+    public int counter = 0;
+
+    @Setup
+    public void setup() {
+        Metadata.Builder builder = Metadata.builder(0);
+        allTableOids = new ArrayList<>();
+
+        for (int s = 0; s < numSchemas; s++) {
+            for (int r = 0; r < 100; r++) {
+                RelationName ident = new RelationName("schema_" + s, "table_" + r);
+                RelationMetadata rel = new RelationMetadata.BlobTable(
+                    builder.tableOidSupplier().nextOid(),
+                    ident,
+                    "uuid_" + s + "_" + r,
+                    Settings.EMPTY,
+                    IndexMetadata.State.OPEN
+                );
+                builder.setRelation(rel);
+                allTableOids.add(rel.oid());
+            }
+        }
+        metadata = builder.build();
+    }
+
+    @Setup(Level.Trial)
+    public void verify() {
+        for (int oid : allTableOids) {
+            if (!Objects.equals(metadata.getRelationFast(oid), metadata.getRelation(oid))) {
+                throw new IllegalStateException("The same relationMetadata are expected");
+            }
+        }
+    }
+
+    @Benchmark
+    public void measure_oid_lookup(Blackhole bh) {
+        int targetOid = allTableOids.get(counter++ % allTableOids.size());
+        bh.consume(metadata.getRelation(targetOid));
+    }
+
+    @Benchmark
+    public void measure_improved_oid_lookup(Blackhole bh) {
+        int targetOid = allTableOids.get(counter++ % allTableOids.size());
+        bh.consume(metadata.getRelationFast(targetOid));
+    }
+}

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -168,6 +168,7 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata> {
     private final ImmutableOpenMap<String, SchemaMetadata> schemas;
 
     private final transient ImmutableOpenMap<String, RelationMetadata> indexUUIDsRelations;
+    private final ImmutableOpenMap<Integer, RelationMetadata> oidsRelations;
     private final transient int totalNumberOfShards; // Transient ? not serializable anyway?
     private final int totalOpenIndexShards;
     private final int numberOfShards;
@@ -216,16 +217,19 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata> {
         this.numberOfShards = numberOfShards;
         this.aliasAndIndexLookup = aliasAndIndexLookup;
         var indexUUIDsRelationsBuilder = ImmutableOpenMap.<String, RelationMetadata>builder(indices.size());
+        var oidsRelationsBuilder = ImmutableOpenMap.<Integer, RelationMetadata>builder();
         for (var cursor : schemas) {
             SchemaMetadata schema = cursor.value;
             for (var relCursor : schema.relations()) {
                 var relationMetadata = relCursor.value;
                 for (String indexUUID : relationMetadata.indexUUIDs()) {
+                    oidsRelationsBuilder.put(relationMetadata.oid(), relationMetadata);
                     RelationMetadata old = indexUUIDsRelationsBuilder.put(indexUUID, relationMetadata);
                     assert old == null : "A index must not be referenced from multiple relations";
                 }
             }
         }
+        oidsRelations = oidsRelationsBuilder.build();
         indexUUIDsRelations = indexUUIDsRelationsBuilder.build();
     }
 
@@ -1475,6 +1479,17 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata> {
             }
         }
         return null;
+    }
+
+    @Nullable
+    @SuppressWarnings("unchecked")
+    public <T extends RelationMetadata> T getRelationFast(int tableOID) {
+        assert tableOID > Metadata.OID_UNASSIGNED : "Invalid tableOID: " + tableOID;
+        RelationMetadata relationMetadata = oidsRelations.get(tableOID);
+        if (relationMetadata == null) {
+            throw new RelationUnknown("cannot find relation");
+        }
+        return (T) relationMetadata;
     }
 
     /**


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Table oids are the new immutable keys for tables that are unique across schemas. As [suggested](https://github.com/crate/crate/pull/19029#discussion_r2820771766) by @mfussenegger, this PR assesses the benefit of adding a `oid -> RelationMetadata` map for lookup speed.

Note: Although the current commits create the map separately, it could be built together with `indexUUIDsRelations` in the future, which would make the extra build time negligible.

The `getRelation(int tableOID)` method can be updated from a nested loop to a constant-time function.
Before:
```
public <T extends RelationMetadata> T getRelation(int tableOID) {
    assert tableOID > Metadata.OID_UNASSIGNED : "Invalid tableOID: " + tableOID;
    for (ObjectCursor<SchemaMetadata> s : schemas.values()) {
        SchemaMetadata schemaMetadata = s.value;
        for (ObjectCursor<RelationMetadata> r : schemaMetadata.relations().values()) {
            RelationMetadata relationMetadata = r.value;
            if (relationMetadata.oid() == tableOID) {
                return (T) relationMetadata;
            }
        }
    }
    return null;
}

```
After:
```
public <T extends RelationMetadata> T getRelation(int tableOID) {
    assert tableOID > Metadata.OID_UNASSIGNED : "Invalid tableOID: " + tableOID;
    RelationMetadata relationMetadata = oidsRelations.get(tableOID);
    if (relationMetadata == null) {
        throw new RelationUnknown("cannot find relation");
    }
    return (T) relationMetadata;
```

Performance measurements(n=num_schemas, m=num_tables_per_schema):
```
n=1, m=100: ~20 times faster
n=10, m=100: ~180 times faster
n=50, m=100: ~780 times faster
```
(Please see `measure_perf_impact_of_metadata_oid_relations_map` how the results are obtained)

## Checklist

 - [ ] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
