### PR TITLE
Replace integration test for KILL with a unit test

### DIFF
--- a/server/src/test/java/io/crate/execution/jobs/kill/TransportKillJobsNodeActionTest.java
+++ b/server/src/test/java/io/crate/execution/jobs/kill/TransportKillJobsNodeActionTest.java
@@ -34,6 +34,8 @@ import java.util.concurrent.TimeUnit;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.transport.MockTransportService;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -76,4 +78,26 @@ public class TransportKillJobsNodeActionTest extends CrateDummyClusterServiceUni
             .get(5, TimeUnit.SECONDS);
         verify(tasksService, times(1)).killJobs(eq(toKill), eq("dummy-user"), any(JobKilledException.class));
     }
+
+    @Test
+    public void test_kill_cannot_be_tripped_by_circuit_breaker() throws Exception {
+        TasksService tasksService = mock(TasksService.class, Answers.RETURNS_DEEP_STUBS);
+        TransportService transportService = mock(TransportService.class);
+        new TransportKillJobsNodeAction(
+            tasksService,
+            clusterService,
+            transportService
+        );
+
+        verify(transportService, times(1))
+            .registerRequestHandler(
+                eq(KillJobsNodeAction.NAME),
+                eq(ThreadPool.Names.SAME),
+                eq(true), // forceExecution
+                eq(false), // canTripBreaker
+                any(),
+                any()
+            );
+    }
+
 }

--- a/server/src/test/java/io/crate/integrationtests/KillIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/KillIntegrationTest.java
@@ -25,14 +25,11 @@ import static com.carrotsearch.randomizedtesting.RandomizedTest.$;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.file.Paths;
-import java.util.Iterator;
 import java.util.UUID;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
-import org.elasticsearch.common.breaker.CircuitBreaker;
-import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.test.IntegTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.jspecify.annotations.Nullable;
@@ -172,27 +169,5 @@ public class KillIntegrationTest extends IntegTestCase {
         assertThat(killResponse.rowCount()).isEqualTo(0L);
         SQLResponse logResponse = execute("select * from sys.jobs_log where error = ?", new Object[]{"KILLED"});
         assertThat(logResponse.rowCount()).isEqualTo(0L);
-    }
-
-    @Test
-    public void test_kill_is_not_tripped_by_cb() throws Exception {
-        UUID jobId = UUID.randomUUID();
-        // Use max long to ensure CBE and subtract max int to avoid overflows.
-        long increaseToCBE = Long.MAX_VALUE - Integer.MAX_VALUE;
-        try {
-            Iterator<CircuitBreakerService> it = cluster().getInstances(CircuitBreakerService.class).iterator();
-            while (it.hasNext()) {
-                CircuitBreaker inFlightBreaker = it.next().getBreaker(CircuitBreaker.IN_FLIGHT_REQUESTS);
-                inFlightBreaker.addWithoutBreaking(increaseToCBE);
-            }
-            SQLResponse killResponse = execute("KILL ?", new Object[]{jobId.toString()});
-            assertThat(killResponse.rowCount()).isEqualTo(0L);
-        } finally {
-            Iterator<CircuitBreakerService> it = cluster().getInstances(CircuitBreakerService.class).iterator();
-            while (it.hasNext()) {
-                CircuitBreaker inFlightBreaker = it.next().getBreaker(CircuitBreaker.IN_FLIGHT_REQUESTS);
-                inFlightBreaker.addWithoutBreaking(-increaseToCBE); // Reset CB so that other tests (and teardown) works.
-            }
-        }
     }
 }


### PR DESCRIPTION
If some test is executed in parallel before we release CB bytes in finally, it can cause random flakiness in other tests

Relates to discussion in https://github.com/crate/crate/pull/19049#issuecomment-3919361037

I just saw some random test failures and thought maybe temporal CB increase is visible for tests that are running in parallel before we reduce it back in `finally`