### PR TITLE
Fix issue with col oids on old tables when upgrading to >= 6.0.0

### DIFF
--- a/docs/appendices/release-notes/6.0.0.rst
+++ b/docs/appendices/release-notes/6.0.0.rst
@@ -6,6 +6,23 @@ Version 6.0.0
 
 Released on 2025-07-17.
 
+.. WARNING::
+
+    Do not use this version when upgrading from any previous version
+    containing tables created before :ref:`version_5.5.0` as this may result
+    in data loss!
+
+    If the cluster contains tables created before :ref:`version_5.5.0`, after
+    upgrading to :ref:`version_6.0.0` certain actions on such tables like
+    deleting partitions, changing settings, rename, swap, etc. can lead to
+    corrupted table which causes all the data of the columns created
+    in versions before :ref:`version_5.5.0` to be shown as ``NULL``. The bug
+    has been fixed in :ref:`version_6.0.6`, so we highly recommend to avoid
+    upgrading to any earlier 6.0.x version.
+
+    Once already affected by the bug, existing data may be lost forever, while
+    new data (via ``INSERT`` or ``UPDATE``) can be retrieved normally.
+
 .. NOTE::
 
     If you are upgrading a cluster, you must be running CrateDB 5.0.0 or higher

--- a/docs/appendices/release-notes/6.0.1.rst
+++ b/docs/appendices/release-notes/6.0.1.rst
@@ -6,6 +6,23 @@ Version 6.0.1
 
 Released on 2025-09-23.
 
+.. WARNING::
+
+    Do not use this version when upgrading from any previous version
+    containing tables created before :ref:`version_5.5.0` as this may result
+    in data loss!
+
+    If the cluster contains tables created before :ref:`version_5.5.0`, after
+    upgrading to :ref:`version_6.0.1` certain actions on such tables like
+    deleting partitions, changing settings, rename, swap, etc. can lead to
+    corrupted table which causes all the data of the columns created
+    in versions before :ref:`version_5.5.0` to be shown as ``NULL``. The bug
+    has been fixed in :ref:`version_6.0.6`, so we highly recommend to avoid
+    upgrading to any earlier 6.0.x version.
+
+    Once already affected by the bug, existing data may be lost forever, while
+    new data (via ``INSERT`` or ``UPDATE``) can be retrieved normally.
+
 .. NOTE::
 
     If you are upgrading a cluster, you must be running CrateDB 5.0.0 or higher

--- a/docs/appendices/release-notes/6.0.2.rst
+++ b/docs/appendices/release-notes/6.0.2.rst
@@ -6,6 +6,23 @@ Version 6.0.2
 
 Released on 2025-09-24.
 
+.. WARNING::
+
+    Do not use this version when upgrading from any previous version
+    containing tables created before :ref:`version_5.5.0` as this may result
+    in data loss!
+
+    If the cluster contains tables created before :ref:`version_5.5.0`, after
+    upgrading to :ref:`version_6.0.2` certain actions on such tables like
+    deleting partitions, changing settings, rename, swap, etc. can lead to
+    corrupted table which causes all the data of the columns created
+    in versions before :ref:`version_5.5.0` to be shown as ``NULL``. The bug
+    has been fixed in :ref:`version_6.0.6`, so we highly recommend to avoid
+    upgrading to any earlier 6.0.x version.
+
+    Once already affected by the bug, existing data may be lost forever, while
+    new data (via ``INSERT`` or ``UPDATE``) can be retrieved normally.
+
 .. NOTE::
 
     If you are upgrading a cluster, you must be running CrateDB 5.0.0 or higher

--- a/docs/appendices/release-notes/6.0.3.rst
+++ b/docs/appendices/release-notes/6.0.3.rst
@@ -6,6 +6,23 @@ Version 6.0.3
 
 Released on 2025-10-13.
 
