### PR TITLE
Add blake3 hashing function

### DIFF
--- a/docs/appendices/release-notes/6.4.0.rst
+++ b/docs/appendices/release-notes/6.4.0.rst
@@ -78,7 +78,9 @@ None
 Scalar and Aggregation Functions
 --------------------------------
 
-None
+- `Robert Palmer <https://github.com/robd003>`_ added the
+  :ref:`blake3 <scalar-blake3>` scalar function for computing BLAKE3 checksums of
+  strings.
 
 Performance and Resilience Improvements
 ---------------------------------------

--- a/docs/general/builtins/scalar-functions.rst
+++ b/docs/general/builtins/scalar-functions.rst
@@ -386,6 +386,27 @@ Returns: ``text``
      SELECT 1 row in set (... sec)
 
 
+.. _scalar-blake3:
+
+``blake3('string')``
+--------------------
+
+Returns: ``text``
+
+Computes the BLAKE3 checksum of the given string using the default 256-bit
+digest.
+
+::
+
+    cr> select blake3('foo') AS blake3;
+    +------------------------------------------------------------------+
+    | blake3                                                           |
+    +------------------------------------------------------------------+
+    | 04e0bb39f30b1a3feb89f536c93be15055482df748674b00d26e5a75777702e9 |
+    +------------------------------------------------------------------+
+    SELECT 1 row in set (... sec)
+
+
 .. _scalar-sha1:
 
 ``sha1('string')``

--- a/server/src/main/java/io/crate/expression/scalar/string/HashFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/HashFunctions.java
@@ -22,10 +22,9 @@
 package io.crate.expression.scalar.string;
 
 import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 
+import org.apache.commons.codec.digest.Blake3;
 import org.elasticsearch.common.hash.MessageDigests;
 
 import io.crate.common.Hex;
