### PR TITLE
Use List instead of Set in Repository list API

### DIFF
--- a/libs/opendal/src/main/java/io/crate/opendal/OpenDALBlobContainer.java
+++ b/libs/opendal/src/main/java/io/crate/opendal/OpenDALBlobContainer.java
@@ -24,11 +24,10 @@ package io.crate.opendal;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.FileAlreadyExistsException;
+import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -121,14 +120,14 @@ public class OpenDALBlobContainer implements BlobContainer {
     }
 
     @Override
-    public Set<String> listBlobs() throws IOException {
+    public List<String> listBlobs() throws IOException {
         return listBlobsByPrefix("");
     }
 
     @Override
-    public Set<String> listBlobsByPrefix(String blobNamePrefix) throws IOException {
+    public List<String> listBlobsByPrefix(String blobNamePrefix) throws IOException {
         String fullPath = this.path.buildAsString() + blobNamePrefix;
-        HashSet<String> result = new HashSet<>();
+        List<String> result = new ArrayList<>();
         for (var entry : operator.list(fullPath)) {
             result.add(entry.getPath());
         }

--- a/plugins/es-repository-url/src/main/java/org/elasticsearch/common/blobstore/url/URLBlobContainer.java
+++ b/plugins/es-repository-url/src/main/java/org/elasticsearch/common/blobstore/url/URLBlobContainer.java
@@ -28,7 +28,6 @@ import java.net.URL;
 import java.nio.file.NoSuchFileException;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import org.elasticsearch.common.blobstore.BlobContainer;
 import org.elasticsearch.common.blobstore.BlobPath;
@@ -78,7 +77,7 @@ public class URLBlobContainer extends AbstractBlobContainer {
      * This operation is not supported by URLBlobContainer
      */
     @Override
-    public Set<String> listBlobs() throws IOException {
+    public List<String> listBlobs() throws IOException {
         throw new UnsupportedOperationException("URL repository doesn't support this operation");
     }
 
@@ -91,7 +90,7 @@ public class URLBlobContainer extends AbstractBlobContainer {
      * This operation is not supported by URLBlobContainer
      */
     @Override
-    public Set<String> listBlobsByPrefix(String blobNamePrefix) throws IOException {
+    public List<String> listBlobsByPrefix(String blobNamePrefix) throws IOException {
         throw new UnsupportedOperationException("URL repository doesn't support this operation");
     }
 

--- a/server/src/main/java/org/elasticsearch/common/blobstore/BlobContainer.java
+++ b/server/src/main/java/org/elasticsearch/common/blobstore/BlobContainer.java
@@ -25,7 +25,6 @@ import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.NoSuchFileException;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * An interface for managing a repository of blob entries, where each blob entry is just a named group of bytes.
@@ -148,20 +147,17 @@ public interface BlobContainer {
     /**
      * Lists all blobs in the container.
      *
-     * @return  A map of all the blobs in the container.  The keys in the map are the names of the blobs and
-     *          the values are {@link BlobMetadata}, containing basic information about each blob.
+     * @return  A List of all the blobs in the container.
      * @throws  IOException if there were any failures in reading from the blob container.
      */
-    Set<String> listBlobs() throws IOException;
+    List<String> listBlobs() throws IOException;
 
     /**
      * Lists all blobs in the container that match the specified prefix.
      *
      * @param   blobNamePrefix
      *          The prefix to match against blob names in the container.
-     * @return  A map of the matching blobs in the container.  The keys in the map are the names of the blobs
-     *          and the values are {@link BlobMetadata}, containing basic information about each blob.
-     * @throws  IOException if there were any failures in reading from the blob container.
+     * @return  A List of the matching blobs in the container.
      */
-    Set<String> listBlobsByPrefix(String blobNamePrefix) throws IOException;
+    List<String> listBlobsByPrefix(String blobNamePrefix) throws IOException;
 }

--- a/server/src/main/java/org/elasticsearch/common/blobstore/fs/FsBlobContainer.java
+++ b/server/src/main/java/org/elasticsearch/common/blobstore/fs/FsBlobContainer.java
@@ -19,8 +19,8 @@
 
 package org.elasticsearch.common.blobstore.fs;
 
+import static java.util.Collections.unmodifiableList;
 import static java.util.Collections.unmodifiableMap;
-import static java.util.Collections.unmodifiableSet;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -38,12 +38,11 @@ import java.nio.file.SimpleFileVisitor;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.blobstore.BlobContainer;
@@ -75,7 +74,7 @@ public class FsBlobContainer extends AbstractBlobContainer {
     }
 
     @Override
-    public Set<String> listBlobs() throws IOException {
+    public List<String> listBlobs() throws IOException {
         return listBlobsByPrefix(null);
     }
 
@@ -94,8 +93,8 @@ public class FsBlobContainer extends AbstractBlobContainer {
     }
 
     @Override
-    public Set<String> listBlobsByPrefix(String blobNamePrefix) throws IOException {
-        Set<String> blobs = new HashSet<>();
+    public List<String> listBlobsByPrefix(String blobNamePrefix) throws IOException {
+        List<String> blobs = new ArrayList<>();
 
         blobNamePrefix = blobNamePrefix == null ? "" : blobNamePrefix;
         try (DirectoryStream<Path> stream = Files.newDirectoryStream(path, blobNamePrefix + "*")) {
@@ -112,7 +111,7 @@ public class FsBlobContainer extends AbstractBlobContainer {
                 }
             }
         }
-        return unmodifiableSet(blobs);
+        return unmodifiableList(blobs);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -560,7 +560,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
             threadPool.executor(ThreadPool.Names.SNAPSHOT).execute(new RejectableRunnable() {
                 @Override
                 public void doRun() throws Exception {
-                    final Set<String> rootBlobs = blobContainer().listBlobs();
+                    final List<String> rootBlobs = blobContainer().listBlobs();
                     final RepositoryData repositoryData = safeRepositoryData(repositoryStateId, rootBlobs);
                     // Cache the indices that were found before writing out the new index-N blob so that a stuck master will never
                     // delete an index that was created by another master node after writing this index-N blob.
@@ -590,7 +590,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
      * @param rootBlobs         Blobs at the repository root
      * @return RepositoryData
      */
-    private RepositoryData safeRepositoryData(long repositoryStateId, Set<String> rootBlobs) {
+    private RepositoryData safeRepositoryData(long repositoryStateId, List<String> rootBlobs) {
         final long generation = latestGeneration(rootBlobs);
         final long genToLoad;
         if (bestEffortConsistency) {
@@ -626,7 +626,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
      * @param listener          Listener to invoke once finished
      */
     private void doDeleteShardSnapshots(Collection<SnapshotId> snapshotIds, long repositoryStateId, Map<String, BlobContainer> foundIndices,
-                                        Set<String> rootBlobs, RepositoryData repositoryData, Version repoMetaVersion,
+                                        List<String> rootBlobs, RepositoryData repositoryData, Version repoMetaVersion,
                                         ActionListener<RepositoryData> listener) {
 
         if (SnapshotsService.useShardGenerations(repoMetaVersion)) {
@@ -676,7 +676,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
     }
 
     private void asyncCleanupUnlinkedRootAndIndicesBlobs(Collection<SnapshotId> deletedSnapshots, Map<String, BlobContainer> foundIndices,
-                                                         Set<String> rootBlobs, RepositoryData updatedRepoData,
+                                                         List<String> rootBlobs, RepositoryData updatedRepoData,
                                                          ActionListener<Void> listener) {
         threadPool.executor(ThreadPool.Names.SNAPSHOT).execute(ActionRunnable.wrap(
             listener,
@@ -760,7 +760,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                         @Override
                         public void doRun() throws Exception {
                             final BlobContainer shardContainer = shardContainer(indexId, finalShardId);
-                            final Set<String> blobs = shardContainer.listBlobs();
+                            final List<String> blobs = shardContainer.listBlobs();
                             final BlobStoreIndexShardSnapshots blobStoreIndexShardSnapshots;
                             final long newGen;
                             if (useUUIDs) {
@@ -833,7 +833,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
      */
     private void cleanupStaleBlobs(Collection<SnapshotId> deletedSnapshots,
                                    Map<String, BlobContainer> foundIndices,
-                                   Set<String> rootBlobs,
+                                   List<String> rootBlobs,
                                    RepositoryData newRepoData,
                                    ActionListener<Long> listener) {
         final ActionListener<Long> groupedListener = new MultiActionListener<>(2, Collectors.summingLong(Long::longValue), listener);
@@ -849,7 +849,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
     }
 
     // Finds all blobs directly under the repository root path that are not referenced by the current RepositoryData
-    private List<String> staleRootBlobs(RepositoryData repositoryData, Set<String> rootBlobNames) {
+    private List<String> staleRootBlobs(RepositoryData repositoryData, List<String> rootBlobNames) {
         final Set<String> allSnapshotIds =
             repositoryData.getSnapshotIds().stream().map(SnapshotId::getUUID).collect(Collectors.toSet());
         return rootBlobNames.stream().filter(
@@ -1743,7 +1743,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
             final String generation = ShardGenerations.fixShardGeneration(snapshotStatus.generation());
             LOGGER.debug("[{}] [{}] snapshot to [{}] [{}] ...", shardId, snapshotId, metadata.name(), generation);
             final BlobContainer shardContainer = shardContainer(indexId, shardId);
-            final Set<String> blobs;
+            final List<String> blobs;
             if (generation == null) {
                 try {
                     blobs = shardContainer.listBlobsByPrefix(INDEX_FILE_PREFIX);
@@ -1751,7 +1751,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                     throw new IndexShardSnapshotFailedException(shardId, "failed to list blobs", e);
                 }
             } else {
-                blobs = Collections.singleton(INDEX_FILE_PREFIX + generation);
+                blobs = List.of(INDEX_FILE_PREFIX + generation);
             }
 
             Tuple<BlobStoreIndexShardSnapshots, String> tuple = buildBlobStoreIndexShardSnapshots(blobs, shardContainer, generation);
@@ -2193,7 +2193,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
      */
     private ShardSnapshotMetaDeleteResult deleteFromShardSnapshotMeta(Set<SnapshotId> survivingSnapshots, IndexId indexId,
                                                                       int snapshotShardId, Collection<SnapshotId> snapshotIds,
-                                                                      BlobContainer shardContainer, Set<String> blobs,
+                                                                      BlobContainer shardContainer, List<String> blobs,
                                                                       BlobStoreIndexShardSnapshots snapshots,
                                                                       long indexGeneration) {
         // Build a list of snapshots that should be preserved
@@ -2242,7 +2242,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
 
     // Unused blobs are all previous index-, data- and meta-blobs and that are not referenced by the new index- as well as all
     // temporary blobs
-    private static List<String> unusedBlobs(Set<String> blobs, Set<String> survivingSnapshotUUIDs,
+    private static List<String> unusedBlobs(List<String> blobs, Set<String> survivingSnapshotUUIDs,
                                             BlobStoreIndexShardSnapshots updatedSnapshots) {
         return blobs.stream().filter(blob ->
             blob.startsWith(SNAPSHOT_INDEX_PREFIX)
@@ -2277,7 +2277,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
      *                   {@link SnapshotsService#SHARD_GEN_IN_REPO_DATA_VERSION}.
      * @return tuple of BlobStoreIndexShardSnapshots and the last snapshot index generation
      */
-    private Tuple<BlobStoreIndexShardSnapshots, String> buildBlobStoreIndexShardSnapshots(Set<String> blobs,
+    private Tuple<BlobStoreIndexShardSnapshots, String> buildBlobStoreIndexShardSnapshots(List<String> blobs,
                                                                                           BlobContainer shardContainer,
                                                                                           @Nullable String generation) throws IOException {
         if (generation != null) {
@@ -2296,7 +2296,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
      * @param blobs list of blobs in repository
      * @return tuple of BlobStoreIndexShardSnapshots and the last snapshot index generation
      */
-    private Tuple<BlobStoreIndexShardSnapshots, Long> buildBlobStoreIndexShardSnapshots(Set<String> blobs, BlobContainer shardContainer)
+    private Tuple<BlobStoreIndexShardSnapshots, Long> buildBlobStoreIndexShardSnapshots(List<String> blobs, BlobContainer shardContainer)
             throws IOException {
         long latest = latestGeneration(blobs);
         if (latest >= 0) {

--- a/server/src/test/java/org/elasticsearch/repositories/blobstore/BlobStoreRepositoryTest.java
+++ b/server/src/test/java/org/elasticsearch/repositories/blobstore/BlobStoreRepositoryTest.java
@@ -114,7 +114,7 @@ public class BlobStoreRepositoryTest extends IntegTestCase {
     }
 
     void assertBlobsByPrefix(BlobPath path, String prefix, Set<String> blobs) throws Exception {
-        final FutureActionListener<Set<String>> future = new FutureActionListener<>();
+        final FutureActionListener<List<String>> future = new FutureActionListener<>();
         final BlobStoreRepository repository = getRepository();
         repository.threadPool().generic().execute(new ActionRunnable<>(future) {
             @Override
@@ -123,7 +123,7 @@ public class BlobStoreRepositoryTest extends IntegTestCase {
                 future.onResponse(blobStore.blobContainer(path).listBlobsByPrefix(prefix));
             }
         });
-        Set<String> foundBlobs = future.get();
+        List<String> foundBlobs = future.get();
         if (blobs.isEmpty()) {
             assertThat(foundBlobs).isEmpty();
         } else {

--- a/server/src/test/java/org/elasticsearch/snapshots/BlobStoreFormatIT.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/BlobStoreFormatIT.java
@@ -25,7 +25,7 @@ import static org.assertj.core.api.Assertions.fail;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Set;
+import java.util.List;
 
 import org.elasticsearch.ElasticsearchCorruptionException;
 import org.elasticsearch.ElasticsearchParseException;
@@ -127,7 +127,7 @@ public class BlobStoreFormatIT extends AbstractSnapshotIntegTestCase {
         BlobObj blobObj = new BlobObj(veryRedundantText.toString());
         checksumFormat.write(blobObj, blobContainer, "blob-comp", true);
         checksumFormat.write(blobObj, blobContainer, "blob-not-comp", false);
-        Set<String> blobs = blobContainer.listBlobsByPrefix("blob-");
+        List<String> blobs = blobContainer.listBlobsByPrefix("blob-");
         assertThat(2).isEqualTo(blobs.size());
     }
 

--- a/server/src/test/java/org/elasticsearch/snapshots/mockstore/MockEventuallyConsistentRepository.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/mockstore/MockEventuallyConsistentRepository.java
@@ -30,7 +30,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
@@ -256,7 +255,7 @@ public class MockEventuallyConsistentRepository extends BlobStoreRepository {
             }
 
             @Override
-            public Set<String> listBlobs() {
+            public List<String> listBlobs() {
                 ensureNotClosed();
                 final String thisPath = path.buildAsString();
                 synchronized (context.actions) {
@@ -265,7 +264,7 @@ public class MockEventuallyConsistentRepository extends BlobStoreRepository {
                             action -> action.path.startsWith(thisPath) && action.path.substring(thisPath.length()).indexOf('/') == -1
                                 && action.operation == Operation.PUT)
                         .map(action -> action.path.substring(thisPath.length()))
-                        .collect(Collectors.toSet()));
+                        .collect(Collectors.toList()));
                 }
             }
 
@@ -285,18 +284,18 @@ public class MockEventuallyConsistentRepository extends BlobStoreRepository {
             }
 
             @Override
-            public Set<String> listBlobsByPrefix(String blobNamePrefix) {
+            public List<String> listBlobsByPrefix(String blobNamePrefix) {
                 return maybeMissLatestIndexN(listBlobs().stream().filter(entry -> entry.startsWith(
-                    blobNamePrefix)).collect(Collectors.toSet()));
+                    blobNamePrefix)).collect(Collectors.toList()));
             }
 
             // Randomly filter out the index-N blobs from a listing to test that tracking of it in latestKnownRepoGen and the cluster state
             // ensures consistent repository operations
-            private Set<String> maybeMissLatestIndexN(Set<String> listing) {
+            private List<String> maybeMissLatestIndexN(List<String> listing) {
                 // Randomly filter out index-N blobs at the repo root to proof that we don't need them to be consistently listed
                 if (path.parent() == null && context.consistent == false) {
                     listing.removeIf(b -> b.startsWith(BlobStoreRepository.INDEX_FILE_PREFIX) && random.nextBoolean());
-                    return Set.copyOf(listing);
+                    return List.copyOf(listing);
                 }
                 return listing;
             }

--- a/server/src/testFixtures/java/org/elasticsearch/repositories/blobstore/BlobStoreTestUtil.java
+++ b/server/src/testFixtures/java/org/elasticsearch/repositories/blobstore/BlobStoreTestUtil.java
@@ -246,7 +246,7 @@ public final class BlobStoreTestUtil {
                     }
                     if (shardId < shardCount && snapshotInfo.shardFailures().stream().noneMatch(
                         shardFailure -> shardFailure.index().equals(index) && shardFailure.shardId() == shardId)) {
-                        final Set<String> shardPathContents = shardContainer.listBlobs();
+                        final List<String> shardPathContents = shardContainer.listBlobs();
                         assertThat(shardPathContents).contains(
                             String.format(Locale.ROOT, BlobStoreRepository.SNAPSHOT_NAME_FORMAT, snapshotId.getUUID()));
                         assertThat(shardPathContents.stream()

--- a/server/src/testFixtures/java/org/elasticsearch/snapshots/mockstore/BlobContainerWrapper.java
+++ b/server/src/testFixtures/java/org/elasticsearch/snapshots/mockstore/BlobContainerWrapper.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import org.elasticsearch.common.blobstore.BlobContainer;
 import org.elasticsearch.common.blobstore.BlobPath;
@@ -77,7 +76,7 @@ public class BlobContainerWrapper implements BlobContainer {
     }
 
     @Override
-    public Set<String> listBlobs() throws IOException {
+    public List<String> listBlobs() throws IOException {
         return delegate.listBlobs();
     }
 
@@ -87,7 +86,7 @@ public class BlobContainerWrapper implements BlobContainer {
     }
 
     @Override
-    public Set<String> listBlobsByPrefix(String blobNamePrefix) throws IOException {
+    public List<String> listBlobsByPrefix(String blobNamePrefix) throws IOException {
         return delegate.listBlobsByPrefix(blobNamePrefix);
     }
 }

--- a/server/src/testFixtures/java/org/elasticsearch/snapshots/mockstore/MockRepository.java
+++ b/server/src/testFixtures/java/org/elasticsearch/snapshots/mockstore/MockRepository.java
@@ -31,7 +31,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicLong;
@@ -404,7 +403,7 @@ public class MockRepository extends FsRepository {
                 for (BlobContainer child : children().values()) {
                     child.delete();
                 }
-                final Set<String> blobs = listBlobs();
+                final List<String> blobs = listBlobs();
                 for (String blob : blobs) {
                     maybeIOExceptionOrBlock(blob);
                     deleteBlobsIgnoringIfNotExists(Collections.singletonList(blob));
@@ -423,7 +422,7 @@ public class MockRepository extends FsRepository {
             }
 
             @Override
-            public Set<String> listBlobs() throws IOException {
+            public List<String> listBlobs() throws IOException {
                 maybeIOExceptionOrBlock("");
                 return super.listBlobs();
             }
@@ -438,7 +437,7 @@ public class MockRepository extends FsRepository {
             }
 
             @Override
-            public Set<String> listBlobsByPrefix(String blobNamePrefix) throws IOException {
+            public List<String> listBlobsByPrefix(String blobNamePrefix) throws IOException {
                 maybeIOExceptionOrBlock(blobNamePrefix);
                 return super.listBlobsByPrefix(blobNamePrefix);
             }


### PR DESCRIPTION
Follow up to https://github.com/crate/crate/commit/21857e5e63b2976c72f9976472b2fd4663a506de

File names are unique under the same path.
One file can have different versions, but versioning is either disabled by default for some providers or supported in a dedicated API.

Relates to https://github.com/crate/crate/pull/19159#discussion_r2959146948