### PR TITLE
Re-use seqNo, translog and retentionLease stats in ShardRowContext

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/collect/ShardCollectorProvider.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/ShardCollectorProvider.java
@@ -144,6 +144,7 @@ public abstract class ShardCollectorProvider {
     }
 
     public ShardRowContext shardRowContext() {
+        shardRowContext.reset();
         return shardRowContext;
     }
 

--- a/server/src/main/java/io/crate/execution/engine/collect/sources/ShardCollectSource.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/sources/ShardCollectSource.java
@@ -478,7 +478,8 @@ public class ShardCollectSource implements CollectSource, IndexEventListener {
                 ShardId shardId = new ShardId(index, shard.value);
                 try {
                     ShardCollectorProvider shardCollectorProvider = getCollectorProviderSafe(shardId);
-                    shardRowContexts.add(shardCollectorProvider.shardRowContext());
+                    ShardRowContext shardRowContext = shardCollectorProvider.shardRowContext();
+                    shardRowContexts.add(shardRowContext);
                 } catch (ShardNotFoundException | IllegalIndexShardStateException e) {
                     unassignedShards.add(toUnassignedShard(index, shard.value));
                 }

--- a/server/src/main/java/io/crate/expression/reference/sys/shard/ShardRowContext.java
+++ b/server/src/main/java/io/crate/expression/reference/sys/shard/ShardRowContext.java
@@ -33,12 +33,15 @@ import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.metadata.RelationMetadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.index.seqno.RetentionLease;
+import org.elasticsearch.index.seqno.RetentionLeaseStats;
+import org.elasticsearch.index.seqno.SeqNoStats;
 import org.elasticsearch.index.shard.IllegalIndexShardStateException;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.IndexShardClosedException;
 import org.elasticsearch.index.shard.MergeStats;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.store.StoreStats;
+import org.elasticsearch.index.translog.TranslogStats;
 import org.jspecify.annotations.Nullable;
 
 import io.crate.blob.v2.BlobShard;
@@ -62,6 +65,15 @@ public class ShardRowContext {
     private final String blobPath;
     private final Supplier<Boolean> orphanedPartitionSupplier;
     private final MergeStats mergeStats;
+
+    @Nullable
+    private TranslogStats translogStats = null;
+
+    @Nullable
+    private SeqNoStats seqNoStats = null;
+
+    @Nullable
+    private RetentionLeaseStats retentionLeaseStats = null;
 
     public ShardRowContext(IndexShard indexShard, ClusterService clusterService) {
         this(indexShard, null, clusterService, () -> {
@@ -194,9 +206,18 @@ public class ShardRowContext {
         }
     }
 
+    private SeqNoStats seqNoStats() {
+        if (seqNoStats == null) {
+            SeqNoStats stats = indexShard.seqNoStats();
+            seqNoStats = stats;
+            return stats;
+        }
+        return seqNoStats;
+    }
+
     public long maxSeqNo() {
         try {
-            var stats = indexShard.seqNoStats();
+            var stats = seqNoStats();
             return stats.getMaxSeqNo();
         } catch (AlreadyClosedException e) {
             return 0L;
@@ -205,7 +226,7 @@ public class ShardRowContext {
 
     public long localSeqNoCheckpoint() {
         try {
-            var stats = indexShard.seqNoStats();
+            var stats = seqNoStats();
             return stats.getLocalCheckpoint();
         } catch (AlreadyClosedException e) {
             return 0L;
@@ -214,17 +235,26 @@ public class ShardRowContext {
 
     public long globalSeqNoCheckpoint() {
         try {
-            var stats = indexShard.seqNoStats();
+            var stats = seqNoStats();
             return stats.getGlobalCheckpoint();
         } catch (AlreadyClosedException e) {
             return 0L;
         }
     }
 
+    private TranslogStats translogStats() {
+        if (translogStats == null) {
+            TranslogStats stats = indexShard.translogStats();
+            translogStats = stats;
+            return stats;
+        }
+        return translogStats;
+    }
+
     @Nullable
     public Long translogSizeInBytes() {
         try {
-            var stats = indexShard.translogStats();
+            var stats = translogStats();
             return stats == null ? null : stats.getTranslogSizeInBytes();
         } catch (AlreadyClosedException e) {
             return 0L;
@@ -234,7 +264,7 @@ public class ShardRowContext {
     @Nullable
     public Long translogUncommittedSizeInBytes() {
         try {
-            var stats = indexShard.translogStats();
+            var stats = translogStats();
             return stats == null ? null : stats.getUncommittedSizeInBytes();
         } catch (AlreadyClosedException e) {
             return 0L;
@@ -244,7 +274,7 @@ public class ShardRowContext {
     @Nullable
     public Integer translogEstimatedNumberOfOperations() {
         try {
-            var stats = indexShard.translogStats();
+            var stats = translogStats();
             return stats == null ? null : stats.estimatedNumberOfOperations();
         } catch (AlreadyClosedException e) {
             return 0;
@@ -254,7 +284,7 @@ public class ShardRowContext {
     @Nullable
     public Integer translogUncommittedOperations() {
         try {
-            var stats = indexShard.translogStats();
+            var stats = translogStats();
             return stats == null ? null : stats.getUncommittedOperations();
         } catch (AlreadyClosedException e) {
             return 0;
@@ -349,9 +379,18 @@ public class ShardRowContext {
             : recoveryState.getIndex().recoveredFilesPercent();
     }
 
+    private RetentionLeaseStats retentionLeaseStats() {
+        if (retentionLeaseStats == null) {
+            RetentionLeaseStats stats = indexShard.getRetentionLeaseStats();
+            retentionLeaseStats = stats;
+            return stats;
+        }
+        return retentionLeaseStats;
+    }
+
     public Long retentionLeasesPrimaryTerm() {
         try {
-            return indexShard.getRetentionLeaseStats().leases().primaryTerm();
+            return retentionLeaseStats().leases().primaryTerm();
         } catch (AlreadyClosedException | IndexShardClosedException e) {
             return null;
         }
@@ -359,7 +398,7 @@ public class ShardRowContext {
 
     public Long retentionLeasesVersion() {
         try {
-            return indexShard.getRetentionLeaseStats().leases().version();
+            return retentionLeaseStats().leases().version();
         } catch (AlreadyClosedException | IndexShardClosedException e) {
             return null;
         }
@@ -367,7 +406,7 @@ public class ShardRowContext {
 
     public Collection<RetentionLease> retentionLeases() {
         try {
-            return indexShard.getRetentionLeaseStats().leases().leases();
+            return retentionLeaseStats().leases().leases();
         } catch (AlreadyClosedException | IndexShardClosedException e) {
             return List.of();
         }
@@ -399,5 +438,11 @@ public class ShardRowContext {
 
     public long refreshPendingCount() {
         return indexShard.refreshListenerCount();
+    }
+
+    public void reset() {
+        translogStats = null;
+        seqNoStats = null;
+        retentionLeaseStats = null;
     }
 }


### PR DESCRIPTION
Multiple properties within `ShardRowContext` each created seqNoStats,
translogStats and retentionLeaseStats - each of which creates the
structures on-demand.

If all columns were selected on `sys.shards` queries that led to some
redundant work.

This change here ensures the stats objects are only created once per row.

    Q: select * from sys.shards order by schema_name, table_name
    C: 1
    | Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
    |   V1    |        3.445 ±    1.536 |      2.574 |      3.130 |      3.399 |     25.900 |
    |   V2    |        2.450 ±    2.075 |      1.754 |      2.200 |      2.438 |     57.864 |
    ├---------┴-------------------------┴------------┴------------┴------------┴------------┘
    |               -  33.75%                           -  34.90%
    There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 33.75%
    The test has statistical significance

    Q: select * from sys.shards order by schema_name, table_name
    C: 15
    | Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
    |   V1    |        4.611 ±    1.786 |      2.630 |      4.364 |      5.081 |     25.632 |
    |   V2    |        3.076 ±    1.831 |      1.806 |      2.824 |      3.382 |     20.823 |
    ├---------┴-------------------------┴------------┴------------┴------------┴------------┘
    |               -  39.93%                           -  42.86%
    There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 39.93%
    The test has statistical significance

    System/JVM Metrics (durations in ms, byte-values in MB)
        |    YOUNG GC            |       OLD GC           |      HEAP         |     ALLOC
        |  cnt      avg      max |  cnt      avg      max |  initial     used |     rate      total
     V1 |   77     4.73     1.97 |    0     0.00     0.00 |     2147       77 |  1192.24      96798
     V2 |   23    11.25     2.38 |    0     0.00     0.00 |     2147       67 |   378.26      27155

    perf stat
      v1
        branches:u        :   205300607514.00
        cache-misses:u    :     3450426314.00
        instructions:u    :  1024272165026.00
        faults:u          :         191653.00
      v2
        branches:u        :   153403974806.00
        cache-misses:u    :     2584022249.00
        instructions:u    :   773118913398.00
        faults:u          :         173227.00
