### PR TITLE
Ensure noop timeout token remains disabled

### DIFF
--- a/server/src/main/java/io/crate/session/Session.java
+++ b/server/src/main/java/io/crate/session/Session.java
@@ -1076,6 +1076,14 @@ public class Session implements AutoCloseable {
      */
     public static class TimeoutToken {
 
+        private static final TimeoutToken NOOP = new TimeoutToken() {
+
+            @Override
+            public void enable() {
+                // NOOP token remains disabled
+            }
+        };
+
         protected TimeValue statementTimeout;
         private long startNanos;
         private boolean enabled = true;
@@ -1087,11 +1095,12 @@ public class Session implements AutoCloseable {
 
 
         public static TimeoutToken noopToken() {
-            return new TimeoutToken();
+            return NOOP;
         }
 
         private TimeoutToken() {
             this.enabled = false;
+            this.statementTimeout = TimeValue.ZERO;
         }
 
         public void check(String context) {


### PR DESCRIPTION
Currently not an issue, but if some component were to call `.enable()`
followed by `.check()` on a noop timeout token it would lead to an NPE.

This ensures a noop token remains noop, no matter what.
