### PR TITLE
Reduce amount of apply calls for global aggregates

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/aggregation/DocValueAggregator.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/DocValueAggregator.java
@@ -23,12 +23,13 @@ package io.crate.execution.engine.aggregation;
 
 import java.io.IOException;
 
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.DocAndFloatFeatureBuffer;
+import org.elasticsearch.Version;
 import org.jspecify.annotations.Nullable;
 
 import io.crate.data.breaker.RamAccounting;
 import io.crate.memory.MemoryManager;
-import org.apache.lucene.index.LeafReaderContext;
-import org.elasticsearch.Version;
 
 public interface DocValueAggregator<T> {
 
@@ -37,6 +38,12 @@ public interface DocValueAggregator<T> {
     void loadDocValues(LeafReaderContext leafReaderContext) throws IOException;
 
     void apply(RamAccounting ramAccounting, int doc, T state) throws IOException;
+
+    default void applyBulk(RamAccounting ramAccounting, DocAndFloatFeatureBuffer buffer, T state) throws IOException {
+        for (int i = 0; i < buffer.size; i++) {
+            apply(ramAccounting, buffer.docs[i], state);
+        }
+    }
 
     // Aggregations are executed on shard level,
     // that means there is always a final reduce step necessary

--- a/server/src/main/java/io/crate/execution/engine/collect/DocValuesAggregates.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/DocValuesAggregates.java
@@ -29,7 +29,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.lucene.index.LeafReaderContext;
-import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.DocAndFloatFeatureBuffer;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreMode;
@@ -245,6 +245,7 @@ public final class DocValuesAggregates {
         for (int i = 0; i < aggregators.size(); i++) {
             cells[i] = aggregators.get(i).initialState(ramAccounting, memoryManager, minNodeVersion);
         }
+        DocAndFloatFeatureBuffer buffer = new DocAndFloatFeatureBuffer();
         for (var leaf : leaves) {
             Scorer scorer = weight.scorer(leaf);
             if (scorer == null) {
@@ -253,18 +254,20 @@ public final class DocValuesAggregates {
             for (int i = 0; i < aggregators.size(); i++) {
                 aggregators.get(i).loadDocValues(leaf);
             }
-            DocIdSetIterator docs = scorer.iterator();
+            int max = leaf.reader().maxDoc();
             Bits liveDocs = leaf.reader().getLiveDocs();
-            for (int doc = docs.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = docs.nextDoc()) {
-                if (liveDocs != null && !liveDocs.get(doc)) {
-                    continue;
-                }
+            if (scorer.docID() < 0) {
+                scorer.iterator().advance(0);
+            }
+            for (scorer.nextDocsAndScores(max, liveDocs, buffer);
+                    buffer.size > 0;
+                    scorer.nextDocsAndScores(max, liveDocs, buffer)) {
                 Throwable killCause = killed.get();
                 if (killCause != null) {
                     Exceptions.rethrowUnchecked(killCause);
                 }
                 for (int i = 0; i < aggregators.size(); i++) {
-                    aggregators.get(i).apply(ramAccounting, doc, cells[i]);
+                    aggregators.get(i).applyBulk(ramAccounting, buffer, cells[i]);
                 }
             }
         }


### PR DESCRIPTION
Uses `nextDocsAndScores` to load a few doc id's into an array to then replace per-doc `apply` calls with fewer `applyBulk` calls. The reasoning is that virtual `apply` calls can be fairly expensive. https://github.com/apache/lucene/commit/9e7381cc5cc76234eb232b3adab43bbabd167add explains this a bit more.


```
Q: select max(duration) from uservisits
C: 1
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |        8.831 ±   10.121 |      7.070 |      7.930 |      8.599 |    229.301 |
|   V2    |        6.827 ±    7.687 |      5.518 |      5.989 |      6.640 |    174.804 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -  25.60%                           -  27.89%   
There is a 99.96% probability that the observed difference is not random, and the best estimate of that difference is 25.60%
The test has statistical significance

Q: select min(duration) from uservisits
C: 1
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |        7.873 ±    2.741 |      6.887 |      7.398 |      7.773 |     49.279 |
|   V2    |        5.110 ±    2.270 |      4.492 |      4.773 |      4.899 |     49.379 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -  42.56%                           -  43.13%   
There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 42.56%
The test has statistical significance

perf stat
  v1
    branches:u        :  140170587165.00
    cache-misses:u    :     462216830.00
    instructions:u    :  674875392824.00
    faults:u          :         27002.00
    context-switches:u:             0.00
  v2
    branches:u        :   96737983926.00
    cache-misses:u    :     344029293.00
    instructions:u    :  438203838179.00
    faults:u          :         10620.00
    context-switches:u:             0.00
```

JFR diff for max:

<img width="2120" height="2102" alt="image" src="https://github.com/user-attachments/assets/64afcb79-e465-4dc4-9525-69436cb54e74" />


