### PR TITLE
Account for more temporal errors when propagating a failure in DistributingConsumer

### DIFF
--- a/server/src/main/java/io/crate/exceptions/SQLExceptions.java
+++ b/server/src/main/java/io/crate/exceptions/SQLExceptions.java
@@ -170,18 +170,22 @@ public class SQLExceptions {
      * @return true if the error may be temporary; E.g. a network error, a shard initializing or a node booting up
      */
     public static boolean maybeTemporary(Throwable t) {
-        return t instanceof NodeNotConnectedException
-            || t instanceof NodeClosedException
-            || t instanceof NodeDisconnectedException
-            || t instanceof ConnectTransportException
-            || t instanceof ConnectException
+        return maybeTemporaryNetworkError(t)
             || t instanceof ClusterBlockException
-            || t instanceof NoSeedNodeLeftException
             || t instanceof IndexNotFoundException
             || t instanceof NoShardAvailableActionException
             || t instanceof UnavailableShardsException
             || t instanceof AlreadyClosedException
             || t instanceof ElasticsearchTimeoutException;
+    }
+
+    public static boolean maybeTemporaryNetworkError(Throwable t) {
+        return t instanceof NodeNotConnectedException
+            || t instanceof NodeClosedException
+            || t instanceof NodeDisconnectedException
+            || t instanceof ConnectTransportException
+            || t instanceof ConnectException
+            || t instanceof NoSeedNodeLeftException;
     }
 
     public static Throwable prepareForClientTransmission(AccessControl accessControl, Throwable e) {

--- a/server/src/main/java/io/crate/execution/engine/distribution/DistributingConsumer.java
+++ b/server/src/main/java/io/crate/execution/engine/distribution/DistributingConsumer.java
@@ -42,7 +42,6 @@ import org.elasticsearch.action.bulk.BackoffPolicy;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.threadpool.Scheduler.Cancellable;
 import org.elasticsearch.threadpool.ThreadPool;
-import org.elasticsearch.transport.ConnectTransportException;
 import org.jspecify.annotations.Nullable;
 import io.crate.common.annotations.VisibleForTesting;
 
@@ -314,7 +313,7 @@ public class DistributingConsumer implements RowConsumer {
                 downstream.nodeId,
                 err
             );
-            if (err instanceof ConnectTransportException && retries.hasNext()) {
+            if (SQLExceptions.maybeTemporaryNetworkError(err) && retries.hasNext()) {
                 LOGGER.trace("Retry sending result", err);
                 TimeValue delay = retries.next();
                 try {
@@ -352,10 +351,15 @@ public class DistributingConsumer implements RowConsumer {
             // continue because it's necessary to send something to the other downstreams still waiting for data
             if (originalFailure != null) {
                 countdownAndMaybeCloseIt(numActiveRequests, it);
-                if (err instanceof CircuitBreakingException) {
-                    // CBE on `forwardFailure` could imply that the downstream
+                if (err instanceof CircuitBreakingException || SQLExceptions.maybeTemporaryNetworkError(err)) {
+                    // CBE or temporal error on `forwardFailure` could imply that the downstream
                     // didn't receive/handle the forwarded failure
                     // -> broadcast kill to ensure tasks get cleaned up.
+
+                    // If reached that point and still seeing a temporal network error,
+                    // it means that error persisted during retries.
+                    // issuing KILL on network error is a best effort.
+                    // If it doesn't go through, `TasksService.onNodeDisconnected` should eventually trigger and cleanup any related jobs.
 
                     // We don't exclude local node from the KILL broadcast
                     // as it can be a handler node and leave behind unclosed DistResultRXTask

--- a/server/src/test/java/io/crate/integrationtests/ArithmeticIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ArithmeticIntegrationTest.java
@@ -25,6 +25,7 @@ import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
 import static io.crate.testing.Asserts.assertThat;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 
+import java.net.ConnectException;
 import java.util.Collection;
 import java.util.Locale;
 
@@ -349,6 +350,33 @@ public class ArithmeticIntegrationTest extends IntegTestCase {
                     DistributedResultRequest distributedResultRequest = (DistributedResultRequest) request;
                     if (distributedResultRequest.throwable() != null) {
                         throw new CircuitBreakingException("dummy");
+                    }
+                } else {
+                    connection.sendRequest(requestId, action, request, options);
+                }
+            });
+        }
+
+        Asserts.assertSQLError(() -> execute("select log(d, l) from t where log(d, -1) >= 0 group by log(d, l)"))
+            .hasPGError(INTERNAL_ERROR)
+            .hasHTTPError(BAD_REQUEST, 4000)
+            .hasMessageContaining("log(x, b): given arguments would result in: 'NaN'");
+    }
+
+    @Test
+    public void test_temporal_network_error_on_forward_failure_on_distributed_execution_should_not_cause_timeout() throws Exception {
+        execute("create table t (i integer, l long, d double) with (number_of_replicas=0)");
+        ensureYellow();
+        execute("insert into t (i, l, d) values (1, 2, 90.5), (0, 4, 100)");
+        execute("refresh table t");
+
+        for (TransportService transportService : cluster().getDataOrMasterNodeInstances(TransportService.class)) {
+            MockTransportService mockTransportService = (MockTransportService) transportService;
+            mockTransportService.addSendBehavior((connection, requestId, action, request, options) -> {
+                if (action.equals(DistributedResultAction.NAME)) {
+                    DistributedResultRequest distributedResultRequest = (DistributedResultRequest) request;
+                    if (distributedResultRequest.throwable() != null) {
+                        throw new ConnectException("dummy");
                     }
                 } else {
                     connection.sendRequest(requestId, action, request, options);


### PR DESCRIPTION
Follow up to https://github.com/crate/crate/pull/19049 and https://github.com/crate/crate/pull/19077 