### PR TITLE
Remove releaseInbound in a test where it's not needed

### DIFF
--- a/server/src/test/java/io/crate/rest/action/SqlHttpHandlerTest.java
+++ b/server/src/test/java/io/crate/rest/action/SqlHttpHandlerTest.java
@@ -252,7 +252,6 @@ public class SqlHttpHandlerTest {
         var request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/_sql");
 
         channel.writeInbound(request);
-        channel.releaseInbound();
 
         assertThat(request.refCnt()).isEqualTo(0);
         FullHttpResponse response = null;


### PR DESCRIPTION
Artefact of experiments done in https://github.com/crate/crate/commit/5e0a66add0aaf66308592200c6f63861c156b5fc, forgot to remove 

See https://github.com/crate/crate/pull/19128#issuecomment-4055271297, 
`inboundQueue` is null, it's a no-op here and is not needed. 

Forgot to clean up 🤦, noticed when copied this test as a template for another PR.


