### PR TITLE
Use Column store for MIN/MAX aggregations on NUMERIC

### DIFF
--- a/docs/appendices/release-notes/6.4.0.rst
+++ b/docs/appendices/release-notes/6.4.0.rst
@@ -85,7 +85,10 @@ Scalar and Aggregation Functions
 Performance and Resilience Improvements
 ---------------------------------------
 
-None
+
+- Improved the performance of the :ref:`min() <aggregation-min>` and
+  :ref:`max() <aggregation-max>` aggregations for columns of type :ref:`NUMERIC
+  <data-types-numeric>`.
 
 Administration and Operations
 -----------------------------

--- a/server/src/main/java/io/crate/execution/engine/aggregation/AggregationFunction.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/AggregationFunction.java
@@ -147,6 +147,9 @@ public abstract class AggregationFunction<TPartial, TFinal> implements FunctionI
         return null;
     }
 
+
+    /// Returns the first reference from the input list **if** it has doc values
+    /// **and** the granularity is `DOC`. Otherwise, returns `null`.
     protected Reference getAggReference(List<Reference> aggregationReferences) {
         if (aggregationReferences.isEmpty()) {
             return null;
@@ -161,6 +164,12 @@ public abstract class AggregationFunction<TPartial, TFinal> implements FunctionI
         return reference;
     }
 
+    /**
+     * Returns a new {@link DocValueAggregator} that automatically handles
+     * different precisions of numeric doc values (values with precision
+     * <= {@link  NumericStorage#COMPACT_PRECISION} are stored as `long`; others
+     * are stored as binary doc values).
+     */
     protected DocValueAggregator<?> getNumericDocValueAggregator(
         List<Reference> aggregationReferences,
         CheckedTriFunction<RamAccounting, TPartial, BigDecimal, TPartial, IOException> onDocValue) {
@@ -178,9 +187,11 @@ public abstract class AggregationFunction<TPartial, TFinal> implements FunctionI
         NumericType numericType = (NumericType) valueType;
         Integer precision = numericType.numericPrecision();
         Integer scale = numericType.scale();
+        // NB: At the time of writing this (v6.4), it's possible to have numeric columns
+        // without precision or scale.
+        // However, this may be subject to change, so we're leaving this as a guardrail.
         if (precision == null || scale == null) {
-            throw new UnsupportedOperationException(
-                "NUMERIC type requires precision and scale to support aggregation");
+            return null;
         }
         if (precision <= NumericStorage.COMPACT_PRECISION) {
             return new SortedNumericDocValueAggregator<>(

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/MaximumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/MaximumAggregation.java
@@ -57,6 +57,7 @@ import io.crate.types.FixedWidthType;
 import io.crate.types.FloatType;
 import io.crate.types.IntegerType;
 import io.crate.types.LongType;
+import io.crate.types.NumericType;
 import io.crate.types.ShortType;
 import io.crate.types.TimestampType;
 
@@ -312,6 +313,24 @@ public abstract class MaximumAggregation extends AggregationFunction<Object, Obj
                 return state2;
             }
             return state1;
+        }
+
+        @Nullable
+        @Override
+        public DocValueAggregator<?> getDocValueAggregator(LuceneReferenceResolver referenceResolver,
+                                                           List<Reference> aggregationReferences,
+                                                           DocTableInfo table,
+                                                           Version shardCreatedVersion,
+                                                           List<Literal<?>> optionalParams) {
+            Reference reference = getAggReference(aggregationReferences);
+            if (reference == null) {
+                return null;
+            }
+            DataType<?> valueType = reference.valueType();
+            if (valueType instanceof NumericType) {
+                return getNumericDocValueAggregator(aggregationReferences, this::reduce);
+            }
+            return null;
         }
     }
 

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/MinimumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/MinimumAggregation.java
@@ -24,6 +24,7 @@ package io.crate.execution.engine.aggregation.impl;
 import java.io.IOException;
 import java.util.List;
 
+import io.crate.types.NumericType;
 import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.SortedNumericDocValues;
@@ -245,6 +246,24 @@ public abstract class MinimumAggregation extends AggregationFunction<Object, Obj
                 return state2;
             }
             return state1;
