### PR TITLE
Use IntArrayList instead of Set for readerIds in reader allocations

### DIFF
--- a/server/src/main/java/io/crate/execution/dsl/projection/FetchProjection.java
+++ b/server/src/main/java/io/crate/execution/dsl/projection/FetchProjection.java
@@ -29,14 +29,14 @@ import java.util.TreeMap;
 
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.monitor.jvm.JvmInfo;
-import io.crate.common.annotations.VisibleForTesting;
 
+import com.carrotsearch.hppc.IntArrayList;
 import com.carrotsearch.hppc.IntObjectHashMap;
 import com.carrotsearch.hppc.IntObjectMap;
-import com.carrotsearch.hppc.IntSet;
 import com.carrotsearch.hppc.cursors.IntCursor;
 
 import io.crate.Streamer;
+import io.crate.common.annotations.VisibleForTesting;
 import io.crate.common.collections.Lists;
 import io.crate.common.collections.MapBuilder;
 import io.crate.data.Paging;
@@ -57,7 +57,7 @@ public class FetchProjection extends Projection {
     private final int fetchSize;
     private final Map<RelationName, FetchSource> fetchSources;
     private final List<Symbol> outputSymbols;
-    private final Map<String, IntSet> nodeReaders;
+    private final Map<String, IntArrayList> nodeReaders;
     private final TreeMap<Integer, String> readerIndices;
     private final Map<String, RelationName> indicesToIdents;
     private final List<DataType<?>> inputTypes;
@@ -67,7 +67,7 @@ public class FetchProjection extends Projection {
                            Map<RelationName, FetchSource> fetchSources,
                            List<Symbol> outputSymbols,
                            List<DataType<?>> inputTypes,
-                           Map<String, IntSet> nodeReaders,
+                           Map<String, IntArrayList> nodeReaders,
                            TreeMap<Integer, String> readerIndices,
                            Map<String, RelationName> indicesToIdents) {
         assert outputSymbols.stream().noneMatch(s ->
@@ -131,7 +131,7 @@ public class FetchProjection extends Projection {
         return inputTypes;
     }
 
-    public Map<String, IntSet> nodeReaders() {
+    public Map<String, IntArrayList> nodeReaders() {
         return nodeReaders;
     }
 
@@ -180,7 +180,7 @@ public class FetchProjection extends Projection {
 
     public Map<String, ? extends IntObjectMap<Streamer<?>[]>> generateStreamersGroupedByReaderAndNode() {
         HashMap<String, IntObjectHashMap<Streamer<?>[]>> streamersByReaderByNode = new HashMap<>();
-        for (Map.Entry<String, IntSet> entry : nodeReaders.entrySet()) {
+        for (Map.Entry<String, IntArrayList> entry : nodeReaders.entrySet()) {
             IntObjectHashMap<Streamer<?>[]> streamersByReaderId = new IntObjectHashMap<>();
             String nodeId = entry.getKey();
             streamersByReaderByNode.put(nodeId, streamersByReaderId);

--- a/server/src/main/java/io/crate/execution/engine/fetch/FetchMapper.java
+++ b/server/src/main/java/io/crate/execution/engine/fetch/FetchMapper.java
@@ -27,13 +27,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import com.carrotsearch.hppc.IntArrayList;
 import com.carrotsearch.hppc.IntObjectHashMap;
 import com.carrotsearch.hppc.IntObjectMap;
-import com.carrotsearch.hppc.IntSet;
-
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import io.crate.common.concurrent.CompletableFutures;
 import io.crate.data.AsyncFlatMapper;
@@ -46,9 +45,9 @@ public class FetchMapper implements AsyncFlatMapper<ReaderBuckets, Row> {
     private static final Logger LOGGER = LogManager.getLogger(FetchMapper.class);
 
     private final FetchOperation fetchOperation;
-    private final Map<String, IntSet> readerIdsByNode;
+    private final Map<String, IntArrayList> readerIdsByNode;
 
-    public FetchMapper(FetchOperation fetchOperation, Map<String, IntSet> readerIdsByNode) {
+    public FetchMapper(FetchOperation fetchOperation, Map<String, IntArrayList> readerIdsByNode) {
         this.fetchOperation = fetchOperation;
         this.readerIdsByNode = readerIdsByNode;
     }
@@ -56,9 +55,9 @@ public class FetchMapper implements AsyncFlatMapper<ReaderBuckets, Row> {
     @Override
     public CompletableFuture<? extends CloseableIterator<Row>> apply(ReaderBuckets readerBuckets, boolean isLastCall) {
         List<CompletableFuture<IntObjectMap<? extends Bucket>>> futures = new ArrayList<>();
-        Iterator<Map.Entry<String, IntSet>> it = readerIdsByNode.entrySet().iterator();
+        Iterator<Map.Entry<String, IntArrayList>> it = readerIdsByNode.entrySet().iterator();
         while (it.hasNext()) {
-            Map.Entry<String, IntSet> entry = it.next();
+            Map.Entry<String, IntArrayList> entry = it.next();
             IntObjectHashMap<IntArrayList> toFetch = readerBuckets.generateToFetch(entry.getValue());
             if (toFetch.isEmpty() && !isLastCall) {
                 continue;

--- a/server/src/main/java/io/crate/execution/engine/fetch/ReaderBuckets.java
+++ b/server/src/main/java/io/crate/execution/engine/fetch/ReaderBuckets.java
@@ -31,7 +31,6 @@ import org.apache.lucene.util.Accountable;
 import com.carrotsearch.hppc.IntArrayList;
 import com.carrotsearch.hppc.IntObjectHashMap;
 import com.carrotsearch.hppc.IntObjectMap;
-import com.carrotsearch.hppc.IntSet;
 import com.carrotsearch.hppc.cursors.IntCursor;
 import com.carrotsearch.hppc.cursors.IntObjectCursor;
 
@@ -145,7 +144,7 @@ public class ReaderBuckets implements Accountable {
         };
     }
 
-    public IntObjectHashMap<IntArrayList> generateToFetch(IntSet readerIds) {
+    public IntObjectHashMap<IntArrayList> generateToFetch(IntArrayList readerIds) {
         IntObjectHashMap<IntArrayList> toFetch = new IntObjectHashMap<>(readerIds.size());
         for (IntCursor readerIdCursor : readerIds) {
             ReaderBucket readerBucket = readerBuckets.get(readerIdCursor.value);

--- a/server/src/main/java/io/crate/planner/ReaderAllocations.java
+++ b/server/src/main/java/io/crate/planner/ReaderAllocations.java
@@ -21,19 +21,20 @@
 
 package io.crate.planner;
 
-import com.carrotsearch.hppc.IntHashSet;
-import com.carrotsearch.hppc.IntSet;
-import io.crate.metadata.RelationName;
-
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.TreeMap;
 
+import com.carrotsearch.hppc.IntArrayList;
+import com.carrotsearch.hppc.IntHashSet;
+
+import io.crate.metadata.RelationName;
+
 public final class ReaderAllocations {
 
     private final TreeMap<Integer, String> readerIndices = new TreeMap<>();
-    private final Map<String, IntSet> nodeReaders = new HashMap<>();
+    private final Map<String, IntArrayList> nodeReaders = new HashMap<>();
     private final TreeMap<String, Integer> bases;
     private final Map<RelationName, Collection<String>> tableIndices;
     private final Map<String, RelationName> indicesToIdents;
@@ -59,12 +60,14 @@ public final class ReaderAllocations {
             }
             for (Map.Entry<Integer, String> nodeEntries : entry.getValue().entrySet()) {
                 int readerId = base + nodeEntries.getKey();
-                IntSet readerIds = nodeReaders.get(nodeEntries.getValue());
+                IntArrayList readerIds = nodeReaders.get(nodeEntries.getValue());
                 if (readerIds == null) {
-                    readerIds = new IntHashSet();
+                    readerIds = new IntArrayList();
                     nodeReaders.put(nodeEntries.getValue(), readerIds);
                 }
                 readerIds.add(readerId);
+                assert new IntHashSet(readerIds).size() == readerIds.size()
+                    : "readerIds must be unique";
             }
         }
     }
@@ -77,7 +80,7 @@ public final class ReaderAllocations {
         return readerIndices;
     }
 
-    public Map<String, IntSet> nodeReaders() {
+    public Map<String, IntArrayList> nodeReaders() {
         return nodeReaders;
     }
 

--- a/server/src/test/java/io/crate/execution/engine/fetch/FetchRowsTest.java
+++ b/server/src/test/java/io/crate/execution/engine/fetch/FetchRowsTest.java
@@ -31,7 +31,7 @@ import java.util.Map;
 
 import org.junit.Test;
 
-import com.carrotsearch.hppc.IntHashSet;
+import com.carrotsearch.hppc.IntArrayList;
 import com.carrotsearch.hppc.IntObjectHashMap;
 
 import io.crate.breaker.CellsSizeEstimator;
@@ -89,7 +89,7 @@ public class FetchRowsTest extends CrateDummyClusterServiceUnitTest {
             CellsSizeEstimator.constant(0),
             RamAccounting.NO_ACCOUNTING
         );
-        IntHashSet readerIds = new IntHashSet(2);
+        IntArrayList readerIds = new IntArrayList(2);
         readerIds.add(1);
         readerIds.add(2);
         readerBuckets.add(new RowN(fetchIdRel1, fetchIdRel2, 42));

--- a/server/src/test/java/io/crate/execution/engine/fetch/ReaderBucketsTest.java
+++ b/server/src/test/java/io/crate/execution/engine/fetch/ReaderBucketsTest.java
@@ -29,7 +29,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import org.junit.Test;
 
-import com.carrotsearch.hppc.IntHashSet;
+import com.carrotsearch.hppc.IntArrayList;
 import com.carrotsearch.hppc.IntObjectHashMap;
 
 import io.crate.breaker.CellsSizeEstimator;
@@ -89,10 +89,10 @@ public class ReaderBucketsTest extends CrateDummyClusterServiceUnitTest {
         bucketsByReader.put(readerId, new CollectionBucket(List.<Object[]>of(
             new Object[] {"I eat memory for breakfast"}
         )));
-        IntHashSet readerIds = new IntHashSet(2);
+        IntArrayList readerIds = new IntArrayList(2);
         readerIds.add(readerId);
         readerBuckets.generateToFetch(readerIds);
-        try (var outputRows = readerBuckets.getOutputRows(List.of(bucketsByReader))) {
+        try (var _ = readerBuckets.getOutputRows(List.of(bucketsByReader))) {
             assertThat(bytesAccounted.get()).isEqualTo(1024L);
             assertThat(readerBuckets.ramBytesUsed()).isEqualTo(136L);
         }

--- a/server/src/test/java/io/crate/planner/RoutingBuilderTest.java
+++ b/server/src/test/java/io/crate/planner/RoutingBuilderTest.java
@@ -31,7 +31,7 @@ import org.elasticsearch.common.Randomness;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.carrotsearch.hppc.IntSet;
+import com.carrotsearch.hppc.IntArrayList;
 
 import io.crate.analyze.WhereClause;
 import io.crate.expression.operator.EqOperator;
@@ -101,12 +101,12 @@ public class RoutingBuilderTest extends CrateDummyClusterServiceUnitTest {
         assertThat(readerAllocations.indices().get(0)).isEqualTo(indexUUID);
         assertThat(readerAllocations.nodeReaders()).hasSize(2);
 
-        IntSet n1 = readerAllocations.nodeReaders().get("n1");
+        IntArrayList n1 = readerAllocations.nodeReaders().get("n1");
         assertThat(n1).hasSize(2);
         assertThat(n1.contains(0)).isTrue();
         assertThat(n1.contains(2)).isTrue();
 
-        IntSet n2 = readerAllocations.nodeReaders().get("n2");
+        IntArrayList n2 = readerAllocations.nodeReaders().get("n2");
         assertThat(n2).hasSize(2);
         assertThat(n2.contains(1)).isTrue();
         assertThat(n2.contains(3)).isTrue();


### PR DESCRIPTION
The way readerIds are generated (base+nodeEntries) should already ensure
that the readerIds are unique and the deduplication/hashing isn't
necessary.
