### PR TITLE
Add parse_ident scalar function

### DIFF
--- a/docs/appendices/release-notes/6.3.0.rst
+++ b/docs/appendices/release-notes/6.3.0.rst
@@ -119,6 +119,10 @@ Scalar and Aggregation Functions
   :ref:`regexp_instr <scalar-regexp_instr>` scalar function to find the
   position of the ``N`` th regular expression match.
 
+- `Dhruv Patel <https://github.com/DHRUV6029>`_ added support for the
+  :ref:`parse_ident <scalar-parse_ident>` scalar function to split a qualified
+  SQL identifier string into an array of identifiers.
+
 Performance and Resilience Improvements
 ---------------------------------------
 

--- a/docs/general/builtins/scalar-functions.rst
+++ b/docs/general/builtins/scalar-functions.rst
@@ -608,6 +608,42 @@ The quoted string can be used as an identifier in an SQL statement.
     SELECT 1 row in set (... sec)
 
 
+.. _scalar-parse_ident:
+
+``pg_catalog.parse_ident(text [, boolean])``
+--------------------------------------------
+
+Returns: ``text[]``
+
+Splits a qualified identifier string into an array of identifiers, removing any
+quoting of individual identifiers. By default, extra characters after the last
+identifier are considered an error; but if the second parameter is ``false``,
+then such extra characters are ignored.
+
+Unquoted identifiers are case-folded to lowercase. Quoted identifiers preserve
+their original case.
+
+::
+
+    cr> select pg_catalog.parse_ident('"SomeSchema".sometable') AS parsed;
+    +-----------------------------+
+    | parsed                      |
+    +-----------------------------+
+    | ["SomeSchema", "sometable"] |
+    +-----------------------------+
+    SELECT 1 row in set (... sec)
+
+::
+
+    cr> select pg_catalog.parse_ident('myschema.mytable') AS parsed;
+    +-------------------------+
+    | parsed                  |
+    +-------------------------+
+    | ["myschema", "mytable"] |
+    +-------------------------+
+    SELECT 1 row in set (... sec)
+
+
 .. _scalar-left:
 
 ``left('string', len)``

--- a/libs/sql-parser/src/main/java/io/crate/sql/parser/SqlParser.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/parser/SqlParser.java
@@ -55,6 +55,7 @@ import io.crate.sql.parser.antlr.SqlBaseParserBaseListener;
 import io.crate.sql.tree.Expression;
 import io.crate.sql.tree.MultiStatement;
 import io.crate.sql.tree.Node;
