### PR TITLE
Remove CollectTask dependency from GenericFunctionQuery

### DIFF
--- a/docs/appendices/release-notes/6.2.2.rst
+++ b/docs/appendices/release-notes/6.2.2.rst
@@ -115,3 +115,6 @@ Fixes
        {"arr":[{"b": "str_val"}, {"b": ["array_val"]}]}
     $$);
 
+- Fixed an issue causing cache to retain some heavy structures, potentially
+  leading to an ``OutOfMemoryError``.
+

--- a/server/src/main/java/io/crate/execution/engine/collect/DocValuesAggregates.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/DocValuesAggregates.java
@@ -113,7 +113,7 @@ public final class DocValuesAggregates {
             table,
             indexShard.getVersionCreated(),
             indexService.cache(),
-            collectTask::raiseIfKilled
+            collectTask.killToken()::raiseIfKilled
         );
 
         AtomicReference<Throwable> killed = new AtomicReference<>();

--- a/server/src/main/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIterator.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIterator.java
@@ -154,7 +154,7 @@ final class DocValuesGroupByOptimizedIterator {
             table,
             shardCreatedVersion,
             indexService.cache(),
-            collectTask::raiseIfKilled
+            collectTask.killToken()::raiseIfKilled
         );
 
         if (columnKeyRefs.size() == 1) {

--- a/server/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
@@ -176,7 +176,7 @@ final class GroupByOptimizedIterator {
             table,
             shardCreatedVersion,
             indexService.cache(),
-            collectTask::raiseIfKilled
+            collectTask.killToken()::raiseIfKilled
         );
 
         return getIterator(

--- a/server/src/main/java/io/crate/execution/engine/collect/LuceneShardCollectorProvider.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/LuceneShardCollectorProvider.java
@@ -144,7 +144,7 @@ public class LuceneShardCollectorProvider extends ShardCollectorProvider {
             table,
             shardCreatedVersion,
             indexService.cache(),
-            collectTask::raiseIfKilled
+            collectTask.killToken()::raiseIfKilled
         );
         InputFactory.Context<? extends LuceneCollectorExpression<?>> docCtx =
             docInputFactory.extractImplementations(collectTask.txnCtx(), collectPhase);
@@ -226,7 +226,7 @@ public class LuceneShardCollectorProvider extends ShardCollectorProvider {
             table,
             shardCreatedVersion,
             indexService.cache(),
-            collectTask::raiseIfKilled
+            collectTask.killToken()::raiseIfKilled
         );
         ctx = docInputFactory.extractImplementations(collectTask.txnCtx(), phase);
         collectorContext = new CollectorContext(

--- a/server/src/main/java/io/crate/lucene/GenericFunctionQuery.java
+++ b/server/src/main/java/io/crate/lucene/GenericFunctionQuery.java
@@ -82,7 +82,8 @@ public class GenericFunctionQuery extends Query implements Accountable {
             + RamUsageEstimator.shallowSizeOf(collectorContext)
             + RamUsageEstimator.shallowSizeOf(docInputFactory)
             + RamUsageEstimator.shallowSizeOf(txnCtx)
-            + RamUsageEstimator.NUM_BYTES_OBJECT_HEADER // raiseIfKilled
+            // raiseIfKilled references KillToken which has a link to Throwable.
+            + RamUsageEstimator.NUM_BYTES_OBJECT_HEADER + RamUsageEstimator.NUM_BYTES_OBJECT_REF
             + 8; // ramBytesUsed
     }
 

--- a/server/src/test/java/io/crate/lucene/GenericFunctionQueryTest.java
+++ b/server/src/test/java/io/crate/lucene/GenericFunctionQueryTest.java
@@ -80,7 +80,7 @@ public class GenericFunctionQueryTest extends CrateDummyClusterServiceUnitTest {
         try (QueryTester tester = builder.build()) {
             var query = tester.toQuery("abs(a) * abs(b) = 1");
             assertThat(query).isInstanceOf(GenericFunctionQuery.class);
-            assertThat(CustomLRUQueryCache.getRamBytesUsed(query)).isEqualTo(1668L);
+            assertThat(CustomLRUQueryCache.getRamBytesUsed(query)).isEqualTo(1672L);
         }
     }
 
@@ -97,7 +97,7 @@ public class GenericFunctionQueryTest extends CrateDummyClusterServiceUnitTest {
         try (QueryTester tester = builder.build()) {
             var query = tester.toQuery("abs(a) = 1 AND abs(b) = 1");
             assertThat(query).isInstanceOf(BooleanQuery.class);
-            assertThat(CustomLRUQueryCache.getRamBytesUsed(query)).isEqualTo(1808L);
+            assertThat(CustomLRUQueryCache.getRamBytesUsed(query)).isEqualTo(1816L);
         }
     }
 }


### PR DESCRIPTION
Relates to https://github.com/crate/support/issues/819

Follow up to https://github.com/crate/crate/pull/18925

Fix:
Changing directed GC graph from
`GenericFunctionQuery` -> `CollectTask`
to
`GenericFunctionQuery` -> `KillToken` <- `CollectTask`

This way queries in cache don't retain potentially heavy `CollectTask` instances

---
Reproduction:
keep only first commit and run a new test - OOM after some time

---
Get the second commit in and re-run the test: see GC overhead messages 
(because we keep creating heavy CollectTask instances), but no OOM as GC does its job.

<details><summary>
Heap dump without the fix (references CollectTask)</summary>
<img width="737" height="899" alt="Screenshot" src="https://github.com/user-attachments/assets/cd356362-d121-446e-b745-88a8191eb4b2" />
</details>

<details><summary>Heap dump with the fix (references only KillToken instance)</summary>
<img width="793" height="841" alt="Screenshot 2" src="https://github.com/user-attachments/assets/ab4428ea-1c74-4ec9-952b-924128118929" />
</details>