### PR TITLE
Avoid empty partition creation during inserts on partitioned table

### DIFF
--- a/server/src/main/java/io/crate/execution/ddl/SwapRelationsOperation.java
+++ b/server/src/main/java/io/crate/execution/ddl/SwapRelationsOperation.java
@@ -248,7 +248,7 @@ public class SwapRelationsOperation {
                 .build();
             onProcessedIndex.accept(sourceIndex.getUUID());
             updatedMetadata.put(targetMd, true);
-            blocksBuilder.addBlocks(targetMd);
+            blocksBuilder.addIndexBlocks(targetMd);
             routingBuilder.addAsFromCloseToOpen(targetMd);
         }
     }

--- a/server/src/main/java/io/crate/execution/ddl/index/TransportSwapAndDropIndexName.java
+++ b/server/src/main/java/io/crate/execution/ddl/index/TransportSwapAndDropIndexName.java
@@ -75,8 +75,8 @@ public class TransportSwapAndDropIndexName extends AbstractDDLTransportAction<Sw
 
     @Override
     protected ClusterBlockException checkBlock(SwapAndDropIndexRequest request, ClusterState state) {
-        return state.blocks().indicesBlockedException(
-            ClusterBlockLevel.METADATA_WRITE,
-            new String[] { request.source(), request.target() });
+        String targetIndexUUID = request.target();
+        // No need to check blocks on the source index as it is a new index that will replace the target
+        return state.blocks().blockedException(ClusterBlockLevel.METADATA_WRITE, state.metadata().getRelationOid(targetIndexUUID), targetIndexUUID);
     }
 }

--- a/server/src/main/java/io/crate/execution/ddl/tables/AlterTableClient.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/AlterTableClient.java
@@ -187,13 +187,14 @@ public class AlterTableClient {
     private CompletableFuture<Long> setSettings(BoundAlterTable analysis) {
         try {
             PartitionName partitionName = analysis.partitionName();
+            boolean isTableLevelRequest = partitionName == null;
             AlterTableRequest request = new AlterTableRequest(
                 analysis.table().ident(),
-                partitionName == null ? List.of() : partitionName.values(),
+                isTableLevelRequest ? List.of() : partitionName.values(),
                 analysis.isPartitioned(),
                 analysis.excludePartitions(),
-                analysis.settings()
-            );
+                isTableLevelRequest,
+                analysis.settings());
             GenericProperties<Object> withProperties = analysis.withProperties();
             Object timeout = withProperties.get("timeout");
             if (timeout != null) {

--- a/server/src/main/java/io/crate/execution/ddl/tables/AlterTableRequest.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/AlterTableRequest.java
@@ -44,16 +44,19 @@ public class AlterTableRequest extends AcknowledgedRequest<AlterTableRequest> {
     private final boolean isPartitioned;
     private final boolean excludePartitions;
     private final Settings settings;
+    private final boolean isTableLevelRequest;
 
     public AlterTableRequest(RelationName table,
                              List<String> partitionValues,
                              boolean isPartitioned,
                              boolean excludePartitions,
+                             boolean isTableLevelRequest,
                              Settings settings) throws IOException {
         this.table = table;
         this.partitionValues = partitionValues;
         this.isPartitioned = isPartitioned;
         this.excludePartitions = excludePartitions;
+        this.isTableLevelRequest = isTableLevelRequest;
         this.settings = settings;
     }
 
@@ -75,6 +78,11 @@ public class AlterTableRequest extends AcknowledgedRequest<AlterTableRequest> {
         }
         isPartitioned = in.readBoolean();
         excludePartitions = in.readBoolean();
+        if (in.getVersion().onOrAfter(Version.V_6_3_0)) {
+            isTableLevelRequest = in.readBoolean();
+        } else {
+            isTableLevelRequest = false;
+        }
         settings = readSettingsFromStream(in);
         if (before510) {
             in.readOptionalString(); // mappingDelta
@@ -101,6 +109,9 @@ public class AlterTableRequest extends AcknowledgedRequest<AlterTableRequest> {
         }
         out.writeBoolean(isPartitioned);
         out.writeBoolean(excludePartitions);
+        if (out.getVersion().onOrAfter(Version.V_6_3_0)) {
+            out.writeBoolean(isTableLevelRequest);
+        }
         writeSettingsToStream(out, settings);
         if (before510) {
             out.writeOptionalString(null);
@@ -123,6 +134,10 @@ public class AlterTableRequest extends AcknowledgedRequest<AlterTableRequest> {
         return excludePartitions;
     }
 
+    public boolean isTableLevelRequest() {
+        return isTableLevelRequest;
+    }
+
     public Settings settings() {
         return settings;
     }
@@ -135,6 +150,7 @@ public class AlterTableRequest extends AcknowledgedRequest<AlterTableRequest> {
         result = prime * result + partitionValues.hashCode();
         result = prime * result + (isPartitioned ? 1231 : 1237);
         result = prime * result + (excludePartitions ? 1231 : 1237);
+        result = prime * result + (isTableLevelRequest ? 1231 : 1237);
         result = prime * result + settings.hashCode();
         return result;
     }
@@ -146,6 +162,7 @@ public class AlterTableRequest extends AcknowledgedRequest<AlterTableRequest> {
             && partitionValues.equals(other.partitionValues)
             && isPartitioned == other.isPartitioned
             && excludePartitions == other.excludePartitions
+            && isTableLevelRequest == other.isTableLevelRequest
             && settings.equals(other.settings);
     }
 }

--- a/server/src/main/java/io/crate/execution/ddl/tables/TransportCloseTable.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/TransportCloseTable.java
@@ -194,13 +194,15 @@ public final class TransportCloseTable extends TransportMasterNodeAction<CloseTa
                     continue;
                 }
                 final IndexMetadata indexMetadata = metadata.getSafe(index);
+                final String indexUUID = index.getUUID();
+
                 if (indexMetadata.getState() == IndexMetadata.State.CLOSE) {
                     LOGGER.debug("verification of shards before closing {} succeeded but index is already closed", index);
-                    assert currentState.blocks().hasIndexBlock(index.getUUID(), IndexMetadata.INDEX_CLOSED_BLOCK);
+                    assert currentState.blocks().hasIndexBlock(indexUUID, IndexMetadata.INDEX_CLOSED_BLOCK);
                     continue;
                 }
                 final ClusterBlock closingBlock = blockedIndices.get(index);
-                if (currentState.blocks().hasIndexBlock(index.getUUID(), closingBlock) == false) {
+                if (currentState.blocks().hasIndexBlock(indexUUID, closingBlock) == false) {
                     LOGGER.debug("verification of shards before closing {} succeeded but block has been removed in the meantime", index);
                     continue;
                 }
@@ -247,13 +249,13 @@ public final class TransportCloseTable extends TransportMasterNodeAction<CloseTa
         if (isEmptyPartitionedTable(request.table(), state)) {
             return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE);
         }
-        String[] indexNames = state.metadata().getIndices(
+        String[] indexUUIDs = state.metadata().getIndices(
             request.table(),
             request.partitionValues(),
             false,
-            idxMd -> idxMd.getIndex().getName()
+            idxMd -> idxMd.getIndex().getUUID()
         ).toArray(String[]::new);
-        return state.blocks().indicesBlockedException(ClusterBlockLevel.METADATA_WRITE, indexNames);
+        return state.blocks().blockedException(ClusterBlockLevel.METADATA_WRITE, new int[]{state.metadata().getRelationOid(request.table())}, indexUUIDs);
     }
 
     public static boolean isEmptyPartitionedTable(RelationName relationName,

--- a/server/src/main/java/io/crate/execution/ddl/tables/TransportDropPartitionsAction.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/TransportDropPartitionsAction.java
@@ -126,7 +126,7 @@ public class TransportDropPartitionsAction extends AbstractDDLTransportAction<Dr
 
     @Override
     protected ClusterBlockException checkBlock(DropPartitionsRequest request, ClusterState state) {
-        String[] indexNames = getIndices(state, request, im -> im.getIndex().getName()).toArray(String[]::new);
-        return state.blocks().indicesBlockedException(ClusterBlockLevel.METADATA_WRITE, indexNames);
+        String[] indexUUIDs = getIndices(state, request, im -> im.getIndex().getUUID()).toArray(String[]::new);
+        return state.blocks().blockedException(ClusterBlockLevel.METADATA_WRITE, new int[]{state.metadata().getRelationOid(request.relationName())}, indexUUIDs);
     }
 }

--- a/server/src/main/java/io/crate/execution/ddl/tables/TransportDropTable.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/TransportDropTable.java
@@ -79,12 +79,12 @@ public class TransportDropTable extends AbstractDDLTransportAction<DropTableRequ
 
     @Override
     protected ClusterBlockException checkBlock(DropTableRequest request, ClusterState state) {
-        String[] indexUUIDS = state.metadata().getIndices(
+        String[] indexUUIDs = state.metadata().getIndices(
             request.tableIdent(),
             List.of(),
             false,
             imd -> imd.getIndex().getUUID()
         ).toArray(String[]::new);
-        return state.blocks().indicesBlockedException(ClusterBlockLevel.METADATA_WRITE, indexUUIDS);
+        return state.blocks().blockedException(ClusterBlockLevel.METADATA_WRITE, new int[]{state.metadata().getRelationOid(request.tableIdent())}, indexUUIDs);
     }
 }

--- a/server/src/main/java/io/crate/execution/ddl/tables/TransportOpenTable.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/TransportOpenTable.java
@@ -91,12 +91,12 @@ public class TransportOpenTable extends AbstractDDLTransportAction<OpenTableRequ
         if (isEmptyPartitionedTable(relation, state)) {
             return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE);
         }
-        String[] indexNames = state.metadata().getIndices(
+        String[] indexUUIDs = state.metadata().getIndices(
             relation,
             request.partitionValues(),
             true,
-            imd -> imd.getIndex().getName()
+            imd -> imd.getIndex().getUUID()
         ).toArray(String[]::new);
-        return state.blocks().indicesBlockedException(ClusterBlockLevel.METADATA_WRITE, indexNames);
+        return state.blocks().blockedException(ClusterBlockLevel.METADATA_WRITE, new int[]{state.metadata().getRelationOid(relation)}, indexUUIDs);
     }
 }

--- a/server/src/main/java/io/crate/execution/ddl/tables/TransportRenameTable.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/TransportRenameTable.java
@@ -131,14 +131,14 @@ public class TransportRenameTable extends TransportMasterNodeAction<RenameTableR
             return null;
         }
         boolean strict = !request.isPartitioned();
-        return state.blocks().indicesBlockedException(
+        String[] indexUUIDs = state.metadata().getIndices(
+            request.sourceName(),
+            List.of(),
+            strict,
+            imd -> imd.getIndex().getUUID()).toArray(String[]::new);
+        return state.blocks().blockedException(
             ClusterBlockLevel.METADATA_WRITE,
-            state.metadata().getIndices(
-                request.sourceName(),
-                List.of(),
-                strict,
-                imd -> imd.getIndex().getName()
-            ).toArray(String[]::new)
-        );
+            new int[]{relationMetadata.oid()},
+            indexUUIDs);
     }
 }

