### PR TITLE
Fix NPE on HTTP request handling 

### DIFF
--- a/server/src/main/java/io/crate/rest/action/SqlHttpHandler.java
+++ b/server/src/main/java/io/crate/rest/action/SqlHttpHandler.java
@@ -58,6 +58,7 @@ import io.crate.data.breaker.BlockBasedRamAccounting;
 import io.crate.data.breaker.RamAccounting;
 import io.crate.exceptions.SQLExceptions;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.settings.CoordinatorSessionSettings;
 import io.crate.netty.AccountedByteBuf;
 import io.crate.protocols.http.Headers;
 import io.crate.protocols.postgres.ConnectionProperties;
@@ -93,7 +94,8 @@ public class SqlHttpHandler extends SimpleChannelInboundHandler<FullHttpRequest>
     private final Roles roles;
     private final boolean checkJwtProperties;
 
-    private Session session;
+    @VisibleForTesting
+    Session session;
 
     public SqlHttpHandler(Settings settings,
                           Sessions sessions,
@@ -138,7 +140,8 @@ public class SqlHttpHandler extends SimpleChannelInboundHandler<FullHttpRequest>
         handleSQLRequest(session, resultBuffer, content, paramContainFlag(parameters, "types"))
             .whenComplete((_, t) -> {
                 try {
-                    sendResponse(ctx, request, parameters, resultBuffer, t);
+                    // Use local sessionSettings to avoid async ref mutation from channelUnregistered
+                    sendResponse(session.sessionSettings(), ctx, request, parameters, resultBuffer, t);
                 } catch (Throwable ex) {
                     resultBuffer.release();
                     LOGGER.error("Error sending response", ex);
@@ -168,7 +171,8 @@ public class SqlHttpHandler extends SimpleChannelInboundHandler<FullHttpRequest>
         super.channelUnregistered(ctx);
     }
 
-    void sendResponse(ChannelHandlerContext ctx,
+    void sendResponse(CoordinatorSessionSettings sessionSettings,
+                      ChannelHandlerContext ctx,
                       FullHttpRequest request,
                       Map<String, List<String>> parameters,
                       ByteBuf result,
@@ -184,7 +188,6 @@ public class SqlHttpHandler extends SimpleChannelInboundHandler<FullHttpRequest>
             // In case of partial success buffer can contain some data
             // Clearing buffer to ensure that error is not mixed with partial result.
             result.clear();
-            var sessionSettings = session.sessionSettings();
             AccessControl accessControl = roles.getAccessControl(sessionSettings.authenticatedUser(), sessionSettings.sessionUser());
             var throwable = SQLExceptions.prepareForClientTransmission(accessControl, t);
             HttpError httpError = HttpError.fromThrowable(throwable);
@@ -214,7 +217,8 @@ public class SqlHttpHandler extends SimpleChannelInboundHandler<FullHttpRequest>
         ctx.writeAndFlush(resp, promise);
     }
 
-    private CompletableFuture<XContentBuilder> handleSQLRequest(Session session,
+    @VisibleForTesting
+    CompletableFuture<XContentBuilder> handleSQLRequest(Session session,
                                                                 ByteBuf resultBuffer,
                                                                 ByteBuf content,
                                                                 boolean includeTypes) {

--- a/server/src/test/java/io/crate/rest/action/SqlHttpHandlerTest.java
+++ b/server/src/test/java/io/crate/rest/action/SqlHttpHandlerTest.java
@@ -25,9 +25,11 @@ import static io.crate.role.metadata.RolesHelper.JWT_TOKEN;
 import static io.crate.role.metadata.RolesHelper.JWT_USER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -36,12 +38,14 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.settings.Settings;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
 
 import io.crate.auth.AuthSettings;
 import io.crate.auth.Protocol;
@@ -52,6 +56,8 @@ import io.crate.role.Role;
 import io.crate.role.metadata.RolesHelper;
 import io.crate.session.Session;
 import io.crate.session.Sessions;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.SQLExecutor;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
@@ -65,7 +71,7 @@ import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
 
-public class SqlHttpHandlerTest {
+public class SqlHttpHandlerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testDefaultUserIfHttpHeaderNotPresent() {
@@ -134,7 +140,7 @@ public class SqlHttpHandlerTest {
 
         // 1st call to ensureSession creates a session instance bound to 'dummyUser'
         var session = handler.ensureSession(connectionProperties, mockedRequest);
-        verify(mockedRequest, atLeast(1)).headers();
+        verify(mockedRequest, Mockito.atLeast(1)).headers();
         assertThat(session.sessionSettings().authenticatedUser()).isEqualTo(dummyUser);
         assertThat(session.sessionSettings().searchPath().currentSchema()).contains("doc");
         assertThat(session.sessionSettings().hashJoinsEnabled()).isTrue();
@@ -193,8 +199,8 @@ public class SqlHttpHandlerTest {
         when(ctx.writeAndFlush(responseCaptor.capture(), eq(promise))).thenReturn(promise);
 
         // Create internal session as it shouldn't be null for the test.
-        handler.ensureSession(null, request);
-        handler.sendResponse(ctx, request, Map.of(), resultBuffer, new CircuitBreakingException("CBE"));
+        var session = handler.ensureSession(null, request);
+        handler.sendResponse(session.sessionSettings(), ctx, request, Map.of(), resultBuffer, new CircuitBreakingException("CBE"));
 
         FullHttpResponse response = responseCaptor.getValue();
         ByteBuf responseContent = response.content();
@@ -267,6 +273,46 @@ public class SqlHttpHandlerTest {
                 response.release();
             }
 
+        }
+    }
+
+    @Test
+    public void test_channel_unregistered_during_execution_can_send_response() throws Exception {
+        var sessions = SQLExecutor.of(clusterService).sqlOperations;
+        SqlHttpHandler handler = spy(new SqlHttpHandler(
+            Settings.EMPTY,
+            sessions,
+            _ -> new NoopCircuitBreaker("dummy"),
+            () -> List.of(Role.CRATE_USER)
+        ));
+
+        doAnswer(invocation -> {
+            // Imitate that session was set to null via channelUnregistered
+            // during execution that failed with some exception.
+            // sendResponse should be safe from NPE regardless
+            handler.session = null;
+            return CompletableFuture.failedFuture(new RuntimeException("dummy"));
+        }).when(handler).handleSQLRequest(any(), any(), any(), anyBoolean());
+        EmbeddedChannel channel = new EmbeddedChannel(handler);
+
+        var request = new DefaultFullHttpRequest(
+            HttpVersion.HTTP_1_1, HttpMethod.POST,
+            "/_sql",
+            Unpooled.copiedBuffer("{\"stmt\":\"select 1\"}", StandardCharsets.UTF_8)
+        );
+
+        channel.writeInbound(request);
+
+        FullHttpResponse response = null;
+        try {
+            response = channel.readOutbound();
+            assertThat(response).isNotNull();
+            assertThat(response.status()).isEqualTo(HttpResponseStatus.INTERNAL_SERVER_ERROR);
+            assertThat(response.content().toString(StandardCharsets.UTF_8)).contains("dummy");
+        } finally {
+            if (response != null) {
+                response.release();
+            }
         }
     }
 }


### PR DESCRIPTION
Relates to https://github.com/crate/support/issues/847

Fixes a regression introduced with https://github.com/crate/crate/commit/a6869c042f458721b03a07fa3804e009bfa445a0

UPD: see https://github.com/crate/crate/pull/19130#issuecomment-4067451177, it's a regression, but not really a using facing issue

We shouldn't use field (and instead use captured session) as session can be nullified during the async execution in `channelUnregistered` event

Reproduction: added `channelUnregistered` call before sendResponse, got NPE-s, see https://jenkins.crate.io/job/CrateDB/job/crate_on_pr/3858/#showFailuresLink

Then reverted  https://github.com/crate/crate/commit/a6869c042f458721b03a07fa3804e009bfa445a0 and kept channelUnregistered: [all but 1 test pass](https://jenkins.crate.io/job/CrateDB/job/crate_on_pr/3861/).
`test_connection_reset_doesnt_leak_bufs_or_sessions` fails in `assertThat(numSessions).isEqualTo(1)`
because we close session in reproduction, but other tests pass and there is no NPE anymore.

