### PR TITLE
Cleanup & optimize regexp_matches

### DIFF
--- a/server/src/main/java/io/crate/expression/tablefunctions/MatchesFunction.java
+++ b/server/src/main/java/io/crate/expression/tablefunctions/MatchesFunction.java
@@ -32,12 +32,11 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.elasticsearch.common.settings.Settings;
-import org.jspecify.annotations.Nullable;
 
-import io.crate.common.annotations.VisibleForTesting;
 import io.crate.data.Input;
 import io.crate.data.Row;
 import io.crate.data.RowN;
+import io.crate.expression.RegexpFlags;
 import io.crate.expression.symbol.Symbol;
 import io.crate.legacy.LegacySettings;
 import io.crate.metadata.FunctionType;
@@ -94,18 +93,50 @@ public final class MatchesFunction extends TableFunctionImplementation<String> {
         );
     }
 
-    @Nullable
-    private final Pattern pattern;
     private final RowType returnType;
 
     private MatchesFunction(Signature signature, BoundSignature boundSignature, RowType returnType) {
-        this(signature, boundSignature, null, returnType);
+        super(signature, boundSignature);
+        this.returnType = returnType;
     }
 
-    private MatchesFunction(Signature signature, BoundSignature boundSignature, @Nullable Pattern pattern, RowType returnType) {
-        super(signature, boundSignature);
-        this.pattern = pattern;
-        this.returnType = returnType;
+    static class CompiledMatchesFunction extends TableFunctionImplementation<String> {
+
+        private final Matcher matcher;
+        private final RowType returnType;
+        private final boolean isGlobal;
+
+        private CompiledMatchesFunction(Signature signature,
+                                        BoundSignature boundSignature,
+                                        RowType returnType,
+                                        String pattern,
+                                        String flags) {
+            super(signature, boundSignature);
+            this.returnType = returnType;
+            this.isGlobal = RegexpFlags.isGlobal(flags);
+            this.matcher = Pattern.compile(pattern, RegexpFlags.parseFlags(flags)).matcher("");
+        }
+
+        @Override
+        @SafeVarargs
+        public final Iterable<Row> evaluate(TransactionContext txnCtx, NodeContext nodeContext, Input<String>... args) {
+            String value = args[0].value();
+            if (value == null) {
+                return List.of();
+            }
+            matcher.reset(value);
+            return matchesToRows(matcher, isGlobal);
+        }
+
+        @Override
+        public RowType returnType() {
+            return returnType;
+        }
+
+        @Override
+        public boolean hasLazyResultSet() {
+            return false;
+        }
     }
 
     @Override
@@ -116,11 +147,6 @@ public final class MatchesFunction extends TableFunctionImplementation<String> {
     @Override
     public boolean hasLazyResultSet() {
         return false;
-    }
-
-    @VisibleForTesting
-    Pattern pattern() {
-        return pattern;
     }
 
     @Override
@@ -145,11 +171,12 @@ public final class MatchesFunction extends TableFunctionImplementation<String> {
                 return this;
             }
         }
-        return new MatchesFunction(
+        return new CompiledMatchesFunction(
             signature,
             boundSignature,
-            Pattern.compile(pattern, parseFlags(flags)),
-            returnType
+            returnType,
+            pattern,
+            flags
         );
     }
 
@@ -162,8 +189,8 @@ public final class MatchesFunction extends TableFunctionImplementation<String> {
         if (value == null) {
             return List.of();
         }
-        String pattern = args[1].value();
-        if (pattern == null) {
+        String patternStr = args[1].value();
+        if (patternStr == null) {
             return List.of();
         }
         String flags = null;
@@ -171,59 +198,43 @@ public final class MatchesFunction extends TableFunctionImplementation<String> {
             flags = args[2].value();
         }
 
-        Pattern matchPattern;
-        if (this.pattern == null) {
-            matchPattern = Pattern.compile(pattern, parseFlags(flags));
-        } else {
-            matchPattern = this.pattern;
-        }
-        Matcher matcher = matchPattern.matcher(value);
-        List<List<String>> rowGroups;
-        if (isGlobal(flags)) {
-            List<String> groups = groups(matcher);
-            if (groups != null) {
-                rowGroups = new ArrayList<>();
-                while (groups != null) {
-                    rowGroups.add(groups);
-                    groups = groups(matcher);
-                }
-            } else {
-                rowGroups = List.of();
-            }
-        } else {
-            List<String> groups = groups(matcher);
-            rowGroups = groups == null ? List.of() : List.of(groups);
+        Pattern pattern = Pattern.compile(patternStr, parseFlags(flags));
+        Matcher matcher = pattern.matcher(value);
+        return matchesToRows(matcher, isGlobal(flags));
+    }
+
+    private static Iterable<Row> matchesToRows(Matcher matcher, boolean global) {
+        if (!matcher.find()) {
+            return List.of();
         }
         return () -> new Iterator<>() {
-            final Object[] columns = new Object[]{null};
-            final RowN row = new RowN(columns);
-            int idx = 0;
+            private final Object[] columns = new Object[]{null};
+            private final RowN row = new RowN(columns);
+            private boolean hasNext = true;
 
             @Override
             public boolean hasNext() {
-                return idx < rowGroups.size();
+                return hasNext;
             }
 
             @Override
             public Row next() {
-                if (!hasNext()) {
+                if (!hasNext) {
                     throw new NoSuchElementException("no more rows");
                 }
-                columns[0] = rowGroups.get(idx++);
+                columns[0] = groups(matcher);
+                hasNext = global && matcher.find();
                 return row;
             }
         };
     }
 
     private static List<String> groups(Matcher matcher) {
-        if (!matcher.find()) {
-            return null;
-        }
         int groupCount = matcher.groupCount();
         if (groupCount == 0) {
             return List.of(matcher.group());
         }
-        List<String> groups = new ArrayList<>(groupCount);
+        ArrayList<String> groups = new ArrayList<>(groupCount);
         for (int i = 1; i <= groupCount; i++) {
             groups.add(matcher.group(i));
         }

--- a/server/src/test/java/io/crate/expression/tablefunctions/MatchesFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/tablefunctions/MatchesFunctionTest.java
@@ -26,6 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.assertj.core.api.ThrowingConsumer;
 import org.junit.Test;
 
+import io.crate.expression.tablefunctions.MatchesFunction.CompiledMatchesFunction;
 import io.crate.metadata.Scalar;
 
 
@@ -34,8 +35,7 @@ public class MatchesFunctionTest extends AbstractTableFunctionsTest {
     @Test
     public void test_compile_creates_regex_matcher_instance_on_table_function() throws Exception {
         ThrowingConsumer<Scalar<?, ?>> matcher = func -> {
-            assertThat(func).isExactlyInstanceOf(MatchesFunction.class);
-            assertThat(((MatchesFunction) func).pattern()).isNotNull();
+            assertThat(func).isExactlyInstanceOf(CompiledMatchesFunction.class);
         };
         assertCompile("regexp_matches(name, '.*(ba).*')", matcher);
     }


### PR DESCRIPTION
See commits

Note the main bottleneck is pattern parsing and matcher.find(), so the actual improvement is probably lower than the data shown below and the 8% could be within the variance. But fewer branches + instructions show that there's at least some improvement.

Main motivation is to have fewer functions which people copy from where the compiled version does redundant work.

```
Q: select regexp_matches('#abc #abc   #def #def #ghi #ghi', '(#[^\s]*) (#[^\s]*)', 'g') from generate_series(1, 10000) as t(x)
C: 1
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |        6.514 ±    5.193 |      5.314 |      5.818 |      6.102 |    161.903 |
|   V2    |        5.974 ±    4.880 |      4.852 |      5.343 |      5.703 |    154.008 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -   8.66%                           -   8.51%   
There is a 98.35% probability that the observed difference is not random, and the best estimate of that difference is 8.66%
The test has statistical significance


System/JVM Metrics (durations in ms, byte-values in MB)
    |    YOUNG GC            |       OLD GC           |      HEAP         |     ALLOC     
    |  cnt      avg      max |  cnt      avg      max |  initial     used |     rate      total
 V1 |    6    13.40    12.97 |    0     0.00     0.00 |     2147       36 |   606.79       7470
 V2 |    4    13.59    13.20 |    0     0.00     0.00 |     2147     1290 |   461.23       5159


perf stat
  v1
    branches:u        :   26938716495.00
    cache-misses:u    :     316300969.00
    instructions:u    :  136173412636.00
    faults:u          :        257084.00
    context-switches:u:             0.00
  v2
    branches:u        :   25839125131.00
    cache-misses:u    :     292865204.00
    instructions:u    :  126771193467.00
    faults:u          :        252681.00
    context-switches:u:             0.00
```