--- a/server/src/main/java/io/crate/execution/dml/TransportShardAction.java
+++ b/server/src/main/java/io/crate/execution/dml/TransportShardAction.java
@@ -103,7 +103,9 @@ public abstract class TransportShardAction<
     protected void shardOperationOnPrimary(Request request,
                                            IndexShard primary,
                                            ActionListener<PrimaryResult<ReplicaReq, ShardResponse>> listener) {
-        if (tasksService.recentlyFailed(request.jobId())) {
+        if (tasksService.recentlyFailed(request.jobId()) &&
+            // unblocked requests must always proceed
+            !request.unblockedRequest()) {
             listener.onFailure(JobKilledException.of(JobKilledException.MESSAGE));
             return;
         }

--- a/server/src/main/java/io/crate/execution/dml/UpsertReplicaRequest.java
+++ b/server/src/main/java/io/crate/execution/dml/UpsertReplicaRequest.java
@@ -51,11 +51,20 @@ public class UpsertReplicaRequest extends ShardRequest<UpsertReplicaRequest, Ups
     private final List<Reference> columns;
     private final SessionSettings sessionSettings;
 
-    public UpsertReplicaRequest(ShardId shardId,
-                                UUID jobId,
-                                SessionSettings sessionSettings,
-                                List<Reference> columns,
-                                List<UpsertReplicaRequest.Item> items) {
+    public static UpsertReplicaRequest of(ShardId shardId,
+                                          UUID jobId,
+                                          SessionSettings sessionSettings,
+                                          List<Reference> columns,
+                                          List<UpsertReplicaRequest.Item> items,
+                                          boolean unblockedRequest) {
+        return new UpsertReplicaRequest(shardId, jobId, sessionSettings, columns, items).unblockedRequest(unblockedRequest);
+    }
+
+    private UpsertReplicaRequest(ShardId shardId,
+                                 UUID jobId,
+                                 SessionSettings sessionSettings,
+                                 List<Reference> columns,
+                                 List<UpsertReplicaRequest.Item> items) {
         super(shardId, jobId);
         this.sessionSettings = sessionSettings;
         this.columns = columns;
@@ -71,7 +80,7 @@ public class UpsertReplicaRequest extends ShardRequest<UpsertReplicaRequest, Ups
                 request.sessionSettings(),
                 Arrays.asList(request.insertColumns()),
                 Lists.mapLazy(request.items(), UpsertReplicaRequest.Item::of)
-            );
+            ).unblockedRequest(request.unblockedRequest());
         } else {
             return new UpsertReplicaRequest(schemas, in);
         }
@@ -117,7 +126,7 @@ public class UpsertReplicaRequest extends ShardRequest<UpsertReplicaRequest, Ups
                 null, // updateColumns are only used on primary via UpdateToInsert logic
                 insertColumns,
                 null // return values are only used on primary
-            );
+            ).unblockedRequest(this.unblockedRequest());
             for (int i = 0; i < items.size(); i++) {
                 var item = items.get(i);
                 var primaryItem = ShardUpsertRequest.Item.forInsert(

--- a/server/src/main/java/io/crate/execution/dml/upsert/ShardUpsertRequest.java
+++ b/server/src/main/java/io/crate/execution/dml/upsert/ShardUpsertRequest.java
@@ -567,7 +567,7 @@ public final class ShardUpsertRequest extends ShardRequest<ShardUpsertRequest, S
             this.returnValues = returnValue;
         }
 
-        public ShardUpsertRequest newRequest(ShardId shardId) {
+        public ShardUpsertRequest newRequest(ShardId shardId, boolean unblockedRequest) {
             return new ShardUpsertRequest(
                 shardId,
                 jobId,
@@ -577,7 +577,7 @@ public final class ShardUpsertRequest extends ShardRequest<ShardUpsertRequest, S
                 assignmentsColumns,
                 missingAssignmentsColumns,
                 returnValues
-            ).timeout(timeout);
+            ).timeout(timeout).unblockedRequest(unblockedRequest);
         }
     }
 

--- a/server/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
+++ b/server/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
@@ -250,13 +250,14 @@ public class TransportShardUpsertAction extends TransportShardAction<
         // Create the replica requests with already sanitized item values and updated(guessed) insert columns
         // It's important that the insert columns are in sync with the item values AND registered references (types),
         // since the replica request stream reader will resolve the references from the table.
-        UpsertReplicaRequest replicaRequest = new UpsertReplicaRequest(
+        UpsertReplicaRequest replicaRequest = UpsertReplicaRequest.of(
             request.shardId(),
             request.jobId(),
             request.sessionSettings(),
             indexer.onConflictIndexer() == null ?
                 indexer.insertColumns() : indexer.onConflictIndexer().insertColumns(),
-            replicaItems
+            replicaItems,
+            request.unblockedRequest()
         );
         return new WritePrimaryResult<>(replicaRequest, shardResponse, translogLocation, indexShard);
     }

