### PR TITLE
Rename ForeignTable to ForeignTableInfo

### DIFF
--- a/server/src/main/java/io/crate/analyze/TableInfoToAST.java
+++ b/server/src/main/java/io/crate/analyze/TableInfoToAST.java
@@ -41,7 +41,7 @@ import org.jspecify.annotations.Nullable;
 import io.crate.common.unit.TimeValue;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.format.Style;
-import io.crate.fdw.ForeignTable;
+import io.crate.fdw.ForeignTableInfo;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.FulltextAnalyzerResolver;
 import io.crate.metadata.GeneratedReference;
@@ -106,9 +106,9 @@ public class TableInfoToAST {
                 extractTableProperties(),
                 true
             );
-        } else if (tableInfo instanceof ForeignTable foreignTable) {
+        } else if (tableInfo instanceof ForeignTableInfo foreignTableInfo) {
             Map<String, Expression> options = new HashMap<>();
-            for (var entry : foreignTable.options().getAsStructuredMap().entrySet()) {
+            for (var entry : foreignTableInfo.options().getAsStructuredMap().entrySet()) {
                 String optionName = entry.getKey();
                 Object optionValue = entry.getValue();
                 options.put(optionName, Literal.fromObject(optionValue));
@@ -117,7 +117,7 @@ public class TableInfoToAST {
                 name,
                 true,
                 tableElements,
-                foreignTable.server(),
+                foreignTableInfo.server(),
                 options
             );
         } else {

--- a/server/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
@@ -66,7 +66,7 @@ import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.Symbols;
 import io.crate.expression.tablefunctions.TableFunctionFactory;
 import io.crate.expression.tablefunctions.ValuesFunction;
-import io.crate.fdw.ForeignTable;
+import io.crate.fdw.ForeignTableInfo;
 import io.crate.fdw.ForeignTableRelation;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.FunctionImplementation;
@@ -696,7 +696,7 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
                 case DocTableInfo docTable ->
                     // Dispatching of doc relations is based on the returned class of the schema information.
                     relation = new DocTableRelation(docTable);
-                case ForeignTable table -> relation = new ForeignTableRelation(table);
+                case ForeignTableInfo table -> relation = new ForeignTableRelation(table);
                 case TableInfo table -> relation = new TableRelation(table);
                 case ViewInfo viewInfo -> {
                     Statement viewQuery = SqlParser.createStatement(viewInfo.definition());

--- a/server/src/main/java/io/crate/execution/engine/collect/sources/InformationSchemaIterables.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/sources/InformationSchemaIterables.java
@@ -47,7 +47,7 @@ import io.crate.common.collections.Iterators;
 import io.crate.execution.engine.collect.files.SqlFeatureContext;
 import io.crate.execution.engine.collect.files.SqlFeatures;
 import io.crate.expression.reference.information.ColumnContext;
-import io.crate.fdw.ForeignTable;
+import io.crate.fdw.ForeignTableInfo;
 import io.crate.fdw.ForeignTablesMetadata;
 import io.crate.fdw.ServersMetadata;
 import io.crate.fdw.ServersMetadata.Server;
@@ -372,12 +372,12 @@ public class InformationSchemaIterables {
         return servers.getUserMappingOptions();
     }
 
-    public Iterable<ForeignTable> foreignTables() {
+    public Iterable<ForeignTableInfo> foreignTables() {
         Metadata metadata = clusterService.state().metadata();
         return metadata.custom(ForeignTablesMetadata.TYPE, ForeignTablesMetadata.EMPTY);
     }
 
-    public Iterable<ForeignTable.Option> foreignTableOptions() {
+    public Iterable<ForeignTableInfo.Option> foreignTableOptions() {
         Metadata metadata = clusterService.state().metadata();
         ForeignTablesMetadata foreignTables = metadata.custom(
             ForeignTablesMetadata.TYPE,

--- a/server/src/main/java/io/crate/fdw/ForeignDataWrapper.java
+++ b/server/src/main/java/io/crate/fdw/ForeignDataWrapper.java
@@ -52,14 +52,14 @@ public interface ForeignDataWrapper {
      *
      * If this returns `false` filtering must be done via dedicated filter operator
      * because the query parameter to
-     * {@link #getIterator(Role, Server, ForeignTable, TransactionContext, List, Symbol)}
+     * {@link #getIterator(Role, Server, ForeignTableInfo, TransactionContext, List, Symbol)}
      * is ignored.
      **/
     boolean supportsQueryPushdown(Symbol query);
 
     CompletableFuture<BatchIterator<Row>> getIterator(Role user,
                                                       Server server,
-                                                      ForeignTable foreignTable,
+                                                      ForeignTableInfo foreignTableInfo,
                                                       TransactionContext txnCtx,
                                                       List<Symbol> collect,
                                                       Symbol query);

--- a/server/src/main/java/io/crate/fdw/ForeignDataWrappers.java
+++ b/server/src/main/java/io/crate/fdw/ForeignDataWrappers.java
@@ -60,7 +60,6 @@ public class ForeignDataWrappers implements CollectSource {
     );
 
     private final ClusterService clusterService;
-    private final InputFactory inputFactory;
     private final Map<String, ForeignDataWrapper> wrappers;
     private final Roles roles;
 
@@ -69,9 +68,8 @@ public class ForeignDataWrappers implements CollectSource {
                                ClusterService clusterService,
                                NodeContext nodeContext) {
         this.clusterService = clusterService;
-        this.inputFactory = new InputFactory(nodeContext);
         this.wrappers = Map.of(
-            "jdbc", new JdbcForeignDataWrapper(settings, inputFactory)
+            "jdbc", new JdbcForeignDataWrapper(settings, new InputFactory(nodeContext))
         );
         this.roles = nodeContext.roles();
     }
@@ -103,23 +101,23 @@ public class ForeignDataWrappers implements CollectSource {
         if (foreignTables == null) {
             throw new RelationUnknown(phase.relationName());
         }
-        ForeignTable foreignTable = foreignTables.get(phase.relationName());
-        if (foreignTable == null) {
+        ForeignTableInfo foreignTableInfo = foreignTables.get(phase.relationName());
+        if (foreignTableInfo == null) {
             throw new RelationUnknown(phase.relationName());
         }
         ServersMetadata servers = metadata.custom(ServersMetadata.TYPE);
         if (servers == null) {
             throw new ResourceNotFoundException(
-                String.format(Locale.ENGLISH, "Server `%s` not found", foreignTable.server()));
+                String.format(Locale.ENGLISH, "Server `%s` not found", foreignTableInfo.server()));
         }
-        Server server = servers.get(foreignTable.server());
+        Server server = servers.get(foreignTableInfo.server());
         ForeignDataWrapper fdw = wrappers.get(server.fdw());
         if (fdw == null) {
             throw new ResourceNotFoundException(String.format(
                 Locale.ENGLISH,
                 "Foreign data wrapper '%s' used by server '%s' no longer exists",
                 server.fdw(),
-                foreignTable.server()
+                foreignTableInfo.server()
             ));
         }
         String executeAs = phase.executeAs();
@@ -129,7 +127,7 @@ public class ForeignDataWrappers implements CollectSource {
         return fdw.getIterator(
             requireNonNull(roles.findUser(executeAs), "current user must exist"),
             server,
-            foreignTable,
+            foreignTableInfo,
             txnCtx,
             collectPhase.toCollect(),
             phase.query()

--- a/server/src/main/java/io/crate/fdw/ForeignTableInfo.java
+++ b/server/src/main/java/io/crate/fdw/ForeignTableInfo.java
@@ -65,12 +65,12 @@ import io.crate.metadata.table.Operation;
 import io.crate.metadata.table.TableInfo;
 import io.crate.types.DataTypes;
 
-public record ForeignTable(RelationName name,
-                           Map<ColumnIdent, Reference> references,
-                           String server,
-                           Settings options) implements Writeable, TableInfo {
+public record ForeignTableInfo(RelationName name,
+                               Map<ColumnIdent, Reference> references,
+                               String server,
+                               Settings options) implements Writeable, TableInfo {
 
-    ForeignTable(StreamInput in) throws IOException {
+    ForeignTableInfo(StreamInput in) throws IOException {
         this(
             new RelationName(in),
             in.readMap(LinkedHashMap::new, ColumnIdent::of, Reference::fromStream),
@@ -87,7 +87,7 @@ public record ForeignTable(RelationName name,
         Settings.writeSettingsToStream(out, options);
     }
 
-    public static ForeignTable fromXContent(NodeContext nodeCtx, RelationName name, XContentParser parser) throws IOException {
+    public static ForeignTableInfo fromXContent(NodeContext nodeCtx, RelationName name, XContentParser parser) throws IOException {
         Map<ColumnIdent, Reference> references = null;
         String server = null;
         Settings options = null;
@@ -140,7 +140,7 @@ public record ForeignTable(RelationName name,
                 }
             }
         }
-        return new ForeignTable(
+        return new ForeignTableInfo(
             requireNonNull(name),
             requireNonNull(references),
             requireNonNull(server),

--- a/server/src/main/java/io/crate/fdw/ForeignTableRelation.java
+++ b/server/src/main/java/io/crate/fdw/ForeignTableRelation.java
@@ -34,9 +34,9 @@ import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Reference;
 import io.crate.metadata.table.Operation;
 
-public class ForeignTableRelation extends AbstractTableRelation<ForeignTable> {
+public class ForeignTableRelation extends AbstractTableRelation<ForeignTableInfo> {
 
-    public ForeignTableRelation(ForeignTable table) {
+    public ForeignTableRelation(ForeignTableInfo table) {
         super(table, List.copyOf(table.rootColumns()), List.of());
     }
 

--- a/server/src/main/java/io/crate/fdw/ForeignTablesMetadata.java
+++ b/server/src/main/java/io/crate/fdw/ForeignTablesMetadata.java
@@ -50,19 +50,19 @@ import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
 
 public final class ForeignTablesMetadata extends AbstractNamedDiffable<Metadata.Custom>
-        implements Metadata.Custom, Iterable<ForeignTable> {
+        implements Metadata.Custom, Iterable<ForeignTableInfo> {
 
     public static final String TYPE = "foreign_tables";
     public static final ForeignTablesMetadata EMPTY = new ForeignTablesMetadata(Map.of());
 
-    private final Map<RelationName, ForeignTable> tables;
+    private final Map<RelationName, ForeignTableInfo> tables;
 
-    ForeignTablesMetadata(Map<RelationName, ForeignTable> tables) {
+    ForeignTablesMetadata(Map<RelationName, ForeignTableInfo> tables) {
         this.tables = tables;
     }
 
     public ForeignTablesMetadata(StreamInput in) throws IOException {
-        this.tables = in.readMap(RelationName::new, ForeignTable::new);
+        this.tables = in.readMap(RelationName::new, ForeignTableInfo::new);
     }
 
     @Override
@@ -71,7 +71,7 @@ public final class ForeignTablesMetadata extends AbstractNamedDiffable<Metadata.
     }
 
     public static ForeignTablesMetadata fromXContent(NodeContext nodeCtx, XContentParser parser) throws IOException {
-        HashMap<RelationName, ForeignTable> tables = new HashMap<>();
+        HashMap<RelationName, ForeignTableInfo> tables = new HashMap<>();
         if (parser.currentToken() == START_OBJECT) {
             parser.nextToken();
         }
@@ -83,7 +83,7 @@ public final class ForeignTablesMetadata extends AbstractNamedDiffable<Metadata.
             if (parser.currentToken() == FIELD_NAME) {
                 RelationName name = RelationName.fromIndexName(parser.currentName());
                 parser.nextToken();
-                ForeignTable table = ForeignTable.fromXContent(nodeCtx, name, parser);
+                ForeignTableInfo table = ForeignTableInfo.fromXContent(nodeCtx, name, parser);
                 tables.put(name, table);
             }
         }
@@ -114,8 +114,8 @@ public final class ForeignTablesMetadata extends AbstractNamedDiffable<Metadata.
                                      Collection<Reference> columns,
                                      String server,
                                      Settings options) {
-        HashMap<RelationName, ForeignTable> newTables = new HashMap<>(tables);
-        ForeignTable value = new ForeignTable(
+        HashMap<RelationName, ForeignTableInfo> newTables = new HashMap<>(tables);
+        ForeignTableInfo value = new ForeignTableInfo(
             tableName,
             columns.stream().collect(Collectors.toMap(Reference::column, x -> x)),
             server,
@@ -126,7 +126,7 @@ public final class ForeignTablesMetadata extends AbstractNamedDiffable<Metadata.
     }
 
     @Nullable
-    public ForeignTable get(RelationName name) {
+    public ForeignTableInfo get(RelationName name) {
         return tables.get(name);
     }
 
@@ -135,7 +135,7 @@ public final class ForeignTablesMetadata extends AbstractNamedDiffable<Metadata.
     }
 
     public ForeignTablesMetadata removeAllForServers(List<String> names) {
-        HashMap<RelationName, ForeignTable> newTables = new HashMap<>();
+        HashMap<RelationName, ForeignTableInfo> newTables = new HashMap<>();
         for (var entry : tables.entrySet()) {
             var relationName = entry.getKey();
             var foreignTable = entry.getValue();
@@ -147,9 +147,9 @@ public final class ForeignTablesMetadata extends AbstractNamedDiffable<Metadata.
     }
 
     public ForeignTablesMetadata remove(List<RelationName> relations, boolean ifExists) {
-        HashMap<RelationName, ForeignTable> newTables = new HashMap<>(tables);
+        HashMap<RelationName, ForeignTableInfo> newTables = new HashMap<>(tables);
         for (var relation : relations) {
-            ForeignTable removed = newTables.remove(relation);
+            ForeignTableInfo removed = newTables.remove(relation);
             if (removed == null && !ifExists) {
                 throw new RelationUnknown(relation);
             }
@@ -158,7 +158,7 @@ public final class ForeignTablesMetadata extends AbstractNamedDiffable<Metadata.
     }
 
     @Override
-    public Iterator<ForeignTable> iterator() {
+    public Iterator<ForeignTableInfo> iterator() {
         return tables.values().iterator();
     }
 
@@ -173,7 +173,7 @@ public final class ForeignTablesMetadata extends AbstractNamedDiffable<Metadata.
             && tables.equals(other.tables);
     }
 
-    public Iterable<ForeignTable.Option> tableOptions() {
+    public Iterable<ForeignTableInfo.Option> tableOptions() {
         return () -> tables.values().stream()
             .flatMap(table -> table.getOptions())
             .iterator();

--- a/server/src/main/java/io/crate/fdw/JdbcForeignDataWrapper.java
+++ b/server/src/main/java/io/crate/fdw/JdbcForeignDataWrapper.java
@@ -116,7 +116,7 @@ final class JdbcForeignDataWrapper implements ForeignDataWrapper {
     @Override
     public CompletableFuture<BatchIterator<Row>> getIterator(Role currentUser,
                                                              Server server,
-                                                             ForeignTable foreignTable,
+                                                             ForeignTableInfo foreignTableInfo,
                                                              TransactionContext txnCtx,
                                                              List<Symbol> collect,
                                                              Symbol query) {
@@ -167,11 +167,11 @@ final class JdbcForeignDataWrapper implements ForeignDataWrapper {
             throw new UnsupportedOperationException(
                 "Only a super user can connect to localhost unless `fdw.allow_local` is set to true");
         }
-        String remoteSchema = schemaName.get(foreignTable.options());
-        String remoteTable = tableName.get(foreignTable.options());
+        String remoteSchema = schemaName.get(foreignTableInfo.options());
+        String remoteTable = tableName.get(foreignTableInfo.options());
         RelationName remoteName = new RelationName(
-            remoteSchema.isEmpty() ? foreignTable.name().schema() : remoteSchema,
-            remoteTable.isEmpty() ? foreignTable.name().name() : remoteTable);
+            remoteSchema.isEmpty() ? foreignTableInfo.name().schema() : remoteSchema,
+            remoteTable.isEmpty() ? foreignTableInfo.name().name() : remoteTable);
 
         assert supportsQueryPushdown(query)
             : "ForeignCollect must only have a query where `supportsQueryPushDown` is true";

--- a/server/src/main/java/io/crate/metadata/Schemas.java
+++ b/server/src/main/java/io/crate/metadata/Schemas.java
@@ -51,7 +51,7 @@ import io.crate.exceptions.RelationUnknown;
 import io.crate.exceptions.SchemaUnknownException;
 import io.crate.expression.udf.UserDefinedFunctionMetadata;
 import io.crate.expression.udf.UserDefinedFunctionsMetadata;
-import io.crate.fdw.ForeignTable;
+import io.crate.fdw.ForeignTableInfo;
 import io.crate.fdw.ForeignTablesMetadata;
 import io.crate.metadata.blob.BlobSchemaInfo;
 import io.crate.metadata.doc.DocSchemaInfo;
@@ -286,7 +286,7 @@ public class Schemas extends AbstractLifecycleComponent implements Iterable<Sche
      * </p>
      *
      * @return {@link TableInfo}. Can be upcast to {@link DocTableInfo} or
-     *         {@link ForeignTable}
+     *         {@link ForeignTableInfo }
      * @throws io.crate.exceptions.SchemaUnknownException if schema given in
      *                                                    <code>ident</code>
      *                                                    does not exist
@@ -453,7 +453,7 @@ public class Schemas extends AbstractLifecycleComponent implements Iterable<Sche
 
 
     @Nullable
-    private ForeignTable getForeignTable(String schemaName, String tableName) {
+    private ForeignTableInfo getForeignTable(String schemaName, String tableName) {
         Metadata metadata = clusterService.state().metadata();
         ForeignTablesMetadata foreignTables = metadata.custom(ForeignTablesMetadata.TYPE);
         if (foreignTables == null) {
@@ -507,9 +507,9 @@ public class Schemas extends AbstractLifecycleComponent implements Iterable<Sche
         }
         Metadata metadata = clusterService.state().metadata();
         ForeignTablesMetadata foreignTables = metadata.custom(ForeignTablesMetadata.TYPE, ForeignTablesMetadata.EMPTY);
-        for (ForeignTable foreignTable : foreignTables) {
-            if (oid == OidHash.relationOid(foreignTable)) {
-                return foreignTable.ident();
+        for (ForeignTableInfo foreignTableInfo : foreignTables) {
+            if (oid == OidHash.relationOid(foreignTableInfo)) {
+                return foreignTableInfo.ident();
             }
         }
         return null;

--- a/server/src/main/java/io/crate/metadata/information/ForeignTableOptionsTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/information/ForeignTableOptionsTableInfo.java
@@ -22,7 +22,7 @@
 package io.crate.metadata.information;
 
 import io.crate.Constants;
-import io.crate.fdw.ForeignTable;
+import io.crate.fdw.ForeignTableInfo;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.SystemTable;
 import io.crate.types.DataTypes;
@@ -32,11 +32,11 @@ public class ForeignTableOptionsTableInfo {
     public static final String NAME = "foreign_table_options";
     public static final RelationName IDENT = new RelationName(InformationSchemaInfo.NAME, NAME);
 
-    public static SystemTable<ForeignTable.Option> INSTANCE = SystemTable.<ForeignTable.Option>builder(IDENT)
+    public static SystemTable<ForeignTableInfo.Option> INSTANCE = SystemTable.<ForeignTableInfo.Option>builder(IDENT)
         .add("foreign_table_catalog", DataTypes.STRING, ignored -> Constants.DB_NAME)
         .add("foreign_table_schema", DataTypes.STRING, x -> x.relationName().schema())
         .add("foreign_table_name", DataTypes.STRING, x -> x.relationName().name())
-        .add("option_name", DataTypes.STRING, ForeignTable.Option::name)
-        .add("option_value", DataTypes.STRING, ForeignTable.Option::value)
+        .add("option_name", DataTypes.STRING, ForeignTableInfo.Option::name)
+        .add("option_value", DataTypes.STRING, ForeignTableInfo.Option::value)
         .build();
 }

--- a/server/src/main/java/io/crate/metadata/information/ForeignTableTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/information/ForeignTableTableInfo.java
@@ -22,7 +22,7 @@
 package io.crate.metadata.information;
 
 import io.crate.Constants;
-import io.crate.fdw.ForeignTable;
+import io.crate.fdw.ForeignTableInfo;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.SystemTable;
 import io.crate.types.DataTypes;
@@ -32,11 +32,11 @@ public class ForeignTableTableInfo {
     public static final String NAME = "foreign_tables";
     public static final RelationName IDENT = new RelationName(InformationSchemaInfo.NAME, NAME);
 
-    public static SystemTable<ForeignTable> INSTANCE = SystemTable.<ForeignTable>builder(IDENT)
+    public static SystemTable<ForeignTableInfo> INSTANCE = SystemTable.<ForeignTableInfo>builder(IDENT)
         .add("foreign_table_catalog", DataTypes.STRING, ignored -> Constants.DB_NAME)
         .add("foreign_table_schema", DataTypes.STRING, table -> table.name().schema())
         .add("foreign_table_name", DataTypes.STRING, table -> table.name().name())
         .add("foreign_server_catalog", DataTypes.STRING, ignored -> Constants.DB_NAME)
-        .add("foreign_server_name", DataTypes.STRING, ForeignTable::server)
+        .add("foreign_server_name", DataTypes.STRING, ForeignTableInfo::server)
         .build();
 }

--- a/server/src/test/java/io/crate/fdw/JdbcForeignDataWrapperTest.java
+++ b/server/src/test/java/io/crate/fdw/JdbcForeignDataWrapperTest.java
@@ -67,7 +67,7 @@ public class JdbcForeignDataWrapperTest extends CrateDummyClusterServiceUnitTest
             null
         );
         Map<ColumnIdent, Reference> references = Map.of(nameRef.column(), nameRef);
-        ForeignTable foreignTable = new ForeignTable(relationName, references, server.name(), Settings.EMPTY);
+        ForeignTableInfo foreignTable = new ForeignTableInfo(relationName, references, server.name(), Settings.EMPTY);
         assertThatThrownBy(() -> fdw.getIterator(arthur, server, foreignTable, txnCtx, List.of(nameRef), Literal.BOOLEAN_TRUE))
             .hasMessage("Only a super user can connect to localhost unless `fdw.allow_local` is set to true");
     }
@@ -92,7 +92,7 @@ public class JdbcForeignDataWrapperTest extends CrateDummyClusterServiceUnitTest
             null
         );
         Map<ColumnIdent, Reference> references = Map.of(nameRef.column(), nameRef);
-        ForeignTable foreignTable = new ForeignTable(relationName, references, server.name(), Settings.EMPTY);
+        ForeignTableInfo foreignTable = new ForeignTableInfo(relationName, references, server.name(), Settings.EMPTY);
         // validates that no exception is thrown
         fdw.getIterator(arthur, server, foreignTable, txnCtx, List.of(nameRef), Literal.BOOLEAN_TRUE);
     }


### PR DESCRIPTION
Since `RelationMetadata.ForeignTable` is going to be introduced, it's better to rename it to `ForeignTableInfo` to match `DocTableInfo`, `ViewInfo`, etc. since it implements `TableInfo`.
