### PR TITLE
Docs: Add `VIEW` as a securable to `DENY` synopsis

### DIFF
--- a/docs/sql/statements/deny.rst
+++ b/docs/sql/statements/deny.rst
@@ -13,7 +13,7 @@ Synopsis
 .. code-block:: psql
 
   DENY { { DQL | DML | DDL | AL [,...] } | ALL [ PRIVILEGES ] }
-  [ON {SCHEMA | TABLE} identifier [, ...]]
+  [ON {SCHEMA | TABLE | VIEW} identifier [, ...]]
   TO user_name [, ...];
 
 Description
@@ -22,8 +22,8 @@ Description
 ``DENY`` is a management statement to deny one or many privileges
 on a specific object to one or many existing users.
 
-``ON {SCHEMA | TABLE}`` is optional, if not specified the privilege will be
-denied on the ``CLUSTER`` level.
+``ON {SCHEMA | TABLE | VIEW}`` is optional, if not specified the privilege will
+be denied on the ``CLUSTER`` level.
 
 For usage of the ``DENY`` statement see :ref:`administration-privileges`.
 
@@ -33,7 +33,7 @@ Parameters
 :identifier:
   The identifier of the corresponding object.
 
-  If ``TABLE`` is specified the ``identifier`` should include the
+  If ``TABLE`` or ``VIEW`` is specified the ``identifier`` should include the
   table's full qualified name. Otherwise the table will be looked up in
   the current schema.
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Documentation for [GRANT](https://cratedb.com/docs/crate/reference/en/latest/sql/statements/grant.html) specifies that it can be executed `ON {SCHEMA | TABLE | VIEW}`, but [DENY](https://cratedb.com/docs/crate/reference/en/latest/sql/statements/deny.html) only mentions `ON {SCHEMA | TABLE}`.

A practical test shows that `VIEW` works with `DENY` as well:

```sh
cr> CREATE VIEW doc.v_test AS SELECT 1;
CREATE OK, 1 row affected (0.023 sec)
cr> CREATE USER u1 WITH (password = 'u1');
CREATE OK, 1 row affected (0.064 sec)
cr> GRANT DQL ON SCHEMA doc TO u1;
GRANT OK, 1 row affected (0.020 sec)
cr> DENY DQL ON VIEW doc.v_test TO u1;
DENY OK, 1 row affected (0.020 sec)
cr> SELECT * FROM sys.privileges WHERE grantee = 'u1';
+--------+---------+---------+------------+-------+------+
| class  | grantee | grantor | ident      | state | type |
+--------+---------+---------+------------+-------+------+
| SCHEMA | u1      | crate   | doc        | GRANT | DQL  |
| VIEW   | u1      | crate   | doc.v_test | DENY  | DQL  |
+--------+---------+---------+------------+-------+------+
SELECT 2 rows in set (0.002 sec)
```

## Checklist

 - [X] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [X] Updated documentation & `sql_features` table for user facing changes
 - [X] Touched code is covered by tests
 - [X] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
