### PR TITLE
Ensure table OIDs are assigned starting from 6.3 master

### DIFF
--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgConstraintTable.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgConstraintTable.java
@@ -22,12 +22,15 @@
 package io.crate.metadata.pgcatalog;
 
 import static io.crate.metadata.pgcatalog.OidHash.constraintOid;
+import static io.crate.metadata.pgcatalog.OidHash.relationOid;
 import static io.crate.metadata.pgcatalog.OidHash.schemaOid;
 import static io.crate.types.DataTypes.BOOLEAN;
 import static io.crate.types.DataTypes.INTEGER;
 import static io.crate.types.DataTypes.INTEGER_ARRAY;
 import static io.crate.types.DataTypes.SHORT_ARRAY;
 import static io.crate.types.DataTypes.STRING;
+
+import org.elasticsearch.cluster.metadata.Metadata;
 
 import io.crate.metadata.RelationName;
 import io.crate.metadata.SystemTable;
@@ -50,7 +53,7 @@ public final class PgConstraintTable {
         .add("condeferrable", BOOLEAN, c -> false)
         .add("condeferred", BOOLEAN, c -> false)
         .add("convalidated", BOOLEAN, c -> true)
-        .add("conrelid", INTEGER, c -> c.relationInfo().oid())
+        .add("conrelid", INTEGER, c -> c.relationInfo().oid() == Metadata.OID_UNASSIGNED ? relationOid(c.relationInfo()) : c.relationInfo().oid())
         .add("contypid", INTEGER, c -> 0)
         .add("conindid", INTEGER, c -> 0)
         .add("conparentid", INTEGER, c -> 0)

--- a/server/src/main/java/io/crate/types/Regclass.java
+++ b/server/src/main/java/io/crate/types/Regclass.java
@@ -23,6 +23,7 @@ package io.crate.types;
 
 import java.io.IOException;
 
+import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -40,7 +41,9 @@ public final class Regclass implements Comparable<Regclass>, Writeable {
 
 
     public static Regclass relationOid(RelationInfo relation) {
-        return new Regclass(relation.oid(), relation.ident().fqn());
+        int oid = relation.oid();
+        oid = oid == Metadata.OID_UNASSIGNED ? OidHash.relationOid(relation) : oid;
+        return new Regclass(oid, relation.ident().fqn());
     }
 
     public static Regclass primaryOid(RelationInfo relation) {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequest.java
@@ -291,8 +291,6 @@ public class RestoreSnapshotRequest extends MasterNodeRequest<RestoreSnapshotReq
         }
         if (version.onOrAfter(Version.V_6_3_0)) {
             out.writeBoolean(includeViews);
-        } else {
-            out.writeBoolean(Arrays.asList(customMetadataTypes).contains("VIEWS"));
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -982,8 +982,8 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata> {
             return Metadata.getRelation(relation, schemas::get);
         }
 
-        public Builder setBlobTable(RelationName name, String indexUUID, Settings settings, State state) {
-            setRelation(new RelationMetadata.BlobTable(this.tableOidSupplier().nextOid(), name, indexUUID, settings, state));
+        public Builder setBlobTable(RelationName name, String indexUUID, Settings settings, State state, int tableOID) {
+            setRelation(new RelationMetadata.BlobTable(tableOID, name, indexUUID, settings, state));
             return this;
         }
 
@@ -1181,7 +1181,7 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata> {
 
             SortedMap<String, AliasOrIndex> aliasAndIndexLookup = Collections.unmodifiableSortedMap(buildAliasAndIndexLookup());
 
-            assert validateTableOIDs(tableOidSupplier.peek());
+            validateTableOIDs(tableOidSupplier.peek());
 
             return new Metadata(
                 clusterUUID,
@@ -1200,30 +1200,28 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata> {
             );
         }
 
-        private boolean validateTableOIDs(int tableOidSupplierValue) {
+        private void validateTableOIDs(int tableOidSupplierValue) {
+            // do not validate if table oids are not assigned yet i.e. during upgrades or upgraded tables are assigned OID_UNASSIGNED
+            if (tableOidSupplierValue == OID_UNASSIGNED) {
+                return;
+            }
             BitSet relationOIDs = new BitSet(tableOidSupplierValue + 1);
             for (var schemaMetadata : schemas.values()) {
                 for (var relationMetadata : schemaMetadata.relations().values()) {
-                    Version versionCreated = IndexMetadata.SETTING_INDEX_VERSION_CREATED.get(relationMetadata.settings());
                     int relationOID = relationMetadata.oid();
 
-                    // Skip below assert for tables created >= 6.0 and < 6.3.0 - for a single test case to pass -
-                    // test_6_1_object_reference_with_undefined_inner_type_and_no_child_reference
-                    if (relationMetadata instanceof RelationMetadata.View ||
-                        relationMetadata instanceof RelationMetadata.ForeignTable ||
-                        (versionCreated.onOrAfter(Version.V_6_0_0) && versionCreated.before(Version.V_6_3_0) && relationOID == 0)) {
+                    if (relationMetadata instanceof RelationMetadata.View || relationMetadata instanceof RelationMetadata.ForeignTable) {
                         continue;
                     }
 
-                    // below assert also implicitly validates that the current table OID supplier's value is greater than
-                    // zero when there is at least one relationMetadata
-                    assert relationOID > 0 && relationOID <= tableOidSupplierValue :
-                        "All OIDs assigned to tables are > 0 and they all are less than or equal to the current table OID supplier's value";
-                    assert !relationOIDs.get(relationOID) : "All Table OIDs are unique";
+                    // table oid can be unassigned - i.e. upgraded tables, recovered dangling indices
+                    assert relationOID >= 0 && relationOID <= tableOidSupplierValue :
+                        "Table OIDs are less than equal to tableOidSupplierValue and >= OID_UNASSIGNED";
+                    assert relationOID == 0 || !relationOIDs.get(relationOID) : "All Table OIDs are unique";
+
                     relationOIDs.set(relationOID);
                 }
             }
-            return true;
         }
 
         private SortedMap<String, AliasOrIndex> buildAliasAndIndexLookup() {
@@ -1857,6 +1855,12 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata> {
             nextOid = start;
         }
 
+        /**
+         * Returns the next available table oid.
+         * <p>
+         * WARNING: this method must only be called from the master node and assigned to tables.
+         * Non-master nodes must only receive the oids, never generate one.
+         */
         public int nextOid() {
             return ++nextOid;
         }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
@@ -282,7 +282,7 @@ public class MetadataCreateIndexService {
 
             return indicesService.withTempIndexService(indexMetadata, indexService -> {
                 Metadata.Builder mdBuilder = Metadata.builder(currentState.metadata());
-                mdBuilder.setBlobTable(relationName, indexUUID, settings, State.OPEN);
+                mdBuilder.setBlobTable(relationName, indexUUID, settings, State.OPEN, mdBuilder.tableOidSupplier().nextOid());
                 ClusterState updatedState = addIndex(
                     allocationService,
                     indexService,

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataUpgradeService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataUpgradeService.java
@@ -134,7 +134,7 @@ public class MetadataUpgradeService {
             assert relation == null
                 : "If there is still a template present there shouldn't be any RelationMetadata";
 
-            DocTableInfo docTable = tableFactory.create(template, newMetadata.tableOidSupplier().nextOid());
+            DocTableInfo docTable = tableFactory.create(template, OID_UNASSIGNED);
             Version versionCreated = getFixedVersionCreated(metadata, docTable);
 
             // versionCreated could be missing from the template settings and "calculated" afterwards
@@ -161,7 +161,7 @@ public class MetadataUpgradeService {
                 docTable.isClosed() ? IndexMetadata.State.CLOSE : IndexMetadata.State.OPEN,
                 List.of(),
                 docTable.tableVersion(),
-                docTable.oid()
+                OID_UNASSIGNED
             );
         }
 
@@ -186,7 +186,7 @@ public class MetadataUpgradeService {
                 RelationName relationName = indexParts.toRelationName();
                 relation = newMetadata.getRelation(relationName);
                 if (!BlobIndex.isBlobIndex(indexName)) {
-                    tableInfo = tableFactory.create(newIndexMetadata, newMetadata.tableOidSupplier().nextOid());
+                    tableInfo = tableFactory.create(newIndexMetadata, OID_UNASSIGNED);
                 }
             }
             if (relation == null) {
@@ -207,14 +207,15 @@ public class MetadataUpgradeService {
                         newIndexMetadata.getState(),
                         List.of(newIndexMetadata.getIndexUUID()),
                         docTable.tableVersion(),
-                        docTable.oid()
+                        OID_UNASSIGNED
                     );
                 } else if (BlobIndex.isBlobIndex(indexName)) {
                     newMetadata.setBlobTable(
                         RelationName.fromIndexName(indexName),
                         indexUUID,
                         newIndexMetadata.getSettings(),
-                        newIndexMetadata.getState()
+                        newIndexMetadata.getState(),
+                        OID_UNASSIGNED
                     );
                 } else {
                     throw new AssertionError("If the relation is missing we need a DocTableInfo instance or it must be a blob index");

--- a/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -642,7 +642,7 @@ public class RestoreService implements ClusterStateApplier {
                     table.state(),
                     Lists.concatUnique(existingTable.indexUUIDs(), indexUUIDs),
                     table.tableVersion(),
-                    mdBuilder.tableOidSupplier().nextOid()
+                    existingTable.oid() // use the existing table's oid when restoring a partition of the table
                 );
             } else if (existingRelation == null) {
                 if (snapshotRelation instanceof RelationMetadata.Table table) {

--- a/server/src/testFixtures/java/io/crate/testing/SQLExecutor.java
+++ b/server/src/testFixtures/java/io/crate/testing/SQLExecutor.java
@@ -954,6 +954,7 @@ public class SQLExecutor {
             Row.EMPTY,
             SubQueryResults.EMPTY,
             new NumberOfShards(clusterService));
+        settings = Settings.builder().put(settings).put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT).build();
 
         ClusterState prevState = clusterService.state();
         RelationName relationName = analyzedStmt.relationName();
@@ -965,7 +966,7 @@ public class SQLExecutor {
 
         Metadata.Builder mdBuilder = Metadata.builder(prevState.metadata());
         mdBuilder
-            .setBlobTable(relationName, indexMetadata.getIndexUUID(), settings, State.OPEN)
+            .setBlobTable(relationName, indexMetadata.getIndexUUID(), settings, State.OPEN, mdBuilder.tableOidSupplier().nextOid())
             .put(indexMetadata, true);
         ClusterState state = ClusterState.builder(prevState)
             .metadata(mdBuilder)


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

As [suggested](https://github.com/crate/crate/pull/19271#discussion_r3117570032) by @mfussenegger, this PR ensures table OID assignments to start after the master node is upgrade to 6.3. 

Expected table oids from all nodes at any stages of the rolling upgrade:

* Tables created before 6.3
  
  * On 6.3: returns UNASSIGNED
  * On 6.2: returns OidHash value
* Tables created on 6.3
  
  * On 6.2: returns OidHash value regardless of the version of the master node
  * On 6.3: returns newly assigned oid if master is also on 6.3. If master is still on 6.2, returns UNASSIGNED.

Above describes _internal_ table oids. When the oids are returned via `pg_class` or `regclass`, any UNASSIGNED table oids are converted to OidHash generated values which were expected before `6.3`. 

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
