### PR TITLE
Fix RestoreSnapshotRequest streaming BWC

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequest.java
@@ -291,8 +291,6 @@ public class RestoreSnapshotRequest extends MasterNodeRequest<RestoreSnapshotReq
         }
         if (version.onOrAfter(Version.V_6_3_0)) {
             out.writeBoolean(includeViews);
-        } else {
-            out.writeBoolean(Arrays.asList(customMetadataTypes).contains("VIEWS"));
         }
     }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes below exception when restoring snapshots during a rolling upgrade from `6.2` > `6.3`:
```
cr> RESTORE SNAPSHOT repo.snapshot ALL WITH (wait_for_completion = true);
IllegalStateException[Message not fully read (request) for requestId [264], action [cluster:admin/snapshot/restore], available [0]; resetting]
```

## Checklist

 - [ ] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
