### PR TITLE
Add support for empty statements containing comments

### DIFF
--- a/docs/appendices/release-notes/6.3.0.rst
+++ b/docs/appendices/release-notes/6.3.0.rst
@@ -79,6 +79,9 @@ SQL Statements
 SQL Standard and PostgreSQL Compatibility
 -----------------------------------------
 
+- Added support for statements containing only comments like ``/* ping */`` for
+  compatibility with clients like pgx - which is used by Grafana since 12.4.
+
 - Added support for ``DEFAULT`` expressions in :ref:`INSERT INTO <sql-insert>`
   statements to explicitly declare that the default expression of a column
   should be used.

--- a/libs/sql-parser/src/main/antlr/io/crate/sql/parser/antlr/SqlBaseParser.g4
+++ b/libs/sql-parser/src/main/antlr/io/crate/sql/parser/antlr/SqlBaseParser.g4
@@ -24,11 +24,11 @@ parser grammar SqlBaseParser;
 options { tokenVocab=SqlBaseLexer; } // use tokens from SqlBaseLexer.g4
 
 statements
-    : statement (SEMICOLON statement)* SEMICOLON? EOF
+    : statement? (SEMICOLON statement)* SEMICOLON? EOF
     ;
 
 singleStatement
-    : statement SEMICOLON? EOF
+    : statement? SEMICOLON? EOF
     ;
 
 singleExpression

--- a/libs/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
@@ -91,6 +91,7 @@ import io.crate.sql.tree.DropSubscription;
 import io.crate.sql.tree.DropTable;
 import io.crate.sql.tree.DropUserMapping;
 import io.crate.sql.tree.DropView;
+import io.crate.sql.tree.EmptyStatement;
 import io.crate.sql.tree.EscapedCharStringLiteral;
 import io.crate.sql.tree.Explain;
 import io.crate.sql.tree.Expression;