+.. WARNING::
+
+    Do not use this version when upgrading from any previous version
+    containing tables created before :ref:`version_5.5.0` as this may result
+    in data loss!
+
+    If the cluster contains tables created before :ref:`version_5.5.0`, after
+    upgrading to :ref:`version_6.0.3` certain actions on such tables like
+    deleting partitions, changing settings, rename, swap, etc. can lead to
+    corrupted table which causes all the data of the columns created
+    in versions before :ref:`version_5.5.0` to be shown as ``NULL``. The bug
+    has been fixed in :ref:`version_6.0.6`, so we highly recommend to avoid
+    upgrading to any earlier 6.0.x version.
+
+    Once already affected by the bug, existing data may be lost forever, while
+    new data (via ``INSERT`` or ``UPDATE``) can be retrieved normally.
+
 .. NOTE::
 
     If you are upgrading a cluster, you must be running CrateDB 5.0.0 or higher

--- a/docs/appendices/release-notes/6.0.4.rst
+++ b/docs/appendices/release-notes/6.0.4.rst
@@ -6,6 +6,23 @@ Version 6.0.4
 
 Released on 2025-11-19.
 
+.. WARNING::
+
+    Do not use this version when upgrading from any previous version
+    containing tables created before :ref:`version_5.5.0` as this may result
+    in data loss!
+
+    If the cluster contains tables created before :ref:`version_5.5.0`, after
+    upgrading to :ref:`version_6.0.4` certain actions on such tables like
+    deleting partitions, changing settings, rename, swap, etc. can lead to
+    corrupted table which causes all the data of the columns created
+    in versions before :ref:`version_5.5.0` to be shown as ``NULL``. The bug
+    has been fixed in :ref:`version_6.0.6`, so we highly recommend to avoid
+    upgrading to any earlier 6.0.x version.
+
+    Once already affected by the bug, existing data may be lost forever, while
+    new data (via ``INSERT`` or ``UPDATE``) can be retrieved normally.
+
 .. NOTE::
 
     If you are upgrading a cluster, you must be running CrateDB 5.0.0 or higher

--- a/docs/appendices/release-notes/6.0.5.rst
+++ b/docs/appendices/release-notes/6.0.5.rst
@@ -6,6 +6,23 @@ Version 6.0.5
 
 Released on 2025-12-11.
 
+.. WARNING::
+
+    Do not use this version when upgrading from any previous version
+    containing tables created before :ref:`version_5.5.0` as this may result
+    in data loss!
+
+    If the cluster contains tables created before :ref:`version_5.5.0`, after
+    upgrading to :ref:`version_6.0.5` certain actions on such tables like
+    deleting partitions, changing settings, rename, swap, etc. can lead to
+    corrupted table which causes all the data of the columns created
+    in versions before :ref:`version_5.5.0` to be shown as ``NULL``. The bug
+    has been fixed in :ref:`version_6.0.6`, so we highly recommend to avoid
+    upgrading to any earlier 6.0.x version.
+
+    Once already affected by the bug, existing data may be lost forever, while
+    new data (via ``INSERT`` or ``UPDATE``) can be retrieved normally.
+
 .. NOTE::
 
     If you are upgrading a cluster, you must be running CrateDB 5.0.0 or higher

--- a/docs/appendices/release-notes/6.0.6.rst
+++ b/docs/appendices/release-notes/6.0.6.rst
@@ -56,3 +56,11 @@ Fixes
   partitioned tables to be rejected with ``IllegalStateException`` due to wrong
   version upgrade migration logic. Only tables created on or before 5.10.x are
   affected.
+
+- Fixed an issue that could lead to data loss for due to corruption of the
+  metadata for tables created before :ref:`version_5.5.0`, when the cluster is
+  upgraded to versions :ref:`version_6.0.0` or newer, and certain actions take
+  place on these tables, e.g.: ``ALTER TABLE SET <config_param>=value``,
+  dropping a partition, etc. The corruption will cause all columns to return
+  ``NULL`` values, for all existing data in the table, whereas new data (via
+  ``INSERT`` or ``UPDATE``), can be retrieved normally.