--- a/server/src/main/java/io/crate/execution/engine/indexing/GroupRowsByShard.java
+++ b/server/src/main/java/io/crate/execution/engine/indexing/GroupRowsByShard.java
@@ -171,7 +171,7 @@ public final class GroupRowsByShard<TReq extends ShardRequest<TReq, TItem>, TIte
                 }
                 shardedRequests.add(item, partitionName, routing, rowSourceInfo);
             } else {
-                shardedRequests.add(item, shardLocation, rowSourceInfo);
+                shardedRequests.add(item, shardLocation, rowSourceInfo, false);
             }
             return item;
         } catch (CircuitBreakingException e) {
@@ -250,7 +250,7 @@ public final class GroupRowsByShard<TReq extends ShardRequest<TReq, TItem>, TIte
                 if (shardLocation == null) {
                     throw new IllegalStateException("shardLocation not resolvable after createIndices");
                 }
-                requests.add(itemAndRoutingAndSourceInfo.item(), shardLocation, itemAndRoutingAndSourceInfo.rowSourceInfo());
+                requests.add(itemAndRoutingAndSourceInfo.item(), shardLocation, itemAndRoutingAndSourceInfo.rowSourceInfo(), true);
                 it.remove();
             }
             if (items.isEmpty()) {

--- a/server/src/main/java/io/crate/execution/engine/indexing/ShardedRequests.java
+++ b/server/src/main/java/io/crate/execution/engine/indexing/ShardedRequests.java
@@ -25,7 +25,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
+import java.util.function.BiFunction;
 
 import org.apache.lucene.util.Accountable;
 import org.elasticsearch.common.lease.Releasable;
@@ -44,7 +44,7 @@ public final class ShardedRequests<TReq extends ShardRequest<TReq, TItem>, TItem
     final List<RowSourceInfo> rowSourceInfos = new ArrayList<>();
     final Map<ShardLocation, TReq> itemsByShard = new HashMap<>();
 
-    private final Function<ShardId, TReq> requestFactory;
+    private final BiFunction<ShardId, Boolean, TReq> requestFactory;
     private final RamAccounting ramAccounting;
 
     private int location = -1;
@@ -53,7 +53,7 @@ public final class ShardedRequests<TReq extends ShardRequest<TReq, TItem>, TItem
     /**
      * @param requestFactory function to create a request
      */
-    public ShardedRequests(Function<ShardId, TReq> requestFactory, RamAccounting ramAccounting) {
+    public ShardedRequests(BiFunction<ShardId, Boolean, TReq> requestFactory, RamAccounting ramAccounting) {
         this.requestFactory = requestFactory;
         this.ramAccounting = ramAccounting;
     }
@@ -66,13 +66,13 @@ public final class ShardedRequests<TReq extends ShardRequest<TReq, TItem>, TItem
         items.add(new ItemAndRoutingAndSourceInfo<>(item, routing, rowSourceInfo));
     }
 
-    public void add(TItem item, ShardLocation shardLocation, RowSourceInfo rowSourceInfo) {
+    public void add(TItem item, ShardLocation shardLocation, RowSourceInfo rowSourceInfo, boolean unblockedRequest) {
         long itemSizeInBytes = item.ramBytesUsed();
         ramAccounting.addBytes(itemSizeInBytes);
         usedMemoryEstimate += itemSizeInBytes;
         TReq req = itemsByShard.get(shardLocation);
         if (req == null) {
-            req = requestFactory.apply(shardLocation.shardId);
+            req = requestFactory.apply(shardLocation.shardId, unblockedRequest);
             itemsByShard.put(shardLocation, req);
         }
         location++;

--- a/server/src/main/java/io/crate/execution/engine/indexing/ShardingUpsertExecutor.java
+++ b/server/src/main/java/io/crate/execution/engine/indexing/ShardingUpsertExecutor.java
@@ -32,6 +32,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -92,7 +93,7 @@ public class ShardingUpsertExecutor
     private final Executor executor;
     private final int bulkSize;
     private final UUID jobId;
-    private final Function<ShardId, ShardUpsertRequest> requestFactory;
+    private final BiFunction<ShardId, Boolean, ShardUpsertRequest> requestFactory;
     private final BulkRequestExecutor<ShardUpsertRequest> requestExecutor;
     private final Client elasticsearchClient;
     private final BulkShardCreationLimiter bulkShardCreationLimiter;
@@ -117,7 +118,7 @@ public class ShardingUpsertExecutor
                            UUID jobId,
                            RowShardResolver rowShardResolver,
                            ItemFactory<ShardUpsertRequest.Item> itemFactory,
-                           Function<ShardId, ShardUpsertRequest> requestFactory,
+                           BiFunction<ShardId, Boolean, ShardUpsertRequest> requestFactory,
                            List<? extends CollectExpression<Row, ?>> expressions,
                            Supplier<PartitionName> partitionResolver,
                            boolean autoCreateIndices,

--- a/server/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
+++ b/server/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
@@ -568,7 +568,7 @@ public class ProjectionToProjectorVisitor
             context.ramAccounting,
             circuitBreakerService.getBreaker(CircuitBreaker.QUERY),
             nodeJobsCounter,
-            () -> builder.newRequest(shardId),
+            () -> builder.newRequest(shardId, false),
             id -> {
                 Long requiredVersion = projection.requiredVersion();
                 return ShardUpsertRequest.Item.forUpdate(

--- a/server/src/main/java/io/crate/metadata/Schemas.java
+++ b/server/src/main/java/io/crate/metadata/Schemas.java
@@ -474,6 +474,7 @@ public class Schemas extends AbstractLifecycleComponent implements Iterable<Sche
         return viewInfo;
     }
 
+    @Override
     @Nullable
     public RelationName getRelationName(int oid) {
         for (SchemaInfo schema : this) {
@@ -496,6 +497,7 @@ public class Schemas extends AbstractLifecycleComponent implements Iterable<Sche
         return null;
     }
 
+    @Override
     public int getRelationOid(RelationName relationName) {
         RelationMetadata relationMetadata = clusterService.state().metadata().getRelation(relationName);
         return relationMetadata == null ? OidHash.relationOid(OidHash.Type.TABLE, relationName) : relationMetadata.oid();

--- a/server/src/main/java/io/crate/metadata/cluster/AlterTableClusterStateExecutor.java
+++ b/server/src/main/java/io/crate/metadata/cluster/AlterTableClusterStateExecutor.java
@@ -29,11 +29,13 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsRequest;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.block.ClusterBlocks;
 import org.elasticsearch.cluster.metadata.AutoExpandReplicas;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.MappingMetadata;
@@ -73,6 +75,18 @@ public class AlterTableClusterStateExecutor extends DDLClusterStateTaskExecutor<
 
     @Override
     protected ClusterState execute(ClusterState currentState, AlterTableRequest request) throws Exception {
+        if (!request.isTableLevelRequest()) {
+            for (var tableOnlySetting : TableParameters.TABLE_ONLY_SETTINGS) {
+                if (tableOnlySetting.exists(request.settings())) {
+                    throw new IllegalArgumentException(String.format(
+                        Locale.ENGLISH,
+                        "\"%s\" cannot be changed on partition level",
+                        tableOnlySetting.getKey()
+                    ));
+                }
+            }
+        }
+
         String policy = request.settings().get(TableParameters.COLUMN_POLICY.getKey());
         ColumnPolicy columnPolicy = policy == null ? null : ColumnPolicy.of(policy);
 
@@ -82,46 +96,57 @@ public class AlterTableClusterStateExecutor extends DDLClusterStateTaskExecutor<
         Settings settings = settingsBuilder.build();
 
         Metadata metadata = currentState.metadata();
-        RelationMetadata relation = metadata.getRelation(request.tableIdent());
-        if (request.partitionValues().isEmpty() && relation instanceof RelationMetadata.Table table) {
+        if (request.isTableLevelRequest()) {
+            RelationMetadata relation = metadata.getRelation(request.tableIdent());
             Metadata.Builder newMetadata = Metadata.builder(metadata);
-            Builder newSettings = Settings.builder()
-                .put(table.settings())
-                .put(settings);
-            for (String setting : settings.keySet()) {
-                if (!settings.hasValue(setting)) {
-                    newSettings.remove(setting);
+            ClusterBlocks.Builder blocks = ClusterBlocks.builder().blocks(currentState.blocks());
+            if (relation instanceof RelationMetadata.Table table) {
+                Builder newSettings = Settings.builder()
+                    .put(table.settings())
+                    .put(settings);
+                for (String setting : settings.keySet()) {
+                    if (!settings.hasValue(setting)) {
+                        newSettings.remove(setting);
+                    }
                 }
+                newMetadata.setTable(
+                    table.name(),
+                    table.columns(),
+                    newSettings.build(),
+                    table.routingColumn(),
+                    columnPolicy == null ? table.columnPolicy() : columnPolicy,
+                    table.pkConstraintName(),
+                    table.checkConstraints(),
+                    table.primaryKeys(),
+                    table.partitionedBy(),
+                    table.state(),
+                    table.indexUUIDs(),
+                    table.tableVersion() + 1,
+                    table.oid()
+                );
+            } else if (relation instanceof RelationMetadata.BlobTable blob) {
+                Builder newSettings = Settings.builder()
+                    .put(blob.settings())
+                    .put(settings);
+                for (String setting : settings.keySet()) {
+                    if (!settings.hasValue(setting)) {
+                        newSettings.remove(setting);
+                    }
+                }
+                newMetadata.setBlobTable(
+                    blob.name(),
+                    blob.indexUUID(),
+                    newSettings.build(),
+                    blob.state()
+                );
             }
-            newMetadata.setTable(
-                table.name(),
-                table.columns(),
-                newSettings.build(),
-                table.routingColumn(),
-                columnPolicy == null ? table.columnPolicy() : columnPolicy,
-                table.pkConstraintName(),
-                table.checkConstraints(),
-                table.primaryKeys(),
-                table.partitionedBy(),
-                table.state(),
-                table.indexUUIDs(),
-                table.tableVersion() + 1,
-                table.oid()
-            );
+            blocks.updateTableBlocks(Objects.requireNonNull(newMetadata.getRelation(request.tableIdent())));
             currentState = ClusterState.builder(currentState)
                 .metadata(newMetadata)
+                .blocks(blocks)
                 .build();
-        } else if (!request.partitionValues().isEmpty()) {
-            for (var tableOnlySetting : TableParameters.TABLE_ONLY_SETTINGS) {
-                if (tableOnlySetting.exists(settings)) {
-                    throw new IllegalArgumentException(String.format(
-                        Locale.ENGLISH,
-                        "\"%s\" cannot be changed on partition level",
-                        tableOnlySetting.getKey()
-                    ));
-                }
-            }
         }
+
         List<Index> concreteIndices = metadata.getIndices(
             request.tableIdent(),
             request.partitionValues(),
@@ -131,7 +156,7 @@ public class AlterTableClusterStateExecutor extends DDLClusterStateTaskExecutor<
         List<PartitionName> partitions = partitions(request);
         if (request.isPartitioned()) {
             if (!request.partitionValues().isEmpty()) {
-                currentState = updateSettings(currentState, settings, partitions);
+                currentState = updateSettingsForPartitions(currentState, settings, partitions);
             } else {
                 if (!request.excludePartitions()) {
                     // These settings only apply for already existing partitions
@@ -143,13 +168,13 @@ public class AlterTableClusterStateExecutor extends DDLClusterStateTaskExecutor<
                     // auto_expand_replicas must be explicitly added as it is hidden under NumberOfReplicasSetting
                     supportedSettings.add(AutoExpandReplicas.SETTING);
 
-                    currentState = updateSettings(currentState, filterSettings(settings, supportedSettings), partitions);
+                    currentState = updateSettingsForPartitions(currentState, filterSettings(settings, supportedSettings), partitions);
                     currentState = updateMapping(currentState, concreteIndices, columnPolicy);
                 }
             }
         } else {
             currentState = updateMapping(currentState, concreteIndices, columnPolicy);
-            currentState = updateSettings(currentState, settings, partitions);
+            currentState = updateSettingsForPartitions(currentState, settings, partitions);
         }
 
         // ensure the new table can still be parsed into a Doc|BlobTableInfo to avoid breaking the table.
@@ -196,7 +221,7 @@ public class AlterTableClusterStateExecutor extends DDLClusterStateTaskExecutor<
     /**
      * The logic is taken over from {@link MetadataUpdateSettingsService#updateSettings(UpdateSettingsRequest, ActionListener)}
      */
-    private ClusterState updateSettings(final ClusterState currentState, final Settings settings, List<PartitionName> partitions) {
+    private ClusterState updateSettingsForPartitions(final ClusterState currentState, final Settings settings, List<PartitionName> partitions) {
         final Settings normalizedSettings = Settings.builder()
             .put(markArchivedSettings(settings))
             .normalizePrefix(IndexMetadata.INDEX_SETTING_PREFIX)
@@ -222,7 +247,7 @@ public class AlterTableClusterStateExecutor extends DDLClusterStateTaskExecutor<
         }
         final Settings closedSettings = settingsForClosedIndices.build();
         final Settings openSettings = settingsForOpenIndices.build();
-        return updateSettingsService.updateState(
+        return updateSettingsService.updateStateForPartitions(
             currentState,
             partitions,
             skippedSettings,

--- a/server/src/main/java/io/crate/metadata/cluster/RenameTableClusterStateExecutor.java
+++ b/server/src/main/java/io/crate/metadata/cluster/RenameTableClusterStateExecutor.java
@@ -134,7 +134,7 @@ public class RenameTableClusterStateExecutor {
                     .build();
                 newMetadata.put(targetMd, true);
                 newRoutingTable.addAsFromCloseToOpen(targetMd);
-                blocksBuilder.addBlocks(targetMd);
+                blocksBuilder.addIndexBlocks(targetMd);
             }
         }
 

--- a/server/src/main/java/io/crate/metadata/cluster/SwapAndDropIndexExecutor.java
+++ b/server/src/main/java/io/crate/metadata/cluster/SwapAndDropIndexExecutor.java
@@ -80,7 +80,7 @@ public class SwapAndDropIndexExecutor extends DDLClusterStateTaskExecutor<SwapAn
             .build();
         mdBuilder.put(newIndexMetadata, true);
         routingBuilder.addAsFromCloseToOpen(newIndexMetadata);
-        blocksBuilder.addBlocks(newIndexMetadata);
+        blocksBuilder.addIndexBlocks(newIndexMetadata);
 
         RelationMetadata relation = metadata.getRelation(originalIndexUUID);
         if (relation instanceof RelationMetadata.Table table) {

--- a/server/src/main/java/io/crate/metadata/upgrade/ClusterStateUpgrader.java
+++ b/server/src/main/java/io/crate/metadata/upgrade/ClusterStateUpgrader.java
@@ -31,6 +31,8 @@ import org.elasticsearch.cluster.block.ClusterBlocks;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.metadata.MetadataUpgradeService;
+import org.elasticsearch.cluster.metadata.RelationMetadata;
+import org.elasticsearch.cluster.metadata.SchemaMetadata;
 import org.elasticsearch.cluster.routing.IndexRoutingTable;
 import org.elasticsearch.cluster.routing.RoutingTable;
 
@@ -131,8 +133,13 @@ public class ClusterStateUpgrader {
         for (ClusterBlock block : state.blocks().global()) {
             builder.addGlobalBlock(block);
         }
+        for (SchemaMetadata schemaMetadata : state.metadata().schemas().values()) {
+            for (RelationMetadata relationMetadata : schemaMetadata.relations().values()) {
+                builder.updateTableBlocks(relationMetadata);
+            }
+        }
         for (final IndexMetadata indexMetadata : state.metadata()) {
-            builder.addBlocks(indexMetadata);
+            builder.addIndexBlocks(indexMetadata);
         }
         return builder.build();
     }

--- a/server/src/main/java/io/crate/planner/node/dml/UpdateById.java
+++ b/server/src/main/java/io/crate/planner/node/dml/UpdateById.java
@@ -153,7 +153,7 @@ public final class UpdateById implements Plan {
 
         @Override
         public ShardUpsertRequest newRequest(ShardId shardId) {
-            return requestBuilder.newRequest(shardId);
+            return requestBuilder.newRequest(shardId, false);
         }
 
         @Override

--- a/server/src/main/java/io/crate/planner/operators/InsertFromValues.java
+++ b/server/src/main/java/io/crate/planner/operators/InsertFromValues.java
@@ -623,7 +623,7 @@ public class InsertFromValues implements LogicalPlan {
                     requestItemsIterator.remove();
                     continue;
                 }
-                shardedRequests.add(itemAndRoutingAndSourceInfo.item(), shardLocation, null);
+                shardedRequests.add(itemAndRoutingAndSourceInfo.item(), shardLocation, null, true);
                 requestItemsIterator.remove();
             }
             if (requestItems.isEmpty()) {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/create/TransportCreateSnapshot.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/create/TransportCreateSnapshot.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.action.admin.cluster.snapshots.create;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
@@ -81,13 +82,13 @@ public class TransportCreateSnapshot extends TransportMasterNodeAction<CreateSna
         if (clusterBlockException != null) {
             return clusterBlockException;
         }
-        String[] indices = request.relationNames().stream()
+        String[] indexUUIDs = request.relationNames().stream()
             .map(r ->
                 state.metadata().getIndices(r, List.of(), false, IndexMetadata::getIndexUUID))
             .flatMap(Collection::stream)
             .toArray(String[]::new);
         return state.blocks()
-            .indicesBlockedException(ClusterBlockLevel.READ, indices);
+            .blockedException(ClusterBlockLevel.READ, Arrays.stream(indexUUIDs).mapToInt(indexUUID -> state.metadata().getRelationOid(indexUUID)).toArray(), indexUUIDs);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/create/TransportCreatePartitions.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/create/TransportCreatePartitions.java
@@ -385,9 +385,6 @@ public class TransportCreatePartitions extends TransportMasterNodeAction<CreateP
 
     @Override
     protected ClusterBlockException checkBlock(CreatePartitionsRequest request, ClusterState state) {
-        return state.blocks().indicesBlockedException(
-            ClusterBlockLevel.METADATA_WRITE,
-            request.indexNames().toArray(String[]::new)
-        );
+        return state.blocks().tableBlockedException(ClusterBlockLevel.WRITE, request.tableOID());
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/forcemerge/TransportForceMergeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/forcemerge/TransportForceMergeAction.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.action.admin.indices.forcemerge;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 
 import org.elasticsearch.action.ActionListener;
@@ -107,6 +108,7 @@ public class TransportForceMergeAction extends TransportBroadcastByNodeAction<Fo
 
     @Override
     protected ClusterBlockException checkRequestBlock(ClusterState state, ForceMergeRequest request, String[] concreteIndices) {
-        return state.blocks().indicesBlockedException(ClusterBlockLevel.METADATA_WRITE, concreteIndices);
+        int[] oids = Arrays.stream(concreteIndices).mapToInt(index -> state.metadata().getRelationOid(index)).toArray();
+        return state.blocks().blockedException(ClusterBlockLevel.METADATA_WRITE, oids, concreteIndices);
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/retention/TransportSyncRetentionLeasesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/retention/TransportSyncRetentionLeasesAction.java
@@ -22,6 +22,7 @@
 package org.elasticsearch.action.admin.indices.retention;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 
 import org.elasticsearch.action.ActionListener;
@@ -124,6 +125,6 @@ public class TransportSyncRetentionLeasesAction extends TransportBroadcastByNode
 
     @Override
     protected ClusterBlockException checkRequestBlock(ClusterState state, SyncRetentionLeasesRequest request, String[] concreteIndices) {
-        return state.blocks().indicesBlockedException(ClusterBlockLevel.METADATA_WRITE, concreteIndices);
+        return state.blocks().blockedException(ClusterBlockLevel.METADATA_WRITE, Arrays.stream(concreteIndices).mapToInt(index -> state.metadata().getRelationOid(index)).toArray(), concreteIndices);
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/settings/put/TransportUpdateSettings.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/settings/put/TransportUpdateSettings.java
@@ -22,6 +22,7 @@ package org.elasticsearch.action.admin.indices.settings.put;
 import static org.elasticsearch.common.settings.AbstractScopedSettings.ARCHIVED_SETTINGS_PREFIX;
 
 import java.io.IOException;
+import java.util.Arrays;
 
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.action.ActionListener;
@@ -86,10 +87,10 @@ public class TransportUpdateSettings extends TransportMasterNodeAction<UpdateSet
             || IndexMetadata.INDEX_BLOCKS_READ_ONLY_ALLOW_DELETE_SETTING.exists(settings)) {
             return null;
         }
-        String[] indices = state.metadata()
-            .getIndices(request.partitions(), false, im -> im.getIndex().getName())
+        String[] indexUUIDs = state.metadata()
+            .getIndices(request.partitions(), false, im -> im.getIndex().getUUID())
             .toArray(String[]::new);
-        return state.blocks().indicesBlockedException(ClusterBlockLevel.METADATA_WRITE, indices);
+        return state.blocks().blockedException(ClusterBlockLevel.METADATA_WRITE, Arrays.stream(indexUUIDs).mapToInt(index -> state.metadata().getRelationOid(index)).toArray(), indexUUIDs);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/shrink/TransportResize.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/shrink/TransportResize.java
@@ -94,13 +94,13 @@ public class TransportResize extends TransportMasterNodeAction<ResizeRequest, Re
 
     @Override
     protected ClusterBlockException checkBlock(ResizeRequest request, ClusterState state) {
-        String[] indices = state.metadata().getIndices(
+        String[] indexUUIDs = state.metadata().getIndices(
             request.table(),
             request.partitionValues(),
             false,
             idxMd -> idxMd.getIndex().getUUID()
         ).toArray(String[]::new);
-        return state.blocks().indicesBlockedException(ClusterBlockLevel.METADATA_WRITE, indices);
+        return state.blocks().blockedException(ClusterBlockLevel.METADATA_WRITE, new int[]{state.metadata().getRelationOid(request.table())}, indexUUIDs);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/stats/TransportIndicesStats.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/stats/TransportIndicesStats.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.action.admin.indices.stats;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 
 import org.apache.lucene.store.AlreadyClosedException;
@@ -88,7 +89,7 @@ public class TransportIndicesStats extends TransportBroadcastByNodeAction<Indice
 
     @Override
     protected ClusterBlockException checkRequestBlock(ClusterState state, IndicesStatsRequest request, String[] concreteIndices) {
-        return state.blocks().indicesBlockedException(ClusterBlockLevel.METADATA_READ, concreteIndices);
+        return state.blocks().blockedException(ClusterBlockLevel.METADATA_READ, Arrays.stream(concreteIndices).mapToInt(index -> state.metadata().getRelationOid(index)).toArray(), concreteIndices);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/support/replication/ReplicationRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/ReplicationRequest.java
@@ -56,6 +56,8 @@ public abstract class ReplicationRequest<Request extends ReplicationRequest<Requ
 
     private long routedBasedOnClusterVersion = 0;
 
+    private boolean unblockedRequest = false;
+
     /**
      * Creates a new request with resolved shard id
      */
@@ -70,6 +72,16 @@ public abstract class ReplicationRequest<Request extends ReplicationRequest<Requ
     public final Request timeout(TimeValue timeout) {
         this.timeout = timeout;
         return (Request) this;
+    }
+
+    @SuppressWarnings("unchecked")
+    public final Request unblockedRequest(boolean unblockedRequest) {
+        this.unblockedRequest = unblockedRequest;
+        return (Request) this;
+    }
+
+    public boolean unblockedRequest() {
+        return unblockedRequest;
     }
 
     public TimeValue timeout() {
@@ -128,6 +140,9 @@ public abstract class ReplicationRequest<Request extends ReplicationRequest<Requ
             in.readString();
         }
         routedBasedOnClusterVersion = in.readVLong();
+        if (in.getVersion().onOrAfter(Version.V_6_3_0)) {
+            unblockedRequest = in.readBoolean();
+        }
     }
 
     @Override
@@ -143,6 +158,9 @@ public abstract class ReplicationRequest<Request extends ReplicationRequest<Requ
             out.writeString(shardId.getIndexName());
         }
         out.writeVLong(routedBasedOnClusterVersion);
+        if (out.getVersion().onOrAfter(Version.V_6_3_0)) {
+            out.writeBoolean(unblockedRequest);
+        }
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
@@ -246,13 +246,16 @@ public abstract class TransportReplicationAction<
         return null;
     }
 
-    private ClusterBlockException blockExceptions(final ClusterState state, final String indexUUID) {
+    private ClusterBlockException blockExceptions(final ClusterState state, final String indexUUID, boolean skipCheckIndexBlocks) {
         ClusterBlockLevel globalBlockLevel = globalBlockLevel();
         if (globalBlockLevel != null) {
             ClusterBlockException blockException = state.blocks().globalBlockedException(globalBlockLevel);
             if (blockException != null) {
                 return blockException;
             }
+        }
+        if (skipCheckIndexBlocks) {
+            return null;
         }
         ClusterBlockLevel indexBlockLevel = indexBlockLevel();
         if (indexBlockLevel != null) {
@@ -334,7 +337,7 @@ public abstract class TransportReplicationAction<
                 final ClusterState clusterState = clusterService.state();
                 final IndexMetadata indexMetadata = clusterState.metadata().getIndexSafe(primaryShardReference.routingEntry().index());
 
-                final ClusterBlockException blockException = blockExceptions(clusterState, indexMetadata.getIndex().getUUID());
+                final ClusterBlockException blockException = blockExceptions(clusterState, indexMetadata.getIndex().getUUID(), primaryRequest.getRequest().unblockedRequest());
                 if (blockException != null) {
                     logger.trace("cluster is blocked, action failed on primary", blockException);
                     throw blockException;
@@ -615,7 +618,7 @@ public abstract class TransportReplicationAction<
         @Override
         public void doRun() {
             final ClusterState state = observer.setAndGetObservedState();
-            final ClusterBlockException blockException = blockExceptions(state, request.shardId().getIndexUUID());
+            final ClusterBlockException blockException = blockExceptions(state, request.shardId().getIndexUUID(), request.unblockedRequest());
             if (blockException != null) {
                 if (blockException.retryable()) {
                     logger.trace("cluster is blocked, scheduling a retry", blockException);

--- a/server/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
@@ -246,7 +246,7 @@ public abstract class TransportReplicationAction<
         return null;
     }
 
-    private ClusterBlockException blockExceptions(final ClusterState state, final String indexName) {
+    private ClusterBlockException blockExceptions(final ClusterState state, final String indexUUID) {
         ClusterBlockLevel globalBlockLevel = globalBlockLevel();
         if (globalBlockLevel != null) {
             ClusterBlockException blockException = state.blocks().globalBlockedException(globalBlockLevel);
@@ -256,10 +256,7 @@ public abstract class TransportReplicationAction<
         }
         ClusterBlockLevel indexBlockLevel = indexBlockLevel();
         if (indexBlockLevel != null) {
-            ClusterBlockException blockException = state.blocks().indexBlockedException(indexBlockLevel, indexName);
-            if (blockException != null) {
-                return blockException;
-            }
+            return state.blocks().blockedException(indexBlockLevel, state.metadata().getRelationOid(indexUUID), indexUUID);
         }
         return null;
     }

--- a/server/src/main/java/org/elasticsearch/action/support/single/shard/TransportSingleShardAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/single/shard/TransportSingleShardAction.java
@@ -183,7 +183,8 @@ public abstract class TransportSingleShardAction<Request extends SingleShardRequ
                 index = indexMetadata.getIndex();
             }
 
-            blockException = blocks.indexBlockedException(ClusterBlockLevel.READ, index.getUUID());
+            String indexUUID = index.getUUID();
+            blockException = blocks.blockedException(ClusterBlockLevel.READ, clusterState.metadata().getRelationOid(indexUUID), indexUUID);
             if (blockException != null) {
                 throw blockException;
             }

--- a/server/src/main/java/org/elasticsearch/cluster/block/ClusterBlocks.java
+++ b/server/src/main/java/org/elasticsearch/cluster/block/ClusterBlocks.java
@@ -34,12 +34,16 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.cluster.Diffable;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.RelationMetadata;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.settings.Settings;
 import org.jspecify.annotations.Nullable;
 
+import io.crate.common.annotations.VisibleForTesting;
 import io.crate.rest.action.HttpErrorStatus;
 
 /**
@@ -47,22 +51,29 @@ import io.crate.rest.action.HttpErrorStatus;
  */
 public class ClusterBlocks implements Diffable<ClusterBlocks> {
 
-    public static final ClusterBlocks EMPTY_CLUSTER_BLOCK = new ClusterBlocks(emptySet(), Map.of());
+    public static final ClusterBlocks EMPTY_CLUSTER_BLOCK = new ClusterBlocks(emptySet(), Map.of(), Map.of());
 
     private final Set<ClusterBlock> global;
+
+    private final Map<Integer, Set<ClusterBlock>> tablesBlocks;
 
     private final Map<String, Set<ClusterBlock>> indicesBlocks;
 
     private final EnumMap<ClusterBlockLevel, ImmutableLevelHolder> levelHolders;
 
-    ClusterBlocks(Set<ClusterBlock> global, Map<String, Set<ClusterBlock>> indicesBlocks) {
+    ClusterBlocks(Set<ClusterBlock> global, Map<Integer, Set<ClusterBlock>> tablesBlocks, Map<String, Set<ClusterBlock>> indicesBlocks) {
         this.global = global;
+        this.tablesBlocks = tablesBlocks;
         this.indicesBlocks = indicesBlocks;
-        levelHolders = generateLevelHolders(global, indicesBlocks);
+        levelHolders = generateLevelHolders(global, tablesBlocks, indicesBlocks);
     }
 
     public Set<ClusterBlock> global() {
         return global;
+    }
+
+    public Map<Integer, Set<ClusterBlock>> tables() {
+        return tablesBlocks;
     }
 
     public Map<String, Set<ClusterBlock>> indices() {
@@ -83,15 +94,12 @@ public class ClusterBlocks implements Diffable<ClusterBlocks> {
         return blocks;
     }
 
-    public Map<String, Set<ClusterBlock>> indices(ClusterBlockLevel level) {
-        return levelHolders.get(level).indices();
-    }
-
-    private Set<ClusterBlock> blocksForIndex(ClusterBlockLevel level, String index) {
-        return indices(level).getOrDefault(index, emptySet());
+    private Set<ClusterBlock> blocksForIndex(ClusterBlockLevel level, String indexUUID) {
+        return levelHolders.get(level).indices().getOrDefault(indexUUID, emptySet());
     }
 
     private static EnumMap<ClusterBlockLevel, ImmutableLevelHolder> generateLevelHolders(Set<ClusterBlock> global,
+                                                                                         Map<Integer, Set<ClusterBlock>> tablesBlocks,
                                                                                          Map<String, Set<ClusterBlock>> indicesBlocks) {
         EnumMap<ClusterBlockLevel, ImmutableLevelHolder> levelHolders = new EnumMap<>(ClusterBlockLevel.class);
         for (final ClusterBlockLevel level : ClusterBlockLevel.values()) {
@@ -99,6 +107,15 @@ public class ClusterBlocks implements Diffable<ClusterBlocks> {
             Set<ClusterBlock> newGlobal = unmodifiableSet(global.stream()
                 .filter(containsLevel)
                 .collect(toSet()));
+
+            HashMap<Integer, Set<ClusterBlock>> tablesBuilder = HashMap.newHashMap(tablesBlocks.size());
+            for (var entry : tablesBlocks.entrySet()) {
+                Integer key = entry.getKey();
+                Set<ClusterBlock> value = entry.getValue();
+                tablesBuilder.put(key, unmodifiableSet(value.stream()
+                    .filter(containsLevel)
+                    .collect(toSet())));
+            }
 
             HashMap<String, Set<ClusterBlock>> indicesBuilder = HashMap.newHashMap(indicesBlocks.size());
             for (var entry : indicesBlocks.entrySet()) {
@@ -108,7 +125,7 @@ public class ClusterBlocks implements Diffable<ClusterBlocks> {
                     .filter(containsLevel)
                     .collect(toSet())));
             }
-            levelHolders.put(level, new ImmutableLevelHolder(newGlobal, Map.copyOf(indicesBuilder)));
+            levelHolders.put(level, new ImmutableLevelHolder(newGlobal, Map.copyOf(tablesBuilder), Map.copyOf(indicesBuilder)));
         }
         return levelHolders;
     }
@@ -138,10 +155,6 @@ public class ClusterBlocks implements Diffable<ClusterBlocks> {
         return false;
     }
 
-    public boolean hasGlobalBlockWithLevel(ClusterBlockLevel level) {
-        return global(level).size() > 0;
-    }
-
     /**
      * Is there a global block with the provided status?
      */
@@ -155,10 +168,11 @@ public class ClusterBlocks implements Diffable<ClusterBlocks> {
     }
 
     public boolean hasIndexBlock(String indexUUID, ClusterBlock block) {
-        return indicesBlocks.containsKey(indexUUID) && indicesBlocks.get(indexUUID).contains(block);
+        return indicesBlocks.getOrDefault(indexUUID, emptySet()).contains(block);
     }
 
-    public boolean hasIndexBlockWithId(String indexUUID, int blockId) {
+    @VisibleForTesting
+    boolean hasIndexBlockWithId(String indexUUID, int blockId) {
         final Set<ClusterBlock> clusterBlocks = indicesBlocks.get(indexUUID);
         if (clusterBlocks != null) {
             for (ClusterBlock clusterBlock : clusterBlocks) {
@@ -170,8 +184,9 @@ public class ClusterBlocks implements Diffable<ClusterBlocks> {
         return false;
     }
 
+    @VisibleForTesting
     @Nullable
-    public ClusterBlock getIndexBlockWithId(final String indexUUID, final int blockId) {
+    ClusterBlock getIndexBlockWithId(final String indexUUID, final int blockId) {
         final Set<ClusterBlock> clusterBlocks = indicesBlocks.get(indexUUID);
         if (clusterBlocks != null) {
             for (ClusterBlock clusterBlock : clusterBlocks) {
@@ -194,35 +209,44 @@ public class ClusterBlocks implements Diffable<ClusterBlocks> {
         return new ClusterBlockException(global(level));
     }
 
-    public ClusterBlockException indexBlockedException(ClusterBlockLevel level, String index) {
-        if (!indexBlocked(level, index)) {
+    private Set<ClusterBlock> tableBlocks(ClusterBlockLevel level, int tableOid) {
+        return levelHolders.get(level).tables().getOrDefault(tableOid, emptySet());
+    }
+
+    public ClusterBlockException tableBlockedException(ClusterBlockLevel level, int tableOid) {
+        Set<ClusterBlock> blocks = tableBlocks(level, tableOid);
+        if (blocks.isEmpty()) {
             return null;
         }
-        Stream<ClusterBlock> blocks = concat(
-                global(level).stream(),
-                blocksForIndex(level, index).stream());
-        return new ClusterBlockException(unmodifiableSet(blocks.collect(toSet())));
+        throw new ClusterBlockException(blocks);
     }
 
-    public boolean indexBlocked(ClusterBlockLevel level, String index) {
-        return globalBlocked(level) || blocksForIndex(level, index).isEmpty() == false;
+    public boolean isBlocked(ClusterBlockLevel level, int tableOid, String indexUUID) {
+        return globalBlocked(level) || !tableBlocks(level, tableOid).isEmpty() || !blocksForIndex(level, indexUUID).isEmpty();
     }
 
-    public ClusterBlockException indicesBlockedException(ClusterBlockLevel level, String[] indices) {
-        boolean indexIsBlocked = false;
+    public ClusterBlockException blockedException(ClusterBlockLevel level, int tableOid, String indexUUID) {
+        Set<ClusterBlock> blocks = new HashSet<>(global(level));
+        blocks.addAll(tableBlocks(level, tableOid));
+        blocks.addAll(blocksForIndex(level, indexUUID));
+        if (blocks.isEmpty()) {
+            return null;
+        }
+        return new ClusterBlockException(blocks);
+    }
+
+    public ClusterBlockException blockedException(ClusterBlockLevel level, int[] tableOids, String[] indices) {
+        Set<ClusterBlock> blocks = new HashSet<>(global(level));
+        for (int oid : tableOids) {
+            blocks.addAll(tableBlocks(level, oid));
+        }
         for (String index : indices) {
-            if (indexBlocked(level, index)) {
-                indexIsBlocked = true;
-            }
+            blocks.addAll(blocksForIndex(level, index));
         }
-        if (globalBlocked(level) == false && indexIsBlocked == false) {
+        if (blocks.isEmpty()) {
             return null;
         }
-        Function<String, Stream<ClusterBlock>> blocksForIndexAtLevel = index -> blocksForIndex(level, index).stream();
-        Stream<ClusterBlock> blocks = concat(
-                global(level).stream(),
-                Stream.of(indices).flatMap(blocksForIndexAtLevel));
-        return new ClusterBlockException(unmodifiableSet(blocks.collect(toSet())));
+        return new ClusterBlockException(blocks);
     }
 
     /**
@@ -273,6 +297,9 @@ public class ClusterBlocks implements Diffable<ClusterBlocks> {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         writeBlockSet(global, out);
+        if (out.getVersion().onOrAfter(Version.V_6_3_0)) {
+            out.writeMap(tablesBlocks, StreamOutput::writeInt, (o, s) -> writeBlockSet(s, o));
+        }
         out.writeMap(indicesBlocks, StreamOutput::writeString, (o, s) -> writeBlockSet(s, o));
     }
 
@@ -282,12 +309,16 @@ public class ClusterBlocks implements Diffable<ClusterBlocks> {
 
     public static ClusterBlocks readFrom(StreamInput in) throws IOException {
         final Set<ClusterBlock> global = readBlockSet(in);
+        Map<Integer, Set<ClusterBlock>> tablesBlocks = Map.of();
+        if (in.getVersion().onOrAfter(Version.V_6_3_0)) {
+            tablesBlocks = in.readMap(StreamInput::readInt, ClusterBlocks::readBlockSet);
+        }
         Map<String, Set<ClusterBlock>> indicesBlocks =
             in.readMap(i -> i.readString().intern(), ClusterBlocks::readBlockSet);
-        if (global.isEmpty() && indicesBlocks.isEmpty()) {
+        if (global.isEmpty() && tablesBlocks.isEmpty() && indicesBlocks.isEmpty()) {
             return EMPTY_CLUSTER_BLOCK;
         }
-        return new ClusterBlocks(global, indicesBlocks);
+        return new ClusterBlocks(global, tablesBlocks, indicesBlocks);
     }
 
     private static Set<ClusterBlock> readBlockSet(StreamInput in) throws IOException {
@@ -295,13 +326,14 @@ public class ClusterBlocks implements Diffable<ClusterBlocks> {
         return blocks.isEmpty() ? blocks : unmodifiableSet(blocks);
     }
 
-    record ImmutableLevelHolder(Set<ClusterBlock> global, Map<String, Set<ClusterBlock>> indices) {
+    record ImmutableLevelHolder(Set<ClusterBlock> global, Map<Integer, Set<ClusterBlock>> tables, Map<String, Set<ClusterBlock>> indices) {
     }
 
     @Override
     public int hashCode() {
         int result = 1;
         result = 31 * result + global.hashCode();
+        result = 31 * result + tablesBlocks.hashCode();
         result = 31 * result + indicesBlocks.hashCode();
         result = 31 * result + levelHolders.hashCode();
         return result;
@@ -311,6 +343,7 @@ public class ClusterBlocks implements Diffable<ClusterBlocks> {
     public boolean equals(Object obj) {
         return obj instanceof ClusterBlocks other
             && global.equals(other.global)
+            && tablesBlocks.equals(other.tablesBlocks)
             && indicesBlocks.equals(other.indicesBlocks)
             && levelHolders.equals(other.levelHolders);
     }
@@ -322,7 +355,7 @@ public class ClusterBlocks implements Diffable<ClusterBlocks> {
     public static class Builder {
 
         private final Set<ClusterBlock> global = new HashSet<>();
-
+        private final Map<Integer, Set<ClusterBlock>> tables = new HashMap<>();
         private final Map<String, Set<ClusterBlock>> indices = new HashMap<>();
 
         public Builder() {
@@ -330,6 +363,12 @@ public class ClusterBlocks implements Diffable<ClusterBlocks> {
 
         public Builder blocks(ClusterBlocks blocks) {
             global.addAll(blocks.global());
+            for (var entry : blocks.tablesBlocks.entrySet()) {
+                Integer oid = entry.getKey();
+                for (ClusterBlock block : entry.getValue()) {
+                    addTableBlock(oid, block);
+                }
+            }
             for (var entry : blocks.indices().entrySet()) {
                 String key = entry.getKey();
                 Set<ClusterBlock> value = entry.getValue();
@@ -341,24 +380,56 @@ public class ClusterBlocks implements Diffable<ClusterBlocks> {
             return this;
         }
 
-        public Builder addBlocks(IndexMetadata indexMetadata) {
+        public Builder updateTableBlocks(RelationMetadata relationMetadata) {
+            int oid = relationMetadata.oid();
+            Settings settings = relationMetadata.settings();
+            if (IndexMetadata.INDEX_READ_ONLY_SETTING.get(settings)) {
+                addTableBlock(oid, IndexMetadata.INDEX_READ_ONLY_BLOCK);
+            } else {
+                removeTableBlock(oid, IndexMetadata.INDEX_READ_ONLY_BLOCK);
+            }
+            if (IndexMetadata.INDEX_BLOCKS_READ_SETTING.get(settings)) {
+                addTableBlock(oid, IndexMetadata.INDEX_READ_BLOCK);
+            } else {
+                removeTableBlock(oid, IndexMetadata.INDEX_READ_BLOCK);
+            }
+            if (IndexMetadata.INDEX_BLOCKS_WRITE_SETTING.get(settings)) {
+                addTableBlock(oid, IndexMetadata.INDEX_WRITE_BLOCK);
+            } else {
+                removeTableBlock(oid, IndexMetadata.INDEX_WRITE_BLOCK);
+            }
+            if (IndexMetadata.INDEX_BLOCKS_METADATA_SETTING.get(settings)) {
+                addTableBlock(oid, IndexMetadata.INDEX_METADATA_BLOCK);
+            } else {
+                removeTableBlock(oid, IndexMetadata.INDEX_METADATA_BLOCK);
+            }
+            if (IndexMetadata.INDEX_BLOCKS_READ_ONLY_ALLOW_DELETE_SETTING.get(settings)) {
+                addTableBlock(oid, IndexMetadata.INDEX_READ_ONLY_ALLOW_DELETE_BLOCK);
+            } else {
+                removeTableBlock(oid, IndexMetadata.INDEX_READ_ONLY_ALLOW_DELETE_BLOCK);
+            }
+            return this;
+        }
+
+        public Builder addIndexBlocks(IndexMetadata indexMetadata) {
             String indexUUID = indexMetadata.getIndex().getUUID();
             if (indexMetadata.getState() == IndexMetadata.State.CLOSE) {
                 addIndexBlock(indexUUID, IndexMetadata.INDEX_CLOSED_BLOCK);
             }
-            if (IndexMetadata.INDEX_READ_ONLY_SETTING.get(indexMetadata.getSettings())) {
+            Settings settings = indexMetadata.getSettings();
+            if (IndexMetadata.INDEX_READ_ONLY_SETTING.get(settings)) {
                 addIndexBlock(indexUUID, IndexMetadata.INDEX_READ_ONLY_BLOCK);
             }
-            if (IndexMetadata.INDEX_BLOCKS_READ_SETTING.get(indexMetadata.getSettings())) {
+            if (IndexMetadata.INDEX_BLOCKS_READ_SETTING.get(settings)) {
                 addIndexBlock(indexUUID, IndexMetadata.INDEX_READ_BLOCK);
             }
-            if (IndexMetadata.INDEX_BLOCKS_WRITE_SETTING.get(indexMetadata.getSettings())) {
+            if (IndexMetadata.INDEX_BLOCKS_WRITE_SETTING.get(settings)) {
                 addIndexBlock(indexUUID, IndexMetadata.INDEX_WRITE_BLOCK);
             }
-            if (IndexMetadata.INDEX_BLOCKS_METADATA_SETTING.get(indexMetadata.getSettings())) {
+            if (IndexMetadata.INDEX_BLOCKS_METADATA_SETTING.get(settings)) {
                 addIndexBlock(indexUUID, IndexMetadata.INDEX_METADATA_BLOCK);
             }
-            if (IndexMetadata.INDEX_BLOCKS_READ_ONLY_ALLOW_DELETE_SETTING.get(indexMetadata.getSettings())) {
+            if (IndexMetadata.INDEX_BLOCKS_READ_ONLY_ALLOW_DELETE_SETTING.get(settings)) {
                 addIndexBlock(indexUUID, IndexMetadata.INDEX_READ_ONLY_ALLOW_DELETE_BLOCK);
             }
             return this;
@@ -369,19 +440,20 @@ public class ClusterBlocks implements Diffable<ClusterBlocks> {
             if (indexMetadata.getState() == IndexMetadata.State.CLOSE) {
                 addIndexBlock(indexName, IndexMetadata.INDEX_CLOSED_BLOCK);
             }
-            if (IndexMetadata.INDEX_READ_ONLY_SETTING.get(indexMetadata.getSettings())) {
+            Settings settings = indexMetadata.getSettings();
+            if (IndexMetadata.INDEX_READ_ONLY_SETTING.get(settings)) {
                 addIndexBlock(indexName, IndexMetadata.INDEX_READ_ONLY_BLOCK);
             }
-            if (IndexMetadata.INDEX_BLOCKS_READ_SETTING.get(indexMetadata.getSettings())) {
+            if (IndexMetadata.INDEX_BLOCKS_READ_SETTING.get(settings)) {
                 addIndexBlock(indexName, IndexMetadata.INDEX_READ_BLOCK);
             }
-            if (IndexMetadata.INDEX_BLOCKS_WRITE_SETTING.get(indexMetadata.getSettings())) {
+            if (IndexMetadata.INDEX_BLOCKS_WRITE_SETTING.get(settings)) {
                 addIndexBlock(indexName, IndexMetadata.INDEX_WRITE_BLOCK);
             }
-            if (IndexMetadata.INDEX_BLOCKS_METADATA_SETTING.get(indexMetadata.getSettings())) {
+            if (IndexMetadata.INDEX_BLOCKS_METADATA_SETTING.get(settings)) {
                 addIndexBlock(indexName, IndexMetadata.INDEX_METADATA_BLOCK);
             }
-            if (IndexMetadata.INDEX_BLOCKS_READ_ONLY_ALLOW_DELETE_SETTING.get(indexMetadata.getSettings())) {
+            if (IndexMetadata.INDEX_BLOCKS_READ_ONLY_ALLOW_DELETE_SETTING.get(settings)) {
                 addIndexBlock(indexName, IndexMetadata.INDEX_READ_ONLY_ALLOW_DELETE_BLOCK);
             }
             return this;
@@ -390,7 +462,7 @@ public class ClusterBlocks implements Diffable<ClusterBlocks> {
         public Builder updateBlocks(IndexMetadata indexMetadata) {
             // let's remove all blocks for this index and add them back -- no need to remove all individual blocks....
             indices.remove(indexMetadata.getIndex().getUUID());
-            return addBlocks(indexMetadata);
+            return addIndexBlocks(indexMetadata);
         }
 
         public Builder addGlobalBlock(ClusterBlock block) {
@@ -417,20 +489,26 @@ public class ClusterBlocks implements Diffable<ClusterBlocks> {
             return this;
         }
 
-        public Builder removeIndexBlocks(String indexUUID) {
-            if (!indices.containsKey(indexUUID)) {
-                return this;
+        public Builder addTableBlock(int tableOid, ClusterBlock block) {
+            if (!tables.containsKey(tableOid)) {
+                tables.put(tableOid, new HashSet<>());
             }
+            tables.get(tableOid).add(block);
+            return this;
+        }
+
+        public Builder removeIndexBlocks(String indexUUID) {
             indices.remove(indexUUID);
             return this;
         }
 
         public Builder removeIndexBlock(String index, ClusterBlock block) {
-            if (!indices.containsKey(index)) {
+            Set<ClusterBlock> blocks = indices.get(index);
+            if (blocks == null) {
                 return this;
             }
-            indices.get(index).remove(block);
-            if (indices.get(index).isEmpty()) {
+            blocks.remove(block);
+            if (blocks.isEmpty()) {
                 indices.remove(index);
             }
             return this;
@@ -448,16 +526,32 @@ public class ClusterBlocks implements Diffable<ClusterBlocks> {
             return this;
         }
 
+        public Builder removeTableBlock(Integer tableOid, ClusterBlock block) {
+            Set<ClusterBlock> blocks = tables.get(tableOid);
+            if (blocks == null) {
+                return this;
+            }
+            blocks.remove(block);
+            if (blocks.isEmpty()) {
+                tables.remove(tableOid);
+            }
+            return this;
+        }
+
         public ClusterBlocks build() {
-            if (indices.isEmpty() && global.isEmpty()) {
+            if (indices.isEmpty() && tables.isEmpty() && global.isEmpty()) {
                 return EMPTY_CLUSTER_BLOCK;
             }
             // We copy the block sets here in case of the builder is modified after build is called
+            HashMap<Integer, Set<ClusterBlock>> tablesBuilder = HashMap.newHashMap(tables.size());
+            for (Map.Entry<Integer, Set<ClusterBlock>> entry : tables.entrySet()) {
+                tablesBuilder.put(entry.getKey(), Set.copyOf(entry.getValue()));
+            }
             HashMap<String, Set<ClusterBlock>> indicesBuilder = HashMap.newHashMap(indices.size());
             for (Map.Entry<String, Set<ClusterBlock>> entry : indices.entrySet()) {
                 indicesBuilder.put(entry.getKey(), Set.copyOf(entry.getValue()));
             }
-            return new ClusterBlocks(Set.copyOf(global), Map.copyOf(indicesBuilder));
+            return new ClusterBlocks(Set.copyOf(global), Map.copyOf(tablesBuilder), Map.copyOf(indicesBuilder));
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -1648,6 +1648,19 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata> {
         return indexUUIDsRelations.get(indexUUID);
     }
 
+    public int getRelationOid(String indexUUID) {
+        RelationMetadata relationMetadata = getRelation(indexUUID);
+        if (relationMetadata == null) {
+            return OID_UNASSIGNED;
+        }
+        return relationMetadata.oid();
+    }
+
+    public int getRelationOid(RelationName relationName) {
+        RelationMetadata relationMetadata = getRelation(relationName);
+        return relationMetadata == null ? OID_UNASSIGNED : relationMetadata.oid();
+    }
+
     @Nullable
     @SuppressWarnings("unchecked")
     public <T extends RelationMetadata> T getRelation(int tableOID) {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
@@ -353,7 +353,7 @@ public class MetadataCreateIndexService {
             if (metadata.hasIndex(resizedIndexUUID)) {
                 throw new ResourceAlreadyExistsException(resizedIndexUUID);
             }
-            if (!currentState.blocks().indexBlocked(ClusterBlockLevel.WRITE, sourceIndexUUID)) {
+            if (!currentState.blocks().isBlocked(ClusterBlockLevel.WRITE, metadata.getRelationOid(sourceIndexUUID), sourceIndexUUID)) {
                 throw new IllegalStateException("index " + sourceIndex + " must be read-only to resize index. use \"index.blocks.write=true\"");
             }
 

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataUpdateSettingsService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataUpdateSettingsService.java
@@ -118,7 +118,7 @@ public class MetadataUpdateSettingsService {
 
             @Override
             public ClusterState execute(ClusterState currentState) {
-                return updateState(
+                return updateStateForPartitions(
                     currentState,
                     request.partitions(),
                     skippedSettings,
@@ -130,11 +130,11 @@ public class MetadataUpdateSettingsService {
         clusterService.submitStateUpdateTask("update-settings", updateTask);
     }
 
-    public ClusterState updateState(ClusterState currentState,
-                                    List<PartitionName> partitions,
-                                    final Set<String> skippedSettings,
-                                    final Settings closedSettings,
-                                    final Settings openSettings) {
+    public ClusterState updateStateForPartitions(ClusterState currentState,
+                                                 List<PartitionName> partitions,
+                                                 final Set<String> skippedSettings,
+                                                 final Settings closedSettings,
+                                                 final Settings openSettings) {
         RoutingTable.Builder routingTableBuilder = RoutingTable.builder(currentState.routingTable());
         Metadata.Builder metadataBuilder = Metadata.builder(currentState.metadata());
 
@@ -178,15 +178,15 @@ public class MetadataUpdateSettingsService {
 
         ClusterBlocks.Builder blocks = ClusterBlocks.builder().blocks(currentState.blocks());
         maybeUpdateClusterBlock(indexes, blocks, IndexMetadata.INDEX_READ_ONLY_BLOCK,
-                IndexMetadata.INDEX_READ_ONLY_SETTING, openSettings);
+            IndexMetadata.INDEX_READ_ONLY_SETTING, openSettings);
         maybeUpdateClusterBlock(indexes, blocks, IndexMetadata.INDEX_READ_ONLY_ALLOW_DELETE_BLOCK,
-                IndexMetadata.INDEX_BLOCKS_READ_ONLY_ALLOW_DELETE_SETTING, openSettings);
+            IndexMetadata.INDEX_BLOCKS_READ_ONLY_ALLOW_DELETE_SETTING, openSettings);
         maybeUpdateClusterBlock(indexes, blocks, IndexMetadata.INDEX_METADATA_BLOCK,
-                IndexMetadata.INDEX_BLOCKS_METADATA_SETTING, openSettings);
+            IndexMetadata.INDEX_BLOCKS_METADATA_SETTING, openSettings);
         maybeUpdateClusterBlock(indexes, blocks, IndexMetadata.INDEX_WRITE_BLOCK,
-                IndexMetadata.INDEX_BLOCKS_WRITE_SETTING, openSettings);
+            IndexMetadata.INDEX_BLOCKS_WRITE_SETTING, openSettings);
         maybeUpdateClusterBlock(indexes, blocks, IndexMetadata.INDEX_READ_BLOCK,
-                IndexMetadata.INDEX_BLOCKS_READ_SETTING, openSettings);
+            IndexMetadata.INDEX_BLOCKS_READ_SETTING, openSettings);
 
         for (IndexMetadata indexMetadata : indexes) {
             Settings.Builder updates = Settings.builder();
@@ -246,12 +246,13 @@ public class MetadataUpdateSettingsService {
     private static void maybeUpdateClusterBlock(List<IndexMetadata> indexes, ClusterBlocks.Builder blocks, ClusterBlock block, Setting<Boolean> setting, Settings openSettings) {
         if (setting.exists(openSettings)) {
             final boolean updateBlock = setting.get(openSettings);
-            for (IndexMetadata im : indexes) {
-                String indexUUID = im.getIndex().getUUID();
-                if (updateBlock) {
-                    blocks.addIndexBlock(indexUUID, block);
-                } else {
-                    blocks.removeIndexBlock(indexUUID, block);
+            if (updateBlock) {
+                for (IndexMetadata im : indexes) {
+                    blocks.addIndexBlock(im.getIndex().getUUID(), block);
+                }
+            } else {
+                for (IndexMetadata im : indexes) {
+                    blocks.removeIndexBlock(im.getIndex().getUUID(), block);
                 }
             }
         }

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/DiskThresholdMonitor.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/DiskThresholdMonitor.java
@@ -312,7 +312,7 @@ public class DiskThresholdMonitor {
             listener.onResponse(null);
         }
 
-        indicesToMarkReadOnly.removeIf(indexUUID -> state.blocks().indexBlocked(ClusterBlockLevel.WRITE, indexUUID));
+        indicesToMarkReadOnly.removeIf(indexUUID -> state.blocks().isBlocked(ClusterBlockLevel.WRITE, metadata.getRelationOid(indexUUID), indexUUID));
         LOGGER.trace("marking indices as read-only: [{}]", indicesToMarkReadOnly);
         if (indicesToMarkReadOnly.isEmpty() == false) {
             updateIndicesReadOnly(indicesToMarkReadOnly, metadata::index, listener, true);

--- a/server/src/main/java/org/elasticsearch/gateway/ClusterStateUpdaters.java
+++ b/server/src/main/java/org/elasticsearch/gateway/ClusterStateUpdaters.java
@@ -30,6 +30,8 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlocks;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.metadata.RelationMetadata;
+import org.elasticsearch.cluster.metadata.SchemaMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.RoutingTable;
@@ -85,8 +87,14 @@ public final class ClusterStateUpdaters {
             blocks.addGlobalBlock(Metadata.CLUSTER_READ_ONLY_ALLOW_DELETE_BLOCK);
         }
 
+        for (SchemaMetadata schemaMetadata : state.metadata().schemas().values()) {
+            for (RelationMetadata relationMetadata : schemaMetadata.relations().values()) {
+                blocks.updateTableBlocks(relationMetadata);
+            }
+        }
+
         for (final IndexMetadata indexMetadata : state.metadata()) {
-            blocks.addBlocks(indexMetadata);
+            blocks.addIndexBlocks(indexMetadata);
         }
 
         return ClusterState.builder(state).blocks(blocks).build();

--- a/server/src/main/java/org/elasticsearch/gateway/LocalAllocateDangledIndices.java
+++ b/server/src/main/java/org/elasticsearch/gateway/LocalAllocateDangledIndices.java
@@ -166,7 +166,7 @@ public class LocalAllocateDangledIndices {
                                 .version(indexMetadata.getVersion() + 1).build();
                         }
                         metadataBuilder.put(upgradedIndexMetadata, false);
-                        blocks.addBlocks(upgradedIndexMetadata);
+                        blocks.addIndexBlocks(upgradedIndexMetadata);
                         if (upgradedIndexMetadata.getState() == IndexMetadata.State.OPEN || isIndexVerifiedBeforeClosed(indexMetadata)) {
                             routingTableBuilder.addAsFromDangling(upgradedIndexMetadata);
                         }

--- a/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -482,7 +482,7 @@ public class RestoreService implements ClusterStateApplier {
                         shardLimitValidator.validateShardLimit(snapshotIndexMetadata.getSettings(), currentState);
                         IndexMetadata updatedIndexMetadata = indexMdBuilder.build();
                         rtBuilder.addAsNewRestore(updatedIndexMetadata, recoverySource);
-                        blocks.addBlocks(updatedIndexMetadata);
+                        blocks.addIndexBlocks(updatedIndexMetadata);
                         mdBuilder.put(updatedIndexMetadata, true);
                         renamedIndex = updatedIndexMetadata.getIndex();
                     } else {

--- a/server/src/test/java/io/crate/execution/ddl/tables/AlterTableRequestTest.java
+++ b/server/src/test/java/io/crate/execution/ddl/tables/AlterTableRequestTest.java
@@ -39,8 +39,8 @@ public class AlterTableRequestTest {
     public void test_streaming_bwc() throws Exception {
         RelationName tbl = new RelationName("doc", "tbl");
         List<AlterTableRequest> requests = List.of(
-            new AlterTableRequest(tbl, List.of(), true, false, Settings.EMPTY),
-            new AlterTableRequest(tbl, Arrays.asList("1", null, "3"), true, false, Settings.EMPTY)
+            new AlterTableRequest(tbl, List.of(), true, false, false, Settings.EMPTY),
+            new AlterTableRequest(tbl, Arrays.asList("1", null, "3"), true, false, false, Settings.EMPTY)
         );
         for (var request : requests) {
             try (var out = new BytesStreamOutput()) {

--- a/server/src/test/java/io/crate/execution/dml/UpsertReplicaRequestTest.java
+++ b/server/src/test/java/io/crate/execution/dml/UpsertReplicaRequestTest.java
@@ -133,12 +133,13 @@ public class UpsertReplicaRequestTest extends CrateDummyClusterServiceUnitTest {
             new UpsertReplicaRequest.Item("1", new Object[] { 1, "Arthur" }, List.of("1"), 1, 2, 3),
             new UpsertReplicaRequest.Item("2", new Object[] { 2, "Trillian" }, List.of("2"), 4, 5, 6)
         );
-        UpsertReplicaRequest replicaRequest = new UpsertReplicaRequest(
+        UpsertReplicaRequest replicaRequest = UpsertReplicaRequest.of(
             shardId,
             jobId,
             sessionSettings,
             List.of(idRef, nameRef),
-            items
+            items,
+            false
         );
         try (var out = new BytesStreamOutput()) {
             out.setVersion(Version.V_5_10_10);
@@ -169,12 +170,13 @@ public class UpsertReplicaRequestTest extends CrateDummyClusterServiceUnitTest {
             new UpsertReplicaRequest.Item("1", new Object[] { 1, "Arthur" }, List.of("1"), 1, 2, 3),
             new UpsertReplicaRequest.Item("2", new Object[] { 2, "Trillian" }, List.of("2"), 4, 5, 6)
         );
-        UpsertReplicaRequest replicaRequest = new UpsertReplicaRequest(
+        UpsertReplicaRequest replicaRequest = UpsertReplicaRequest.of(
             shardId,
             jobId,
             sessionSettings,
             List.of(idRef, nameRef),
-            items
+            items,
+            false
         );
         for (var version : List.of(Version.V_6_1_0, Version.CURRENT)) {
             try (var out = new BytesStreamOutput()) {

--- a/server/src/test/java/io/crate/execution/dml/upsert/ShardUpsertRequestTest.java
+++ b/server/src/test/java/io/crate/execution/dml/upsert/ShardUpsertRequestTest.java
@@ -87,7 +87,7 @@ public class ShardUpsertRequestTest extends CrateDummyClusterServiceUnitTest {
             assignmentColumns,
             missingAssignmentColumns,
             null,
-            jobId).newRequest(shardId);
+            jobId).newRequest(shardId, false);
 
         request.add(123, ShardUpsertRequest.Item.forInsert(
             "99",
@@ -146,7 +146,7 @@ public class ShardUpsertRequestTest extends CrateDummyClusterServiceUnitTest {
             missingAssignmentColumns,
             null,
             jobId
-        ).newRequest(shardId);
+        ).newRequest(shardId, false);
 
         request.add(123, ShardUpsertRequest.Item.forInsert(
             "99",
@@ -201,7 +201,7 @@ public class ShardUpsertRequestTest extends CrateDummyClusterServiceUnitTest {
             missingAssignmentColumns,
             null,
             jobId
-        ).newRequest(shardId);
+        ).newRequest(shardId, false);
 
         request.add(42, ShardUpsertRequest.Item.forInsert(
             "42",

--- a/server/src/test/java/io/crate/execution/dml/upsert/TransportShardUpsertActionTest.java
+++ b/server/src/test/java/io/crate/execution/dml/upsert/TransportShardUpsertActionTest.java
@@ -243,7 +243,7 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
             missingAssignmentsColumns,
             null,
             UUID.randomUUID()
-        ).newRequest(shardId);
+        ).newRequest(shardId, false);
         request.add(1, ShardUpsertRequest.Item.forInsert(
                 "1",
                 List.of(),
@@ -274,7 +274,7 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
             missingAssignmentsColumns,
             null,
             UUID.randomUUID()
-        ).newRequest(shardId);
+        ).newRequest(shardId, false);
         request.add(1, ShardUpsertRequest.Item.forInsert(
             "1",
             List.of(),
@@ -307,7 +307,7 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
             missingAssignmentsColumns,
             null,
             UUID.randomUUID()
-        ).newRequest(shardId);
+        ).newRequest(shardId, false);
         request.add(1, ShardUpsertRequest.Item.forInsert(
             "1",
             List.of(),
@@ -339,7 +339,7 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
         );
         ShardId shardId = new ShardId(TABLE_IDENT.indexNameOrAlias(), charactersIndexUUID, 0);
         String itemId = "1";
-        var request = new UpsertReplicaRequest(
+        var request = UpsertReplicaRequest.of(
             shardId,
             UUID.randomUUID(),
             DUMMY_SESSION_INFO,
@@ -353,7 +353,8 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
                     1,
                     1
                 )
-            )
+            ),
+            false
         );
 
 
@@ -404,7 +405,7 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
             missingAssignmentsColumns,
             null,
             UUID.randomUUID()
-        ).newRequest(shardId);
+        ).newRequest(shardId, false);
         request.add(2, ShardUpsertRequest.Item.forInsert(
             "2",
             List.of(),
@@ -457,7 +458,7 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
             missingAssignmentsColumns,
             null,
             UUID.randomUUID()
-        ).newRequest(shardId);
+        ).newRequest(shardId, false);
         request.add(1,
             ShardUpsertRequest.Item.forInsert(
                 "1", List.of(), Translog.UNSET_AUTO_GENERATED_TIMESTAMP,

--- a/server/src/test/java/io/crate/execution/engine/indexing/BulkShardCreationLimiterTest.java
+++ b/server/src/test/java/io/crate/execution/engine/indexing/BulkShardCreationLimiterTest.java
@@ -44,7 +44,7 @@ public class BulkShardCreationLimiterTest extends ESTestCase {
         RelationName relationName = new RelationName("doc", "tbl");
         UUID jobId = UUID.randomUUID();
         shardedRequests = new ShardedRequests<>(
-            shardId -> new ShardDeleteRequest(shardId, jobId),
+            (shardId, unblockedRequest) -> new ShardDeleteRequest(shardId, jobId),
             RamAccounting.NO_ACCOUNTING
         );
         shardedRequests.add(

--- a/server/src/test/java/io/crate/integrationtests/AlterTableIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/AlterTableIntegrationTest.java
@@ -520,4 +520,54 @@ public class AlterTableIntegrationTest extends IntegTestCase {
         assertThatThrownBy(() -> execute("alter table t alter column a set default 'hello'"))
             .hasMessageContaining("Cannot cast");
     }
+
+    @Test
+    public void test_table_level_blocks_on_empty_partitioned_table() {
+        execute("create table t (a int) partitioned by (a)");
+        execute("ALTER TABLE t SET (\"blocks.write\" = true)");
+        execute("ALTER TABLE t SET (\"blocks.read\" = true)");
+
+        execute("SELECT table_name, settings['blocks'] FROM information_schema.tables WHERE table_name = 't' ORDER BY 1");
+        assertThat(response).hasRows(
+            "t| {metadata=false, read=true, read_only=false, read_only_allow_delete=false, write=true}"
+        );
+    }
+
+    @Test
+    public void test_table_level_blocks_on_non_empty_partitioned_table() {
+        execute("create table t (a int) partitioned by (a)");
+        execute("insert into t values (1), (2)");
+        execute("refresh table t");
+        execute("ALTER TABLE t SET (\"blocks.write\" = true)");
+        execute("ALTER TABLE t SET (\"blocks.read\" = true)");
+
+        execute("SELECT table_name, settings['blocks'] FROM information_schema.tables WHERE table_name = 't' ORDER BY 1");
+        assertThat(response).hasRows(
+            "t| {metadata=false, read=true, read_only=false, read_only_allow_delete=false, write=true}"
+        );
+        execute("SELECT partition_ident, settings['blocks'] FROM information_schema.table_partitions WHERE table_name = 't' ORDER BY 1");
+        assertThat(response).hasRows(
+            "04132| {metadata=false, read=true, read_only=false, read_only_allow_delete=false, write=true}",
+            "04134| {metadata=false, read=true, read_only=false, read_only_allow_delete=false, write=true}"
+        );
+    }
+
+    @Test
+    public void test_partition_level_blocks_on_non_empty_partitioned_table() {
+        execute("create table t (a int) partitioned by (a)");
+        execute("insert into t values (1), (2)");
+        execute("refresh table t");
+        execute("ALTER TABLE t PARTITION (a=1) SET (\"blocks.write\" = true)");
+        execute("ALTER TABLE t PARTITION (a=1) SET (\"blocks.read\" = true)");
+
+        execute("SELECT table_name, settings['blocks'] FROM information_schema.tables WHERE table_name = 't' ORDER BY 1");
+        assertThat(response).hasRows(
+            "t| {metadata=false, read=false, read_only=false, read_only_allow_delete=false, write=false}"
+        );
+        execute("SELECT partition_ident, settings['blocks'] FROM information_schema.table_partitions WHERE table_name = 't' ORDER BY 1");
+        assertThat(response).hasRows(
+            "04132| {metadata=false, read=true, read_only=false, read_only_allow_delete=false, write=true}",
+            "04134| {metadata=false, read=false, read_only=false, read_only_allow_delete=false, write=false}"
+        );
+    }
 }

--- a/server/src/test/java/io/crate/integrationtests/BlobTableIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/BlobTableIntegrationTest.java
@@ -23,7 +23,6 @@ package io.crate.integrationtests;
 
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
 import static io.crate.testing.Asserts.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 import static io.netty.handler.codec.http.HttpResponseStatus.FORBIDDEN;
 
 import org.elasticsearch.cluster.metadata.RelationMetadata;
@@ -128,9 +127,9 @@ public class BlobTableIntegrationTest extends SQLHttpIntegrationTest {
         execute("alter blob table b1 set (\"blocks.read_only_allow_delete\"=true)");
 
         Asserts.assertSQLError(() -> execute("drop blob table b1"))
-                .hasPGError(INTERNAL_ERROR)
-                .hasHTTPError(FORBIDDEN, 4037)
-                .hasMessageContaining("blocked by: ");
+            .hasPGError(INTERNAL_ERROR)
+            .hasHTTPError(FORBIDDEN, 4037)
+            .hasMessageContaining("blocked by: ");
 
         execute("alter blob table b1 set (\"blocks.read_only_allow_delete\"=false)");
         execute("drop blob table b1");

--- a/server/src/test/java/io/crate/integrationtests/PartitionedTableConcurrentIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/PartitionedTableConcurrentIntegrationTest.java
@@ -639,17 +639,16 @@ public class PartitionedTableConcurrentIntegrationTest extends IntegTestCase {
 
         assertThat(error.get()).isNull();
 
-        execute("refresh table t");
-
         execute("select count(*) from information_schema.table_partitions where table_name = 't'");
         long partitionCount = (long) response.rows()[0][0];
 
-        execute("select count(*) from t");
-        long rowCount = (long) response.rows()[0][0];
+        assertBusy(() -> {
+            execute("select count(*) from t");
+            long rowCount = (long) response.rows()[0][0];
 
-        // TODO: this is commented out because it is not working yet and will be fixed separately
-        // assertThat(rowCount)
-        //     .as("The number of partitions created and rows inserted as not equal (Partitions: %d, Rows: %d)", partitionCount, rowCount)
-        //     .isEqualTo(partitionCount);
+            assertThat(rowCount)
+                .as("The number of partitions created and rows inserted as not equal (Partitions: %d, Rows: %d)", partitionCount, rowCount)
+                .isEqualTo(partitionCount);
+        });
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/PartitionedTableConcurrentIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/PartitionedTableConcurrentIntegrationTest.java
@@ -24,6 +24,7 @@ package io.crate.integrationtests;
 import static com.carrotsearch.randomizedtesting.RandomizedTest.$;
 import static com.carrotsearch.randomizedtesting.RandomizedTest.randomAsciiLettersOfLength;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -40,6 +41,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateRequest;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
+import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
@@ -62,6 +64,7 @@ import io.crate.metadata.PartitionName;
 import io.crate.metadata.RelationName;
 import io.crate.testing.SQLResponse;
 import io.crate.testing.SQLTransportExecutor;
+import io.crate.testing.UseJdbc;
 
 @IntegTestCase.ClusterScope(numDataNodes = 2)
 public class PartitionedTableConcurrentIntegrationTest extends IntegTestCase {
@@ -598,5 +601,55 @@ public class PartitionedTableConcurrentIntegrationTest extends IntegTestCase {
         assertThat(response.rows()[0][0]).isEqualTo(50L);
         execute("select count(*) from information_schema.table_partitions where table_name = 't2'");
         assertThat(response.rows()[0][0]).isEqualTo(50L);
+    }
+
+    @UseJdbc(0)
+    @Test
+    public void test_concurrent_insert_query_creating_partitions_and_set_write_block_query() throws Exception {
+        execute("create table t (p int) partitioned by (p)");
+
+        final AtomicReference<Throwable> error = new AtomicReference<>();
+        final CyclicBarrier barrier = new CyclicBarrier(2);
+
+        Thread t1 = new Thread(() -> {
+            try {
+                barrier.await();
+                assertThatThrownBy(() -> execute("insert into t select * from generate_series(1, 50)"))
+                    .isExactlyInstanceOf(ClusterBlockException.class);
+            } catch (Throwable e) {
+                error.set(e);
+            }
+        });
+
+        Thread t2 = new Thread(() -> {
+            try {
+                barrier.await();
+                Thread.sleep(500);
+                execute("ALTER TABLE t SET (\"blocks.write\" = true)");
+            } catch (Throwable e) {
+                error.set(e);
+            }
+        });
+
+        t1.start();
+        t2.start();
+
+        t1.join();
+        t2.join();
+
+        assertThat(error.get()).isNull();
+
+        execute("refresh table t");
+
+        execute("select count(*) from information_schema.table_partitions where table_name = 't'");
+        long partitionCount = (long) response.rows()[0][0];
+
+        execute("select count(*) from t");
+        long rowCount = (long) response.rows()[0][0];
+
+        // TODO: this is commented out because it is not working yet and will be fixed separately
+        // assertThat(rowCount)
+        //     .as("The number of partitions created and rows inserted as not equal (Partitions: %d, Rows: %d)", partitionCount, rowCount)
+        //     .isEqualTo(partitionCount);
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/disruption/discovery/AbstractDisruptionTestCase.java
+++ b/server/src/test/java/io/crate/integrationtests/disruption/discovery/AbstractDisruptionTestCase.java
@@ -167,7 +167,7 @@ public abstract class AbstractDisruptionTestCase extends IntegTestCase {
                 .isNull();
             if (expectedBlocks != null) {
                 for (ClusterBlockLevel level : expectedBlocks.levels()) {
-                    assertThat(state.blocks().hasGlobalBlockWithLevel(level)).as("node [" + node + "] does have level [" + level + "] in it's blocks").isTrue();
+                    assertThat(!state.blocks().global(level).isEmpty()).as("node [" + node + "] does have level [" + level + "] in it's blocks").isTrue();
                 }
             }
         }, maxWaitTime.millis(), TimeUnit.MILLISECONDS);

--- a/server/src/test/java/io/crate/metadata/upgrade/ClusterStateUpgraderTest.java
+++ b/server/src/test/java/io/crate/metadata/upgrade/ClusterStateUpgraderTest.java
@@ -27,7 +27,6 @@ import static org.elasticsearch.test.IntegTestCase.resolveIndex;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.block.ClusterBlocks;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.MetadataUpgradeService;
 import org.elasticsearch.common.settings.IndexScopedSettings;
@@ -93,10 +92,6 @@ public class ClusterStateUpgraderTest extends CrateDummyClusterServiceUnitTest {
         Index index = resolveIndex("doc.t", "doc", clusterState.metadata());
         String indexUUID = index.getUUID();
         String indexName = index.getName();
-
-        clusterState = ClusterState.builder(clusterState)
-            .blocks(ClusterBlocks.builder().addIndexBlock(indexUUID, IndexMetadata.INDEX_READ_ONLY_BLOCK))
-            .build();
 
         assertThat(clusterState.blocks().hasIndexBlock(indexUUID, IndexMetadata.INDEX_READ_ONLY_BLOCK)).isTrue();
         assertThat(clusterState.blocks().hasIndexBlock(indexName, IndexMetadata.INDEX_READ_ONLY_BLOCK)).isFalse();

--- a/server/src/test/java/org/elasticsearch/cluster/block/ClusterBlockTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/block/ClusterBlockTests.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.elasticsearch.Version;
+import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -79,8 +80,8 @@ public class ClusterBlockTests extends ESTestCase {
 
     public void testGlobalBlocksCheckedIfNoIndicesSpecified() {
         ClusterBlock globalBlock = randomClusterBlock();
-        ClusterBlocks clusterBlocks = new ClusterBlocks(Collections.singleton(globalBlock), Map.of());
-        ClusterBlockException exception = clusterBlocks.indicesBlockedException(randomFrom(globalBlock.levels()), new String[0]);
+        ClusterBlocks clusterBlocks = new ClusterBlocks(Collections.singleton(globalBlock), Map.of(), Map.of());
+        ClusterBlockException exception = clusterBlocks.blockedException(randomFrom(globalBlock.levels()), new int[]{Metadata.OID_UNASSIGNED}, new String[0]);
         assertThat(exception).isNotNull();
         assertThat(Collections.singleton(globalBlock)).isEqualTo(exception.blocks());
     }
@@ -139,7 +140,7 @@ public class ClusterBlockTests extends ESTestCase {
         assertThat(builder.build().getIndexBlockWithId("index", randomValueOtherThan(blockId, ESTestCase::randomInt))).isNull();
     }
 
-    private ClusterBlock randomClusterBlock() {
+    static ClusterBlock randomClusterBlock() {
         final String uuid = randomBoolean() ? UUIDs.randomBase64UUID() : null;
         final List<ClusterBlockLevel> levels = Arrays.asList(ClusterBlockLevel.values());
         return new ClusterBlock(randomInt(), uuid, "cluster block #" + randomInt(), randomBoolean(), randomBoolean(), randomBoolean(),

--- a/server/src/test/java/org/elasticsearch/cluster/block/ClusterBlocksTest.java
+++ b/server/src/test/java/org/elasticsearch/cluster/block/ClusterBlocksTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package org.elasticsearch.cluster.block;
+
+import static io.crate.testing.Asserts.assertThat;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.test.ESTestCase;
+import org.junit.Test;
+
+public class ClusterBlocksTest extends ESTestCase {
+
+    @Test
+    public void test_serialization() throws IOException {
+        Set<ClusterBlock> global = Set.of(ClusterBlockTests.randomClusterBlock());
+        Map<Integer, Set<ClusterBlock>> tablesBlocks = new HashMap<>();
+        Map<String, Set<ClusterBlock>> indicesBlocks = new HashMap<>();
+        tablesBlocks.put(1, Set.of(ClusterBlockTests.randomClusterBlock()));
+        indicesBlocks.put("dummy", Set.of(ClusterBlockTests.randomClusterBlock()));
+
+        ClusterBlocks clusterBlocks = new ClusterBlocks(global, tablesBlocks, indicesBlocks);
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        out.setVersion(Version.V_6_3_0);
+        clusterBlocks.writeTo(out);
+        var in = out.bytes().streamInput();
+        in.setVersion(Version.V_6_3_0);
+
+        ClusterBlocks actual = ClusterBlocks.readFrom(in);
+
+        assertThat(actual.global()).isEqualTo(global);
+        assertThat(actual.tables()).isEqualTo(tablesBlocks);
+        assertThat(actual.indices()).isEqualTo(indicesBlocks);
+
+        out = new BytesStreamOutput();
+        out.setVersion(Version.V_6_2_0);
+        clusterBlocks.writeTo(out);
+        in = out.bytes().streamInput();
+        in.setVersion(Version.V_6_2_0);
+
+        actual = ClusterBlocks.readFrom(in);
+
+        assertThat(actual.global()).isEqualTo(global);
+        assertThat(actual.tables()).isEmpty();
+        assertThat(actual.indices()).isEqualTo(indicesBlocks);
+    }
+}

--- a/server/src/test/java/org/elasticsearch/gateway/GatewayIndexStateIT.java
+++ b/server/src/test/java/org/elasticsearch/gateway/GatewayIndexStateIT.java
@@ -401,6 +401,7 @@ public class GatewayIndexStateIT extends IntegTestCase {
 
         String indexUUID = resolveIndex("test").getUUID();
         final IndexMetadata metadata = state.metadata().index(indexUUID);
+        final Settings prevSettings = metadata.getSettings();
         final IndexMetadata.Builder brokenMeta = IndexMetadata.builder(metadata).settings(Settings.builder().put(metadata.getSettings())
             .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT.minimumIndexCompatibilityVersion().internalId)
             // this is invalid but should be archived
@@ -435,6 +436,13 @@ public class GatewayIndexStateIT extends IntegTestCase {
                 .hasPGError(INTERNAL_ERROR)
                 .hasHTTPError(INTERNAL_SERVER_ERROR, 5000)
                 .hasMessageContaining("Failed to verify index " + metadata.getIndex().getUUID());
+
+        // Reset Settings for the indexMetadata such that 'test' table can be dropped during the clean up phase of the itest
+        final IndexMetadata indexMetadata = state.metadata().index(indexUUID);
+        final IndexMetadata.Builder indexMetadataBuilder = IndexMetadata.builder(indexMetadata).settings(prevSettings);
+        restartNodesOnBrokenClusterState(ClusterState.builder(state).metadata(Metadata.builder(state.metadata()).put(indexMetadataBuilder)));
+        ensureStableCluster(cluster().size());
+        execute("alter table test open");
     }
 
     @Test

--- a/server/src/testFixtures/java/io/crate/testing/SQLExecutor.java
+++ b/server/src/testFixtures/java/io/crate/testing/SQLExecutor.java
@@ -774,7 +774,7 @@ public class SQLExecutor {
             mdBuilder.put(indexMetadata, true);
             routingBuilder.addAsNew(indexMetadata);
             indexUUIDs.add(indexMetadata.getIndexUUID());
-            blocksBuilder.addBlocks(indexMetadata);
+            blocksBuilder.addIndexBlocks(indexMetadata);
         }
         RelationMetadata relation = prevState.metadata().getRelation(boundCreateTable.tableName());
         if (partitioned && relation instanceof RelationMetadata.Table table) {
@@ -798,6 +798,7 @@ public class SQLExecutor {
             0,
             mdBuilder.tableOidSupplier().nextOid()
         );
+        blocksBuilder.updateTableBlocks(mdBuilder.getRelation(boundCreateTable.tableName()));
         ClusterState newState = ClusterState.builder(prevState)
             .metadata(mdBuilder.build())
             .routingTable(routingBuilder.build())

--- a/server/src/testFixtures/java/org/elasticsearch/test/TestCluster.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/TestCluster.java
@@ -24,6 +24,10 @@ import static io.crate.lucene.CrateLuceneTestCase.rarely;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.elasticsearch.cluster.coordination.ClusterBootstrapService.INITIAL_MASTER_NODES_SETTING;
+import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_BLOCKS_METADATA;
+import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_BLOCKS_READ;
+import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_BLOCKS_WRITE;
+import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_READ_ONLY;
 import static org.elasticsearch.discovery.DiscoveryModule.DISCOVERY_TYPE_SETTING;
 import static org.elasticsearch.discovery.DiscoveryModule.ZEN2_DISCOVERY_TYPE;
 import static org.elasticsearch.test.ESTestCase.assertBusy;
@@ -148,13 +152,16 @@ import com.carrotsearch.randomizedtesting.generators.RandomStrings;
 import io.crate.common.concurrent.CompletableFutures;
 import io.crate.common.io.IOUtils;
 import io.crate.common.unit.TimeValue;
+import io.crate.execution.ddl.tables.AlterTableRequest;
 import io.crate.execution.ddl.tables.DropTableRequest;
+import io.crate.execution.ddl.tables.TransportAlterTable;
 import io.crate.execution.ddl.tables.TransportDropTable;
 import io.crate.execution.engine.collect.sources.InformationSchemaIterables;
 import io.crate.execution.jobs.TasksService;
 import io.crate.metadata.RelationInfo.RelationType;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.SystemTable;
+import io.crate.metadata.doc.DocTableInfo;
 import io.crate.protocols.postgres.PostgresNetty;
 import io.crate.session.Sessions;
 import io.crate.testing.SQLTransportExecutor;
@@ -390,7 +397,33 @@ public final class TestCluster implements Closeable {
             for (var relation : infoSchema.relations()) {
                 if (relation.relationType() == RelationType.BASE_TABLE && relation instanceof SystemTable<?> == false) {
                     relationNames.add(relation.ident());
-                    futures.add(client().execute(TransportDropTable.ACTION, new DropTableRequest(relation.ident())));
+                    boolean isPartitioned = relation instanceof DocTableInfo docTableInfo && docTableInfo.isPartitioned();
+                    Settings clearAllBlocksSettings = Settings.builder()
+                        .put(SETTING_BLOCKS_WRITE, false)
+                        .put(SETTING_BLOCKS_READ, false)
+                        .put(SETTING_BLOCKS_METADATA, false)
+                        .put(SETTING_READ_ONLY, false)
+                        .build();
+                    AlterTableRequest clearAllTableBlocks;
+                    AlterTableRequest clearAllPartitionsBlocks;
+                    try {
+                        clearAllTableBlocks = new AlterTableRequest(relation.ident(), List.of(), isPartitioned, false, true, clearAllBlocksSettings);
+                        clearAllPartitionsBlocks = new AlterTableRequest(relation.ident(), List.of(), isPartitioned, false, false, clearAllBlocksSettings);
+                    } catch (Exception e) {
+                        throw new IllegalStateException("Could not clear all blocks on " + relation.ident());
+                    }
+                    futures.add(
+                        client().execute(TransportAlterTable.ACTION, clearAllTableBlocks)
+                            .thenCompose(r -> {
+                                assertAcked(r);
+                                return client().execute(TransportAlterTable.ACTION, clearAllPartitionsBlocks);
+                            })
+                            .thenCompose(
+                                r -> {
+                                    assertAcked(r);
+                                    return client().execute(TransportDropTable.ACTION, new DropTableRequest(relation.ident()));
+                                })
+                    );
                 }
             }
             CompletableFuture<List<AcknowledgedResponse>> allResponses = CompletableFutures.allAsList(futures);


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Part 2 of https://github.com/crate/crate/pull/19117.

> 2. Unblock the initial inserts to the newly created partitions such that every new partition contains at least one row which prevents the existence of empty(invalid) partitions.

Insert queries that create new partitions are done in two stages, 1) create partitions 2) insert to the partitions. If the table gets blocked in between, 2) are blocked causing empty partitions. The approach to fix is to allow such inserts to ignore cluster blocks.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
