### PR TITLE
Use vector API for global max aggregates on long columns

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,8 +53,11 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${versions.plugin.compiler}</version>
                 <configuration>
+                    <enablePreview>true</enablePreview>
                     <compilerArgs>
                         <arg>-proc:full</arg>
+                        <arg>--add-modules</arg>
+                        <arg>jdk.incubator.vector</arg>
                     </compilerArgs>
                 </configuration>
             </plugin>
@@ -301,7 +304,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.release>25</maven.compiler.release>
+        <maven.compiler.release>26</maven.compiler.release>
 
         <!-- see surefire plugin configuration for explanation -->
         <skipRunTests>false</skipRunTests>

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/MaximumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/MaximumAggregation.java
@@ -27,6 +27,8 @@ import java.util.List;
 import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.SortedNumericDocValues;
+import org.apache.lucene.search.DocAndFloatFeatureBuffer;
+import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.NumericUtils;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
@@ -60,6 +62,9 @@ import io.crate.types.LongType;
 import io.crate.types.NumericType;
 import io.crate.types.ShortType;
 import io.crate.types.TimestampType;
+import jdk.incubator.vector.LongVector;
+import jdk.incubator.vector.VectorOperators;
+import jdk.incubator.vector.VectorSpecies;
 
 public abstract class MaximumAggregation extends AggregationFunction<Object, Object> {
 
@@ -91,8 +96,10 @@ public abstract class MaximumAggregation extends AggregationFunction<Object, Obj
 
     private static class LongMax implements DocValueAggregator<MutableLong> {
 
+        private static final VectorSpecies<Long> SPECIES = LongVector.SPECIES_PREFERRED;
         private final String columnName;
         private final DataType<?> partialType;
+        private long[] longValues = new long[64];
         private SortedNumericDocValues values;
 
         public LongMax(String columnName, DataType<?> partialType) {
@@ -116,6 +123,36 @@ public abstract class MaximumAggregation extends AggregationFunction<Object, Obj
             if (values.advanceExact(doc) && values.docValueCount() == 1) {
                 long value = values.nextValue();
                 if (value >= state.value()) {
+                    state.setValue(value);
+                }
+            }
+            return state;
+        }
+
+        @Override
+        public MutableLong applyBulk(RamAccounting ramAccounting, DocAndFloatFeatureBuffer buffer, MutableLong state) throws IOException {
+            longValues = ArrayUtil.growNoCopy(longValues, buffer.size);
+            for (int i = 0; i < buffer.size; i++) {
+                int doc = buffer.docs[i];
+                if (values.advanceExact(doc) && values.docValueCount() == 1) {
+                    longValues[i] = values.nextValue();
+                } else {
+                    longValues[i] = Long.MIN_VALUE;
+                }
+            }
+            int i = 0;
+            int upperBound = SPECIES.loopBound(buffer.size);
+            for (; i < upperBound; i += SPECIES.length()) {
+                var mask = SPECIES.indexInRange(i, buffer.size);
+                LongVector vec = LongVector.fromArray(SPECIES, longValues, i, mask);
+                long max = vec.reduceLanes(VectorOperators.MAX);
+                if (max > state.value()) {
+                    state.setValue(max);
+                }
+            }
+            for (; i < buffer.size; i++) {
+                long value = longValues[i];
+                if (value > state.value()) {
                     state.setValue(value);
                 }
             }

--- a/server/src/test/java/io/crate/integrationtests/AggregateExpressionIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/AggregateExpressionIntegrationTest.java
@@ -45,6 +45,16 @@ public class AggregateExpressionIntegrationTest extends IntegTestCase {
     }
 
     @Test
+    public void test_max_long() throws Exception {
+        execute("create table tbl (x long)");
+        execute("insert into tbl (x) values (1), (2), (3)");
+        execute("refresh table tbl");
+
+        execute("select max(x) from tbl");
+        assertThat(response).hasRows("3");
+    }
+
+    @Test
     public void test_min_and_max_by() {
         execute("create table tbl (name text, x int)");
         execute("insert into tbl (name, x) values (?, ?)",


### PR DESCRIPTION
Parking this for now to first get a couple of nightly benchmarks that include Lucene 10.4 and https://github.com/crate/crate/pull/19146

But looks like it could give another slight boost. Although variance is a bit higher. Will also need to run it on CPUs with different SIMD extensions. I can imagine that the long values array filling might lead to a slow down on different hardware.

```
Q: select max(duration) from uservisits
C: 1
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |        7.207 ±    7.864 |      5.815 |      6.364 |      7.147 |    179.092 |
|   V2    |        6.286 ±    8.082 |      5.045 |      5.438 |      5.831 |    182.546 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -  13.66%                           -  15.69%   
There is a 93.20% probability that the observed difference is not random, and the best estimate of that difference is 13.66%
The test has no statistical significance
```

<img width="2904" height="1218" alt="image" src="https://github.com/user-attachments/assets/2492534a-5b4b-45d0-b088-2d36a32c8b27" />