--- a/docs/appendices/release-notes/6.1.0.rst
+++ b/docs/appendices/release-notes/6.1.0.rst
@@ -6,6 +6,22 @@ Version 6.1.0
 
 Released on 2025-10-20.
 
+.. WARNING::
+
+    Do not use this version when upgrading from any previous version
+    containing tables created before :ref:`version_5.5.0` as this may result
+    in data loss!
+
+    If the cluster contains tables created before :ref:`version_5.5.0`, after
+    upgrading to :ref:`version_6.1.0` certain actions on such tables like
+    deleting partitions, changing settings, rename, swap, etc. can lead to
+    corrupted table which causes all the data of the columns created
+    in versions before :ref:`version_5.5.0` to be shown as ``NULL``. The bug
+    has been fixed in :ref:`version_6.1.4`, so we highly recommend to avoid
+    upgrading to any earlier 6.1.x version.
+
+    Once already affected by the bug, existing data may be lost forever, while
+    new data (via ``INSERT`` or ``UPDATE``) can be retrieved normally.
 
 .. NOTE::
 

--- a/docs/appendices/release-notes/6.1.1.rst
+++ b/docs/appendices/release-notes/6.1.1.rst
@@ -6,6 +6,23 @@ Version 6.1.1
 
 Released on 2025-11-19.
 
+.. WARNING::
+
+    Do not use this version when upgrading from any previous version
+    containing tables created before :ref:`version_5.5.0` as this may result
+    in data loss!
+
+    If the cluster contains tables created before :ref:`version_5.5.0`, after
+    upgrading to :ref:`version_6.1.1` certain actions on such tables like
+    deleting partitions, changing settings, rename, swap, etc. can lead to
+    corrupted table which causes all the data of the columns created
+    in versions before :ref:`version_5.5.0` to be shown as ``NULL``. The bug
+    has been fixed in :ref:`version_6.1.4`, so we highly recommend to avoid
+    upgrading to any earlier 6.1.x version.
+
+    Once already affected by the bug, existing data may be lost forever, while
+    new data (via ``INSERT`` or ``UPDATE``) can be retrieved normally.
+
 .. NOTE::
 
     If you are upgrading a cluster, you must be running CrateDB 5.0.0 or higher

--- a/docs/appendices/release-notes/6.1.2.rst
+++ b/docs/appendices/release-notes/6.1.2.rst
@@ -6,6 +6,23 @@ Version 6.1.2
 
 Released on 2025-12-10.
 
+.. WARNING::
+
+    Do not use this version when upgrading from any previous version
+    containing tables created before :ref:`version_5.5.0` as this may result
+    in data loss!
+
+    If the cluster contains tables created before :ref:`version_5.5.0`, after
+    upgrading to :ref:`version_6.1.2` certain actions on such tables like
+    deleting partitions, changing settings, rename, swap, etc. can lead to
+    corrupted table which causes all the data of the columns created
+    in versions before :ref:`version_5.5.0` to be shown as ``NULL``. The bug
+    has been fixed in :ref:`version_6.1.4`, so we highly recommend to avoid
+    upgrading to any earlier 6.1.x version.
+
+    Once already affected by the bug, existing data may be lost forever, while
+    new data (via ``INSERT`` or ``UPDATE``) can be retrieved normally.
+
 .. NOTE::
 
     If you are upgrading a cluster, you must be running CrateDB 5.0.0 or higher

--- a/docs/appendices/release-notes/6.1.3.rst
+++ b/docs/appendices/release-notes/6.1.3.rst
@@ -6,6 +6,23 @@ Version 6.1.3
 
 Released on 2026-02-03.
 
