### PR TITLE
Add support  json array for geo_point 

### DIFF
--- a/docs/appendices/release-notes/6.4.0.rst
+++ b/docs/appendices/release-notes/6.4.0.rst
@@ -72,7 +72,10 @@ SQL Standard and PostgreSQL Compatibility
 Data Types
 ----------
 
-None
+- Added support for ``geo_point`` values in JSON array string format, for
+  example ``"[14.988999953493476, 51.10299998894334]"``. This allows CSV files
+  containing ``geo_point`` values in this format to be imported without
+  transforming the source data first.
 
 
 Scalar and Aggregation Functions

--- a/docs/general/ddl/data-types.rst
+++ b/docs/general/ddl/data-types.rst
@@ -3185,6 +3185,10 @@ using an array of doubles in the following format::
 
     [<lon_value>, <lat_value>]
 
+String values can also use the same JSON array representation, for example
+``"[<lon_value>, <lat_value>]"``. This is useful when importing
+``GEO_POINT`` values from string-based formats like CSV.
+
 Alternatively, a `WKT`_ string can also be used to declare geo points::
 
     'POINT ( <lon_value> <lat_value> )'

--- a/server/src/main/java/io/crate/types/GeoPointType.java
+++ b/server/src/main/java/io/crate/types/GeoPointType.java
@@ -23,6 +23,7 @@ package io.crate.types;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 import java.util.List;
 import java.util.Locale;
@@ -31,6 +32,10 @@ import java.util.function.Function;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.DeprecationHandler;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.locationtech.spatial4j.context.jts.JtsSpatialContext;
 import org.locationtech.spatial4j.exception.InvalidShapeException;
 import org.locationtech.spatial4j.io.WKTReader;
@@ -112,35 +117,15 @@ public class GeoPointType extends DataType<Point> implements Streamer<Point>, Fi
             return point;
         } else if (value instanceof Double[] doubles) {
             checkLengthIs2(doubles.length);
-            if (doubles[0] == null || doubles[1] == null) {
-                return null;
-            }
-            ensurePointsInRange(doubles[0], doubles[1]);
-            return new PointImpl(doubles[0], doubles[1], JtsSpatialContext.GEO);
+            return pointFromCoordinates(doubles[0], doubles[1]);
         } else if (value instanceof Object[] values) {
             checkLengthIs2(values.length);
-            if (values[0] == null || values[1] == null) {
-                return null;
-            }
-            PointImpl point = new PointImpl(
-                ((Number) values[0]).doubleValue(),
-                ((Number) values[1]).doubleValue(),
-                JtsSpatialContext.GEO);
-            ensurePointsInRange(point.getX(), point.getY());
-            return point;
+            return pointFromCoordinates(values[0], values[1]);
         } else if (value instanceof String str) {
             return pointFromString(str);
         } else if (value instanceof List<?> values) {
             checkLengthIs2(values.size());
-            if (values.getFirst() == null || values.getLast() == null) {
-                return null;
-            }
-            PointImpl point = new PointImpl(
-                ((Number) values.get(0)).doubleValue(),
-                ((Number) values.get(1)).doubleValue(),
-                JtsSpatialContext.GEO);
-            ensurePointsInRange(point.getX(), point.getY());
-            return point;
+            return pointFromCoordinates(values.getFirst(), values.getLast());
         } else {
             throw new ClassCastException("Can't cast '" + value + "' to " + getName());
         }
@@ -152,21 +137,13 @@ public class GeoPointType extends DataType<Point> implements Streamer<Point>, Fi
             return null;
         } else if (value instanceof List<?> values) {
             checkLengthIs2(values.size());
-            if (values.getFirst() == null || values.getLast() == null) {
-                return null;
-            }
-            PointImpl point = new PointImpl(
-                ((Number) values.get(0)).doubleValue(),
-                ((Number) values.get(1)).doubleValue(),
-                JtsSpatialContext.GEO);
-            ensurePointsInRange(point.getX(), point.getY());
-            return point;
+            return pointFromCoordinates(values.getFirst(), values.getLast());
         } else {
             return (Point) value;
         }
     }
 
