### PR TITLE
Add debug logging for non-IOExceptions shown to users

### DIFF
--- a/server/src/main/java/io/crate/protocols/http/MainAndStaticFileHandler.java
+++ b/server/src/main/java/io/crate/protocols/http/MainAndStaticFileHandler.java
@@ -112,14 +112,19 @@ public class MainAndStaticFileHandler extends SimpleChannelInboundHandler<FullHt
                     .addListener(ChannelFutureListener.CLOSE);
             }
             case IOException _ -> {
-                if (message.contains("Connection reset")) {
+                if (LOGGER.isDebugEnabled() && message.contains("Connection reset")) {
                     LOGGER.debug(message);
                 } else {
                     LOGGER.warn(message, cause);
                     send500(ctx, message);
                 }
             }
-            default -> send500(ctx, message);
+            default -> {
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.debug(message);
+                }
+                send500(ctx, message);
+            }
         }
     }
 


### PR DESCRIPTION
There was a leak report in logs:

```
io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:918) |  
io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1429) |  
io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:359) |  
io.netty.channel.AbstractChannelHandlerContext.invokeExceptionCaught(AbstractChannelHandlerContext.java:289) |  
io.netty.handler.ssl.SslHandler.exceptionCaught(SslHandler.java:1238) |  
io.netty.channel.AbstractChannelHandlerContext.fireExceptionCaught(AbstractChannelHandlerContext.java:271) |  
io.netty.channel.AbstractChannelHandlerContext.invokeExceptionCaught(AbstractChannelHandlerContext.java:289) |  
io.crate.protocols.http.HttpBlobHandler.exceptionCaught(HttpBlobHandler.java:249) |  
io.netty.channel.ChannelInboundHandlerAdapter.exceptionCaught(ChannelInboundHandlerAdapter.java:143) |  
io.netty.channel.AbstractChannelHandlerContext.fireExceptionCaught(AbstractChannelHandlerContext.java:271) |  
io.netty.channel.AbstractChannelHandlerContext.invokeExceptionCaught(AbstractChannelHandlerContext.java:289) |  
io.crate.protocols.http.MainAndStaticFileHandler.exceptionCaught(MainAndStaticFileHandler.java:122) |  
io.crate.protocols.http.MainAndStaticFileHandler.send500(MainAndStaticFileHandler.java:127) |  
 io.netty.buffer.ByteBufUtil.writeUtf8(ByteBufUtil.java:830) |  
 io.netty.buffer.AbstractByteBufAllocator.buffer(AbstractByteBufAllocator.java:96) |  
io.netty.buffer.AbstractByteBufAllocator.directBuffer(AbstractByteBufAllocator.java:159) |  
io.netty.buffer.AbstractByteBufAllocator.directBuffer(AbstractByteBufAllocator.java:168) |  
io.netty.buffer.AdaptiveByteBufAllocator.newDirectBuffer(AdaptiveByteBufAllocator.java:67) |  
 Created at:
```

Speaking about `send500` usages: currently `MainAndStaticFileHandler.exceptionCaught` only logs IOExceptions.
Leak mentions `send500` which is also used for non-IOExceptions, so adding some logs to get more insights about the error.

BTW `send500` does allocate a buffer in `ByteBuf content = ByteBufUtil.writeUtf8(ctx.alloc(), message)`, 
but I don't think it can be leaked - if it throws in allocate, we have nothing to release. 

`DefaultFullHttpResponse` ctor and `setContentLength` can't throw and once `writeAndFlush` takes ownership of the buffer, it's responsible for releasing it (even in case of failures)


