### PR TITLE
Avoid repeated readers iterations to create translog stats

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/translog/Translog.java
+++ b/server/src/main/java/org/elasticsearch/index/translog/Translog.java
@@ -405,13 +405,6 @@ public class Translog extends AbstractIndexShardComponent implements Closeable {
     }
 
     /**
-     * Returns the size in bytes of the v files
-     */
-    public long sizeInBytes() {
-        return sizeInBytesByMinGen(-1);
-    }
-
-    /**
      * Returns the number of operations in the translog files at least the given generation
      */
     public int totalOperationsByMinGen(long minGeneration) {
@@ -826,12 +819,30 @@ public class Translog extends AbstractIndexShardComponent implements Closeable {
     public TranslogStats stats() {
         // acquire lock to make the two numbers roughly consistent (no file change half way)
         try (ReleasableLock _ = readLock.acquire()) {
+            ensureOpen();
             long uncommittedGen = getMinGenerationForSeqNo(deletionPolicy.getLocalCheckpointOfSafeCommit() + 1).translogFileGeneration;
+            int totalOperations = current.totalOperations();
+            long sizeInBytes = current.sizeInBytes();
+            int totalOperationsByMinGen = 0;
+            long sizeInBytesByMinGen = 0;
+            if (current.getGeneration() >= uncommittedGen) {
+                totalOperationsByMinGen += current.totalOperations();
+                sizeInBytesByMinGen += current.sizeInBytes();
+            }
+            for (var reader : readers) {
+                totalOperations += reader.totalOperations();
+                sizeInBytes += reader.sizeInBytes();
+                if (reader.getGeneration() >= uncommittedGen) {
+                    totalOperationsByMinGen += reader.totalOperations();
+                    sizeInBytesByMinGen += reader.sizeInBytes();
+                }
+            }
             return new TranslogStats(
-                totalOperations(),
-                sizeInBytes(),
-                totalOperationsByMinGen(uncommittedGen),
-                sizeInBytesByMinGen(uncommittedGen));
+                totalOperations,
+                sizeInBytes,
+                totalOperationsByMinGen,
+                sizeInBytesByMinGen
+            );
         }
     }
 


### PR DESCRIPTION
Spotted this in the heatmap of the nightly benchmarks:

<img width="3800" height="1136" alt="image" src="https://github.com/user-attachments/assets/d6034faa-60b7-467e-91fe-7dab2e4e1bfc" />


    Q: select * from sys.shards order by schema_name, table_name
    C: 1
    | Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
    |   V1    |        3.375 ±    1.449 |      2.446 |      3.138 |      3.472 |     24.643 |
    |   V2    |        2.786 ±    2.228 |      1.845 |      2.429 |      2.859 |     62.878 |
    ├---------┴-------------------------┴------------┴------------┴------------┴------------┘
    |               -  19.12%                           -  25.46%
    There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 19.12%
    The test has statistical significance

    Q: select * from sys.shards order by schema_name, table_name
    C: 15
    | Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
    |   V1    |        4.593 ±    2.118 |      2.678 |      4.261 |      5.096 |     36.921 |
    |   V2    |        3.346 ±    2.010 |      1.860 |      3.021 |      3.643 |     21.164 |
    ├---------┴-------------------------┴------------┴------------┴------------┴------------┘
    |               -  31.42%                           -  34.07%
    There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 31.42%
    The test has statistical significance

     System/JVM Metrics (durations in ms, byte-values in MB)
        |    YOUNG GC            |       OLD GC           |      HEAP         |     ALLOC
        |  cnt      avg      max |  cnt      avg      max |  initial     used |     rate      total
     V1 |   77     4.74     1.96 |    0     0.00     0.00 |     2147       76 |  1254.13      95765
     V2 |   25    10.19     2.20 |    0     0.00     0.00 |     2147       67 |   378.82      29845