-    private void ensurePointsInRange(double x, double y) {
+    private static void ensurePointsInRange(double x, double y) {
         if (!arePointsInRange(x, y)) {
             throw new IllegalArgumentException(String.format(Locale.ENGLISH,
                 "Failed to validate geo point [lon=%f, lat=%f], not a valid location.",
@@ -186,12 +163,44 @@ public class GeoPointType extends DataType<Point> implements Streamer<Point>, Fi
     }
 
     private static Point pointFromString(String value) {
+        String trimmed = value.trim();
+
+        if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+            return pointFromJsonArray(trimmed);
+        }
+
         try {
             return (Point) WKT_READER.parse(value);
         } catch (ParseException | InvalidShapeException e) {
             throw new IllegalArgumentException(String.format(Locale.ENGLISH,
                 "Cannot convert \"%s\" to geo_point. %s", value, e.getLocalizedMessage()), e);
         }
+    }
+
+    private static Point pointFromJsonArray(String value) {
+        try (XContentParser parser = JsonXContent.JSON_XCONTENT.createParser(
+            NamedXContentRegistry.EMPTY,
+            DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
+            value.getBytes(StandardCharsets.UTF_8)
+        )) {
+            List<Object> values = parser.list();
+            checkLengthIs2(values.size());
+            return pointFromCoordinates(values.getFirst(), values.getLast());
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Cannot parse `" + value + "` as geo_point", e);
+        }
+    }
+
+    private static Point pointFromCoordinates(Object lon, Object lat) {
+        if (lon == null || lat == null) {
+            return null;
+        }
+        PointImpl point = new PointImpl(
+            ((Number) lon).doubleValue(),
+            ((Number) lat).doubleValue(),
+            JtsSpatialContext.GEO);
+        ensurePointsInRange(point.getX(), point.getY());
+        return point;
     }
 
     @Override

--- a/server/src/test/java/io/crate/types/GeoPointTypeTest.java
+++ b/server/src/test/java/io/crate/types/GeoPointTypeTest.java
@@ -139,13 +139,6 @@ public class GeoPointTypeTest extends DataTypeTestCase<Point> {
     }
 
     @Test
-    public void test_cast_exported_array_format_string_to_geo_point() throws Exception {
-        Point value = DataTypes.GEO_POINT.implicitCast("[11.888655507937074, 51.0029999865219]");
-        assertThat(value.getX()).isCloseTo(11.888655507937074d, Offset.offset(0.0001));
-        assertThat(value.getY()).isCloseTo(51.0029999865219d, Offset.offset(0.0001));
-    }
-
-    @Test
     public void test_cast_array_format_string_without_spaces() throws Exception {
         Point value = DataTypes.GEO_POINT.implicitCast("[11.58862218260765,50.90299998410046]");
         assertThat(value.getX()).isCloseTo(11.58862218260765d, Offset.offset(0.0001));

--- a/server/src/test/java/io/crate/types/GeoPointTypeTest.java
+++ b/server/src/test/java/io/crate/types/GeoPointTypeTest.java
@@ -131,6 +131,48 @@ public class GeoPointTypeTest extends DataTypeTestCase<Point> {
             .hasMessage("Failed to validate geo point [lon=-187.654000, lat=123.456000], not a valid location.");
     }
 
+    @Test
+    public void test_cast_array_format_string_to_geo_point() throws Exception {
+        Point value = DataTypes.GEO_POINT.implicitCast("[14.988999953493476, 51.10299998894334]");
+        assertThat(value.getX()).isCloseTo(14.988999953493476d, Offset.offset(0.0001));
+        assertThat(value.getY()).isCloseTo(51.10299998894334d, Offset.offset(0.0001));
+    }
+
+    @Test
+    public void test_cast_exported_array_format_string_to_geo_point() throws Exception {
+        Point value = DataTypes.GEO_POINT.implicitCast("[11.888655507937074, 51.0029999865219]");
+        assertThat(value.getX()).isCloseTo(11.888655507937074d, Offset.offset(0.0001));
+        assertThat(value.getY()).isCloseTo(51.0029999865219d, Offset.offset(0.0001));
+    }
+
+    @Test
+    public void test_cast_array_format_string_without_spaces() throws Exception {
+        Point value = DataTypes.GEO_POINT.implicitCast("[11.58862218260765,50.90299998410046]");
+        assertThat(value.getX()).isCloseTo(11.58862218260765d, Offset.offset(0.0001));
+        assertThat(value.getY()).isCloseTo(50.90299998410046d, Offset.offset(0.0001));
+    }
+
+    @Test
+    public void test_cast_array_format_string_with_extra_spaces() throws Exception {
+        Point value = DataTypes.GEO_POINT.implicitCast("[  11.58862218260765  ,  50.90299998410046  ]");
+        assertThat(value.getX()).isCloseTo(11.58862218260765d, Offset.offset(0.0001));
+        assertThat(value.getY()).isCloseTo(50.90299998410046d, Offset.offset(0.0001));
+    }
+
+    @Test
+    public void test_cast_array_format_string_invalid_longitude_throws_exception() {
+        assertThatThrownBy(() -> DataTypes.GEO_POINT.implicitCast("[187.654, 51.1]"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Failed to validate geo point [lon=187.654000, lat=51.100000], not a valid location.");
+    }
+
+    @Test
+    public void test_cast_array_format_string_invalid_latitude_throws_exception() {
+        assertThatThrownBy(() -> DataTypes.GEO_POINT.implicitCast("[14.98, 91.1]"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Failed to validate geo point [lon=14.980000, lat=91.100000], not a valid location.");
+    }
+
     @Override
     public void test_reference_resolver_docvalues_off() throws Exception {
         assumeFalse("GeoPointType cannot disable column store", true);


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
This relates to #19192 . This allows `geo_point` to support strings which are in Json format. Currently it doesn't support format like `"[14.988999953493476, 51.10299998894334]"` and this will enable it.  


- Removed some redundancy in `GeoPointType` while I was touching those related code. 
 

## Checklist

 - [X] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [X] Touched code is covered by tests
 - [X] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)

## Testing 
- Reproduced issue
- After fix ran below commands and verified it loaded all data :
```
CREATE TABLE locations (
   "timestamp" TIMESTAMP WITHOUT TIME ZONE,
   "geo_location" GEO_POINT,
   "data" TEXT
)
CLUSTERED INTO 4 SHARDS
WITH (
   column_policy = 'strict',
   number_of_replicas = '0-1'
);   
```

```
COPY locations
FROM 'https://guided-path.s3.us-east-1.amazonaws.com/demo_climate_data_export.csv'
WITH (
    format = 'csv',
    header = true
) return summary;

```
 
<img width="1326" height="560" alt="Screenshot 2026-04-24 at 3 38 32 PM" src="https://github.com/user-attachments/assets/c0311d3f-3d15-4157-9361-6a1854e1775c" />


