### PR TITLE
docs: add no-animal-violence Vale package for inclusive language checking

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -2,18 +2,9 @@ StylesPath = .github/styles
 MinAlertLevel = warning
 
 Vocab = CrateDB
-# See https://vale.sh/docs/topics/config/#skippedscopes
-# Additions to default:
-# - a: For links to stuff like pg_tables
-# - th: For parameter or option descriptions like:
-#     :table_ident:
-#       <description>
-# - dt: For option/property descriptions like:
-#   **drop_source**
-#     | *Default*: ``false``
-#
-#     <description>
 SkippedScopes = script, style, pre, figure, a, th, dt
 
+Packages = https://github.com/Open-Paws/vale-no-animal-violence/releases/latest/download/NoAnimalViolence.zip
+
 [*.rst]
-BasedOnStyles = Vale,CrateDB
+BasedOnStyles = Vale, CrateDB, NoAnimalViolence


### PR DESCRIPTION
Adds the [NoAnimalViolence](https://github.com/Open-Paws/vale-no-animal-violence) Vale package to the existing Vale setup. This package flags phrases that normalize violence toward animals and suggests clearer professional alternatives.

## Changes

- `.vale.ini`: add `NoAnimalViolence` package URL to a new `Packages =` line and `NoAnimalViolence` to `BasedOnStyles`

## The package

The [vale-no-animal-violence](https://github.com/Open-Paws/vale-no-animal-violence) package detects phrases like:
- "kill two birds with one stone" → "accomplish two things at once"
- "beat a dead horse" → "belabor the point"
- "guinea pig" → "test subject"
- "cattle vs. pets" → "ephemeral vs. persistent"
- "canary deployment" → "progressive rollout"
- "monkey patch" → "runtime patch"

All rules are at `warning` level — informational, not blocking.

Part of the [Open Paws](https://openpaws.ai) no-animal-violence toolchain for inclusive language.