### PR TITLE
Fix buffer leak when HTTP request fails on session creation

### DIFF
--- a/docs/appendices/release-notes/6.2.3.rst
+++ b/docs/appendices/release-notes/6.2.3.rst
@@ -51,3 +51,7 @@ Fixes
 
 - Fixed an issue causing memory leaks when accessing
   :ref:`BLOB endpoint<blob-endpoint>`.
+
+- Fixed an issue causing memory leaks if requests to the ``HTTP`` endpoint
+  failed to create a session, for example, due to wrong authentication headers.
+

--- a/server/src/main/java/io/crate/rest/action/SqlHttpHandler.java
+++ b/server/src/main/java/io/crate/rest/action/SqlHttpHandler.java
@@ -109,32 +109,45 @@ public class SqlHttpHandler extends SimpleChannelInboundHandler<FullHttpRequest>
 
     @Override
     protected void channelRead0(ChannelHandlerContext ctx, FullHttpRequest request) {
-        if (request.uri().startsWith("/_sql")) {
-            Session session = ensureSession(
+        if (!request.uri().startsWith("/_sql")) {
+            ctx.fireChannelRead(request);
+            return;
+        }
+
+        Session session;
+        Map<String, List<String>> parameters;
+        try {
+            session = ensureSession(
                 new ConnectionProperties(
                     null, // not used
                     Netty4HttpServerTransport.getRemoteAddress(ctx.channel()),
                     Protocol.HTTP,
-                    getSession(ctx.channel())),
-                request);
-            Map<String, List<String>> parameters = new QueryStringDecoder(request.uri()).parameters();
-            ByteBuf content = request.content();
-            ByteBuf resultBuffer = ctx.alloc().buffer();
-            handleSQLRequest(session, resultBuffer, content, paramContainFlag(parameters, "types"))
-                .whenComplete((_, t) -> {
-                    try {
-                        sendResponse(ctx, request, parameters, resultBuffer, t);
-                    } catch (Throwable ex) {
-                        resultBuffer.release();
-                        LOGGER.error("Error sending response", ex);
-                        throw ex;
-                    } finally {
-                        request.release();
-                    }
-                });
-        } else {
-            ctx.fireChannelRead(request);
+                    getSession(ctx.channel())
+                ),
+                request
+            );
+            parameters = new QueryStringDecoder(request.uri()).parameters();
+        } catch (Exception ex) {
+            request.release();
+            // Let the last handler deal with it and maybe send failure info to the user.
+            throw ex;
         }
+
+        ByteBuf content = request.content();
+        ByteBuf resultBuffer = ctx.alloc().buffer();
+        handleSQLRequest(session, resultBuffer, content, paramContainFlag(parameters, "types"))
+            .whenComplete((_, t) -> {
+                try {
+                    sendResponse(ctx, request, parameters, resultBuffer, t);
+                } catch (Throwable ex) {
+                    resultBuffer.release();
+                    LOGGER.error("Error sending response", ex);
+                    throw ex;
+                } finally {
+                    request.release();
+                }
+            });
+
     }
 
     /**

--- a/server/src/test/java/io/crate/rest/action/SqlHttpHandlerTest.java
+++ b/server/src/test/java/io/crate/rest/action/SqlHttpHandlerTest.java
@@ -54,6 +54,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
+import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
 import io.netty.handler.codec.http.DefaultHttpHeaders;
 import io.netty.handler.codec.http.FullHttpRequest;
@@ -199,6 +200,31 @@ public class SqlHttpHandlerTest {
         assertThat(responseBody).doesNotContain("dummy data written before it was interrupted");
         assertThat(responseBody).contains("CBE");
         assertThat(response.status()).isEqualTo(HttpResponseStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    @Test
+    public void session_creation_failure_does_not_leak_request() {
+        Role dummyUser = RolesHelper.userOf("crate");
+        var sessionSettings = new CoordinatorSessionSettings(dummyUser);
+        var mockedSession = mock(Session.class);
+        when(mockedSession.sessionSettings()).thenReturn(sessionSettings);
+
+        var sessions = mock(Sessions.class);
+        when(sessions.newSession(any(), any(), any())).thenThrow(new RuntimeException("dummy"));
+
+        SqlHttpHandler sqlHttpHandler = new SqlHttpHandler(
+            Settings.EMPTY,
+            sessions,
+            _ -> new NoopCircuitBreaker("dummy"),
+            () -> List.of(Role.CRATE_USER)
+        );
+
+        EmbeddedChannel channel = new EmbeddedChannel(sqlHttpHandler);
+        var request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/_sql");
+        try {
+            channel.writeInbound(request);
+        } catch (Exception ignored) { }
+        assertThat(request.refCnt()).isEqualTo(0);
     }
 }
 


### PR DESCRIPTION
<img width="867" height="847" alt="Screenshot 2026-03-06 at 18 08 37" src="https://github.com/user-attachments/assets/62180471-425b-4818-ac06-4c28decf22b8" />


Judging by the JFR data, `ALTER USER SET (<session_setting> = <value`) can accept invalid `statement_timeout`.
It needs to be fixed separately. 

This change fixes existing metadata handling, so that it doesn't cause buffer leaks