+.. WARNING::
+
+    Do not use this version when upgrading from any previous version
+    containing tables created before :ref:`version_5.5.0` as this may result
+    in data loss!
+
+    If the cluster contains tables created before :ref:`version_5.5.0`, after
+    upgrading to :ref:`version_6.1.3` certain actions on such tables like
+    deleting partitions, changing settings, rename, swap, etc. can lead to
+    corrupted table which causes all the data of the columns created
+    in versions before :ref:`version_5.5.0` to be shown as ``NULL``. The bug
+    has been fixed in :ref:`version_6.1.4`, so we highly recommend to avoid
+    upgrading to any earlier 6.1.x version.
+
+    Once already affected by the bug, existing data may be lost forever, while
+    new data (via ``INSERT`` or ``UPDATE``) can be retrieved normally.
+
 .. NOTE::
 
     If you are upgrading a cluster, you must be running CrateDB 5.0.0 or higher

--- a/docs/appendices/release-notes/6.1.4.rst
+++ b/docs/appendices/release-notes/6.1.4.rst
@@ -56,3 +56,11 @@ Fixes
   partitioned tables to be rejected with ``IllegalStateException`` due to wrong
   version upgrade migration logic. Only tables created on or before 5.10.x are
   affected.
+
+- Fixed an issue that could lead to data loss for due to corruption of the
+  metadata for tables created before :ref:`version_5.5.0`, when the cluster is
+  upgraded to versions :ref:`version_6.0.0` or newer, and certain actions take
+  place on these tables, e.g.: ``ALTER TABLE SET <config_param>=value``,
+  dropping a partition, etc. The corruption will cause all columns to return
+  ``NULL`` values, for all existing data in the table, whereas new data (via
+  ``INSERT`` or ``UPDATE``), can be retrieved normally.

--- a/docs/appendices/release-notes/6.2.0.rst
+++ b/docs/appendices/release-notes/6.2.0.rst
@@ -6,6 +6,22 @@ Version 6.2.0
 
 Released on 2025-01-13.
 
+.. WARNING::
+
+    Do not use this version when upgrading from any previous version
+    containing tables created before :ref:`version_5.5.0` as this may result
+    in data loss!
+
+    If the cluster contains tables created before :ref:`version_5.5.0`, after
+    upgrading to :ref:`version_6.2.0` certain actions on such tables like
+    deleting partitions, changing settings, rename, swap, etc. can lead to
+    corrupted table which causes all the data of the columns created
+    in versions before :ref:`version_5.5.0` to be shown as ``NULL``. The bug
+    has been fixed in :ref:`version_6.2.6`, so we highly recommend to avoid
+    upgrading to any earlier 6.2.x version.
+
+    Once already affected by the bug, existing data may be lost forever, while
+    new data (via ``INSERT`` or ``UPDATE``) can be retrieved normally.
 
 .. NOTE::
 

--- a/docs/appendices/release-notes/6.2.1.rst
+++ b/docs/appendices/release-notes/6.2.1.rst
@@ -6,6 +6,23 @@ Version 6.2.1
 
 Released on 2026-02-03.
 
+.. WARNING::
+
+    Do not use this version when upgrading from any previous version
+    containing tables created before :ref:`version_5.5.0` as this may result
+    in data loss!
+
+    If the cluster contains tables created before :ref:`version_5.5.0`, after
+    upgrading to :ref:`version_6.2.1` certain actions on such tables like
+    deleting partitions, changing settings, rename, swap, etc. can lead to
+    corrupted table which causes all the data of the columns created
+    in versions before :ref:`version_5.5.0` to be shown as ``NULL``. The bug
+    has been fixed in :ref:`version_6.2.6`, so we highly recommend to avoid
+    upgrading to any earlier 6.2.x version.
+
+    Once already affected by the bug, existing data may be lost forever, while
+    new data (via ``INSERT`` or ``UPDATE``) can be retrieved normally.
+
 .. NOTE::
 
     If you are upgrading a cluster, you must be running CrateDB 5.0.0 or higher

--- a/docs/appendices/release-notes/6.2.2.rst
+++ b/docs/appendices/release-notes/6.2.2.rst
@@ -6,6 +6,23 @@ Version 6.2.2
 
 Released on 2026-03-03.
 
