### PR TITLE
Store UDFs in SchemaMetadata instead of custom metadata

### DIFF
--- a/server/src/main/java/io/crate/expression/udf/TransportCreateUserDefinedFunction.java
+++ b/server/src/main/java/io/crate/expression/udf/TransportCreateUserDefinedFunction.java
@@ -86,7 +86,7 @@ public class TransportCreateUserDefinedFunction
         if (errorMessage != null) {
             throw new ScriptException(errorMessage, metadata.language());
         }
-        udfService.registerFunction(metadata, request.replace(), listener, request.masterNodeTimeout());
+        udfService.submitAddUDF(metadata, request.replace(), listener, request.masterNodeTimeout());
     }
 
     @Override

--- a/server/src/main/java/io/crate/expression/udf/TransportDropUserDefinedFunction.java
+++ b/server/src/main/java/io/crate/expression/udf/TransportDropUserDefinedFunction.java
@@ -79,7 +79,7 @@ public class TransportDropUserDefinedFunction
     protected void masterOperation(final DropUserDefinedFunctionRequest request,
                                    ClusterState state,
                                    ActionListener<AcknowledgedResponse> listener) throws Exception {
-        udfService.dropFunction(
+        udfService.submitDropUDF(
             request.schema(),
             request.name(),
             request.argumentTypes(),

--- a/server/src/main/java/io/crate/expression/udf/UserDefinedFunctionMetadata.java
+++ b/server/src/main/java/io/crate/expression/udf/UserDefinedFunctionMetadata.java
@@ -128,7 +128,7 @@ public class UserDefinedFunctionMetadata implements Writeable {
         return specificName;
     }
 
-    boolean sameSignature(String schema, String name, List<DataType<?>> types) {
+    public boolean sameSignature(String schema, String name, List<DataType<?>> types) {
         return this.schema().equals(schema) && this.name().equals(name) && this.argumentTypes().equals(types);
     }
 
@@ -243,4 +243,8 @@ public class UserDefinedFunctionMetadata implements Writeable {
             types.stream().map(DataType::getName).collect(Collectors.joining(", ")));
     }
 
+    @Override
+    public String toString() {
+        return "UDF{" + schema + "." + name + "}";
+    }
 }

--- a/server/src/main/java/io/crate/expression/udf/UserDefinedFunctionService.java
+++ b/server/src/main/java/io/crate/expression/udf/UserDefinedFunctionService.java
@@ -40,15 +40,15 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateListener;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.metadata.SchemaMetadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.jspecify.annotations.Nullable;
-import io.crate.common.annotations.VisibleForTesting;
 
+import io.crate.common.annotations.VisibleForTesting;
 import io.crate.common.collections.Lists;
 import io.crate.common.unit.TimeValue;
 import io.crate.exceptions.UserDefinedFunctionAlreadyExistsException;
-import io.crate.exceptions.UserDefinedFunctionUnknownException;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.FunctionName;
@@ -89,23 +89,15 @@ public class UserDefinedFunctionService extends AbstractLifecycleComponent imple
         languageRegistry.put(language.name(), language);
     }
 
-    void registerFunction(final UserDefinedFunctionMetadata metadata,
-                          final boolean replace,
-                          final ActionListener<AcknowledgedResponse> listener,
-                          final TimeValue timeout) {
-        clusterService.submitStateUpdateTask("put_udf [" + metadata.name() + "]",
+    void submitAddUDF(final UserDefinedFunctionMetadata udf,
+                      final boolean replace,
+                      final ActionListener<AcknowledgedResponse> listener,
+                      final TimeValue timeout) {
+        clusterService.submitStateUpdateTask("add_udf [" + udf.name() + "]",
             new ClusterStateUpdateTask() {
                 @Override
                 public ClusterState execute(ClusterState currentState) throws Exception {
-                    Metadata currentMetadata = currentState.metadata();
-                    Metadata.Builder mdBuilder = Metadata.builder(currentMetadata);
-                    UserDefinedFunctionsMetadata functions = putFunction(
-                        currentMetadata.custom(UserDefinedFunctionsMetadata.TYPE),
-                        metadata,
-                        replace
-                    );
-                    mdBuilder.putCustom(UserDefinedFunctionsMetadata.TYPE, functions);
-                    return ClusterState.builder(currentState).metadata(mdBuilder).build();
+                    return addUDF(udf, replace, currentState);
                 }
 
                 @Override
@@ -125,28 +117,36 @@ public class UserDefinedFunctionService extends AbstractLifecycleComponent imple
             });
     }
 
-    void dropFunction(final String schema,
-                      final String name,
-                      final List<DataType<?>> argumentTypes,
-                      final boolean ifExists,
-                      final ActionListener<AcknowledgedResponse> listener,
-                      final TimeValue timeout) {
+
+    @VisibleForTesting
+    static ClusterState addUDF(UserDefinedFunctionMetadata udf,
+                               boolean replace,
+                               ClusterState currentState) {
+        if (!replace) {
+            SchemaMetadata schemaMetadata = currentState.metadata().schemas().get(udf.schema());
+            if (schemaMetadata != null && schemaMetadata.udfs().contains(udf)) {
+                throw new UserDefinedFunctionAlreadyExistsException(udf);
+            }
+        }
+        Metadata.Builder mdBuilder = Metadata.builder(currentState.metadata())
+            .setUDF(udf);
+        return ClusterState.builder(currentState)
+            .metadata(mdBuilder)
+            .build();
+    }
+
+
+    void submitDropUDF(final String schema,
+                       final String name,
+                       final List<DataType<?>> argumentTypes,
+                       final boolean ifExists,
+                       final ActionListener<AcknowledgedResponse> listener,
+                       final TimeValue timeout) {
         clusterService.submitStateUpdateTask("drop_udf [" + schema + "." + name + " - " + argumentTypes + "]",
             new ClusterStateUpdateTask() {
                 @Override
                 public ClusterState execute(ClusterState currentState) throws Exception {
-                    Metadata metadata = currentState.metadata();
-                    Metadata.Builder mdBuilder = Metadata.builder(currentState.metadata());
-                    ensureFunctionIsUnused(schema, name, argumentTypes);
-                    UserDefinedFunctionsMetadata functions = removeFunction(
-                        metadata.custom(UserDefinedFunctionsMetadata.TYPE),
-                        schema,
-                        name,
-                        argumentTypes,
-                        ifExists
-                    );
-                    mdBuilder.putCustom(UserDefinedFunctionsMetadata.TYPE, functions);
-                    return ClusterState.builder(currentState).metadata(mdBuilder).build();
+                    return dropUDF(schema, name, argumentTypes, ifExists, currentState);
                 }
 
                 @Override
@@ -167,59 +167,26 @@ public class UserDefinedFunctionService extends AbstractLifecycleComponent imple
     }
 
     @VisibleForTesting
-    UserDefinedFunctionsMetadata putFunction(@Nullable UserDefinedFunctionsMetadata oldMetadata,
-                                             UserDefinedFunctionMetadata functionMetadata,
-                                             boolean replace) {
-        if (oldMetadata == null) {
-            return UserDefinedFunctionsMetadata.of(functionMetadata);
+    ClusterState dropUDF(final String schema,
+                         final String name,
+                         final List<DataType<?>> argumentTypes,
+                         final boolean ifExists,
+                         ClusterState currentState) {
+        ensureFunctionIsUnused(schema, name, argumentTypes);
+        Metadata metadata = currentState.metadata();
+        Metadata newMetadata = Metadata.builder(metadata)
+            .dropUDF(schema, name, argumentTypes, ifExists)
+            .build();
+
+        if (newMetadata.numUDFs() == metadata.numUDFs()) {
+            return currentState;
         }
 
-        // create a new instance of the metadata, to guarantee the cluster changed action.
-        UserDefinedFunctionsMetadata newMetadata = UserDefinedFunctionsMetadata.newInstance(oldMetadata);
-        if (oldMetadata.contains(functionMetadata.schema(), functionMetadata.name(), functionMetadata.argumentTypes())) {
-            if (!replace) {
-                throw new UserDefinedFunctionAlreadyExistsException(functionMetadata);
-            }
-            newMetadata.replace(functionMetadata);
-        } else {
-            newMetadata.add(functionMetadata);
-        }
-
-        assert !newMetadata.equals(oldMetadata) : "must not be equal to guarantee the cluster change action";
-        return newMetadata;
+        return ClusterState.builder(currentState)
+            .metadata(newMetadata)
+            .build();
     }
 
-    @VisibleForTesting
-    UserDefinedFunctionsMetadata removeFunction(@Nullable UserDefinedFunctionsMetadata functions,
-                                                String schema,
-                                                String name,
-                                                List<DataType<?>> argumentDataTypes,
-                                                boolean ifExists) {
-        if (!ifExists && (functions == null || !functions.contains(schema, name, argumentDataTypes))) {
-            throw new UserDefinedFunctionUnknownException(schema, name, argumentDataTypes);
-        } else if (functions == null) {
-            return UserDefinedFunctionsMetadata.of();
-        } else {
-            // create a new instance of the metadata, to guarantee the cluster changed action.
-            UserDefinedFunctionsMetadata newMetadata = UserDefinedFunctionsMetadata.newInstance(functions);
-            newMetadata.remove(schema, name, argumentDataTypes);
-            return newMetadata;
-        }
-    }
-
-    public void updateImplementations(List<UserDefinedFunctionMetadata> userDefinedFunctions) {
-        final Map<FunctionName, List<FunctionProvider>> implementations = new HashMap<>();
-        for (var functionMetadata : userDefinedFunctions) {
-            FunctionProvider provider = buildFunctionResolver(functionMetadata);
-            if (provider == null) {
-                continue;
-            }
-            FunctionName name = provider.signature().getName();
-            var providers = implementations.computeIfAbsent(name, k -> new ArrayList<>());
-            providers.add(provider);
-        }
-        nodeCtx.functions().setUDFs(implementations);
-    }
 
     @Nullable
     public FunctionProvider buildFunctionResolver(UserDefinedFunctionMetadata udf) {
@@ -282,11 +249,26 @@ public class UserDefinedFunctionService extends AbstractLifecycleComponent imple
 
     @Override
     public void clusterChanged(ClusterChangedEvent event) {
-        if (event.changedCustomMetadataSet().contains(UserDefinedFunctionsMetadata.TYPE)) {
-            Metadata newMetadata = event.state().metadata();
-            UserDefinedFunctionsMetadata udfMetadata = newMetadata.custom(UserDefinedFunctionsMetadata.TYPE);
-            updateImplementations(udfMetadata == null ? List.of() : udfMetadata.functionsMetadata());
+        if (!event.metadataChanged()) {
+            return;
         }
+        updateImplementations(event.state().metadata());
+    }
+
+    public void updateImplementations(Metadata newMetadata) {
+        final Map<FunctionName, List<FunctionProvider>> implementations = new HashMap<>();
+        for (var schema : newMetadata.schemas().values()) {
+            for (var udf : schema.udfs()) {
+                FunctionProvider provider = buildFunctionResolver(udf);
+                if (provider == null) {
+                    continue;
+                }
+                FunctionName name = provider.signature().getName();
+                var providers = implementations.computeIfAbsent(name, k -> new ArrayList<>());
+                providers.add(provider);
+            }
+        }
+        nodeCtx.functions().setUDFs(implementations);
     }
 
     @Override

--- a/server/src/main/java/io/crate/expression/udf/UserDefinedFunctionsMetadata.java
+++ b/server/src/main/java/io/crate/expression/udf/UserDefinedFunctionsMetadata.java
@@ -35,10 +35,12 @@ import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentParser;
-import io.crate.common.annotations.VisibleForTesting;
 
+import io.crate.common.annotations.VisibleForTesting;
 import io.crate.types.DataType;
 
+/// @deprecated Use [org.elasticsearch.cluster.metadata.SchemaMetadata#udfs()] instead
+@Deprecated (since = "6.3.0")
 public class UserDefinedFunctionsMetadata extends AbstractNamedDiffable<Metadata.Custom> implements Metadata.Custom {
 
     public static final String TYPE = "user_defined_functions";

--- a/server/src/main/java/io/crate/metadata/RoutineInfos.java
+++ b/server/src/main/java/io/crate/metadata/RoutineInfos.java
@@ -22,7 +22,6 @@
 package io.crate.metadata;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.Locale;
 
@@ -33,7 +32,6 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 
 import io.crate.common.collections.Iterators;
-import io.crate.expression.udf.UserDefinedFunctionsMetadata;
 import io.crate.metadata.FulltextAnalyzerResolver.CustomType;
 
 public class RoutineInfos implements Iterable<RoutineInfo> {
@@ -90,21 +88,18 @@ public class RoutineInfos implements Iterable<RoutineInfo> {
 
     private Iterator<RoutineInfo> userDefinedFunctions() {
         Metadata metadata = clusterService.state().metadata();
-        UserDefinedFunctionsMetadata udf = metadata.custom(UserDefinedFunctionsMetadata.TYPE);
-        if (udf == null) {
-            return Collections.emptyIterator();
-        }
-        return udf.functionsMetadata().stream()
-            .map(x -> new RoutineInfo(
-                        x.name(),
-                        RoutineType.FUNCTION.getName(),
-                        x.schema(),
-                        x.specificName(),
-                        x.definition(),
-                        x.language(),
-                        x.returnType().getName(),
-                        true)
-            )
+        return metadata.schemas().values().stream()
+            .flatMap(schema -> schema.udfs().stream())
+            .map(udf -> new RoutineInfo(
+                udf.name(),
+                RoutineType.FUNCTION.getName(),
+                udf.schema(),
+                udf.specificName(),
+                udf.definition(),
+                udf.language(),
+                udf.returnType().getName(),
+                true
+            ))
             .iterator();
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -79,9 +79,11 @@ import io.crate.exceptions.DependentObjectsExists;
 import io.crate.exceptions.OperationOnInaccessibleRelationException;
 import io.crate.exceptions.RelationUnknown;
 import io.crate.exceptions.SchemaUnknownException;
+import io.crate.exceptions.UserDefinedFunctionUnknownException;
 import io.crate.execution.ddl.Templates;
 import io.crate.expression.symbol.RefReplacer;
 import io.crate.expression.symbol.ScopedColumn;
+import io.crate.expression.udf.UserDefinedFunctionMetadata;
 import io.crate.expression.udf.UserDefinedFunctionsMetadata;
 import io.crate.fdw.ForeignTablesMetadata;
 import io.crate.metadata.ColumnIdent;
@@ -97,6 +99,7 @@ import io.crate.metadata.view.ViewMetadata;
 import io.crate.metadata.view.ViewsMetadata;
 import io.crate.rest.action.HttpErrorStatus;
 import io.crate.sql.tree.ColumnPolicy;
+import io.crate.types.DataType;
 
 public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata> {
 
@@ -619,6 +622,7 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata> {
         }
     }
 
+    @SuppressWarnings("deprecation")
     public static Metadata readFrom(StreamInput in) throws IOException {
         Builder builder;
         if (in.getVersion().onOrAfter(Version.V_6_3_0)) {
@@ -690,11 +694,21 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata> {
                 }
             }
             builder.customs.remove(ForeignTablesMetadata.TYPE);
+
+            UserDefinedFunctionsMetadata udfs = (UserDefinedFunctionsMetadata) builder.customs.getOrDefault(
+                UserDefinedFunctionsMetadata.TYPE,
+                UserDefinedFunctionsMetadata.EMPTY
+            );
+            for (var udf : udfs.functionsMetadata()) {
+                builder.setUDF(udf);
+            }
+            builder.customs.remove(UserDefinedFunctionsMetadata.TYPE);
         }
         return builder.build();
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void writeTo(StreamOutput out) throws IOException {
         if (out.getVersion().onOrAfter(Version.V_6_3_0)) {
             out.writeInt(currentMaxTableOid);
@@ -751,6 +765,24 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata> {
                     foreignTableMap.put(foreignTable.name(), foreignTable);
                 }
                 copyCustoms.put(ForeignTablesMetadata.TYPE, new ForeignTablesMetadata(foreignTableMap));
+            }
+
+            // Build old UDF Metdata
+            List<UserDefinedFunctionMetadata> udfs = null;
+            for (var schema : schemas.values()) {
+                for (var udf : schema.udfs()) {
+                    if (udfs == null) {
+                        udfs = new ArrayList<>();
+                    }
+                    udfs.add(udf);
+                }
+            }
+            if (udfs != null) {
+                copyCustoms = new HashMap<>(copyCustoms);
+                copyCustoms.put(
+                    UserDefinedFunctionsMetadata.TYPE,
+                    UserDefinedFunctionsMetadata.of(udfs.toArray(UserDefinedFunctionMetadata[]::new))
+                );
             }
         }
         // filter out custom states not supported by the other node
@@ -901,10 +933,15 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata> {
             }
             HashMap<String, RelationMetadata> newRelations = new HashMap<>(schemaMetadata.relations());
             newRelations.remove(relationName.name());
-            if (newRelations.isEmpty() && !schemaMetadata.explicit()) {
+            if (newRelations.isEmpty() && schemaMetadata.udfs().isEmpty() && !schemaMetadata.explicit()) {
                 schemas.remove(relationName.schema());
             } else {
-                schemas.put(relationName.schema(), new SchemaMetadata(newRelations, schemaMetadata.explicit()));
+                SchemaMetadata newSchemaMetadata = new SchemaMetadata(
+                    newRelations,
+                    schemaMetadata.udfs(),
+                    schemaMetadata.explicit()
+                );
+                schemas.put(relationName.schema(), newSchemaMetadata);
             }
             return this;
         }
@@ -929,16 +966,24 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata> {
             String schema = relationName.schema();
             SchemaMetadata schemaMetadata = schemas.get(schema);
             boolean explicit;
+            List<UserDefinedFunctionMetadata> udfs;
             if (schemaMetadata == null) {
                 relations = HashMap.newHashMap(1);
                 relations.put(relationName.name(), relation);
                 explicit = false;
+                udfs = List.of();
             } else {
                 relations = new HashMap<>(schemaMetadata.relations());
                 relations.put(relationName.name(), relation);
                 explicit = schemaMetadata.explicit();
+                udfs = schemaMetadata.udfs();
             }
-            schemas.put(schema, new SchemaMetadata(Collections.unmodifiableMap(relations), explicit));
+            SchemaMetadata newSchemaMetadata = new SchemaMetadata(
+                Collections.unmodifiableMap(relations),
+                udfs,
+                explicit
+            );
+            schemas.put(schema, newSchemaMetadata);
         }
 
         @Deprecated
@@ -1255,6 +1300,61 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata> {
             return builder.build();
         }
 
+        public Builder setUDF(UserDefinedFunctionMetadata udf) {
+            SchemaMetadata schemaMetadata = schemas.get(udf.schema());
+            if (schemaMetadata == null) {
+                List<UserDefinedFunctionMetadata> udfs = List.of(udf);
+                schemaMetadata = new SchemaMetadata(Map.of(), udfs, false);
+            } else {
+                if (schemaMetadata.udfs().contains(udf)) {
+                    return this;
+                }
+                List<UserDefinedFunctionMetadata> newUdfs = new ArrayList<>(schemaMetadata.udfs());
+                newUdfs.add(udf);
+                schemaMetadata = new SchemaMetadata(
+                    schemaMetadata.relations(),
+                    Collections.unmodifiableList(newUdfs),
+                    schemaMetadata.explicit()
+                );
+            }
+            schemas.put(udf.schema(), schemaMetadata);
+            return this;
+        }
+
+        public Builder dropUDF(String schema,
+                               String name,
+                               List<DataType<?>> argTypes,
+                               boolean ifExists) {
+            SchemaMetadata schemaMetadata = schemas.get(schema);
+            if (schemaMetadata == null) {
+                if (ifExists) {
+                    return this;
+                }
+                throw new UserDefinedFunctionUnknownException(schema, name, argTypes);
+            }
+            List<UserDefinedFunctionMetadata> udfs = schemaMetadata.udfs();
+            ArrayList<UserDefinedFunctionMetadata> newUdfs = new ArrayList<>(Math.max(0, udfs.size() - 1));
+            for (var udf : udfs) {
+                if (!(udf.sameSignature(schema, name, argTypes))) {
+                    newUdfs.add(udf);
+                }
+            }
+            if (udfs.size() == newUdfs.size() && !ifExists) {
+                throw new UserDefinedFunctionUnknownException(schema, name, argTypes);
+            }
+            if (newUdfs.isEmpty() && schemaMetadata.relations().isEmpty() && !schemaMetadata.explicit()) {
+                schemas.remove(schema);
+            } else {
+                SchemaMetadata newSchemaMetadata = new SchemaMetadata(
+                    schemaMetadata.relations(),
+                    Collections.unmodifiableList(newUdfs),
+                    schemaMetadata.explicit()
+                );
+                schemas.put(schema, newSchemaMetadata);
+            }
+            return this;
+        }
+
         /**
          * <p>
          * Adds the table, overriding it if a table with the same schema and name exists.
@@ -1420,7 +1520,7 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata> {
 
         /// Explicitly adds a schema
         public Builder createSchema(String schemaName) {
-            schemas.put(schemaName, new SchemaMetadata(Map.of(), true));
+            schemas.put(schemaName, new SchemaMetadata(Map.of(), List.of(), true));
             return this;
         }
 
@@ -1742,5 +1842,11 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata> {
         public int peek() {
             return nextOid;
         }
+    }
+
+    public long numUDFs() {
+        return schemas.values().stream()
+            .mapToLong(schema -> schema.udfs().size())
+            .sum();
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataUpgradeService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataUpgradeService.java
@@ -21,8 +21,8 @@ package org.elasticsearch.cluster.metadata;
 
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_VERSION_CREATED;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_VERSION_UPGRADED;
-import static org.elasticsearch.cluster.metadata.Metadata.Builder.NO_OID_COLUMN_OID_SUPPLIER;
 import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
+import static org.elasticsearch.cluster.metadata.Metadata.Builder.NO_OID_COLUMN_OID_SUPPLIER;
 
 import java.util.List;
 import java.util.function.LongSupplier;
@@ -89,7 +89,11 @@ public class MetadataUpgradeService {
 
         UserDefinedFunctionsMetadata udfMetadata = metadata.custom(UserDefinedFunctionsMetadata.TYPE);
         if (udfMetadata != null) {
-            userDefinedFunctionService.updateImplementations(udfMetadata.functionsMetadata());
+            for (var udf : udfMetadata.functionsMetadata()) {
+                newMetadata.setUDF(udf);
+            }
+            newMetadata.removeCustom(UserDefinedFunctionsMetadata.TYPE);
+            userDefinedFunctionService.updateImplementations(newMetadata.build());
         }
 
         ViewsMetadata viewsMetadata = metadata.custom(ViewsMetadata.TYPE);

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/SchemaMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/SchemaMetadata.java
@@ -22,6 +22,7 @@
 package org.elasticsearch.cluster.metadata;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 
 import org.elasticsearch.Version;
@@ -32,16 +33,21 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.jspecify.annotations.Nullable;
 
+import io.crate.expression.udf.UserDefinedFunctionMetadata;
 import io.crate.metadata.RelationName;
 
 public class SchemaMetadata implements Diffable<SchemaMetadata> {
 
     private final Map<String, RelationMetadata> relations;
+    private final List<UserDefinedFunctionMetadata> udfs;
     private final boolean explicit;
 
     /// @param explicit true indicates this was created via CREATE SCHEMA
-    public SchemaMetadata(Map<String, RelationMetadata> relations, boolean explicit) {
+    public SchemaMetadata(Map<String, RelationMetadata> relations,
+                          List<UserDefinedFunctionMetadata> udfs,
+                          boolean explicit) {
         this.relations = relations;
+        this.udfs = udfs;
         this.explicit = explicit;
     }
 
@@ -53,7 +59,22 @@ public class SchemaMetadata implements Diffable<SchemaMetadata> {
         boolean explicit = in.getVersion().onOrAfter(Version.V_6_2_0)
             ? in.readBoolean()
             : false;
-        return new SchemaMetadata(relations, explicit);
+        List<UserDefinedFunctionMetadata> udfs = in.getVersion().onOrAfter(Version.V_6_3_0)
+            ? in.readList(UserDefinedFunctionMetadata::new)
+            : List.of();
+        return new SchemaMetadata(relations, udfs, explicit);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeMap(relations, StreamOutput::writeString, RelationMetadata::toStream);
+        Version version = out.getVersion();
+        if (version.onOrAfter(Version.V_6_2_0)) {
+            out.writeBoolean(explicit);
+        }
+        if (version.onOrAfter(Version.V_6_3_0)) {
+            out.writeList(udfs);
+        }
     }
 
     public static Diff<SchemaMetadata> readDiffFrom(StreamInput in) throws IOException {
@@ -73,16 +94,12 @@ public class SchemaMetadata implements Diffable<SchemaMetadata> {
         }
     }
 
-    @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        out.writeMap(relations, StreamOutput::writeString, RelationMetadata::toStream);
-        if (out.getVersion().onOrAfter(Version.V_6_2_0)) {
-            out.writeBoolean(explicit);
-        }
-    }
-
     public Map<String, RelationMetadata> relations() {
         return relations;
+    }
+
+    public List<UserDefinedFunctionMetadata> udfs() {
+        return udfs;
     }
 
     @Nullable
@@ -101,15 +118,23 @@ public class SchemaMetadata implements Diffable<SchemaMetadata> {
         return explicit;
     }
 
+
     @Override
     public int hashCode() {
-        return relations.hashCode();
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + relations.hashCode();
+        result = prime * result + udfs.hashCode();
+        result = prime * result + (explicit ? 1231 : 1237);
+        return result;
     }
 
     @Override
     public boolean equals(Object obj) {
         return obj instanceof SchemaMetadata other
-            && relations.equals(other.relations);
+            && relations.equals(other.relations)
+            && udfs.equals(other.udfs)
+            && explicit == other.explicit;
     }
 
     static class SchemaMetadataDiff implements Diff<SchemaMetadata> {
@@ -118,6 +143,7 @@ public class SchemaMetadata implements Diffable<SchemaMetadata> {
             new Diffs.DiffableValueReader<>(RelationMetadata::of, RelationMetadata::readDiffFrom);
 
         private final Diff<Map<String, RelationMetadata>> relations;
+        private final List<UserDefinedFunctionMetadata> udfs;
         private final boolean explicit;
 
         SchemaMetadataDiff(Version version, SchemaMetadata before, SchemaMetadata after) {
@@ -128,24 +154,31 @@ public class SchemaMetadata implements Diffable<SchemaMetadata> {
                 Diffs.stringKeySerializer(),
                 RelationMetadata.VALUE_SERIALIZER
             );
+            this.udfs = after.udfs();
             this.explicit = after.explicit;
         }
 
         SchemaMetadataDiff(StreamInput in) throws IOException {
             relations = Diffs.readMapDiff(in, Diffs.stringKeySerializer(), REL_DIFF_VALUE_READER);
             explicit = in.readBoolean();
+            udfs = in.getVersion().onOrAfter(Version.V_6_3_0)
+                ? in.readList(UserDefinedFunctionMetadata::new)
+                : List.of();
         }
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             relations.writeTo(out);
             out.writeBoolean(explicit);
+            if (out.getVersion().onOrAfter(Version.V_6_3_0)) {
+                out.writeList(udfs);
+            }
         }
 
         @Override
         public SchemaMetadata apply(SchemaMetadata part) {
             Map<String, RelationMetadata> newRelations = relations.apply(part.relations);
-            return new SchemaMetadata(newRelations, explicit);
+            return new SchemaMetadata(newRelations, udfs, explicit);
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -96,6 +96,7 @@ import io.crate.common.unit.TimeValue;
 import io.crate.exceptions.PartitionAlreadyExistsException;
 import io.crate.exceptions.RelationAlreadyExists;
 import io.crate.exceptions.RelationUnknown;
+import io.crate.expression.udf.UserDefinedFunctionsMetadata;
 import io.crate.metadata.IndexName;
 import io.crate.metadata.IndexParts;
 import io.crate.metadata.PartitionName;
@@ -552,10 +553,10 @@ public class RestoreService implements ClusterStateApplier {
                 mdBuilder.persistentSettings(settings);
             }
 
+            // old UDF/ViewsMetadata were already migrated to new structures in
+            // MetadataUpgradeService#upgradeMetadata()
             // Restore views
             if (request.includeViews()) {
-                // old ViewsMetadata have already been migrated to RelationMetadata.View in
-                // MetadataUpgradeService#upgradeMetadata()
                 for (RelationMetadata.View view : snapshotMetadata.relations(RelationMetadata.View.class)) {
                     mdBuilder.setView(
                         view.name(),
@@ -579,6 +580,13 @@ public class RestoreService implements ClusterStateApplier {
                 List<String> customMetadataTypes = Arrays.asList(request.customMetadataTypes());
                 boolean includeAll = customMetadataTypes.isEmpty();
 
+                if (includeAll || customMetadataTypes.contains(UserDefinedFunctionsMetadata.TYPE)) {
+                    for (var schema : snapshotMetadata.schemas().values()) {
+                        for (var udf : schema.udfs()) {
+                            mdBuilder.setUDF(udf);
+                        }
+                    }
+                }
                 for (Map.Entry<String, Metadata.Custom> entry : snapshotMetadata.customs().entrySet()) {
                     if (!RepositoriesMetadata.TYPE.equals(entry.getKey())) {
                         // Don't restore repositories while we are working with them

--- a/server/src/test/java/io/crate/expression/udf/UserDefinedFunctionServiceTest.java
+++ b/server/src/test/java/io/crate/expression/udf/UserDefinedFunctionServiceTest.java
@@ -26,6 +26,8 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 import java.util.List;
 
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.SchemaMetadata;
 import org.junit.Test;
 
 import io.crate.analyze.FunctionArgumentDefinition;
@@ -40,14 +42,12 @@ public class UserDefinedFunctionServiceTest extends UdfUnitTest {
         DocSchemaInfo.NAME, "same", List.of(), DataTypes.INTEGER,
         DUMMY_LANG.name(), "function same(){ return 3; }"
     );
-    private final UserDefinedFunctionMetadata same2 = new UserDefinedFunctionMetadata(
-        DocSchemaInfo.NAME, "same", List.of(), DataTypes.INTEGER,
-        DUMMY_LANG.name(), "function same() { return 2; }"
-    );
+
     private final UserDefinedFunctionMetadata different = new UserDefinedFunctionMetadata(
         DocSchemaInfo.NAME, "different", List.of(), DataTypes.INTEGER,
         DUMMY_LANG.name(), "function different() { return 3; }"
     );
+
     private static final UserDefinedFunctionMetadata FOO = new UserDefinedFunctionMetadata(
         DocSchemaInfo.NAME, "foo", List.of(FunctionArgumentDefinition.of("i", DataTypes.INTEGER)), DataTypes.INTEGER,
         DUMMY_LANG.name(), "function foo(i) { return i; }"
@@ -60,55 +60,37 @@ public class UserDefinedFunctionServiceTest extends UdfUnitTest {
     }
 
     @Test
-    public void testFirstFunction() throws Exception {
-        UserDefinedFunctionsMetadata metadata = udfService.putFunction(null, same1, true);
-        assertThat(metadata.functionsMetadata()).hasSize(1);
-        assertThat(metadata.functionsMetadata()).containsExactly(same1);
+    public void test_create_replace_and_remove_functions() throws Exception {
+        ClusterState state1 = UserDefinedFunctionService.addUDF(same1, true, ClusterState.EMPTY_STATE);
+        SchemaMetadata schema1 = state1.metadata().schemas().get(DocSchemaInfo.NAME);
+        assertThat(schema1).isNotNull();
+        assertThat(schema1.udfs()).containsExactly(same1);
+
+        ClusterState state2 = UserDefinedFunctionService.addUDF(same1, true, state1);
+        SchemaMetadata schema2 = state2.metadata().schemas().get(DocSchemaInfo.NAME);
+        assertThat(schema2).isNotNull();
+        assertThat(schema2.udfs()).containsExactly(same1);
+
+        assertThatThrownBy(() -> UserDefinedFunctionService.addUDF(same1, false, state2))
+            .isExactlyInstanceOf(UserDefinedFunctionAlreadyExistsException.class);
+
+        ClusterState state3 = UserDefinedFunctionService.addUDF(different, true, state2);
+        SchemaMetadata schema3 = state3.metadata().schemas().get(DocSchemaInfo.NAME);
+        assertThat(schema3).isNotNull();
+        assertThat(schema3.udfs()).containsExactly(same1, different);
+
+        ClusterState state4 = udfService.dropUDF("doc", "different", List.of(), true, state3);
+        SchemaMetadata schema4 = state4.metadata().schemas().get(DocSchemaInfo.NAME);
+        assertThat(schema4).isNotNull();
+        assertThat(schema4.udfs()).containsExactly(same1);
+
+        assertThatThrownBy(() -> udfService.dropUDF("doc", "different", List.of(), false, state4))
+            .isExactlyInstanceOf(UserDefinedFunctionUnknownException.class);
+
+        ClusterState state5 = udfService.dropUDF("doc", "different", List.of(), true, state4);
+        assertThat(state5).isEqualTo(state4);
     }
 
-    @Test
-    public void testReplaceExistingFunction() throws Exception {
-        UserDefinedFunctionsMetadata metadata = udfService.putFunction(UserDefinedFunctionsMetadata.of(same1), same2, true);
-        assertThat(metadata.functionsMetadata()).hasSize(1);
-        assertThat(metadata.functionsMetadata()).containsExactly(same2);
-    }
-
-    @Test
-    public void testReplaceNotExistingFunction() throws Exception {
-        UserDefinedFunctionsMetadata metadata =
-            udfService.putFunction(UserDefinedFunctionsMetadata.of(same1), different, true);
-        assertThat(metadata.functionsMetadata()).containsExactlyInAnyOrder(same1, different);
-    }
-
-    @Test
-    public void testRemoveFunction() throws Exception {
-        UserDefinedFunctionsMetadata metadata = UserDefinedFunctionsMetadata.of(same1);
-        UserDefinedFunctionsMetadata newMetadata = udfService.removeFunction(metadata, same1.schema(), same1.name(), same1.argumentTypes(), false);
-        assertThat(metadata).isNotEqualTo(newMetadata); // A new instance of metadata must be returned on a change
-        assertThat(newMetadata.functionsMetadata()).hasSize(0);
-    }
-
-    @Test
-    public void testRemoveIfExistsEmptyMetadata() throws Exception {
-        UserDefinedFunctionsMetadata newMetadata = udfService.removeFunction(null, same1.schema(), same1.name(), same1.argumentTypes(), true);
-        assertThat(newMetadata).isNotNull();
-    }
-
-    @Test
-    public void testRemoveDoesNotExist() throws Exception {
-        UserDefinedFunctionsMetadata metadata = UserDefinedFunctionsMetadata.of(same1);
-        assertThatThrownBy(() ->
-                udfService.removeFunction(metadata, different.schema(), different.name(), different.argumentTypes(), false))
-            .isExactlyInstanceOf(UserDefinedFunctionUnknownException.class)
-            .hasMessage("Cannot resolve user defined function: 'doc.different()'");
-    }
-
-    @Test
-    public void testReplaceIsFalse() throws Exception {
-        assertThatThrownBy(() -> udfService.putFunction(UserDefinedFunctionsMetadata.of(same1), same2, false))
-            .isExactlyInstanceOf(UserDefinedFunctionAlreadyExistsException.class)
-            .hasMessage("User defined Function 'doc.same()' already exists.");
-    }
 
     @Test
     public void test_validate_table_while_dropping_udf() throws Exception {
@@ -125,11 +107,11 @@ public class UserDefinedFunctionServiceTest extends UdfUnitTest {
             ))
             .addTable("create table doc.t1 (id int, gen as foo(id))");
 
-        assertThatThrownBy(() -> udfService.ensureFunctionIsUnused(DocSchemaInfo.NAME, "foo", List.of(DataTypes.LONG)))
+        assertThatThrownBy(() -> udfService.ensureFunctionIsUnused(DocSchemaInfo.NAME, "foo", List.of(DataTypes.INTEGER)))
             .isExactlyInstanceOf(IllegalArgumentException.class)
             .hasMessage("Cannot drop function 'doc.foo'. It is in use by column 'gen' of table 'doc.t1'");
 
-        sqlExecutor.udfService().ensureFunctionIsUnused(DocSchemaInfo.NAME, "foo", List.of(DataTypes.INTEGER));
+        sqlExecutor.udfService().ensureFunctionIsUnused(DocSchemaInfo.NAME, "foo", List.of(DataTypes.LONG));
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/udf/UserDefinedFunctionsTest.java
+++ b/server/src/test/java/io/crate/expression/udf/UserDefinedFunctionsTest.java
@@ -22,6 +22,7 @@
 package io.crate.expression.udf;
 
 import static io.crate.testing.Asserts.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
@@ -147,7 +148,8 @@ public class UserDefinedFunctionsTest extends UdfUnitTest {
             "function valid() { return 42; }"
         );
         // if a functionImpl can't be created, it won't be registered
-        udfService.updateImplementations(List.of(invalid, valid));
+        sqlExecutor.addUDF(invalid);
+        sqlExecutor.addUDF(valid);
 
         Functions functions = sqlExecutor.nodeCtx.functions();
         SearchPath searchPath = SearchPath.pathWithPGCatalogAndDoc();

--- a/server/src/test/java/io/crate/integrationtests/SchemaAndRelationNamesIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SchemaAndRelationNamesIntegrationTest.java
@@ -28,14 +28,16 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.util.List;
 
 import org.elasticsearch.cluster.metadata.RelationMetadata;
+import org.elasticsearch.cluster.metadata.SchemaMetadata;
 import org.elasticsearch.test.IntegTestCase;
 import org.junit.Before;
 import org.junit.Test;
 
+import io.crate.analyze.FunctionArgumentDefinition;
+import io.crate.expression.udf.UserDefinedFunctionMetadata;
 import io.crate.expression.udf.UserDefinedFunctionService;
-import io.crate.expression.udf.UserDefinedFunctionsMetadata;
 import io.crate.metadata.RelationName;
-import io.crate.types.StringType;
+import io.crate.types.DataTypes;
 
 public class SchemaAndRelationNamesIntegrationTest extends IntegTestCase {
 
@@ -63,7 +65,8 @@ public class SchemaAndRelationNamesIntegrationTest extends IntegTestCase {
         assertThat(meta.indices().values().iterator().next().getIndex().getName()).isEqualTo("_Abc..partitioned._T.04132");
 
         // check viewMetadata names as well as its target query
-        RelationMetadata view = meta.schemas().get("_Abc").get(new RelationName("_Abc", "v1"));
+        SchemaMetadata schemaMetadata = meta.schemas().get("_Abc");
+        RelationMetadata view = schemaMetadata.get(new RelationName("_Abc", "v1"));
         assertThat(view).isNotNull();
         assertThat(view).isExactlyInstanceOf(RelationMetadata.View.class);
         assertThat(((RelationMetadata.View) view).stmt()).isEqualTo(
@@ -74,8 +77,18 @@ public class SchemaAndRelationNamesIntegrationTest extends IntegTestCase {
         );
 
         // check udfMetadata for proper schema name
-        UserDefinedFunctionsMetadata userDefinedFunctionsMetadata = meta.custom(UserDefinedFunctionsMetadata.TYPE);
-        assertThat(userDefinedFunctionsMetadata.contains("_Abc", "func", List.of(StringType.INSTANCE))).isTrue();
+        assertThat(schemaMetadata.udfs()).containsExactly(
+            new UserDefinedFunctionMetadata(
+                "_Abc",
+                "func",
+                List.of(
+                    FunctionArgumentDefinition.of(DataTypes.STRING)
+                ),
+                DataTypes.STRING,
+                "dummy_lang",
+                "DUMMY EATS text"
+            )
+        );
 
         // a little more complex scenario involving schema names with upper cases
         execute("create table Abc.\"_T\" (b string, c string as \"_Abc\".func(b))");

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataTest.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataTest.java
@@ -36,6 +36,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Test;
 
+import io.crate.analyze.FunctionArgumentDefinition;
 import io.crate.exceptions.DependentObjectsExists;
 import io.crate.expression.udf.UserDefinedFunctionMetadata;
 import io.crate.expression.udf.UserDefinedFunctionsMetadata;
@@ -51,6 +52,7 @@ import io.crate.metadata.view.ViewsMetadata;
 import io.crate.sql.tree.ColumnPolicy;
 import io.crate.types.DataTypes;
 
+@SuppressWarnings("deprecation")
 public class MetadataTest extends ESTestCase {
 
     @Test
@@ -301,5 +303,33 @@ public class MetadataTest extends ESTestCase {
             )
         );
         assertThat((ForeignTablesMetadata) receivedMetadata.custom(ForeignTablesMetadata.TYPE)).isNull();
+    }
+
+    @Test
+    public void test_bwc_streaming_udfs() throws Exception {
+        UserDefinedFunctionMetadata udf = new UserDefinedFunctionMetadata(
+            "my_schema",
+            "foo",
+            List.of(FunctionArgumentDefinition.of(DataTypes.INTEGER)),
+            DataTypes.INTEGER,
+            "x-lang",
+            "return 42"
+        );
+        Metadata metadata = Metadata.builder(Metadata.OID_UNASSIGNED)
+            .setUDF(udf)
+            .build();
+        try (var out = new BytesStreamOutput()) {
+            out.setVersion(Version.V_6_2_0);
+            metadata.writeTo(out);
+            try (var in = new NamedWriteableAwareStreamInput(out.bytes().streamInput(), writableRegistry())) {
+                in.setVersion(Version.V_6_2_0);
+                Metadata receivedMetadata = Metadata.readFrom(in);
+                UserDefinedFunctionsMetadata udfMetadata = receivedMetadata.custom(UserDefinedFunctionsMetadata.TYPE);
+                assertThat(udfMetadata).isNull();
+                SchemaMetadata schemaMetadata = receivedMetadata.schemas().get("my_schema");
+                assertThat(schemaMetadata).isNotNull();
+                assertThat(schemaMetadata.udfs()).containsExactly(udf);
+            }
+        }
     }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/SchemaMetadataTest.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/SchemaMetadataTest.java
@@ -25,6 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.Diff;
@@ -76,13 +77,13 @@ public class SchemaMetadataTest extends ESTestCase {
         HashMap<String, RelationMetadata> relationsV1 = new HashMap<>();
         relationsV1.put("t1", relT1);
         relationsV1.put("t2", relT2);
-        SchemaMetadata schemaV1 = new SchemaMetadata(relationsV1, true);
+        SchemaMetadata schemaV1 = new SchemaMetadata(relationsV1, List.of(), true);
 
         HashMap<String, RelationMetadata> relationsV2 = new HashMap<>();
         relationsV2.put("t1", relT1);
         relationsV2.put("t2", relT2);
         relationsV2.put("t3", relT3);
-        SchemaMetadata schemaV2 = new SchemaMetadata(relationsV2, true);
+        SchemaMetadata schemaV2 = new SchemaMetadata(relationsV2, List.of(), true);
 
         SchemaMetadata before;
         SchemaMetadata after;

--- a/server/src/testFixtures/java/io/crate/testing/SQLExecutor.java
+++ b/server/src/testFixtures/java/io/crate/testing/SQLExecutor.java
@@ -124,7 +124,6 @@ import io.crate.expression.symbol.Symbol;
 import io.crate.expression.udf.UDFLanguage;
 import io.crate.expression.udf.UserDefinedFunctionMetadata;
 import io.crate.expression.udf.UserDefinedFunctionService;
-import io.crate.expression.udf.UserDefinedFunctionsMetadata;
 import io.crate.fdw.AddForeignTableTask;
 import io.crate.fdw.AddServerTask;
 import io.crate.fdw.CreateServerRequest;
@@ -332,6 +331,7 @@ public class SQLExecutor {
                 tableStats
             );
             var udfService = new UserDefinedFunctionService(clusterService, nodeCtx);
+            udfService.start();
 
             var relationAnalyzer = new RelationAnalyzer(nodeCtx);
             relationAnalyzerRef.set(relationAnalyzer);
@@ -1046,8 +1046,14 @@ public class SQLExecutor {
     }
 
     public SQLExecutor addUDF(UserDefinedFunctionMetadata udf) {
-        UserDefinedFunctionsMetadata udfs = clusterService.state().metadata().custom(UserDefinedFunctionsMetadata.TYPE);
-        udfService.updateImplementations(Lists.concat(udfs == null ? List.of() : udfs.functionsMetadata(), udf));
+        ClusterState state = clusterService.state();
+        Metadata newMetadata = new Metadata.Builder(state.metadata())
+            .setUDF(udf)
+            .build();
+        ClusterState newState = ClusterState.builder(state)
+            .metadata(newMetadata)
+            .build();
+        ClusterServiceUtils.setState(clusterService, newState);
         return this;
     }
 

--- a/server/src/testFixtures/java/org/elasticsearch/test/IntegTestCase.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/IntegTestCase.java
@@ -1771,7 +1771,9 @@ public abstract class IntegTestCase extends ESTestCase {
                         // arguments will be returned. Therefore, we have to assert that
                         // the provided arguments do not match the arguments of the resolved
                         // function if the function was deleted.
-                        assertThat(func.boundSignature().argTypes()).isNotEqualTo(Symbols.typeView(arguments));
+                        assertThat(func.boundSignature().argTypes())
+                            .as("Expected function '" + name + "' to be deleted")
+                            .isNotEqualTo(Symbols.typeView(arguments));
                     }
                 } catch (UnsupportedFunctionException e) {
                     assertThat(e.getMessage()).startsWith("Unknown function");


### PR DESCRIPTION
## TODO:

- [x] Fail if udf already exists on create function
- [x] Add migration logic
- [x] Update unit tests

Relates to: https://github.com/crate/crate/issues/18794