### PR TITLE
Fix: Check for METADATA_WRITE instead of READ for Create/Drop Role/UDF

### DIFF
--- a/server/src/main/java/io/crate/expression/udf/TransportCreateUserDefinedFunction.java
+++ b/server/src/main/java/io/crate/expression/udf/TransportCreateUserDefinedFunction.java
@@ -91,6 +91,6 @@ public class TransportCreateUserDefinedFunction
 
     @Override
     protected ClusterBlockException checkBlock(CreateUserDefinedFunctionRequest request, ClusterState state) {
-        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_READ);
+        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE);
     }
 }

--- a/server/src/main/java/io/crate/expression/udf/TransportDropUserDefinedFunction.java
+++ b/server/src/main/java/io/crate/expression/udf/TransportDropUserDefinedFunction.java
@@ -91,6 +91,6 @@ public class TransportDropUserDefinedFunction
 
     @Override
     protected ClusterBlockException checkBlock(DropUserDefinedFunctionRequest request, ClusterState state) {
-        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_READ);
+        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE);
     }
 }

--- a/server/src/main/java/io/crate/role/TransportCreateRole.java
+++ b/server/src/main/java/io/crate/role/TransportCreateRole.java
@@ -120,7 +120,7 @@ public class TransportCreateRole extends TransportMasterNodeAction<CreateRoleReq
 
     @Override
     protected ClusterBlockException checkBlock(CreateRoleRequest request, ClusterState state) {
-        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_READ);
+        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE);
     }
 
     /**

--- a/server/src/main/java/io/crate/role/TransportDropRole.java
+++ b/server/src/main/java/io/crate/role/TransportDropRole.java
@@ -118,6 +118,6 @@ public class TransportDropRole extends TransportMasterNodeAction<DropRoleRequest
 
     @Override
     protected ClusterBlockException checkBlock(DropRoleRequest request, ClusterState state) {
-        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_READ);
+        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE);
     }
 }

--- a/server/src/test/java/io/crate/expression/udf/TransportCreateUserDefinedFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/udf/TransportCreateUserDefinedFunctionTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.expression.udf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.util.EnumSet;
+
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.block.ClusterBlock;
+import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.block.ClusterBlocks;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+import org.junit.Test;
+
+import io.crate.rest.action.HttpErrorStatus;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+
+public class TransportCreateUserDefinedFunctionTest extends CrateDummyClusterServiceUnitTest {
+
+    @Test
+    public void testCheckBlocks() {
+        var transportCreateUserDefinedFunction = new TransportCreateUserDefinedFunction(
+            mock(TransportService.class),
+            mock(ClusterService.class),
+            mock(ThreadPool.class),
+            mock(UserDefinedFunctionService.class)
+        );
+        var globalBlock = new ClusterBlock(
+            1,
+            "uuid",
+            "cannot write metadata",
+            true,
+            true,
+            true,
+            HttpErrorStatus.UNHANDLED_SERVER_ERROR,
+            EnumSet.of(ClusterBlockLevel.METADATA_WRITE)
+        );
+        var newState = ClusterState.builder(clusterService.state())
+            .blocks(ClusterBlocks.builder().addGlobalBlock(globalBlock))
+            .build();
+
+        assertThat(transportCreateUserDefinedFunction.checkBlock(
+            new CreateUserDefinedFunctionRequest(null, true), newState).blocks())
+            .containsExactly(globalBlock);
+    }
+}

--- a/server/src/test/java/io/crate/expression/udf/TransportDropUserDefinedFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/udf/TransportDropUserDefinedFunctionTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.expression.udf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.util.EnumSet;
+import java.util.List;
+
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.block.ClusterBlock;
+import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.block.ClusterBlocks;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+import org.junit.Test;
+
+import io.crate.rest.action.HttpErrorStatus;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+
+public class TransportDropUserDefinedFunctionTest extends CrateDummyClusterServiceUnitTest {
+
+    @Test
+    public void testCheckBlocks() {
+        var transportDropUserDefinedFunction = new TransportDropUserDefinedFunction(
+            mock(TransportService.class),
+            mock(ClusterService.class),
+            mock(ThreadPool.class),
+            mock(UserDefinedFunctionService.class)
+        );
+        var globalBlock = new ClusterBlock(
+            1,
+            "uuid",
+            "cannot write metadata",
+            true,
+            true,
+            true,
+            HttpErrorStatus.UNHANDLED_SERVER_ERROR,
+            EnumSet.of(ClusterBlockLevel.METADATA_WRITE)
+        );
+        var newState = ClusterState.builder(clusterService.state())
+            .blocks(ClusterBlocks.builder().addGlobalBlock(globalBlock))
+            .build();
+
+        assertThat(transportDropUserDefinedFunction.checkBlock(
+            new DropUserDefinedFunctionRequest("s", "f", List.of(), true), newState).blocks())
+            .containsExactly(globalBlock);
+    }
+}

--- a/server/src/test/java/io/crate/role/TransportCreateRoleTest.java
+++ b/server/src/test/java/io/crate/role/TransportCreateRoleTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.role;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.util.EnumSet;
+
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.block.ClusterBlock;
+import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.block.ClusterBlocks;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+import org.junit.Test;
+
+import io.crate.rest.action.HttpErrorStatus;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+
+public class TransportCreateRoleTest extends CrateDummyClusterServiceUnitTest {
+
+    @Test
+    public void testCheckBlocks() {
+        var transportCreateRole = new TransportCreateRole(
+            mock(TransportService.class),
+            mock(ClusterService.class),
+            mock(ThreadPool.class)
+        );
+        var globalBlock = new ClusterBlock(
+            1,
+            "uuid",
+            "cannot write metadata",
+            true,
+            true,
+            true,
+            HttpErrorStatus.UNHANDLED_SERVER_ERROR,
+            EnumSet.of(ClusterBlockLevel.METADATA_WRITE)
+        );
+        var newState = ClusterState.builder(clusterService.state())
+            .blocks(ClusterBlocks.builder().addGlobalBlock(globalBlock))
+            .build();
+
+        assertThat(transportCreateRole.checkBlock(new CreateRoleRequest("test", true, null, null), newState).blocks())
+            .containsExactly(globalBlock);
+    }
+}

--- a/server/src/test/java/io/crate/role/TransportDropRoleTest.java
+++ b/server/src/test/java/io/crate/role/TransportDropRoleTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.role;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.util.EnumSet;
+
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.block.ClusterBlock;
+import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.block.ClusterBlocks;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+import org.junit.Test;
+
+import io.crate.replication.logical.LogicalReplicationService;
+import io.crate.rest.action.HttpErrorStatus;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+
+public class TransportDropRoleTest extends CrateDummyClusterServiceUnitTest {
+
+    @Test
+    public void testCheckBlocks() {
+        var transportDropRole = new TransportDropRole(
+            mock(TransportService.class),
+            mock(ClusterService.class),
+            mock(ThreadPool.class),
+            mock(LogicalReplicationService.class)
+        );
+        var globalBlock = new ClusterBlock(
+            1,
+            "uuid",
+            "cannot write metadata",
+            true,
+            true,
+            true,
+            HttpErrorStatus.UNHANDLED_SERVER_ERROR,
+            EnumSet.of(ClusterBlockLevel.METADATA_WRITE)
+        );
+        var newState = ClusterState.builder(clusterService.state())
+            .blocks(ClusterBlocks.builder().addGlobalBlock(globalBlock))
+            .build();
+
+        assertThat(transportDropRole.checkBlock(new DropRoleRequest("test", true), newState).blocks())
+            .containsExactly(globalBlock);
+    }
+}


### PR DESCRIPTION
Since we change the Metadata the blocks check should be for WRITE, not READ.

