### PR TITLE
Assign proper table oids when upgrading RelationMetadata

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataUpgradeService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataUpgradeService.java
@@ -229,10 +229,33 @@ public class MetadataUpgradeService {
                     throw new AssertionError("If the relation is missing we need a DocTableInfo instance or it must be a blob index");
                 }
             } else if (relation instanceof RelationMetadata.Table table) {
+                if (table.oid() == OID_UNASSIGNED) {
+                    // assign a new table oid
+                    table = new RelationMetadata.Table(
+                        newMetadata.tableOidSupplier().nextOid(),
+                        table.name(),
+                        table.columns(),
+                        table.settings(),
+                        table.routingColumn(),
+                        table.columnPolicy(),
+                        table.pkConstraintName(),
+                        table.checkConstraints(),
+                        table.primaryKeys(),
+                        table.partitionedBy(),
+                        table.state(),
+                        table.indexUUIDs(),
+                        table.tableVersion()
+                    );
+                    newMetadata.setRelation(table);
+                }
                 if (!table.indexUUIDs().contains(indexUUID)) {
                     newMetadata.addIndexUUIDs(table, List.of(indexUUID));
                 }
             } else if (relation instanceof RelationMetadata.BlobTable blobTable) {
+                if (blobTable.oid() == OID_UNASSIGNED) {
+                    // assign a new table oid
+                    newMetadata.setBlobTable(blobTable.name(), blobTable.indexUUID(), blobTable.settings(), blobTable.state());
+                }
                 assert blobTable.indexUUID().equals(indexUUID)
                     : "If there exists a RelationMetadata.BlobTable entry the incoming IndexMetadata indexUUID must match";
             }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB


## Checklist

 - [ ] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
