### PR TITLE
Fix insert-from-values interleaved with table swaps(renames)

### DIFF
--- a/docs/appendices/release-notes/6.3.2.rst
+++ b/docs/appendices/release-notes/6.3.2.rst
@@ -58,3 +58,7 @@ Fixes
   dropping a partition, etc. The corruption will cause all columns to return
   ``NULL`` values, for all existing data in the table, whereas new data (via
   ``INSERT`` or ``UPDATE``), can be retrieved normally.
+
+- Fixed :ref:`INSERT FROM VALUES <sql-insert>` statements that create new
+  partitions are no longer interrupted by :ref:`SWAP <alter_cluster_swap_table>`
+  or :ref:`RENAME <sql-alter-table-rename-to>` table statements.

--- a/server/src/main/java/io/crate/execution/engine/indexing/GroupRowsByShard.java
+++ b/server/src/main/java/io/crate/execution/engine/indexing/GroupRowsByShard.java
@@ -236,7 +236,7 @@ public final class GroupRowsByShard<TReq extends ShardRequest<TReq, TItem>, TIte
             while (it.hasNext()) {
                 ShardedRequests.ItemAndRoutingAndSourceInfo<TItem> itemAndRoutingAndSourceInfo = it.next();
                 IndexMetadata indexMetadata = metadata.getIndex(
-                    metadata.getRelationName(tableOID),
+                    tableOID == Metadata.OID_UNASSIGNED ? partitionName.relationName() : metadata.getRelationName(tableOID),
                     partitionName.values(),
                     true,
                     x -> x

--- a/server/src/main/java/io/crate/planner/operators/InsertFromValues.java
+++ b/server/src/main/java/io/crate/planner/operators/InsertFromValues.java
@@ -283,7 +283,9 @@ public class InsertFromValues implements LogicalPlan {
         ).thenCompose(_ -> {
             var shardUpsertRequests = resolveAndGroupShardRequests(
                 shardedRequests,
-                dependencies.clusterService()).values();
+                dependencies.clusterService(),
+                tableInfo.oid()
+            ).values();
             return execute(
                 dependencies.nodeLimits(),
                 dependencies.clusterService().state(),
@@ -430,7 +432,9 @@ public class InsertFromValues implements LogicalPlan {
         ).thenCompose(_ -> {
             var shardUpsertRequests = resolveAndGroupShardRequests(
                 shardedRequests,
-                dependencies.clusterService()).values();
+                dependencies.clusterService(),
+                tableInfo.oid()
+            ).values();
             return execute(
                 dependencies.nodeLimits(),
                 dependencies.clusterService().state(),
@@ -561,15 +565,16 @@ public class InsertFromValues implements LogicalPlan {
         return new RowN(cells);
     }
 
-    private static ShardLocation getShardLocation(PartitionName partitionName,
+    private static ShardLocation getShardLocation(RelationName relationName,
+                                                  List<String> partitionValues,
                                                   String id,
                                                   @Nullable String routing,
                                                   OperationRouting operationRouting,
                                                   ClusterState state) {
         Metadata metadata = state.metadata();
-        String indexUUID = metadata.getIndex(partitionName.relationName(), partitionName.values(), true, IndexMetadata::getIndexUUID);
+        String indexUUID = metadata.getIndex(relationName, partitionValues, true, IndexMetadata::getIndexUUID);
         if (indexUUID == null) {
-            throw new IndexNotFoundException(partitionName.asIndexName());
+            throw new IndexNotFoundException(new PartitionName(relationName, partitionValues).asIndexName());
         }
         ShardIterator shardIterator = operationRouting.indexShards(
             state,
@@ -591,7 +596,8 @@ public class InsertFromValues implements LogicalPlan {
 
     private static <TReq extends ShardRequest<TReq, TItem>, TItem extends ShardRequest.Item>
         Map<ShardLocation, TReq> resolveAndGroupShardRequests(ShardedRequests<TReq, TItem> shardedRequests,
-                                                          ClusterService clusterService) {
+                                                              ClusterService clusterService,
+                                                              int tableOID) {
         var itemsByMissingPartition = shardedRequests.itemsByMissingPartition().entrySet().iterator();
         ClusterState state = clusterService.state();
         OperationRouting operationRouting = clusterService.operationRouting();
@@ -601,17 +607,18 @@ public class InsertFromValues implements LogicalPlan {
             List<ItemAndRoutingAndSourceInfo<TItem>> requestItems = entry.getValue();
 
             var requestItemsIterator = requestItems.iterator();
+            Metadata metadata = clusterService.state().metadata();
             while (requestItemsIterator.hasNext()) {
                 var itemAndRoutingAndSourceInfo = requestItemsIterator.next();
                 ShardLocation shardLocation;
                 try {
                     shardLocation = getShardLocation(
-                        partition,
+                        tableOID == Metadata.OID_UNASSIGNED ? partition.relationName() : metadata.getRelationName(tableOID),
+                        partition.values(),
                         itemAndRoutingAndSourceInfo.item().id(),
                         itemAndRoutingAndSourceInfo.routing(),
                         operationRouting,
-                        state
-                    );
+                        state);
                 } catch (IndexNotFoundException | RelationUnknown | ShardNotFoundException e) {
                     requestItemsIterator.remove();
                     continue;

--- a/server/src/test/java/io/crate/integrationtests/PartitionedTableConcurrentIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/PartitionedTableConcurrentIntegrationTest.java
@@ -541,4 +541,62 @@ public class PartitionedTableConcurrentIntegrationTest extends IntegTestCase {
         execute("select count(*) from information_schema.table_partitions where table_name = 't2'");
         assertThat(response.rows()[0][0]).isEqualTo(50L);
     }
+
+    @Test
+    public void test_concurrent_table_swaps_with_insert_from_values() throws Exception {
+        execute("create table t1 (p int) partitioned by (p)");
+        execute("create table t2 (p2 int)");
+
+        final AtomicReference<Throwable> error = new AtomicReference<>();
+        final CyclicBarrier barrier = new CyclicBarrier(2);
+        boolean[] swapInterleaved = {false};
+
+        Thread t1 = new Thread(() -> {
+            try {
+                barrier.await();
+                execute("""
+                    INSERT INTO t1 VALUES
+                    (1), (2), (3), (4), (5), (6), (7), (8), (9), (10),
+                    (11), (12), (13), (14), (15), (16), (17), (18), (19), (20),
+                    (21), (22), (23), (24), (25), (26), (27), (28), (29), (30),
+                    (31), (32), (33), (34), (35), (36), (37), (38), (39), (40),
+                    (41), (42), (43), (44), (45), (46), (47), (48), (49), (50);
+                    """);
+            } catch (Throwable e) {
+                error.set(e);
+            }
+        });
+
+        Thread t2 = new Thread(() -> {
+            try {
+                barrier.await();
+                for (int i = 0; i < 3; i++) {
+                    Thread.sleep(300); // to prevent swap queries to go through at once
+                    execute("ALTER CLUSTER SWAP TABLE t1 TO t2");
+                    if (t1.isAlive()) {
+                        swapInterleaved[0] = true;
+                    }
+                }
+            } catch (Throwable e) {
+                error.set(e);
+            }
+        });
+
+        t1.start();
+        t2.start();
+
+        t1.join();
+        t2.join();
+
+        assertThat(error.get()).isNull();
+        assertThat(swapInterleaved[0])
+            .as("The test failed to interleave a swap with the insert")
+            .isTrue();
+
+        execute("refresh table t1, t2");
+        execute("select count(*) from t2");
+        assertThat(response.rows()[0][0]).isEqualTo(50L);
+        execute("select count(*) from information_schema.table_partitions where table_name = 't2'");
+        assertThat(response.rows()[0][0]).isEqualTo(50L);
+    }
 }


### PR DESCRIPTION
2nd attempt of https://github.com/crate/crate/pull/19237 - the crate-qa failure that caused it to be reverted is now fixed by https://github.com/crate/crate/pull/19290.