+.. WARNING::
+
+    Do not use this version when upgrading from any previous version
+    containing tables created before :ref:`version_5.5.0` as this may result
+    in data loss!
+
+    If the cluster contains tables created before :ref:`version_5.5.0`, after
+    upgrading to :ref:`version_6.2.2` certain actions on such tables like
+    deleting partitions, changing settings, rename, swap, etc. can lead to
+    corrupted table which causes all the data of the columns created
+    in versions before :ref:`version_5.5.0` to be shown as ``NULL``. The bug
+    has been fixed in :ref:`version_6.2.6`, so we highly recommend to avoid
+    upgrading to any earlier 6.2.x version.
+
+    Once already affected by the bug, existing data may be lost forever, while
+    new data (via ``INSERT`` or ``UPDATE``) can be retrieved normally.
+
 .. NOTE::
 
     If you are upgrading a cluster, you must be running CrateDB 5.0.0 or higher

--- a/docs/appendices/release-notes/6.2.3.rst
+++ b/docs/appendices/release-notes/6.2.3.rst
@@ -6,6 +6,23 @@ Version 6.2.3
 
 Released on 2026-03-17.
 
+.. WARNING::
+
+    Do not use this version when upgrading from any previous version
+    containing tables created before :ref:`version_5.5.0` as this may result
+    in data loss!
+
+    If the cluster contains tables created before :ref:`version_5.5.0`, after
+    upgrading to :ref:`version_6.2.3` certain actions on such tables like
+    deleting partitions, changing settings, rename, swap, etc. can lead to
+    corrupted table which causes all the data of the columns created
+    in versions before :ref:`version_5.5.0` to be shown as ``NULL``. The bug
+    has been fixed in :ref:`version_6.2.6`, so we highly recommend to avoid
+    upgrading to any earlier 6.2.x version.
+
+    Once already affected by the bug, existing data may be lost forever, while
+    new data (via ``INSERT`` or ``UPDATE``) can be retrieved normally.
+
 .. NOTE::
 
     If you are upgrading a cluster, you must be running CrateDB 5.0.0 or higher

--- a/docs/appendices/release-notes/6.2.4.rst
+++ b/docs/appendices/release-notes/6.2.4.rst
@@ -6,6 +6,23 @@ Version 6.2.4
 
 Released on 2026-03-30.
 
+.. WARNING::
+
+    Do not use this version when upgrading from any previous version
+    containing tables created before :ref:`version_5.5.0` as this may result
+    in data loss!
+
+    If the cluster contains tables created before :ref:`version_5.5.0`, after
+    upgrading to :ref:`version_6.2.4` certain actions on such tables like
+    deleting partitions, changing settings, rename, swap, etc. can lead to
+    corrupted table which causes all the data of the columns created
+    in versions before :ref:`version_5.5.0` to be shown as ``NULL``. The bug
+    has been fixed in :ref:`version_6.2.6`, so we highly recommend to avoid
+    upgrading to any earlier 6.2.x version.
+
+    Once already affected by the bug, existing data may be lost forever, while
+    new data (via ``INSERT`` or ``UPDATE``) can be retrieved normally.
+
 .. NOTE::
 
     If you are upgrading a cluster, you must be running CrateDB 5.0.0 or higher

--- a/docs/appendices/release-notes/6.2.5.rst
+++ b/docs/appendices/release-notes/6.2.5.rst
@@ -6,6 +6,23 @@ Version 6.2.5
 
 Released on 2026-04-14.
 
+.. WARNING::
+
+    Do not use this version when upgrading from any previous version
+    containing tables created before :ref:`version_5.5.0` as this may result
+    in data loss!
+
+    If the cluster contains tables created before :ref:`version_5.5.0`, after
+    upgrading to :ref:`version_6.2.5` certain actions on such tables like
+    deleting partitions, changing settings, rename, swap, etc. can lead to
+    corrupted table which causes all the data of the columns created
+    in versions before :ref:`version_5.5.0` to be shown as ``NULL``. The bug
+    has been fixed in :ref:`version_6.2.6`, so we highly recommend to avoid
+    upgrading to any earlier 6.2.x version.
+
+    Once already affected by the bug, existing data may be lost forever, while
+    new data (via ``INSERT`` or ``UPDATE``) can be retrieved normally.
+
 .. NOTE::
 
     If you are upgrading a cluster, you must be running CrateDB 5.0.0 or higher

