### PR TITLE
Ensure that errors happened on sendResponse are shown to a user

### DIFF
--- a/docs/appendices/release-notes/6.2.3.rst
+++ b/docs/appendices/release-notes/6.2.3.rst
@@ -55,3 +55,5 @@ Fixes
 - Fixed an issue causing memory leaks if requests to the ``HTTP`` endpoint
   failed to create a session, for example, due to wrong authentication headers.
 
+- Fixed an issue causing clients to not receive errors, happened on sending a
+  response from ``HTTP`` endpoint.

--- a/server/src/main/java/io/crate/rest/action/SqlHttpHandler.java
+++ b/server/src/main/java/io/crate/rest/action/SqlHttpHandler.java
@@ -142,7 +142,8 @@ public class SqlHttpHandler extends SimpleChannelInboundHandler<FullHttpRequest>
                 } catch (Throwable ex) {
                     resultBuffer.release();
                     LOGGER.error("Error sending response", ex);
-                    throw ex;
+                    // Let the last handler deal with it and maybe send failure info to the user.
+                    ctx.fireExceptionCaught(ex);
                 } finally {
                     request.release();
                 }

--- a/server/src/test/java/io/crate/rest/action/SqlHttpHandlerTest.java
+++ b/server/src/test/java/io/crate/rest/action/SqlHttpHandlerTest.java
@@ -33,6 +33,7 @@ import static org.mockito.Mockito.when;
 
 import java.net.InetAddress;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 
@@ -45,6 +46,7 @@ import org.mockito.ArgumentCaptor;
 import io.crate.auth.AuthSettings;
 import io.crate.auth.Protocol;
 import io.crate.metadata.settings.CoordinatorSessionSettings;
+import io.crate.protocols.http.MainAndStaticFileHandler;
 import io.crate.protocols.postgres.ConnectionProperties;
 import io.crate.role.Role;
 import io.crate.role.metadata.RolesHelper;
@@ -225,6 +227,48 @@ public class SqlHttpHandlerTest {
             channel.writeInbound(request);
         } catch (Exception ignored) { }
         assertThat(request.refCnt()).isEqualTo(0);
+    }
+
+    @Test
+    public void test_send_response_failure_sent_to_a_client() throws Exception {
+        var mockedSession = mock(Session.class);
+        // Imitate that sendResponse failed for whatever reason
+        when(mockedSession.sessionSettings()).thenThrow(new RuntimeException("dummy"));
+        var sessions = mock(Sessions.class);
+        when(sessions.newSession(any(), any(), any())).thenReturn(mockedSession);
+
+        SqlHttpHandler handler = new SqlHttpHandler(
+            Settings.EMPTY,
+            sessions,
+            _ -> new NoopCircuitBreaker("dummy"),
+            () -> List.of(RolesHelper.userOf("crate"))
+        );
+
+        EmbeddedChannel channel = new EmbeddedChannel(
+            handler,
+            // Last handler that is catching all exceptions and sending error back to the client.
+            new MainAndStaticFileHandler("node", Path.of("a", "b"), null)
+        );
+        var request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/_sql");
+
+        channel.writeInbound(request);
+        channel.releaseInbound();
+
+        assertThat(request.refCnt()).isEqualTo(0);
+        FullHttpResponse response = null;
+        try {
+            response = channel.readOutbound();
+            assertThat(response).isNotNull();
+            assertThat(response.status()).isEqualTo(HttpResponseStatus.INTERNAL_SERVER_ERROR);
+            assertThat(response.content().toString(StandardCharsets.UTF_8)).contains("dummy");
+        } finally {
+            if (response != null) {
+                // EmbeddedChannel.doWrite retains buffer written in MainAndStaticFileHandler.send500().
+                // After readOutbound() call, test gets an ownership of the buffer, need to release it explicitly.
+                response.release();
+            }
+
+        }
     }
 }
 


### PR DESCRIPTION
Spot this while debugging https://github.com/crate/support/issues/847 but it's not related