+import io.crate.sql.tree.QualifiedNameReference;
 import io.crate.sql.tree.Statement;
 
 public class SqlParser {
@@ -116,6 +117,28 @@ public class SqlParser {
 
     public static Expression createExpression(String expression) {
         return INSTANCE.generateExpression(expression);
+    }
+
+    /**
+     * Parses the leading qualified name from the input using the parser's
+     * {@code qname} rule. Since {@code qname} does not require EOF, any
+     * trailing non-identifier characters are simply ignored.
+     *
+     * @return the parsed qualified name parts
+     * @throws ParsingException if the input does not start with a valid identifier
+     */
+    public static List<String> parseLeadingQualifiedName(String input) {
+        Node node = INSTANCE.invokeParser("qualifiedName", input, SqlBaseParser::qname, null);
+        if (node instanceof QualifiedNameReference ref) {
+            List<String> parts = ref.getName().getParts();
+            for (String part : parts) {
+                if (part.isEmpty()) {
+                    throw new ParsingException("Input does not start with a valid identifier: " + input);
+                }
+            }
+            return parts;
+        }
+        throw new ParsingException("Input does not start with a valid identifier: " + input);
     }
 
     private Expression generateExpression(String expression) {

--- a/server/src/main/java/io/crate/expression/scalar/ScalarFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/ScalarFunctions.java
@@ -78,6 +78,7 @@ import io.crate.expression.scalar.string.InitCapFunction;
 import io.crate.expression.scalar.string.LengthFunction;
 import io.crate.expression.scalar.string.ParseURIFunction;
 import io.crate.expression.scalar.string.ParseURLFunction;
+import io.crate.expression.scalar.string.ParseIdentFunction;
 import io.crate.expression.scalar.string.QuoteIdentFunction;
 import io.crate.expression.scalar.string.ReplaceFunction;
 import io.crate.expression.scalar.string.ReverseFunction;
@@ -198,6 +199,7 @@ public class ScalarFunctions implements FunctionsProvider {
         LengthFunction.register(builder);
         HashFunctions.register(builder);
         ReplaceFunction.register(builder);
+        ParseIdentFunction.register(builder);
         QuoteIdentFunction.register(builder);
 
         Ignore3vlFunction.register(builder);

--- a/server/src/main/java/io/crate/expression/scalar/string/ParseIdentFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/ParseIdentFunction.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.expression.scalar.string;
+
+import java.util.List;
+
+import io.crate.common.annotations.VisibleForTesting;
+import io.crate.data.Input;
+import io.crate.metadata.FunctionName;
+import io.crate.metadata.FunctionType;
+import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.Scalar;
+import io.crate.metadata.TransactionContext;
+import io.crate.metadata.functions.BoundSignature;
+import io.crate.metadata.functions.Signature;
+import io.crate.metadata.pgcatalog.PgCatalogSchemaInfo;
+import io.crate.sql.parser.ParsingException;
+import io.crate.sql.parser.SqlParser;
+import io.crate.sql.tree.Expression;
+import io.crate.sql.tree.FunctionCall;
+import io.crate.sql.tree.QualifiedNameReference;
+import io.crate.types.DataTypes;
+
+/**
+ * PostgreSQL-compatible {@code parse_ident} function.
+ * <p>
+ * Splits a qualified SQL identifier string into an array of identifiers,
+ * removing any quoting of individual identifiers. Unquoted identifiers
+ * are case-folded to lowercase.
+ * <p>
+ * Signature: {@code parse_ident(text [, boolean DEFAULT true]) → text[]}
+ */
+public class ParseIdentFunction extends Scalar<List<String>, Object> {
+
+    private static final FunctionName FQNAME = new FunctionName(PgCatalogSchemaInfo.NAME, "parse_ident");
+
+    public static void register(Functions.Builder module) {
+        // parse_ident(text) → text[]
+        module.add(
+            Signature.builder(FQNAME, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.STRING.getTypeSignature())
+                .returnType(DataTypes.STRING_ARRAY.getTypeSignature())
+                .features(Feature.DETERMINISTIC, Feature.STRICTNULL)
+                .build(),
+            ParseIdentFunction::new
+        );
+        // parse_ident(text, boolean) → text[]
+        module.add(
+            Signature.builder(FQNAME, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.STRING.getTypeSignature(), DataTypes.BOOLEAN.getTypeSignature())
+                .returnType(DataTypes.STRING_ARRAY.getTypeSignature())
+                .features(Feature.DETERMINISTIC, Feature.STRICTNULL)
+                .build(),
+            ParseIdentFunction::new
+        );
+    }
+
+    public ParseIdentFunction(Signature signature, BoundSignature boundSignature) {
+        super(signature, boundSignature);
+    }
+
+    @Override
+    @SafeVarargs
+    public final List<String> evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Object>... args) {
+        assert args.length == 1 || args.length == 2 : "number of args must be 1 or 2";
+
+        String input = (String) args[0].value();
+        if (input == null) {
+            return null;
+        }
+
+        boolean strict = true;
+        if (args.length == 2) {
+            Boolean strictArg = (Boolean) args[1].value();
+            if (strictArg == null) {
+                return null;
+            }
+            strict = strictArg;
+        }
+
+        return parseIdent(input, strict);
+    }
+
+    @VisibleForTesting
+    static List<String> parseIdent(String input, boolean strict) {
+        Expression expression;
+        try {
+            expression = SqlParser.createExpression(input);
+        } catch (ParsingException e) {
+            if (!strict) {
+                return tryParseLeadingIdent(input);
+            }
+            throw new IllegalArgumentException(
+                "String is not a valid identifier: \"" + input + "\"", e);
+        }
+
+        if (expression instanceof QualifiedNameReference ref) {
+            List<String> parts = ref.getName().getParts();
+            for (String part : parts) {
+                if (part.isEmpty()) {
+                    throw new IllegalArgumentException(
+                        "String is not a valid identifier: \"" + input + "\"");
+                }
+            }
+            return parts;
+        }
+
+        if (!strict) {
+            if (expression instanceof FunctionCall func) {
+                return func.getName().getParts();
+            }
+            return tryParseLeadingIdent(input);
+        }
+
+        throw new IllegalArgumentException(
+            "String is not a valid identifier: \"" + input + "\"");
+    }
+
+    private static List<String> tryParseLeadingIdent(String input) {
+        try {
+            return SqlParser.parseLeadingQualifiedName(input);
+        } catch (ParsingException e) {
+            throw new IllegalArgumentException(
+                "String is not a valid identifier: \"" + input + "\"", e);
+        }
+    }
+}

--- a/server/src/test/java/io/crate/expression/scalar/string/ParseIdentFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/string/ParseIdentFunctionTest.java
@@ -1,0 +1,321 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.expression.scalar.string;
+
+import static io.crate.testing.Asserts.isFunction;
+import static io.crate.testing.Asserts.isLiteral;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import io.crate.exceptions.UnsupportedFunctionException;
+import io.crate.expression.scalar.ScalarTestCase;
+import io.crate.expression.symbol.Literal;
+import io.crate.types.DataTypes;
+
+
+public class ParseIdentFunctionTest extends ScalarTestCase {
+
+    @Test
+    public void testZeroArguments() {
+        assertThatThrownBy(() -> assertEvaluateNull("parse_ident()"))
+            .isExactlyInstanceOf(UnsupportedFunctionException.class)
+            .hasMessageContaining("Invalid arguments in: parse_ident()");
+    }
+
+    @Test
+    public void testNullInput() {
+        assertEvaluateNull("parse_ident(null)");
+    }
+
+    @Test
+    public void testNullStrictMode() {
+        assertEvaluateNull("parse_ident('foo', null)");
+    }
+
+    @Test
+    public void testSimpleUnquotedIdentifier() {
+        assertEvaluate("parse_ident('customers')", List.of("customers"));
+    }
+
+    @Test
+    public void testUnquotedIdentifierCaseFolding() {
+        assertEvaluate("parse_ident('SomeTable')", List.of("sometable"));
+    }
+
+    @Test
+    public void testDotSeparatedUnquotedIdentifiers() {
+        assertEvaluate("parse_ident('myschema.mytable')", List.of("myschema", "mytable"));
+    }
+
+    @Test
+    public void testThreePartIdentifier() {
+        assertEvaluate("parse_ident('John.Smith.Lily')", List.of("john", "smith", "lily"));
+    }
+
+    @Test
+    public void testQuotedIdentifierPreservesCase() {
+        assertEvaluate("parse_ident('\"SomeSchema\".sometable')", List.of("SomeSchema", "sometable"));
+    }
+
+    @Test
+    public void testBothQuotedIdentifiers() {
+        assertEvaluate("parse_ident('\"SomeSchema\".\"SomeTable\"')", List.of("SomeSchema", "SomeTable"));
+    }
+
+    @Test
+    public void testQuotedIdentifierWithDot() {
+        assertEvaluate("parse_ident('\"some.schema\".table1')", List.of("some.schema", "table1"));
+    }
+
+    @Test
+    public void testQuotedIdentifierWithEscapedQuote() {
+        assertEvaluate("parse_ident('\"foo\"\"bar\".baz')", List.of("foo\"bar", "baz"));
+    }
+
+    @Test
+    public void testIdentifierWithUnderscore() {
+        assertEvaluate("parse_ident('my_schema.my_table')", List.of("my_schema", "my_table"));
+    }
+
+    @Test
+    public void testIdentifierStartingWithUnderscore() {
+        assertEvaluate("parse_ident('_private')", List.of("_private"));
+    }
+
+    @Test
+    public void testIdentifierWithDigits() {
+        assertEvaluate("parse_ident('table1.col2')", List.of("table1", "col2"));
+    }
+
+    @Test
+    public void testIdentifierWithDollarSignThrows() {
+        // SqlParser does not support $ in unquoted identifiers
+        assertThatThrownBy(() -> assertEvaluateNull("parse_ident('col$1')"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("String is not a valid identifier");
+    }
+
+    @Test
+    public void testQuotedIdentifierWithDollarSign() {
+        assertEvaluate("parse_ident('\"col$1\"')", List.of("col$1"));
+    }
+
+    @Test
+    public void testWhitespaceTrimming() {
+        assertEvaluate("parse_ident('  myschema . mytable  ')", List.of("myschema", "mytable"));
+    }
+
+    // Strict mode tests (default = true)
+
+    @Test
+    public void testStrictModeRejectsTrailingJunk() {
+        assertThatThrownBy(() -> assertEvaluateNull("parse_ident('foo%%%')"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("String is not a valid identifier");
+    }
+
+    @Test
+    public void testStrictModeExplicitTrue() {
+        assertThatThrownBy(() -> assertEvaluateNull("parse_ident('foo%%%', true)"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("String is not a valid identifier");
+    }
+
+    @Test
+    public void testStrictModeRejectsTrailingTextAfterIdentifier() {
+        assertThatThrownBy(() -> assertEvaluateNull("parse_ident('John.Smith.Lily%%%')"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("String is not a valid identifier");
+    }
+
+    // Non-strict mode tests
+
+    @Test
+    public void testNonStrictModeIgnoresTrailingJunk() {
+        assertEvaluate("parse_ident('John.Smith.Lily%%%', false)", List.of("john", "smith", "lily"));
+    }
+
+    @Test
+    public void testNonStrictModeIgnoresTrailingChars() {
+        assertEvaluate("parse_ident('foo()', false)", List.of("foo"));
+    }
+
+    @Test
+    public void testNonStrictModeWithQuotedIdent() {
+        assertEvaluate("parse_ident('\"SomeFunc\"(int)', false)", List.of("SomeFunc"));
+    }
+
+    // Error cases
+
+    @Test
+    public void testEmptyStringThrows() {
+        assertThatThrownBy(() -> assertEvaluateNull("parse_ident('')"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("String is not a valid identifier");
+    }
+
+    @Test
+    public void testOnlyWhitespaceThrows() {
+        assertThatThrownBy(() -> assertEvaluateNull("parse_ident('   ')"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("String is not a valid identifier");
+    }
+
+    @Test
+    public void testTrailingDotThrows() {
+        assertThatThrownBy(() -> assertEvaluateNull("parse_ident('schema.')"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("String is not a valid identifier");
+    }
+
+    @Test
+    public void testStartsWithDigitThrows() {
+        assertThatThrownBy(() -> assertEvaluateNull("parse_ident('1abc')"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("String is not a valid identifier");
+    }
+
+    @Test
+    public void testUnclosedQuoteThrows() {
+        assertThatThrownBy(() -> assertEvaluateNull("parse_ident('\"unclosed')"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("String is not a valid identifier");
+    }
+
+    @Test
+    public void testEmptyQuotedIdentifierThrows() {
+        assertThatThrownBy(() -> assertEvaluateNull("parse_ident('\"\"')"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("String is not a valid identifier");
+    }
+
+    // Normalize and reference tests
+
+    @Test
+    public void testNormalizeWithLiteral() {
+        assertNormalize("parse_ident('myschema.mytable')", isLiteral(List.of("myschema", "mytable")));
+    }
+
+    @Test
+    public void testNormalizeWithRef() {
+        assertNormalize(
+            "parse_ident(name)",
+            isFunction("parse_ident", List.of(DataTypes.STRING)));
+    }
+
+    @Test
+    public void testEvaluateWithRef() {
+        assertEvaluate(
+            "parse_ident(name)", List.of("myschema", "mytable"),
+            Literal.of(DataTypes.STRING, "myschema.mytable"));
+    }
+
+    @Test
+    public void testEvaluateWithRefAndStrictMode() {
+        assertEvaluate(
+            "parse_ident(name, is_awesome)", List.of("foo"),
+            Literal.of(DataTypes.STRING, "foo()"),
+            Literal.of(DataTypes.BOOLEAN, false));
+    }
+
+    // PostgreSQL compatibility: the Grafana use-case from the issue
+    @Test
+    public void testSingleIdentifierArrayLength() {
+        // parse_ident('customers') should return a 1-element array
+        assertEvaluate("parse_ident('customers')", List.of("customers"));
+    }
+
+    @Test
+    public void testSchemaQualifiedIdentifier() {
+        // parse_ident('myschema.customers') should return a 2-element array
+        assertEvaluate("parse_ident('myschema.customers')", List.of("myschema", "customers"));
+    }
+
+    @Test
+    public void testQuotedUnicodeLetterIdentifier() {
+        assertEvaluate("parse_ident('\"tëst\"')", List.of("tëst"));
+    }
+
+    @Test
+    public void test_parse_ident_quoted_with_spaces() {
+        assertEvaluate("parse_ident('\"my schema\".\"my table\"')", List.of("my schema", "my table"));
+    }
+
+    @Test
+    public void test_parse_ident_single_quoted_ident_preserved() {
+        assertEvaluate("parse_ident('\"UPPER\"')", List.of("UPPER"));
+    }
+
+    // Non-strict mode: qname fallback edge cases
+
+    @Test
+    public void test_non_strict_trailing_space_and_word() {
+        assertEvaluate("parse_ident('foo.bar baz', false)", List.of("foo", "bar"));
+    }
+
+    @Test
+    public void test_non_strict_quoted_ident_with_trailing_junk() {
+        assertEvaluate("parse_ident('\"MySchema\".\"MyTable\"%%%', false)", List.of("MySchema", "MyTable"));
+    }
+
+    @Test
+    public void test_non_strict_single_ident_trailing_operators() {
+        assertEvaluate("parse_ident('foo%%%', false)", List.of("foo"));
+    }
+
+    @Test
+    public void test_non_strict_only_junk_throws() {
+        assertThatThrownBy(() -> assertEvaluateNull("parse_ident('%%%', false)"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("String is not a valid identifier");
+    }
+
+    @Test
+    public void test_non_strict_empty_string_throws() {
+        assertThatThrownBy(() -> assertEvaluateNull("parse_ident('', false)"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("String is not a valid identifier");
+    }
+
+    @Test
+    public void test_non_strict_whitespace_only_throws() {
+        assertThatThrownBy(() -> assertEvaluateNull("parse_ident('   ', false)"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("String is not a valid identifier");
+    }
+
+    @Test
+    public void test_strict_trailing_space_and_word_throws() {
+        assertThatThrownBy(() -> assertEvaluateNull("parse_ident('foo.bar baz')"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("String is not a valid identifier");
+    }
+
+    @Test
+    public void test_non_strict_non_reserved_keyword_as_ident() {
+        // Non-reserved keywords like 'analyzer' are valid as identifiers
+        assertEvaluate("parse_ident('analyzer.alias', false)", List.of("analyzer", "alias"));
+    }
+}


### PR DESCRIPTION
PostgreSQL-compatible `parse_ident` function that splits a qualified SQL identifier string into an array of identifiers, with optional strict mode.

Fixes https://github.com/crate/crate/issues/18660

## Summary of the changes / Why this improves CrateDB

Adds the `pg_catalog.parse_ident(text [, boolean])` scalar function for PostgreSQL compatibility. This function is used by tools like Grafana to extract schema and table names from qualified identifiers.

- **1-arg form**: `parse_ident(text)` — strict mode (default), rejects trailing invalid characters
- **2-arg form**: `parse_ident(text, boolean)` — when `false`, ignores extra characters after the last valid identifier

Behavior:
- Unquoted identifiers are case-folded to lowercase
- Quoted identifiers (`"MyTable"`) preserve their original case
- Supports escaped quotes (`""` → `"`) inside quoted identifiers
- Validates identifier start characters (letters, `_`) and continuation characters (letters, digits, `_`, `$`)
- Handles whitespace around identifiers and dot separators

## Checklist

- [ ] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
- [x] Updated documentation & `sql_features` table for user facing changes
- [x] Touched code is covered by tests
- [x] This does not contain breaking changes, or if it does:
   - It is released within a major release
   - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
   - It was marked as deprecated in an earlier release if possible
   - You've thought about the consequences and other components are adapted
     (E.g. AdminUI)