@@ -195,6 +196,12 @@ public final class SqlFormatter {
         @Override
         protected Void visitNode(Node node, Integer indent) {
             throw new UnsupportedOperationException("not yet implemented: " + node);
+        }
+
+        @Override
+        public Void visitEmpty(EmptyStatement emptyStatement, Integer indent) {
+            append(indent, "");
+            return null;
         }
 
         @Override

--- a/libs/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -69,6 +69,7 @@ import io.crate.sql.parser.antlr.SqlBaseParser.MappedUserContext;
 import io.crate.sql.parser.antlr.SqlBaseParser.QueryContext;
 import io.crate.sql.parser.antlr.SqlBaseParser.QueryOptParensContext;
 import io.crate.sql.parser.antlr.SqlBaseParser.SetTransactionContext;
+import io.crate.sql.parser.antlr.SqlBaseParser.StatementContext;
 import io.crate.sql.parser.antlr.SqlBaseParser.StatementsContext;
 import io.crate.sql.parser.antlr.SqlBaseParser.TransactionModeContext;
 import io.crate.sql.parser.antlr.SqlBaseParserBaseVisitor;
@@ -163,6 +164,7 @@ import io.crate.sql.tree.DropSubscription;
 import io.crate.sql.tree.DropTable;
 import io.crate.sql.tree.DropUserMapping;
 import io.crate.sql.tree.DropView;
+import io.crate.sql.tree.EmptyStatement;
 import io.crate.sql.tree.EscapedCharStringLiteral;
 import io.crate.sql.tree.Except;
 import io.crate.sql.tree.ExistsPredicate;
@@ -293,7 +295,11 @@ class AstBuilder extends SqlBaseParserBaseVisitor<Node> {
 
     @Override
     public Node visitSingleStatement(SqlBaseParser.SingleStatementContext context) {
-        return visit(context.statement());
+        StatementContext statement = context.statement();
+        if (statement == null) {
+            return EmptyStatement.INSTANCE;
+        }
+        return visit(statement);
     }
 
     @Override

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
@@ -767,4 +767,8 @@ public abstract class AstVisitor<R, C> {
     public R visitDropSchema(DropSchema dropSchema, C context) {
         return visitStatement(dropSchema, context);
     }
+
+    public R visitEmpty(EmptyStatement emptyStatement, C context) {
+        return visitStatement(emptyStatement, context);
+    }
 }

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/EmptyStatement.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/EmptyStatement.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.sql.tree;
+
+public final class EmptyStatement extends Statement {
+
+    public static final EmptyStatement INSTANCE = new EmptyStatement();
+
+    private EmptyStatement() {
+        super();
+    }
+
+    @Override
+    public int hashCode() {
+        return 0;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return this == obj;
+    }
+
+    @Override
+    public String toString() {
+        return "";
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
+        return visitor.visitEmpty(this, context);
+    }
+}

--- a/libs/sql-parser/src/test/java/io/crate/sql/parser/TestSqlParser.java
+++ b/libs/sql-parser/src/test/java/io/crate/sql/parser/TestSqlParser.java
@@ -220,14 +220,6 @@ public class TestSqlParser {
     }
 
     @Test
-    public void testEmptyStatement() {
-        assertThatThrownBy(
-            () -> SqlParser.createStatement(""))
-            .isExactlyInstanceOf(ParsingException.class)
-            .hasMessageStartingWith("line 1:1: mismatched input '<EOF>' expecting");
-    }
-
-    @Test
     public void testExpressionWithTrailingJunk() {
         assertThatThrownBy(
             () -> SqlParser.createExpression("1 + 1 x"))

--- a/libs/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/libs/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -305,6 +305,14 @@ public class TestStatementBuilder {
     }
 
     @Test
+    public void test_empty() throws Exception {
+        printStatement("");
+        printStatement("--- foo");
+        printStatement("/* ping */");
+        printStatement("/* ping */ ; -- foo");
+    }
+
+    @Test
     public void testNullNotAllowedAsArgToExtractField() {
         assertThatThrownBy(
             () -> printStatement("select extract(null from x)"))
@@ -1888,7 +1896,7 @@ public class TestStatementBuilder {
         assertThatThrownBy(
             () -> printStatement("mismatched input 'default'"))
             .isExactlyInstanceOf(ParsingException.class)
-            .hasMessageStartingWith("line 1:1: mismatched input 'mismatched' expecting {'");
+            .hasMessageStartingWith("line 1:1: mismatched input 'mismatched' expecting {");
     }
 
 

--- a/server/src/main/java/io/crate/analyze/AnalyzedEmpty.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedEmpty.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.analyze;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+import org.jspecify.annotations.Nullable;
+
+import io.crate.expression.symbol.Symbol;
+
+public final class AnalyzedEmpty implements AnalyzedStatement {
+
+    public static final AnalyzedEmpty INSTANCE = new AnalyzedEmpty();
+
+    private AnalyzedEmpty() {
+        super();
+    }
+
+    @Override
+    public <C, R> R accept(AnalyzedStatementVisitor<C, R> visitor, C context) {
+        return visitor.visitEmpty(this, context);
+    }
+
+    @Override
+    public boolean isWriteOperation() {
+        return false;
+    }
+
+    @Override
+    public void visitSymbols(Consumer<? super Symbol> consumer) {
+    }
+
+    @Override
+    @Nullable
+    public List<Symbol> outputs() {
+        return List.of();
+    }
+
+    @Override
+    @Nullable
+    public List<String> outputNames() {
+        return List.of();
+    }
+}

--- a/server/src/main/java/io/crate/analyze/AnalyzedStatementVisitor.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedStatementVisitor.java
@@ -339,4 +339,8 @@ public class AnalyzedStatementVisitor<C, R> {
     public R visitDropSchema(AnalyzedDropSchema dropSchema, C context) {
         return visitAnalyzedStatement(dropSchema, context);
     }
+
+    public R visitEmpty(AnalyzedEmpty empty, C context) {
+        return visitAnalyzedStatement(empty, context);
+    }
 }

--- a/server/src/main/java/io/crate/analyze/Analyzer.java
+++ b/server/src/main/java/io/crate/analyze/Analyzer.java
@@ -107,6 +107,7 @@ import io.crate.sql.tree.DropSubscription;
 import io.crate.sql.tree.DropTable;
 import io.crate.sql.tree.DropUserMapping;
 import io.crate.sql.tree.DropView;
+import io.crate.sql.tree.EmptyStatement;
 import io.crate.sql.tree.Explain;
 import io.crate.sql.tree.Expression;
 import io.crate.sql.tree.Fetch;
@@ -375,6 +376,11 @@ public class Analyzer {
         @Override
         public AnalyzedStatement visitBegin(BeginStatement node, Analysis context) {
             return new AnalyzedBegin();
+        }
+
+        @Override
+        public AnalyzedStatement visitEmpty(EmptyStatement emptyStatement, Analysis context) {
+            return AnalyzedEmpty.INSTANCE;
         }
 
         @Override

--- a/server/src/main/java/io/crate/planner/Planner.java
+++ b/server/src/main/java/io/crate/planner/Planner.java
@@ -79,6 +79,7 @@ import io.crate.analyze.AnalyzedDropSnapshot;
 import io.crate.analyze.AnalyzedDropTable;
 import io.crate.analyze.AnalyzedDropUserMapping;
 import io.crate.analyze.AnalyzedDropView;
+import io.crate.analyze.AnalyzedEmpty;
 import io.crate.analyze.AnalyzedFetch;
 import io.crate.analyze.AnalyzedGCDanglingArtifacts;
 import io.crate.analyze.AnalyzedInsertStatement;
@@ -282,6 +283,11 @@ public class Planner extends AnalyzedStatementVisitor<PlannerContext, Plan> {
 
     @Override
     public Plan visitBegin(AnalyzedBegin analyzedBegin, PlannerContext context) {
+        return NoopPlan.INSTANCE;
+    }
+
+    @Override
+    public Plan visitEmpty(AnalyzedEmpty empty, PlannerContext context) {
         return NoopPlan.INSTANCE;
     }
 

--- a/server/src/main/java/io/crate/protocols/postgres/PostgresWireProtocol.java
+++ b/server/src/main/java/io/crate/protocols/postgres/PostgresWireProtocol.java
@@ -48,13 +48,13 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.Version;
 import org.elasticsearch.http.netty4.Netty4HttpServerTransport;
 import org.jspecify.annotations.Nullable;
-import io.crate.common.annotations.VisibleForTesting;
 
 import io.crate.auth.AccessControl;
 import io.crate.auth.Authentication;
 import io.crate.auth.AuthenticationMethod;
 import io.crate.auth.Credentials;
 import io.crate.auth.Protocol;
+import io.crate.common.annotations.VisibleForTesting;
 import io.crate.common.collections.Lists;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
@@ -807,17 +807,16 @@ public class PostgresWireProtocol {
         String queryString = readCString(buffer);
         assert queryString != null : "query must not be nulL";
 
-        if (queryString.isEmpty() || ";".equals(queryString)) {
-            Messages.sendEmptyQueryResponse(channel);
-            sendReadyForQuery(channel, TransactionState.IDLE);
-            return;
-        }
-
         List<Statement> statements;
         try {
             statements = session.simpleQuery(queryString);
         } catch (Exception ex) {
             Messages.sendErrorResponse(channel, getAccessControl.apply(session.sessionSettings()), ex);
+            sendReadyForQuery(channel, TransactionState.IDLE);
+            return;
+        }
+        if (statements.isEmpty()) {
+            Messages.sendEmptyQueryResponse(channel);
             sendReadyForQuery(channel, TransactionState.IDLE);
             return;
         }

--- a/server/src/main/java/io/crate/session/Session.java
+++ b/server/src/main/java/io/crate/session/Session.java
@@ -130,10 +130,6 @@ public class Session implements AutoCloseable {
     // Logger name should be SQLOperations here
     private static final Logger LOGGER = LogManager.getLogger(Sessions.class);
 
-    // Parser can't handle empty statement but postgres requires support for it.
-    // This rewrite is done so that bind/describe calls on an empty statement will work as well
-    private static final Statement EMPTY_STMT = SqlParser.createStatement("select '' from sys.cluster limit 0");
-
     public static final String UNNAMED = "";
     private final DependencyCarrier executor;
     private final CoordinatorSessionSettings sessionSettings;
@@ -346,12 +342,8 @@ public class Session implements AutoCloseable {
         try {
             statement = SqlParser.createStatement(query);
         } catch (Throwable t) {
-            if ("".equals(query)) {
-                statement = EMPTY_STMT;
-            } else {
-                jobsLogs.logPreExecutionFailure(UUIDs.dirtyUUID(), query, SQLExceptions.messageOf(t), sessionSettings.sessionUser());
-                throw t;
-            }
+            jobsLogs.logPreExecutionFailure(UUIDs.dirtyUUID(), query, SQLExceptions.messageOf(t), sessionSettings.sessionUser());
+            throw t;
         }
         timeoutToken.check("parse");
 

--- a/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
@@ -2308,4 +2308,13 @@ public class TransportSQLActionTest extends IntegTestCase {
         execute("SELECT _id, a FROM tbl_pk WHERE a = '::ffff:192.168.0.1'");
         assertThat(response).hasRows("192.168.0.1| 192.168.0.1");
     }
+
+    @Test
+    public void test_empty_statements() throws Exception {
+        execute("");
+        execute("-- ping");
+        assertThat(response).isEmpty();
+        assertThat(response).hasColumns();
+        execute("-- ping ; /* ping2 */");
+    }
 }

--- a/server/src/test/java/io/crate/session/SessionTest.java
+++ b/server/src/test/java/io/crate/session/SessionTest.java
@@ -574,7 +574,7 @@ public class SessionTest extends CrateDummyClusterServiceUnitTest {
         sqlExecutor.jobsLogs.updateJobsLog(new QueueSink<>(new BlockingEvictingQueue<>(1), () -> {}));
         try (Session session = sqlExecutor.createSession()) {
             assertThatThrownBy(() -> session.simpleQuery("sele"))
-                .hasMessageContaining("mismatched input 'sele' expecting");
+                .hasMessageContaining("extraneous input 'sele' expecting");
 
             assertThat(sqlExecutor.jobsLogs.activeJobs()).isEmpty();
             assertThat(sqlExecutor.jobsLogs.jobsLog()).satisfiesExactly(


### PR DESCRIPTION
Closes https://github.com/crate/crate/issues/16501
See also https://github.com/crate/crate-qa/pull/396 - which fails without this change and passes with it.