### PR TITLE
Mute some deprecation warnings

### DIFF
--- a/server/src/main/java/io/crate/cluster/commands/FixCorruptedMetadataCommand.java
+++ b/server/src/main/java/io/crate/cluster/commands/FixCorruptedMetadataCommand.java
@@ -116,6 +116,7 @@ import joptsimple.OptionSet;
  * See https://github.com/crate/crate/issues/13380
  * </p>
  **/
+@SuppressWarnings("deprecation")
 public class FixCorruptedMetadataCommand extends ElasticsearchNodeCommand {
 
     public static final String METADATA_FIXED_MSG = "Metadata has been fixed";

--- a/server/src/main/java/io/crate/execution/ddl/Templates.java
+++ b/server/src/main/java/io/crate/execution/ddl/Templates.java
@@ -25,8 +25,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.elasticsearch.cluster.metadata.AliasMetadata;
 import org.elasticsearch.cluster.metadata.IndexTemplateMetadata;
 import org.elasticsearch.cluster.metadata.RelationMetadata;
@@ -37,9 +35,8 @@ import io.crate.execution.ddl.tables.MappingUtil;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.RelationName;
 
+@SuppressWarnings("deprecation")
 public final class Templates {
-
-    private static final Logger LOGGER = LogManager.getLogger(Templates.class);
 
     public static IndexTemplateMetadata of(RelationMetadata.Table table) {
         assert table.partitionedBy().isEmpty() == false : "table must be partitioned";

--- a/server/src/main/java/io/crate/metadata/MetadataModule.java
+++ b/server/src/main/java/io/crate/metadata/MetadataModule.java
@@ -46,6 +46,7 @@ import io.crate.role.metadata.UsersPrivilegesMetadata;
 
 public class MetadataModule extends AbstractModule {
 
+    @SuppressWarnings("deprecation")
     public static List<NamedWriteableRegistry.Entry> getNamedWriteables() {
         List<NamedWriteableRegistry.Entry> entries = new ArrayList<>();
         entries.add(new NamedWriteableRegistry.Entry(
@@ -146,6 +147,7 @@ public class MetadataModule extends AbstractModule {
         return entries;
     }
 
+    @SuppressWarnings("deprecation")
     public static List<NamedXContentRegistry.Entry> getNamedXContents(NodeContext nodeCtx) {
         List<NamedXContentRegistry.Entry> entries = new ArrayList<>();
         entries.add(new NamedXContentRegistry.Entry(

--- a/server/src/main/java/io/crate/replication/logical/action/PublicationsStateAction.java
+++ b/server/src/main/java/io/crate/replication/logical/action/PublicationsStateAction.java
@@ -213,6 +213,7 @@ public class PublicationsStateAction extends ActionType<PublicationsStateAction.
             this.relationsInPublications = null;
         }
 
+        @SuppressWarnings("deprecation")
         public Response(StreamInput in) throws IOException {
             if (in.getVersion().before(Version.V_6_0_0)) {
                 Map<RelationName, RelationMetadata> relationsInPublications = in.readMap(RelationName::new, RelationMetadata::new);
@@ -237,6 +238,7 @@ public class PublicationsStateAction extends ActionType<PublicationsStateAction.
         }
 
         @Override
+        @SuppressWarnings("deprecation")
         public void writeTo(StreamOutput out) throws IOException {
             if (out.getVersion().before(Version.V_6_0_0)) {
                 Map<RelationName, RelationMetadata> relationsInPublications = this.relationsInPublications != null ?

--- a/server/src/main/java/io/crate/role/DropRoleTask.java
+++ b/server/src/main/java/io/crate/role/DropRoleTask.java
@@ -65,6 +65,7 @@ public class DropRoleTask extends AckedClusterStateUpdateTask<WriteRoleResponse>
     }
 
     @VisibleForTesting
+    @SuppressWarnings("deprecation")
     static boolean dropRole(Metadata.Builder mdBuilder, String roleNameToDrop) {
         RolesMetadata oldRolesMetadata = (RolesMetadata) mdBuilder.getCustom(RolesMetadata.TYPE);
         UsersMetadata oldUsersMetadata = (UsersMetadata) mdBuilder.getCustom(UsersMetadata.TYPE);

--- a/server/src/main/java/io/crate/role/RolesService.java
+++ b/server/src/main/java/io/crate/role/RolesService.java
@@ -57,6 +57,7 @@ public class RolesService implements Roles, ClusterStateListener {
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void clusterChanged(ClusterChangedEvent event) {
         Metadata prevMetadata = event.previousState().metadata();
         Metadata newMetadata = event.state().metadata();
@@ -74,7 +75,7 @@ public class RolesService implements Roles, ClusterStateListener {
         }
     }
 
-
+    @SuppressWarnings("deprecation")
     static Map<String, Role> getRoles(@Nullable UsersMetadata usersMetadata,
                                       @Nullable RolesMetadata rolesMetadata,
                                       @Nullable UsersPrivilegesMetadata privilegesMetadata) {

--- a/server/src/main/java/io/crate/role/metadata/RolesMetadata.java
+++ b/server/src/main/java/io/crate/role/metadata/RolesMetadata.java
@@ -71,6 +71,7 @@ public class RolesMetadata extends AbstractNamedDiffable<Metadata.Custom> implem
         return new RolesMetadata(new HashMap<>(instance.roles));
     }
 
+    @SuppressWarnings("deprecation")
     public static RolesMetadata ofOldUsersMetadata(@Nullable UsersMetadata usersMetadata,
                                                    @Nullable UsersPrivilegesMetadata usersPrivilegesMetadata) {
         if (usersMetadata == null) {

--- a/server/src/main/java/org/elasticsearch/Version.java
+++ b/server/src/main/java/org/elasticsearch/Version.java
@@ -40,6 +40,7 @@ import org.elasticsearch.monitor.jvm.JvmInfo;
 
 import io.crate.common.SuppressForbidden;
 
+@SuppressWarnings("deprecation") // old lucene versions
 public class Version implements Comparable<Version> {
     /*
      * The logic for ID is: XXYYZZAA, where XX is major version, YY is minor version, ZZ is revision, and AA is alpha/beta/rc indicator AA

--- a/server/src/test/java/io/crate/cluster/commands/FixCorruptedMetadataCommandTest.java
+++ b/server/src/test/java/io/crate/cluster/commands/FixCorruptedMetadataCommandTest.java
@@ -46,6 +46,7 @@ import org.junit.Test;
 import io.crate.common.unit.TimeValue;
 import io.crate.metadata.RelationName;
 
+@SuppressWarnings("deprecation")
 public class FixCorruptedMetadataCommandTest {
 
     @Test

--- a/server/src/test/java/io/crate/metadata/upgrade/MetadataIndexUpgraderTest.java
+++ b/server/src/test/java/io/crate/metadata/upgrade/MetadataIndexUpgraderTest.java
@@ -45,6 +45,7 @@ import io.crate.Constants;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.RelationName;
 
+@SuppressWarnings("deprecation")
 public class MetadataIndexUpgraderTest extends ESTestCase {
 
     @Test

--- a/server/src/test/java/io/crate/metadata/view/ViewMetadataTest.java
+++ b/server/src/test/java/io/crate/metadata/view/ViewMetadataTest.java
@@ -33,6 +33,7 @@ import io.crate.metadata.SearchPath;
 public class ViewMetadataTest {
 
     @Test
+    @SuppressWarnings("deprecation")
     public void test_bwc_streaming() throws Exception {
         var viewMetadata = new ViewMetadata(
             "select 1",

--- a/server/src/test/java/io/crate/metadata/view/ViewsMetadataTest.java
+++ b/server/src/test/java/io/crate/metadata/view/ViewsMetadataTest.java
@@ -34,6 +34,7 @@ import org.junit.Test;
 
 import io.crate.metadata.SearchPath;
 
+@SuppressWarnings("deprecation")
 public class ViewsMetadataTest extends ESTestCase {
 
     public static ViewsMetadata createMetadata() {

--- a/server/src/test/java/io/crate/role/RolesServiceTest.java
+++ b/server/src/test/java/io/crate/role/RolesServiceTest.java
@@ -42,6 +42,7 @@ import io.crate.role.metadata.UsersMetadata;
 import io.crate.role.metadata.UsersPrivilegesMetadata;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 
+@SuppressWarnings("deprecation")
 public class RolesServiceTest extends CrateDummyClusterServiceUnitTest {
 
     private static final Map<String, Role> DEFAULT_USERS = Map.of(CRATE_USER.name(), CRATE_USER);

--- a/server/src/test/java/io/crate/role/TransportRoleTest.java
+++ b/server/src/test/java/io/crate/role/TransportRoleTest.java
@@ -30,7 +30,7 @@ import static io.crate.role.metadata.RolesHelper.SINGLE_USER_ONLY;
 import static io.crate.role.metadata.RolesHelper.getSecureHash;
 import static io.crate.role.metadata.RolesHelper.userOf;
 import static io.crate.role.metadata.RolesHelper.usersMetadataOf;
-import static io.crate.testing.Asserts.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.HashMap;
@@ -57,6 +57,7 @@ import io.crate.role.metadata.UsersPrivilegesMetadata;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 
+@SuppressWarnings("deprecation")
 public class TransportRoleTest extends CrateDummyClusterServiceUnitTest {
 
     @Test

--- a/server/src/test/java/io/crate/role/metadata/RolesHelper.java
+++ b/server/src/test/java/io/crate/role/metadata/RolesHelper.java
@@ -120,6 +120,7 @@ public final class RolesHelper {
             new Privilege(Policy.GRANT, Permission.DML, Securable.SCHEMA, "doc", "crate")
         ));
 
+    @SuppressWarnings("deprecation")
     public static UsersMetadata usersMetadataOf(Map<String, Role> users) {
         Map<String, SecureHash> map = new HashMap<>(users.size());
         for (var user : users.entrySet()) {
@@ -130,6 +131,7 @@ public final class RolesHelper {
         return new UsersMetadata(Collections.unmodifiableMap(map));
     }
 
+    @SuppressWarnings("deprecation")
     public static UsersPrivilegesMetadata usersPrivilegesMetadataOf(Map<String, Role> users) {
         Map<String, Set<Privilege>> map = new HashMap<>(users.size());
         for (var user : users.entrySet()) {

--- a/server/src/test/java/io/crate/role/metadata/UsersMetadataTest.java
+++ b/server/src/test/java/io/crate/role/metadata/UsersMetadataTest.java
@@ -36,6 +36,7 @@ import org.junit.Test;
 import io.crate.role.Role;
 import io.crate.role.SecureHash;
 
+@SuppressWarnings("deprecation")
 public class UsersMetadataTest extends ESTestCase {
 
     @Test

--- a/server/src/test/java/io/crate/role/metadata/UsersPrivilegesMetadataTest.java
+++ b/server/src/test/java/io/crate/role/metadata/UsersPrivilegesMetadataTest.java
@@ -52,6 +52,7 @@ import org.junit.Test;
 
 import io.crate.role.Privilege;
 
+@SuppressWarnings("deprecation")
 public class UsersPrivilegesMetadataTest extends ESTestCase {
 
     private UsersPrivilegesMetadata usersPrivilegesMetadata;


### PR DESCRIPTION
Still a lot warnings left. This mostly focuses on places where we can
get rid of many warnings with low risk of hiding deprecations we should
address.
