### PR TITLE
fix: add catalog_name column to information_schema.schemata

### DIFF
--- a/server/src/main/java/io/crate/metadata/information/InformationSchemataTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/information/InformationSchemataTableInfo.java
@@ -23,6 +23,7 @@ package io.crate.metadata.information;
 
 import static io.crate.types.DataTypes.STRING;
 
+import io.crate.Constants;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.SystemTable;
@@ -34,7 +35,8 @@ public class InformationSchemataTableInfo {
     public static final RelationName IDENT = new RelationName(InformationSchemaInfo.NAME, NAME);
 
     public static SystemTable<SchemaInfo> INSTANCE = SystemTable.<SchemaInfo>builder(IDENT)
+        .addNonNull("catalog_name", STRING, r -> Constants.DB_NAME)
         .add("schema_name", STRING, SchemaInfo::name)
-        .setPrimaryKeys(ColumnIdent.of("schema_name"))
+        .setPrimaryKeys(ColumnIdent.of("catalog_name"), ColumnIdent.of("schema_name"))
         .build();
 }


### PR DESCRIPTION
## Summary

Fixes #19164

Adds the `catalog_name` column to `information_schema.schemata` for PostgreSQL compatibility.

## Problem

PostgreSQL-compatible tools (e.g., [Harlequin](https://harlequin.sh/)) issue introspection queries like:
```sql
SELECT SCHEMA_NAME FROM information_schema.schemata WHERE CATALOG_NAME = $1
```
This fails with `Column catalog_name unknown` because CrateDB's `schemata` table only exposed `schema_name`.

## Changes

- **`InformationSchemataTableInfo.java`**: Added `catalog_name` column using `Constants.DB_NAME` (value: `"crate"`), matching the pattern used by other information schema tables (e.g., `InformationColumnsTableInfo`).
- Updated primary key to `(catalog_name, schema_name)` for PostgreSQL compatibility.

## Testing

- Change follows the established pattern used by `InformationColumnsTableInfo` and other information schema tables.
- Existing queries like `SELECT schema_name FROM information_schema.schemata` continue to work unchanged.
- CI will validate the full test suite.