+        }
+
+        @Nullable
+        @Override
+        public DocValueAggregator<?> getDocValueAggregator(LuceneReferenceResolver referenceResolver,
+                                                           List<Reference> aggregationReferences,
+                                                           DocTableInfo table,
+                                                           Version shardCreatedVersion,
+                                                           List<Literal<?>> optionalParams) {
+            Reference reference = getAggReference(aggregationReferences);
+            if (reference == null) {
+                return null;
+            }
+            DataType<?> valueType = reference.valueType();
+            if (valueType instanceof NumericType) {
+                return getNumericDocValueAggregator(aggregationReferences, this::reduce);
+            }
+            return null;
         }
     }
 

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/MaximumAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/MaximumAggregationTest.java
@@ -21,15 +21,6 @@
 
 package io.crate.execution.engine.aggregation.impl;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
-import java.math.BigDecimal;
-import java.util.List;
-
-import org.joda.time.Period;
-import org.junit.Test;
-
 import io.crate.exceptions.UnsupportedFunctionException;
 import io.crate.metadata.FunctionType;
 import io.crate.metadata.Scalar;
@@ -38,8 +29,88 @@ import io.crate.operation.aggregation.AggregationTestCase;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import io.crate.types.NumericType;
+import org.joda.time.Period;
+import org.junit.Test;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class MaximumAggregationTest extends AggregationTestCase {
+
+    private record NumericTestCase(String name, NumericType type, Object[][] data, BigDecimal expected) {}
+
+    // Numeric values with the precision <= 18 are stored as long values
+    // in the column store, so we're testing both cases.
+    // See NumericStorage for more info.
+    private static List<NumericTestCase> testNumericParameters() {
+        return List.of(
+            new NumericTestCase(
+                "compact precision, simple case",
+                new NumericType(6, 4),
+                new Object[][]{{new BigDecimal("97.6543")}, {new BigDecimal("97.6542")}},
+                new BigDecimal("97.6543")
+            ),
+            new NumericTestCase(
+                "large precision, simple case",
+                new NumericType(22, 4),
+                new Object[][]{{new BigDecimal("97.6543")}, {new BigDecimal("97.6542")}},
+                new BigDecimal("97.6543")
+            ),
+            // See: https://github.com/crate/crate/pull/17371
+            new NumericTestCase(
+                "compact precision, string sorting different",
+                new NumericType(6, 2),
+                new Object[][]{{new BigDecimal("10.00")}, {new BigDecimal("9.00")}},
+                new BigDecimal("10.00")
+            ),
+            // See: https://github.com/crate/crate/pull/17371
+            new NumericTestCase(
+                "large precision, string sorting different",
+                new NumericType(22, 2),
+                new Object[][]{{new BigDecimal("10.00")}, {new BigDecimal("9.00")}},
+                new BigDecimal("10.00")
+            ),
+            new NumericTestCase(
+                "compact precision, single input",
+                new NumericType(6, 4),
+                new Object[][]{{new BigDecimal("97.6542")}},
+                new BigDecimal("97.6542")
+            ),
+            new NumericTestCase(
+                "large precision, single input",
+                new NumericType(22, 4),
+                new Object[][]{{new BigDecimal("97.6542")}},
+                new BigDecimal("97.6542")
+            ),
+            new NumericTestCase(
+                "empty input",
+                new NumericType(22, 2),
+                new Object[][]{},
+                null
+            ),
+            new NumericTestCase(
+                "null input",
+                new NumericType(22, 2),
+                new Object[][]{{null}},
+                null
+            ),
+            new NumericTestCase(
+                "equal values",
+                new NumericType(22, 2),
+                new Object[][]{{new BigDecimal("10.00")}, {new BigDecimal("10.00")}},
+                new BigDecimal("10.00")
+            ),
+            new NumericTestCase(
+                "max value comes after",
+                new NumericType(22, 4),
+                new Object[][]{{new BigDecimal("97.6542")}, {new BigDecimal("97.6543")}},
+                new BigDecimal("97.6543")
+            )
+        );
+    }
 
     private Object executeAggregation(DataType<?> argumentType, Object[][] data) throws Exception {
         return executeAggregation(
@@ -58,13 +129,25 @@ public class MaximumAggregationTest extends AggregationTestCase {
         for (var dataType : DataTypes.NUMERIC_PRIMITIVE_TYPES) {
             assertHasDocValueAggregator(MaximumAggregation.NAME, List.of(dataType));
         }
+        assertHasDocValueAggregator(MaximumAggregation.NAME, List.of(new NumericType(6, 2)));
+    }
+
+    @Test
+    public void test_numeric_aggregation_not_supported_without_scale_or_precision() {
+        assertThat(getDocValueAggregator(MaximumAggregation.NAME, List.of(new NumericType(6, null))))
+            .isNull();
+        assertThat(getDocValueAggregator(MaximumAggregation.NAME, List.of(new NumericType(null, null))))
+            .isNull();
     }
 
     @Test
     public void testNumeric() throws Exception {
-        Object result = executeAggregation(new NumericType(6, 4),
-            new Object[][]{{new BigDecimal("97.6543")}, {new BigDecimal("97.6542")}});
-        assertThat(result).isEqualTo(new BigDecimal("97.6543"));
+        for (var tc : testNumericParameters()) {
+            Object result = executeAggregation(tc.type(), tc.data());
+            assertThat(result)
+                .as(tc.name())
+                .isEqualTo(tc.expected());
+        }
     }
 
     @Test

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/MinimumAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/MinimumAggregationTest.java
@@ -41,6 +41,78 @@ import io.crate.types.NumericType;
 
 public class MinimumAggregationTest extends AggregationTestCase {
 
+    private record NumericTestCase(String name, NumericType type, Object[][] data, BigDecimal expected) {}
+
+    // Numeric values with the precision <= 18 are stored as long values
+    // in the column store, so we're testing both cases.
+    // See NumericStorage for more info.
+    private static List<NumericTestCase> testNumericParameters() {
+        return List.of(
+            new NumericTestCase(
+                "compact precision, simple case",
+                new NumericType(6, 4),
+                new Object[][]{{new BigDecimal("97.6543")}, {new BigDecimal("97.6542")}},
+                new BigDecimal("97.6542")
+            ),
+            new NumericTestCase(
+                "large precision, simple case",
+                new NumericType(22, 4),
+                new Object[][]{{new BigDecimal("97.6543")}, {new BigDecimal("97.6542")}},
+                new BigDecimal("97.6542")
+            ),
+            // See: https://github.com/crate/crate/pull/17371
+            new NumericTestCase(
+                "compact precision, string sorting different",
+                new NumericType(6, 2),
+                new Object[][]{{new BigDecimal("10.00")}, {new BigDecimal("9.00")}},
+                new BigDecimal("9.00")
+            ),
+            // See: https://github.com/crate/crate/pull/17371
+            new NumericTestCase(
+                "large precision, string sorting different",
+                new NumericType(22, 2),
+                new Object[][]{{new BigDecimal("10.00")}, {new BigDecimal("9.00")}},
+                new BigDecimal("9.00")
+            ),
+            new NumericTestCase(
+                "compact precision, single input",
+                new NumericType(6, 4),
+                new Object[][]{{new BigDecimal("97.6542")}},
+                new BigDecimal("97.6542")
+            ),
+            new NumericTestCase(
+                "large precision, single input",
+                new NumericType(22, 4),
+                new Object[][]{{new BigDecimal("97.6542")}},
+                new BigDecimal("97.6542")
+            ),
+            new NumericTestCase(
+                "empty input",
+                new NumericType(22, 2),
+                new Object[][]{},
+                null
+            ),
+            new NumericTestCase(
+                "null input",
+                new NumericType(22, 2),
+                new Object[][]{{null}},
+                null
+            ),
+            new NumericTestCase(
+                "equal values",
+                new NumericType(22, 2),
+                new Object[][]{{new BigDecimal("10.00")}, {new BigDecimal("10.00")}},
+                new BigDecimal("10.00")
+            ),
+            new NumericTestCase(
+                "min value comes first",
+                new NumericType(6, 4),
+                new Object[][]{{new BigDecimal("97.6542")}, {new BigDecimal("97.6543")}},
+                new BigDecimal("97.6542")
+            )
+        );
+    }
+
     private Object executeAggregation(DataType<?> argumentType, Object[][] data) throws Exception {
         return executeAggregation(
                 Signature.builder(MinimumAggregation.NAME, FunctionType.AGGREGATE)
@@ -58,13 +130,26 @@ public class MinimumAggregationTest extends AggregationTestCase {
         for (var dataType : DataTypes.NUMERIC_PRIMITIVE_TYPES) {
             assertHasDocValueAggregator(MinimumAggregation.NAME, List.of(dataType));
         }
+        assertHasDocValueAggregator(MinimumAggregation.NAME, List.of(new NumericType(6, 2)));
+    }
+
+    @Test
+    public void test_numeric_aggregation_not_supported_without_scale_or_precision() {
+        assertThat(getDocValueAggregator(MinimumAggregation.NAME, List.of(new NumericType(6, null))))
+            .isNull();
+
+        assertThat(getDocValueAggregator(MinimumAggregation.NAME, List.of(new NumericType(null, null))))
+            .isNull();
     }
 
     @Test
     public void testNumeric() throws Exception {
-        Object result = executeAggregation(new NumericType(6, 4),
-            new Object[][]{{new BigDecimal("97.6543")}, {new BigDecimal("97.6542")}});
-        assertThat(result).isEqualTo(new BigDecimal("97.6542"));
+        for (var tc : testNumericParameters()) {
+            Object result = executeAggregation(tc.type(), tc.data());
+            assertThat(result)
+                .as(tc.name())
+                .isEqualTo(tc.expected());
+        }
     }
 
     @Test

--- a/server/src/testFixtures/java/io/crate/operation/aggregation/AggregationTestCase.java
+++ b/server/src/testFixtures/java/io/crate/operation/aggregation/AggregationTestCase.java
@@ -21,25 +21,58 @@
 
 package io.crate.operation.aggregation;
 
-import static io.crate.testing.TestingHelpers.createNodeContext;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
-import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
-import static org.elasticsearch.index.shard.IndexShardTestCase.EMPTY_EVENT_LISTENER;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-
+import io.crate.analyze.WhereClause;
+import io.crate.common.collections.Lists;
+import io.crate.common.io.IOUtils;
+import io.crate.concurrent.FutureActionListener;
+import io.crate.data.ArrayBucket;
+import io.crate.data.Row;
+import io.crate.data.breaker.RamAccounting;
+import io.crate.data.testing.TestingRowConsumer;
+import io.crate.execution.ddl.tables.MappingUtil;
+import io.crate.execution.ddl.tables.MappingUtil.AllocPosition;
+import io.crate.execution.dml.IndexItem;
+import io.crate.execution.dml.Indexer;
+import io.crate.execution.dsl.phases.CollectPhase;
+import io.crate.execution.dsl.phases.RoutedCollectPhase;
+import io.crate.execution.dsl.projection.AggregationProjection;
+import io.crate.execution.dsl.projection.Projection;
+import io.crate.execution.engine.aggregation.AggregationFunction;
+import io.crate.execution.engine.aggregation.DocValueAggregator;
+import io.crate.execution.engine.collect.CollectTask;
+import io.crate.execution.engine.collect.DocValuesAggregates;
+import io.crate.execution.engine.collect.MapSideDataCollectOperation;
+import io.crate.execution.engine.collect.RowCollectExpression;
+import io.crate.execution.jobs.SharedShardContexts;
+import io.crate.expression.reference.doc.lucene.LuceneReferenceResolver;
+import io.crate.expression.symbol.AggregateMode;
+import io.crate.expression.symbol.Aggregation;
+import io.crate.expression.symbol.Function;
+import io.crate.expression.symbol.InputColumn;
+import io.crate.expression.symbol.Literal;
+import io.crate.expression.symbol.Symbol;
+import io.crate.lucene.LuceneQueryBuilder;
+import io.crate.memory.MemoryManager;
+import io.crate.memory.OnHeapMemoryManager;
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.CoordinatorTxnCtx;
+import io.crate.metadata.IndexType;
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.PartitionName;
+import io.crate.metadata.Reference;
+import io.crate.metadata.RelationName;
+import io.crate.metadata.Routing;
+import io.crate.metadata.RowGranularity;
+import io.crate.metadata.SearchPath;
+import io.crate.metadata.SimpleReference;
+import io.crate.metadata.doc.DocSchemaInfo;
+import io.crate.metadata.doc.DocTableInfo;
+import io.crate.metadata.functions.Signature;
+import io.crate.metadata.settings.CoordinatorSessionSettings;
+import io.crate.planner.distribution.DistributionInfo;
+import io.crate.sql.tree.ColumnPolicy;
+import io.crate.types.DataType;
+import io.crate.types.StorageSupport;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
@@ -85,57 +118,24 @@ import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.jspecify.annotations.Nullable;
 
-import io.crate.analyze.WhereClause;
-import io.crate.common.collections.Lists;
-import io.crate.common.io.IOUtils;
-import io.crate.concurrent.FutureActionListener;
-import io.crate.data.ArrayBucket;
-import io.crate.data.Row;
-import io.crate.data.breaker.RamAccounting;
-import io.crate.data.testing.TestingRowConsumer;
-import io.crate.execution.ddl.tables.MappingUtil;
-import io.crate.execution.ddl.tables.MappingUtil.AllocPosition;
-import io.crate.execution.dml.IndexItem;
-import io.crate.execution.dml.Indexer;
-import io.crate.execution.dsl.phases.CollectPhase;
-import io.crate.execution.dsl.phases.RoutedCollectPhase;
-import io.crate.execution.dsl.projection.AggregationProjection;
-import io.crate.execution.dsl.projection.Projection;
-import io.crate.execution.engine.aggregation.AggregationFunction;
-import io.crate.execution.engine.collect.CollectTask;
-import io.crate.execution.engine.collect.DocValuesAggregates;
-import io.crate.execution.engine.collect.MapSideDataCollectOperation;
-import io.crate.execution.engine.collect.RowCollectExpression;
-import io.crate.execution.jobs.SharedShardContexts;
-import io.crate.expression.reference.doc.lucene.LuceneReferenceResolver;
-import io.crate.expression.symbol.AggregateMode;
-import io.crate.expression.symbol.Aggregation;
-import io.crate.expression.symbol.Function;
-import io.crate.expression.symbol.InputColumn;
-import io.crate.expression.symbol.Literal;
-import io.crate.expression.symbol.Symbol;
-import io.crate.lucene.LuceneQueryBuilder;
-import io.crate.memory.MemoryManager;
-import io.crate.memory.OnHeapMemoryManager;
-import io.crate.metadata.ColumnIdent;
-import io.crate.metadata.CoordinatorTxnCtx;
-import io.crate.metadata.IndexType;
-import io.crate.metadata.NodeContext;
-import io.crate.metadata.PartitionName;
-import io.crate.metadata.Reference;
-import io.crate.metadata.RelationName;
-import io.crate.metadata.Routing;
-import io.crate.metadata.RowGranularity;
-import io.crate.metadata.SearchPath;
-import io.crate.metadata.SimpleReference;
-import io.crate.metadata.doc.DocSchemaInfo;
-import io.crate.metadata.doc.DocTableInfo;
-import io.crate.metadata.functions.Signature;
-import io.crate.metadata.settings.CoordinatorSessionSettings;
-import io.crate.planner.distribution.DistributionInfo;
-import io.crate.sql.tree.ColumnPolicy;
-import io.crate.types.DataType;
-import io.crate.types.StorageSupport;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static io.crate.testing.TestingHelpers.createNodeContext;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
+import static org.elasticsearch.index.shard.IndexShardTestCase.EMPTY_EVENT_LISTENER;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public abstract class AggregationTestCase extends ESTestCase {
 
@@ -267,7 +267,7 @@ public abstract class AggregationTestCase extends ESTestCase {
     }
 
     private static <T> Object assertAndGetMergedIterAndPartial(AggregationFunction<T, ?> aggregationFunction,
-                                                               AggregationFunction<T ,?> terminatePartialAggFunction,
+                                                               AggregationFunction<T, ?> terminatePartialAggFunction,
                                                                T partialResultWithoutDocValues) {
         Object result1 = terminatePartialAggFunction.terminatePartial(
             RAM_ACCOUNTING,
@@ -380,7 +380,7 @@ public abstract class AggregationTestCase extends ESTestCase {
                                      Object[][] data,
                                      List<Reference> targetColumns) throws IOException {
         DocTableInfo table = new DocTableInfo(
-                Metadata.OID_UNASSIGNED, PARTITION_NAME.relationName(),
+            Metadata.OID_UNASSIGNED, PARTITION_NAME.relationName(),
             targetColumns.stream().collect(Collectors.toMap(Reference::column, r -> r)),
             Map.of(),
             Set.of(),
@@ -601,25 +601,30 @@ public abstract class AggregationTestCase extends ESTestCase {
     }
 
     public void assertHasDocValueAggregator(String functionName, List<DataType<?>> argumentTypes) {
+        var docValueAggregator = getDocValueAggregator(functionName, argumentTypes);
+        assertThat(docValueAggregator)
+            .as("DocValueAggregator is not implemented for "
+                + functionName + "(" + argumentTypes.stream()
+                .map(DataType::toString)
+                .collect(Collectors.joining(", ")) + ")")
+            .isNotNull();
+    }
+
+    @Nullable
+    protected DocValueAggregator<?> getDocValueAggregator(String functionName, List<DataType<?>> argumentTypes) {
         var aggregationFunction = (AggregationFunction<?, ?>) nodeCtx.functions().get(
             null,
             functionName,
             InputColumn.mapToInputColumns(argumentTypes),
             SearchPath.pathWithPGCatalogAndDoc()
         );
-        var docValueAggregator = aggregationFunction.getDocValueAggregator(
+        return aggregationFunction.getDocValueAggregator(
             mock(LuceneReferenceResolver.class),
             toReference(argumentTypes),
             mock(DocTableInfo.class),
             Version.CURRENT,
             List.of()
         );
-        assertThat(docValueAggregator)
-                .as("DocValueAggregator is not implemented for "
-                    + functionName + "(" + argumentTypes.stream()
-                        .map(DataType::toString)
-                        .collect(Collectors.joining(", ")) + ")")
-            .isNotNull();
     }
 
     public static List<Reference> toReference(List<DataType<?>> dataTypes) {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Fixes https://github.com/crate/crate/issues/17372.

I've also tested manually with the column store enabled/disabled (with the tables below).

As a future improvement, it's probably possible to unify the implementations for `min` and `max`. The difference is just in the comparators used in `reduce()` (just the opposite) and the starting values. 

Test tables:

```sql
CREATE TABLE my_table_no_columnstore (
    int_col INTEGER STORAGE WITH (columnstore = false),
    str_col TEXT STORAGE WITH (columnstore = false),
    compact_num_col NUMERIC(10, 3) STORAGE WITH (columnstore = false),
    large_num_col NUMERIC(20, 3) STORAGE WITH (columnstore = false)
);

CREATE TABLE my_table_default (
    int_col INTEGER,
    str_col TEXT,
    compact_num_col NUMERIC(10, 3),
    large_num_col NUMERIC(20, 3)
);
```

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes (not done, no user-facing changes)
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
