### PR TITLE
Release 6.2.3

### DIFF
--- a/docs/appendices/release-notes/6.2.3.rst
+++ b/docs/appendices/release-notes/6.2.3.rst
@@ -1,16 +1,10 @@
 .. _version_6.2.3:
 
-==========================
-Version 6.2.3 - Unreleased
-==========================
+=============
+Version 6.2.3
+=============
 
-.. comment 1. Remove the " - Unreleased" from the header above and adjust the ==
-.. comment 2. Remove the NOTE below and replace with: "Released on 20XX-XX-XX."
-.. comment    (without a NOTE entry, simply starting from col 1 of the line)
-.. NOTE::
-
-    In development. 6.2.3 isn't released yet. These are the release notes for
-    the upcoming release.
+Released on 2026-03-17.
 
 .. NOTE::
 


### PR DESCRIPTION
6.2.3 already has `snapshot=false.` 

We missed to set it to `true` in https://github.com/crate/crate/pull/19103/ 
(afaik shouldn't be a problem for already released versions as it's unused there)