--- a/docs/appendices/release-notes/6.2.6.rst
+++ b/docs/appendices/release-notes/6.2.6.rst
@@ -49,4 +49,10 @@ series.
 Fixes
 =====
 
-None
+- Fixed an issue that could lead to data loss for due to corruption of the
+  metadata for tables created before :ref:`version_5.5.0`, when the cluster is
+  upgraded to versions :ref:`version_6.0.0` or newer, and certain actions take
+  place on these tables, e.g.: ``ALTER TABLE SET <config_param>=value``,
+  dropping a partition, etc. The corruption will cause all columns to return
+  ``NULL`` values, for all existing data in the table, whereas new data (via
+  ``INSERT`` or ``UPDATE``), can be retrieved normally.

--- a/docs/appendices/release-notes/6.3.0.rst
+++ b/docs/appendices/release-notes/6.3.0.rst
@@ -6,6 +6,23 @@ Version 6.3.0
 
 Released on 2026-03-31
 
+.. WARNING::
+
+    Do not use this version when upgrading from any previous version
+    containing tables created before :ref:`version_5.5.0` as this may result
+    in data loss!
+
+    If the cluster contains tables created before :ref:`version_5.5.0`, after
+    upgrading to :ref:`version_6.3.0` certain actions on such tables like
+    deleting partitions, changing settings, rename, swap, etc. can lead to
+    corrupted table which causes all the data of the columns created
+    in versions before :ref:`version_5.5.0` to be shown as ``NULL``. The bug
+    has been fixed in :ref:`version_6.3.2`, so we highly recommend to avoid
+    upgrading to any earlier 6.3.x version.
+
+    Once already affected by the bug, existing data may be lost forever, while
+    new data (via ``INSERT`` or ``UPDATE``) can be retrieved normally.
+
 .. NOTE::
 
     If you are upgrading a cluster, you must be running CrateDB 5.0.0 or higher

--- a/docs/appendices/release-notes/6.3.1.rst
+++ b/docs/appendices/release-notes/6.3.1.rst
@@ -6,6 +6,23 @@ Version 6.3.1
 
 Released on 2026-04-14.
 
+.. WARNING::
+
+    Do not use this version when upgrading from any previous version
+    containing tables created before :ref:`version_5.5.0` as this may result
+    in data loss!
+
+    If the cluster contains tables created before :ref:`version_5.5.0`, after
+    upgrading to :ref:`version_6.3.1` certain actions on such tables like
+    deleting partitions, changing settings, rename, swap, etc. can lead to
+    corrupted table which causes all the data of the columns created
+    in versions before :ref:`version_5.5.0` to be shown as ``NULL``. The bug
+    has been fixed in :ref:`version_6.3.2`, so we highly recommend to avoid
+    upgrading to any earlier 6.3.x version.
+
+    Once already affected by the bug, existing data may be lost forever, while
+    new data (via ``INSERT`` or ``UPDATE``) can be retrieved normally.
+
 .. NOTE::
 
     If you are upgrading a cluster, you must be running CrateDB 5.0.0 or higher

--- a/docs/appendices/release-notes/6.3.2.rst
+++ b/docs/appendices/release-notes/6.3.2.rst
@@ -46,4 +46,10 @@ series.
 Fixes
 =====
 
