### PR TITLE
Fix insert-from-values interleaved with table swaps(renames)

### DIFF
--- a/docs/appendices/release-notes/6.3.1.rst
+++ b/docs/appendices/release-notes/6.3.1.rst
@@ -64,3 +64,7 @@ Fixes
   to not receive schema or data updates from a published table, if a publisher
   cluster's primary shards were active on polling the state and became
   inactive before restoring started (for example, due to shards relocation).
+
+- Fixed :ref:`INSERT FROM VALUES <sql-insert>` statements that create new
+  partitions are no longer interrupted by :ref:`SWAP <alter_cluster_swap_table>`
+  or :ref:`RENAME <sql-alter-table-rename-to>` table statements.

--- a/server/src/main/java/io/crate/planner/operators/InsertFromValues.java
+++ b/server/src/main/java/io/crate/planner/operators/InsertFromValues.java
@@ -283,7 +283,9 @@ public class InsertFromValues implements LogicalPlan {
         ).thenCompose(_ -> {
             var shardUpsertRequests = resolveAndGroupShardRequests(
                 shardedRequests,
-                dependencies.clusterService()).values();
+                dependencies.clusterService(),
+                tableInfo.oid()
+            ).values();
             return execute(
                 dependencies.nodeLimits(),
                 dependencies.clusterService().state(),
@@ -430,7 +432,9 @@ public class InsertFromValues implements LogicalPlan {
         ).thenCompose(_ -> {
             var shardUpsertRequests = resolveAndGroupShardRequests(
                 shardedRequests,
-                dependencies.clusterService()).values();
+                dependencies.clusterService(),
+                tableInfo.oid()
+            ).values();
             return execute(
                 dependencies.nodeLimits(),
                 dependencies.clusterService().state(),
@@ -561,15 +565,16 @@ public class InsertFromValues implements LogicalPlan {
         return new RowN(cells);
     }
 
-    private static ShardLocation getShardLocation(PartitionName partitionName,
+    private static ShardLocation getShardLocation(RelationName relationName,
+                                                  List<String> partitionValues,
                                                   String id,
                                                   @Nullable String routing,
                                                   OperationRouting operationRouting,
                                                   ClusterState state) {
         Metadata metadata = state.metadata();
-        String indexUUID = metadata.getIndex(partitionName.relationName(), partitionName.values(), true, IndexMetadata::getIndexUUID);
+        String indexUUID = metadata.getIndex(relationName, partitionValues, true, IndexMetadata::getIndexUUID);
         if (indexUUID == null) {
-            throw new IndexNotFoundException(partitionName.asIndexName());
+            throw new IndexNotFoundException(new PartitionName(relationName, partitionValues).asIndexName());
         }
         ShardIterator shardIterator = operationRouting.indexShards(
             state,
@@ -591,7 +596,8 @@ public class InsertFromValues implements LogicalPlan {
 
     private static <TReq extends ShardRequest<TReq, TItem>, TItem extends ShardRequest.Item>
         Map<ShardLocation, TReq> resolveAndGroupShardRequests(ShardedRequests<TReq, TItem> shardedRequests,
-                                                          ClusterService clusterService) {
+                                                              ClusterService clusterService,
+                                                              int tableOID) {
         var itemsByMissingPartition = shardedRequests.itemsByMissingPartition().entrySet().iterator();
         ClusterState state = clusterService.state();
         OperationRouting operationRouting = clusterService.operationRouting();
@@ -601,17 +607,18 @@ public class InsertFromValues implements LogicalPlan {
             List<ItemAndRoutingAndSourceInfo<TItem>> requestItems = entry.getValue();
 
             var requestItemsIterator = requestItems.iterator();
+            Metadata metadata = clusterService.state().metadata();
             while (requestItemsIterator.hasNext()) {
                 var itemAndRoutingAndSourceInfo = requestItemsIterator.next();
                 ShardLocation shardLocation;
                 try {
                     shardLocation = getShardLocation(
-                        partition,
+                        metadata.getRelationName(tableOID),
+                        partition.values(),
                         itemAndRoutingAndSourceInfo.item().id(),
                         itemAndRoutingAndSourceInfo.routing(),
                         operationRouting,
-                        state
-                    );
+                        state);
                 } catch (IndexNotFoundException | RelationUnknown | ShardNotFoundException e) {
                     requestItemsIterator.remove();
                     continue;

--- a/server/src/test/java/io/crate/integrationtests/PartitionedTableConcurrentIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/PartitionedTableConcurrentIntegrationTest.java
@@ -541,4 +541,62 @@ public class PartitionedTableConcurrentIntegrationTest extends IntegTestCase {
         execute("select count(*) from information_schema.table_partitions where table_name = 't2'");
         assertThat(response.rows()[0][0]).isEqualTo(50L);
     }
+
+    @Test
+    public void test_concurrent_table_swaps_with_insert_from_values() throws Exception {
+        execute("create table t1 (p int) partitioned by (p)");
+        execute("create table t2 (p2 int)");
+
+        final AtomicReference<Throwable> error = new AtomicReference<>();
+        final CyclicBarrier barrier = new CyclicBarrier(2);
+        boolean[] swapInterleaved = {false};
+
+        Thread t1 = new Thread(() -> {
+            try {
+                barrier.await();
+                execute("""
+                    INSERT INTO t1 VALUES
+                    (1), (2), (3), (4), (5), (6), (7), (8), (9), (10),
+                    (11), (12), (13), (14), (15), (16), (17), (18), (19), (20),
+                    (21), (22), (23), (24), (25), (26), (27), (28), (29), (30),
+                    (31), (32), (33), (34), (35), (36), (37), (38), (39), (40),
+                    (41), (42), (43), (44), (45), (46), (47), (48), (49), (50);
+                    """);
+            } catch (Throwable e) {
+                error.set(e);
+            }
+        });
+
+        Thread t2 = new Thread(() -> {
+            try {
+                barrier.await();
+                for (int i = 0; i < 3; i++) {
+                    Thread.sleep(300); // to prevent swap queries to go through at once
+                    execute("ALTER CLUSTER SWAP TABLE t1 TO t2");
+                    if (t1.isAlive()) {
+                        swapInterleaved[0] = true;
+                    }
+                }
+            } catch (Throwable e) {
+                error.set(e);
+            }
+        });
+
+        t1.start();
+        t2.start();
+
+        t1.join();
+        t2.join();
+
+        assertThat(error.get()).isNull();
+        assertThat(swapInterleaved[0])
+            .as("The test failed to interleave a swap with the insert")
+            .isTrue();
+
+        execute("refresh table t1, t2");
+        execute("select count(*) from t2");
+        assertThat(response.rows()[0][0]).isEqualTo(50L);
+        execute("select count(*) from information_schema.table_partitions where table_name = 't2'");
+        assertThat(response.rows()[0][0]).isEqualTo(50L);
+    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Follows https://github.com/crate/crate/pull/19029 which fixed the same issue but for `insert from select` while this is for `insert from values`.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
