### PR TITLE
Remove intermediate Restore.Request

### DIFF
--- a/server/src/main/java/io/crate/replication/logical/LogicalReplicationService.java
+++ b/server/src/main/java/io/crate/replication/logical/LogicalReplicationService.java
@@ -23,7 +23,6 @@ package io.crate.replication.logical;
 
 import static io.crate.replication.logical.repository.LogicalReplicationRepository.REMOTE_REPOSITORY_PREFIX;
 import static io.crate.replication.logical.repository.LogicalReplicationRepository.TYPE;
-import static org.elasticsearch.action.support.master.MasterNodeRequest.DEFAULT_MASTER_NODE_TIMEOUT;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -43,6 +42,7 @@ import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreClusterStateListener;
+import org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreSnapshotRequest;
 import org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreSnapshotResponse;
 import org.elasticsearch.action.admin.cluster.snapshots.restore.TableOrPartition;
 import org.elasticsearch.action.support.IndicesOptions;
@@ -53,7 +53,6 @@ import org.elasticsearch.cluster.ClusterStateListener;
 import org.elasticsearch.cluster.metadata.MetadataUpgradeService;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.IndexScopedSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.repositories.RepositoriesService;
@@ -62,8 +61,8 @@ import org.elasticsearch.snapshots.RestoreService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.RemoteClusters;
 import org.jspecify.annotations.Nullable;
-import io.crate.common.annotations.VisibleForTesting;
 
+import io.crate.common.annotations.VisibleForTesting;
 import io.crate.concurrent.FutureActionListener;
 import io.crate.exceptions.SubscriptionRestoreException;
 import io.crate.metadata.RelationName;
@@ -270,19 +269,18 @@ public class LogicalReplicationService implements ClusterStateListener, Closeabl
                                               Settings restoreSettings,
                                               List<TableOrPartition> tablesToRestore) {
         var publisherClusterRepoName = LogicalReplicationRepository.REMOTE_REPOSITORY_PREFIX + subscriptionName;
-        final RestoreService.RestoreRequest restoreRequest =
-            new RestoreService.RestoreRequest(
-                publisherClusterRepoName,
-                LogicalReplicationRepository.LATEST,
-                IndicesOptions.LENIENT_EXPAND_OPEN,
-                restoreSettings,
-                DEFAULT_MASTER_NODE_TIMEOUT,
-                true,
-                false,
-                Strings.EMPTY_ARRAY,
-                false,
-                Strings.EMPTY_ARRAY
-            );
+        final var restoreRequest = new RestoreSnapshotRequest(
+            publisherClusterRepoName,
+            LogicalReplicationRepository.LATEST,
+            tablesToRestore,
+            IndicesOptions.LENIENT_EXPAND_OPEN,
+            restoreSettings,
+            true,
+            false,
+            Set.of(),
+            false,
+            List.of()
+        );
 
         FutureActionListener<RestoreService.RestoreCompletionResponse> restoreListener = new FutureActionListener<>();
         activeOperations.incrementAndGet();

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequest.java
@@ -182,6 +182,13 @@ public class RestoreSnapshotRequest extends MasterNodeRequest<RestoreSnapshotReq
         return globalSettings;
     }
 
