### PR TITLE
Add copyright snippet for vscode

### DIFF
--- a/.vscode/java.code-snippets
+++ b/.vscode/java.code-snippets
@@ -1,0 +1,29 @@
+{
+    "copyright": {
+        "scope": "java",
+        "description": "Copyright header",
+        "prefix": ["copyright"],
+        "body": [
+          "/*",
+          " * Licensed to Crate.io GmbH (\"Crate\") under one or more contributor",
+          " * license agreements.  See the NOTICE file distributed with this work for",
+          " * additional information regarding copyright ownership.  Crate licenses",
+          " * this file to you under the Apache License, Version 2.0 (the \"License\");",
+          " * you may not use this file except in compliance with the License.  You may",
+          " * obtain a copy of the License at",
+          " *",
+          " *   http://www.apache.org/licenses/LICENSE-2.0",
+          " *",
+          " * Unless required by applicable law or agreed to in writing, software",
+          " * distributed under the License is distributed on an \"AS IS\" BASIS, WITHOUT",
+          " * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the",
+          " * License for the specific language governing permissions and limitations",
+          " * under the License.",
+          " *",
+          " * However, if you have executed another commercial license agreement",
+          " * with Crate these terms will supersede the license and you may use the",
+          " * software solely pursuant to the terms of the relevant commercial agreement.",
+          " */"
+        ]
+    }
+}


### PR DESCRIPTION
See: https://code.visualstudio.com/docs/editing/userdefinedsnippets#_project-snippet-scope

(Mostly so that I can use it in nvim)
