### PR TITLE
Fix object indexing containing nested arrays of incompatible types

### DIFF
--- a/docs/appendices/release-notes/6.2.2.rst
+++ b/docs/appendices/release-notes/6.2.2.rst
@@ -104,3 +104,14 @@ Fixes
       SELECT unnest([ {child_obj = { known_col = 'foo'}} ]) AS obj_arr
     ) AS sub1;
 
+- Fixed a regression introduced in :ref:`version_6.0.0` that caused an error
+  when trying to insert a nested array, or JSON string containing a nested
+  array, with incompatible inner value types into a column of type
+  ``OBJECT(ARRAY(OBJECT(IGNORED)))``. Example::
+
+    CREATE TABLE t1 (obj OBJECT(DYNAMIC) AS (arr ARRAY(OBJECT(IGNORED))));
+    INSERT INTO t1 (obj) VALUES (
+    $$
+       {"arr":[{"b": "str_val"}, {"b": ["array_val"]}]}
+    $$);
+


### PR DESCRIPTION
Type guessing of nested arrays with incompatible inner types raises an exception while the usage inside ``IGNORED`` objects is allowed.
Only guess such types if no child indexer exists already.

Fixes #19082.