### PR TITLE
Set jmods output file depending on platform

### DIFF
--- a/jlink-jdk/pom.xml
+++ b/jlink-jdk/pom.xml
@@ -83,7 +83,7 @@
             <configuration>
               <url>https://api.adoptium.net/v3/binary/version/jdk-${versions.jdkbuild}/${jmods.os}/${jmods.arch}/jmods/hotspot/normal/eclipse?project=jdk</url>
               <unpack>true</unpack>
-              <outputFileName>jmods.tar.gz</outputFileName>
+              <outputFileName>jmods.${jmods.ext}</outputFileName>
               <outputDirectory>${project.build.directory}</outputDirectory>
             </configuration>
           </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -454,6 +454,7 @@
       <properties>
         <os.classifier>linux-${os.arch.classifier}</os.classifier>
         <jmods.os>linux</jmods.os>
+        <jmods.ext>tar.gz</jmods.ext>
       </properties>
     </profile>
     <profile>
@@ -467,6 +468,7 @@
       <properties>
         <os.classifier>osx-${os.arch.classifier}</os.classifier>
         <jmods.os>mac</jmods.os>
+        <jmods.ext>tar.gz</jmods.ext>
       </properties>
     </profile>
     <profile>
@@ -480,6 +482,7 @@
         <!-- OpenDAL provides x64 packages only, but Windows arm64 >= 10 Build 21277 can emulate it   -->
         <os.classifier>windows-x86_64</os.classifier>
         <jmods.os>windows</jmods.os>
+        <jmods.ext>zip</jmods.ext>
       </properties>
     </profile>
   </profiles>


### PR DESCRIPTION
Backport to be able to create new 6.1 releases with changed release pipeline

Allows to create windows artifacts using:

    ./mvnw -P jmods -Dos.arch=x86_64 -Djmods.os="windows" -Dos.classifier=windows-x86_64 -Djmods.ext=zip package -DskipTests=true -e

(cherry picked from commit 14fc0e91bf1f04065e9a10ecbbc3644b792f3501)

