### PR TITLE
Fix NPE in SQLHttpIntegrationTest

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/SQLHttpIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SQLHttpIntegrationTest.java
@@ -113,7 +113,9 @@ public abstract class SQLHttpIntegrationTest extends IntegTestCase {
 
     @After
     public void closeClient() throws Exception {
-        this.httpClient.close();
+        if (httpClient != null) {
+            httpClient.close();
+        }
     }
 
     @Override


### PR DESCRIPTION
If there is an error in the `IntegTestCase` setup it can happen that the
`httpClient` of `SQLHttpIntegrationTest` doesn't get initialized as the
`Before` logic isn't called.

In that case, it led to another error on the teardown.

    Expecting value to be false but was true
    		at org.elasticsearch.test.TestCluster.wipeAllTables(TestCluster.java:405)
    		at org.elasticsearch.test.TestCluster.wipe(TestCluster.java:381)
    		at org.elasticsearch.test.IntegTestCase.lambda$beforeInternal$0(IntegTestCase.java:346)
    		at com.carrotsearch.randomizedtesting.RandomizedContext.runWithPrivateRandomness(RandomizedContext.java:187)
    		at com.carrotsearch.randomizedtesting.RandomizedContext.runWithPrivateRandomness(RandomizedContext.java:211)
    		at org.elasticsearch.test.IntegTestCase.beforeInternal(IntegTestCase.java:353)
    		at org.elasticsearch.test.IntegTestCase.setupTestCluster(IntegTestCase.java:1175)
    		at java.base/java.lang.reflect.Method.invoke(Method.java:565)
    		at com.carrotsearch.randomizedtesting.RandomizedRunner.invoke(RandomizedRunner.java:1763)
    		at com.carrotsearch.randomizedtesting.RandomizedRunner$9.evaluate(RandomizedRunner.java:980)
    		at com.carrotsearch.randomizedtesting.RandomizedRunner$10.evaluate(RandomizedRunner.java:996)
    		at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:328)
    		... 1 more
    	Suppressed: java.lang.NullPointerException: Cannot invoke "java.net.http.HttpClient.close()" because "this.httpClient" is null
    		at io.crate.integrationtests.SQLHttpIntegrationTest.closeClient(SQLHttpIntegrationTest.java:116)
    		at java.base/java.lang.reflect.Method.invoke(Method.java:565)
    		at com.carrotsearch.randomizedtesting.RandomizedRunner.invoke(RandomizedRunner.java:1763)
    		at com.carrotsearch.randomizedtesting.RandomizedRunner$10.evaluate(RandomizedRunner.java:1004)
    		at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:328)
    		... 1 more