-None
+- Fixed an issue that could lead to data loss for due to corruption of the
+  metadata for tables created before :ref:`version_5.5.0`, when the cluster is
+  upgraded to versions :ref:`version_6.0.0` or newer, and certain actions take
+  place on these tables, e.g.: ``ALTER TABLE SET <config_param>=value``,
+  dropping a partition, etc. The corruption will cause all columns to return
+  ``NULL`` values, for all existing data in the table, whereas new data (via
+  ``INSERT`` or ``UPDATE``), can be retrieved normally.

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -1471,8 +1471,17 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata> {
                                 List<String> indexUUIDs,
                                 long tableVersion,
                                 int tableOID) {
+            LongSupplier oidSupplier = NO_OID_COLUMN_OID_SUPPLIER;
+            Version versionCreated = IndexMetadata.SETTING_INDEX_VERSION_CREATED.get(settings);
+            if (versionCreated.onOrAfter(DocTableInfo.COLUMN_OID_VERSION)) {
+                long maxOid = columns.stream()
+                    .mapToLong(Reference::oid)
+                    .max()
+                    .orElse(OID_UNASSIGNED);
+                oidSupplier = new DocTableInfo.OidSupplier(maxOid);
+            }
             return setTable(
-                new DocTableInfo.OidSupplier(0),
+                oidSupplier,
                 relationName,
                 columns,
                 settings,

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataUpgradeService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataUpgradeService.java
@@ -22,10 +22,8 @@ package org.elasticsearch.cluster.metadata;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_VERSION_CREATED;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_VERSION_UPGRADED;
 import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
-import static org.elasticsearch.cluster.metadata.Metadata.Builder.NO_OID_COLUMN_OID_SUPPLIER;
 
 import java.util.List;
-import java.util.function.LongSupplier;
 import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.LogManager;
@@ -150,9 +148,6 @@ public class MetadataUpgradeService {
                 .build();
 
             newMetadata.setTable(
-                versionCreated.before(DocTableInfo.COLUMN_OID_VERSION)
-                    ? NO_OID_COLUMN_OID_SUPPLIER
-                    : new DocTableInfo.OidSupplier(docTable.maxOid()),
                 relationName,
                 docTable.allReferences(),
                 settings,
@@ -196,11 +191,7 @@ public class MetadataUpgradeService {
             }
             if (relation == null) {
                 if (tableInfo instanceof DocTableInfo docTable) {
-                    LongSupplier columnOidSupplier = docTable.versionCreated().before(DocTableInfo.COLUMN_OID_VERSION)
-                        ? NO_OID_COLUMN_OID_SUPPLIER
-                        : new DocTableInfo.OidSupplier(docTable.maxOid());
                     newMetadata.setTable(
-                        columnOidSupplier,
                         docTable.ident(),
                         docTable.allReferences(),
                         // If RelationMetadata exist in the cluster state, make sure to override them with

--- a/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -21,7 +21,6 @@ package org.elasticsearch.snapshots;
 
 import static io.crate.analyze.SnapshotSettings.IGNORE_UNAVAILABLE;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.INDEX_UUID_NA_VALUE;
-import static org.elasticsearch.cluster.metadata.Metadata.Builder.NO_OID_COLUMN_OID_SUPPLIER;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -35,7 +34,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiConsumer;
-import java.util.function.LongSupplier;
 import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.LogManager;
@@ -101,7 +99,6 @@ import io.crate.metadata.IndexName;
 import io.crate.metadata.IndexParts;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.RelationName;
-import io.crate.metadata.doc.DocTableInfo;
 
 /**
  * Service responsible for restoring snapshots
@@ -629,12 +626,7 @@ public class RestoreService implements ClusterStateApplier {
                 RelationMetadata.Table table = snapshotRelation instanceof RelationMetadata.Table snapshotTable
                     ? snapshotTable
                     : existingTable;
-                LongSupplier columnOidSupplier = IndexMetadata.SETTING_INDEX_VERSION_CREATED.get(table.settings())
-                    .before(DocTableInfo.COLUMN_OID_VERSION)
-                    ? NO_OID_COLUMN_OID_SUPPLIER
-                    : new DocTableInfo.OidSupplier(0);
                 mdBuilder.setTable(
-                    columnOidSupplier,
                     targetName,
                     Lists.map(
                         table.columns(),
@@ -654,12 +646,7 @@ public class RestoreService implements ClusterStateApplier {
                 );
             } else if (existingRelation == null) {
                 if (snapshotRelation instanceof RelationMetadata.Table table) {
-                    LongSupplier columnOidSupplier = IndexMetadata.SETTING_INDEX_VERSION_CREATED.get(table.settings())
-                        .before(DocTableInfo.COLUMN_OID_VERSION)
-                        ? NO_OID_COLUMN_OID_SUPPLIER
-                        : new DocTableInfo.OidSupplier(0);
                     mdBuilder.setTable(
-                        columnOidSupplier,
                         targetName,
                         Lists.map(
                             table.columns(),

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataTest.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataTest.java
@@ -30,6 +30,7 @@ import java.util.stream.Collectors;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.Diff;
+import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
 import org.elasticsearch.common.settings.Settings;
@@ -47,6 +48,7 @@ import io.crate.metadata.RelationName;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.SearchPath;
 import io.crate.metadata.SimpleReference;
+import io.crate.metadata.doc.DocSchemaInfo;
 import io.crate.metadata.view.ViewsMetadata;
 import io.crate.role.Role;
 import io.crate.sql.tree.ColumnPolicy;
@@ -393,5 +395,48 @@ public class MetadataTest extends ESTestCase {
                 assertThat(schemaMetadata.udfs()).containsExactly(udf1);
             }
         }
+    }
+
+    @Test
+    public void test_tables_without_col_oids_do_not_get_assigned_oids() {
+        RelationName tableName = new RelationName(DocSchemaInfo.NAME, "test");
+        Reference col1 = new SimpleReference(tableName, ColumnIdent.of("col1"), RowGranularity.DOC, DataTypes.INTEGER, 1, null);
+        Reference col2 = new SimpleReference(tableName, ColumnIdent.of("col2"), RowGranularity.DOC, DataTypes.STRING, 2, null);
+        List<Reference> columns = List.of(col1, col2);
+        RelationMetadata.Table table = new RelationMetadata.Table(
+            123,
+            tableName,
+            columns,
+            Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.V_5_4_8).build(),
+            null,
+            ColumnPolicy.DYNAMIC,
+            null,
+            Map.of(),
+            List.of(),
+            List.of(),
+            IndexMetadata.State.OPEN,
+            List.of(UUIDs.randomBase64UUID()),
+            0
+        );
+        Metadata.Builder builder = Metadata.builder(Metadata.OID_UNASSIGNED);
+        builder.setRelation(table);
+
+        builder.setTable(
+            tableName,
+            columns,
+            Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.V_5_4_8).build(),
+            null,
+            ColumnPolicy.DYNAMIC,
+            null,
+            Map.of(),
+            List.of(),
+            List.of(),
+            IndexMetadata.State.OPEN,
+            List.of(UUIDs.randomBase64UUID()),
+            table.tableVersion() + 1,
+            table.oid()
+        );
+        List<Reference> newCols = ((RelationMetadata.Table) builder.getRelation(tableName)).columns();
+        assertThat(newCols).containsExactlyInAnyOrder(col1, col2);
     }
 }


### PR DESCRIPTION
Tables created before `5.5.0` didn't have col oids, so their Lucene fields names matched the col names. With `5.5.0` we introduced col oids so each col is assigned one, and the Lucene fields are stored using those oids instead of column names. Due to a bug in `Metadata.setTable()` where we don't pass an `oidSupplier`, certain actions like delete partitions, alter table settings etc. which call this method, would assign incrementing col oids to those old tables. As a result when trying to retrieve data, from then on, the col oids would be used but the existing data is stored in Lucene using the col names, thus returning `NULL`.

Add similar logic, that we use in other places, to the problematic flavor of `Metatada.setTable()` to check the `version created` of the table and don't assign oids for those older tables.