+    public boolean hasNonDefaultRenamePatterns() {
+        return SnapshotSettings.TABLE_RENAME_PATTERN.exists(settings)
+            || SnapshotSettings.TABLE_RENAME_REPLACEMENT.exists(settings)
+            || SnapshotSettings.SCHEMA_RENAME_PATTERN.exists(settings)
+            || SnapshotSettings.SCHEMA_RENAME_REPLACEMENT.exists(settings);
+    }
+
     public RestoreSnapshotRequest(StreamInput in) throws IOException {
         super(in);
         snapshot = in.readString();

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/TransportRestoreSnapshot.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/TransportRestoreSnapshot.java
@@ -89,19 +89,7 @@ public class TransportRestoreSnapshot extends TransportMasterNodeAction<RestoreS
     protected void masterOperation(final RestoreSnapshotRequest request,
                                    final ClusterState state,
                                    final ActionListener<RestoreSnapshotResponse> listener) {
-        RestoreService.RestoreRequest restoreRequest = new RestoreService.RestoreRequest(
-            request.repository(),
-            request.snapshot(),
-            request.indicesOptions(),
-            request.settings(),
-            request.masterNodeTimeout(),
-            request.includeTables(),
-            request.includeCustomMetadata(),
-            request.customMetadataTypes(),
-            request.includeGlobalSettings(),
-            request.globalSettings()
-        );
-        restoreService.restoreSnapshot(restoreRequest, request.tablesToRestore(), new ActionListener<>() {
+        restoreService.restoreSnapshot(request, request.tablesToRestore(), new ActionListener<>() {
             @Override
             public void onResponse(RestoreCompletionResponse restoreCompletionResponse) {
                 if (restoreCompletionResponse.getRestoreInfo() == null && request.waitForCompletion()) {

--- a/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -20,10 +20,6 @@
 package org.elasticsearch.snapshots;
 
 import static io.crate.analyze.SnapshotSettings.IGNORE_UNAVAILABLE;
-import static io.crate.analyze.SnapshotSettings.SCHEMA_RENAME_PATTERN;
-import static io.crate.analyze.SnapshotSettings.SCHEMA_RENAME_REPLACEMENT;
-import static io.crate.analyze.SnapshotSettings.TABLE_RENAME_PATTERN;
-import static io.crate.analyze.SnapshotSettings.TABLE_RENAME_REPLACEMENT;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.INDEX_UUID_NA_VALUE;
 import static org.elasticsearch.cluster.metadata.Metadata.Builder.NO_OID_COLUMN_OID_SUPPLIER;
 
@@ -48,8 +44,8 @@ import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreSnapshotRequest;
 import org.elasticsearch.action.admin.cluster.snapshots.restore.TableOrPartition;
-import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateApplier;
@@ -92,7 +88,6 @@ import org.elasticsearch.repositories.RepositoriesService;
 import org.elasticsearch.repositories.Repository;
 import org.elasticsearch.repositories.RepositoryData;
 
-import io.crate.analyze.SnapshotSettings;
 import io.crate.common.annotations.VisibleForTesting;
 import io.crate.common.collections.Lists;
 import io.crate.common.collections.MapBuilder;
@@ -175,21 +170,21 @@ public class RestoreService implements ClusterStateApplier {
      *                        and NULL when used in logical replication.
      * @param listener restore listener
      */
-    public void restoreSnapshot(final RestoreRequest request,
+    public void restoreSnapshot(final RestoreSnapshotRequest request,
                                 final List<TableOrPartition> tablesToRestore,
                                 final ActionListener<RestoreCompletionResponse> listener) {
-        final String repositoryName = request.repositoryName;
+        final String repositoryName = request.repository();
         Repository repository;
         try {
             // Read snapshot info and metadata from the repository
             repository = repositoriesService.repository(repositoryName);
         } catch (Exception e) {
-            LOGGER.warn(() -> new ParameterizedMessage("[{}] failed to restore snapshot", request.repositoryName + ":" + request.snapshotName), e);
+            LOGGER.warn(() -> new ParameterizedMessage("[{}] failed to restore snapshot", request.repository() + ":" + request.snapshot()), e);
             listener.onFailure(e);
             return;
         }
         repository.getRepositoryData().thenCompose(repositoryData -> {
-            final String snapshotName = request.snapshotName;
+            final String snapshotName = request.snapshot();
             final Optional<SnapshotId> matchingSnapshotId = repositoryData.getSnapshotIds().stream()
                 .filter(s -> snapshotName.equals(s.getName())).findFirst();
             if (matchingSnapshotId.isPresent() == false) {
@@ -259,10 +254,10 @@ public class RestoreService implements ClusterStateApplier {
     }
 
     static Map<RelationName, RestoreRelation> resolveRelations(List<TableOrPartition> tablesToRestore,
-                                                               RestoreRequest request,
+                                                               RestoreSnapshotRequest request,
                                                                Metadata snapshotMetadata,
                                                                SnapshotInfo snapshotInfo) {
-        boolean strict = !IGNORE_UNAVAILABLE.get(request.settings);
+        boolean strict = !IGNORE_UNAVAILABLE.get(request.settings());
         HashMap<RelationName, RestoreRelation> restoreRelations = new HashMap<>();
 
         BiConsumer<RelationName, List<String>> resolver = (relationName, partitionValues) -> {
@@ -369,7 +364,7 @@ public class RestoreService implements ClusterStateApplier {
         private final RepositoryData repositoryData;
         private final Snapshot snapshot;
         private final ActionListener<RestoreCompletionResponse> listener;
-        private final RestoreRequest request;
+        private final RestoreSnapshotRequest request;
         private final Map<RelationName, RestoreRelation> restoreRelations;
 
         private final Metadata snapshotMetadata;
@@ -381,7 +376,7 @@ public class RestoreService implements ClusterStateApplier {
                                           RepositoryData repositoryData,
                                           Snapshot snapshot,
                                           ActionListener<RestoreCompletionResponse> listener,
-                                          RestoreRequest request,
+                                          RestoreSnapshotRequest request,
                                           Map<RelationName, RestoreRelation> restoreRelations,
                                           Metadata snapshotMetadata) {
             this.snapshotInfo = snapshotInfo;
@@ -412,7 +407,7 @@ public class RestoreService implements ClusterStateApplier {
             Map<ShardId, RestoreInProgress.ShardRestoreStatus> shards;
 
             MapBuilder<ShardId, RestoreInProgress.ShardRestoreStatus> shardsBuilder = MapBuilder.newMapBuilder();
-            boolean ignoreUnavailable = IGNORE_UNAVAILABLE.get(request.settings);
+            boolean ignoreUnavailable = IGNORE_UNAVAILABLE.get(request.settings());
             HashSet<String> restoreIndexNames = new HashSet<>();
 
             for (Map.Entry<RelationName, RestoreRelation> entry : restoreRelations.entrySet()) {
@@ -936,7 +931,7 @@ public class RestoreService implements ClusterStateApplier {
         return failedShards;
     }
 
-    private static RelationName applyRenameToRelation(RestoreRequest request, RelationName relationName) {
+    private static RelationName applyRenameToRelation(RestoreSnapshotRequest request, RelationName relationName) {
         boolean applyRenamePattern = request.hasNonDefaultRenamePatterns();
         RelationName renamed = relationName;
         // At least one non-default value is provided.
@@ -1004,50 +999,6 @@ public class RestoreService implements ClusterStateApplier {
             }
         } catch (Exception t) {
             LOGGER.warn("Failed to update restore state ", t);
-        }
-    }
-
-    /**
-     * Restore snapshot request
-     */
-    public record RestoreRequest(String repositoryName,
-                                 String snapshotName,
-                                 IndicesOptions indicesOptions,
-                                 Settings settings,
-                                 TimeValue masterNodeTimeout,
-                                 boolean includeTables,
-                                 boolean includeCustomMetadata,
-                                 String[] customMetadataTypes,
-                                 boolean includeGlobalSettings,
-                                 String[] globalSettings) {
-
-        /**
-         * @return rename pattern
-         */
-        public String tableRenamePattern() {
-            return SnapshotSettings.TABLE_RENAME_PATTERN.get(settings);
-        }
-
-        /**
-         * @return table rename replacement
-         */
-        public String tableRenameReplacement() {
-            return SnapshotSettings.TABLE_RENAME_REPLACEMENT.get(settings);
-        }
-
-        public String schemaRenamePattern() {
-            return SnapshotSettings.SCHEMA_RENAME_PATTERN.get(settings);
-        }
-
-        public String schemaRenameReplacement() {
-            return SnapshotSettings.SCHEMA_RENAME_REPLACEMENT.get(settings);
-        }
-
-        public boolean hasNonDefaultRenamePatterns() {
-            return TABLE_RENAME_PATTERN.exists(settings)
-                || TABLE_RENAME_REPLACEMENT.exists(settings)
-                || SCHEMA_RENAME_PATTERN.exists(settings)
-                || SCHEMA_RENAME_REPLACEMENT.exists(settings);
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/snapshots/RestoreServiceTest.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/RestoreServiceTest.java
@@ -28,8 +28,9 @@ import static org.elasticsearch.test.IntegTestCase.resolveIndex;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
-import org.apache.logging.log4j.util.Strings;
+import org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreSnapshotRequest;
 import org.elasticsearch.action.admin.cluster.snapshots.restore.TableOrPartition;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.cluster.metadata.Metadata;
@@ -38,7 +39,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.Index;
 import org.junit.Test;
 
-import io.crate.common.unit.TimeValue;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.doc.DocSchemaInfo;
@@ -69,17 +69,17 @@ public class RestoreServiceTest extends CrateDummyClusterServiceUnitTest {
             List.of(),
             SnapshotState.SUCCESS
         );
-        RestoreService.RestoreRequest restoreRequest = new RestoreService.RestoreRequest(
+        var restoreRequest = new RestoreSnapshotRequest(
             "repo1",
             snapshotInfo.snapshotId().getUUID(),
+            tablesToRestore,
             IndicesOptions.LENIENT_EXPAND_OPEN,
             Settings.EMPTY,
-            TimeValue.timeValueSeconds(30),
             true,
             true,
-            Strings.EMPTY_ARRAY,
+            Set.of(),
             true,
-            Strings.EMPTY_ARRAY
+            List.of()
         );
 
         Map<RelationName, RestoreService.RestoreRelation> restoreRelations = resolveRelations(
@@ -108,20 +108,20 @@ public class RestoreServiceTest extends CrateDummyClusterServiceUnitTest {
             List.of(),
             SnapshotState.SUCCESS
         );
-        var restoreRequest = new RestoreService.RestoreRequest(
-            "repo1",
-            snapshotInfo.snapshotId().getName(),
-            IndicesOptions.LENIENT_EXPAND_OPEN,
-            Settings.builder().put(IGNORE_UNAVAILABLE.getKey(), true).build(),
-            TimeValue.timeValueSeconds(30),
-            true,
-            true,
-            Strings.EMPTY_ARRAY,
-            true,
-            Strings.EMPTY_ARRAY
-        );
         List<TableOrPartition> tablesToRestore = List.of(
             new TableOrPartition(relationName, "046jcchm6krj4e1g60o30c0")
+        );
+        var restoreRequest = new RestoreSnapshotRequest(
+            "repo1",
+            snapshotInfo.snapshotId().getName(),
+            tablesToRestore,
+            IndicesOptions.LENIENT_EXPAND_OPEN,
+            Settings.builder().put(IGNORE_UNAVAILABLE.getKey(), true).build(),
+            true,
+            true,
+            Set.of(),
+            true,
+            List.of()
         );
 
         Metadata metadata = clusterService.state().metadata();
@@ -153,20 +153,20 @@ public class RestoreServiceTest extends CrateDummyClusterServiceUnitTest {
             SnapshotState.SUCCESS
         );
 
-        RestoreService.RestoreRequest restoreRequest = new RestoreService.RestoreRequest(
-            "repo1",
-            snapshotInfo.snapshotId().getName(),
-            IndicesOptions.LENIENT_EXPAND_OPEN,
-            Settings.EMPTY,
-            TimeValue.timeValueSeconds(30),
-            true,
-            true,
-            Strings.EMPTY_ARRAY,
-            true,
-            Strings.EMPTY_ARRAY
-        );
         List<TableOrPartition> tablesToRestore = List.of(
             new TableOrPartition(relationName, "046jcchm6krj4e1g60o30c0")
+        );
+        var restoreRequest = new RestoreSnapshotRequest(
+            "repo1",
+            snapshotInfo.snapshotId().getName(),
+            tablesToRestore,
+            IndicesOptions.LENIENT_EXPAND_OPEN,
+            Settings.EMPTY,
+            true,
+            true,
+            Set.of(),
+            true,
+            List.of()
         );
 
         Map<RelationName, RestoreService.RestoreRelation> restoreRelations = resolveRelations(
@@ -195,20 +195,20 @@ public class RestoreServiceTest extends CrateDummyClusterServiceUnitTest {
             SnapshotState.SUCCESS
         );
 
-        RestoreService.RestoreRequest restoreRequest = new RestoreService.RestoreRequest(
-            "repo1",
-            snapshotInfo.snapshotId().getName(),
-            IndicesOptions.LENIENT_EXPAND_OPEN,
-            Settings.EMPTY,
-            TimeValue.timeValueSeconds(30),
-            true,
-            true,
-            Strings.EMPTY_ARRAY,
-            true,
-            Strings.EMPTY_ARRAY
-        );
         List<TableOrPartition> tablesToRestore = List.of(
             new TableOrPartition(relationName, null)
+        );
+        var restoreRequest = new RestoreSnapshotRequest(
+            "repo1",
+            snapshotInfo.snapshotId().getName(),
+            tablesToRestore,
+            IndicesOptions.LENIENT_EXPAND_OPEN,
+            Settings.EMPTY,
+            true,
+            true,
+            Set.of(),
+            true,
+            List.of()
         );
 
         Map<RelationName, RestoreService.RestoreRelation> restoreRelations = resolveRelations(
@@ -248,17 +248,17 @@ public class RestoreServiceTest extends CrateDummyClusterServiceUnitTest {
             List.of(),
             SnapshotState.SUCCESS
         );
-        RestoreService.RestoreRequest restoreRequest = new RestoreService.RestoreRequest(
+        var restoreRequest = new RestoreSnapshotRequest(
             "repo1",
             snapshotInfo.snapshotId().getUUID(),
+            tablesToRestore,
             IndicesOptions.LENIENT_EXPAND_OPEN,
             Settings.EMPTY,
-            TimeValue.timeValueSeconds(30),
             true,
             true,
-            Strings.EMPTY_ARRAY,
+            Set.of(),
             true,
-            Strings.EMPTY_ARRAY
+            List.of()
         );
 
         Map<RelationName, RestoreService.RestoreRelation> restoreRelations = resolveRelations(


### PR DESCRIPTION
We can instead use the original RestoreSnapshotRequest which has mostly
the same properties.