@@ -38,9 +37,16 @@ import io.crate.types.DataTypes;
 
 public final class HashFunctions {
 
+    private static final UnaryOperator<byte[]> BLAKE3_HASHER = bytes -> {
+        Blake3 digest = Blake3.initHash();
+        digest.update(bytes);
+        return digest.doFinalize(32);
+    };
+
     public static void register(Functions.Builder builder) {
         register(builder, "md5", HashMethod.MD5::digest);
         register(builder, "sha1", HashMethod.SHA1::digest);
+        register(builder, "blake3", HashMethod.BLAKE3::digest);
     }
 
     private static void register(Functions.Builder builder, String name, UnaryOperator<String> func) {
@@ -56,24 +62,18 @@ public final class HashFunctions {
     }
 
     private enum HashMethod {
-        MD5(MessageDigests::md5),
-        SHA1(MessageDigests::sha1);
+        MD5(bytes -> MessageDigests.md5().digest(bytes)),
+        SHA1(bytes -> MessageDigests.sha1().digest(bytes)),
+        BLAKE3(BLAKE3_HASHER);
 
-        /**
-         * Do not pass the MessageDigest in directly but resolve it during
-         * runtime to avoid concurrency issue when the hash function is
-         * used by multiple threads at the same time.
-         */
-        private final Supplier<MessageDigest> messageDigestSupplier;
+        private final UnaryOperator<byte[]> byteHasher;
 
-        HashMethod(Supplier<MessageDigest> digestSupplier) {
-            this.messageDigestSupplier = digestSupplier;
+        HashMethod(UnaryOperator<byte[]> byteHasher) {
+            this.byteHasher = byteHasher;
         }
 
         public String digest(String input) {
-            MessageDigest messageDigest = messageDigestSupplier.get();
-            byte[] result = messageDigest.digest(input.getBytes(StandardCharsets.UTF_8));
-            return Hex.encodeHexString(result);
+            return Hex.encodeHexString(byteHasher.apply(input.getBytes(StandardCharsets.UTF_8)));
         }
     }
 }

--- a/server/src/main/java/io/crate/expression/scalar/string/HashFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/HashFunctions.java
@@ -37,12 +37,6 @@ import io.crate.types.DataTypes;
 
 public final class HashFunctions {
 
-    private static final UnaryOperator<byte[]> BLAKE3_HASHER = bytes -> {
-        Blake3 digest = Blake3.initHash();
-        digest.update(bytes);
-        return digest.doFinalize(32);
-    };
-
     public static void register(Functions.Builder builder) {
         register(builder, "md5", HashMethod.MD5::digest);
         register(builder, "sha1", HashMethod.SHA1::digest);
@@ -64,7 +58,12 @@ public final class HashFunctions {
     private enum HashMethod {
         MD5(bytes -> MessageDigests.md5().digest(bytes)),
         SHA1(bytes -> MessageDigests.sha1().digest(bytes)),
-        BLAKE3(BLAKE3_HASHER);
+        BLAKE3(bytes -> {
+            Blake3 digest = Blake3.initHash();
+            digest.update(bytes);
+            // Blake3 defaults to 32 byte (256-bit) output
+            return digest.doFinalize(32);
+        });
 
         private final UnaryOperator<byte[]> byteHasher;
 

--- a/server/src/test/java/io/crate/expression/scalar/HashFunctionsTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/HashFunctionsTest.java
@@ -39,6 +39,9 @@ public class HashFunctionsTest extends ScalarTestCase {
         assertEvaluate("sha1('©rate')", "9a437faeb9adff59cc06313bfb23fe1d46181924");
         assertEvaluate("sha1('crate')", "1673dc397042322a0a5ac49c79cc08d3a25cb0f6");
         assertEvaluate("sha1('')", "da39a3ee5e6b4b0d3255bfef95601890afd80709");
+        assertEvaluate("blake3('©rate')", "7e60e9aec3049dd63fc695ea89fc20ae8abe5ea32388a5a60cf08d97b9e25ff4");
+        assertEvaluate("blake3('crate')", "012efcab3db1a63a5d50510e48f1fbf3ac26dbd28a3cec099457eff5fefa96aa");
+        assertEvaluate("blake3('')", "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262");
     }
 
     @Test
@@ -49,6 +52,9 @@ public class HashFunctionsTest extends ScalarTestCase {
         assertNormalize("sha1('©rate')", isLiteral("9a437faeb9adff59cc06313bfb23fe1d46181924"));
         assertNormalize("sha1('crate')", isLiteral("1673dc397042322a0a5ac49c79cc08d3a25cb0f6"));
         assertNormalize("sha1('')", isLiteral("da39a3ee5e6b4b0d3255bfef95601890afd80709"));
+        assertNormalize("blake3('©rate')", isLiteral("7e60e9aec3049dd63fc695ea89fc20ae8abe5ea32388a5a60cf08d97b9e25ff4"));
+        assertNormalize("blake3('crate')", isLiteral("012efcab3db1a63a5d50510e48f1fbf3ac26dbd28a3cec099457eff5fefa96aa"));
+        assertNormalize("blake3('')", isLiteral("af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262"));
     }
 
     @Test
@@ -57,6 +63,8 @@ public class HashFunctionsTest extends ScalarTestCase {
         assertEvaluateNull("md5(null)", Literal.of(DataTypes.STRING, null));
         assertEvaluateNull("sha1(null)");
         assertEvaluateNull("sha1(name)", Literal.of(DataTypes.STRING, null));
+        assertEvaluateNull("blake3(null)");
+        assertEvaluateNull("blake3(name)", Literal.of(DataTypes.STRING, null));
     }
 
     @Test
@@ -65,6 +73,8 @@ public class HashFunctionsTest extends ScalarTestCase {
         assertEvaluate("md5(name)", "dd4827af87b26de9ed92e6fb08efc5ab", Literal.of("crate"));
         assertNormalize("sha1(name)", isFunction("sha1"));
         assertEvaluate("sha1(name)", "1673dc397042322a0a5ac49c79cc08d3a25cb0f6", Literal.of("crate"));
+        assertNormalize("blake3(name)", isFunction("blake3"));
+        assertEvaluate("blake3(name)", "012efcab3db1a63a5d50510e48f1fbf3ac26dbd28a3cec099457eff5fefa96aa", Literal.of("crate"));
     }
 
     /*
@@ -73,6 +83,7 @@ public class HashFunctionsTest extends ScalarTestCase {
     @Test
     public void testConcatenation() throws Exception {
         assertEvaluate("'crate ' || sha1('')", "crate da39a3ee5e6b4b0d3255bfef95601890afd80709");
+        assertEvaluate("'crate ' || blake3('')", "crate af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262");
     }
 
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Added blake3 hash for fast collision resistant hashing

## Checklist

 - [X] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [X] Updated documentation & `sql_features` table for user facing changes
 - [X] Touched code is covered by tests
 - [X] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
