### PR TITLE
Add Largest Triangle Three Buckets initial implementation

### DIFF
--- a/docs/appendices/release-notes/6.4.0.rst
+++ b/docs/appendices/release-notes/6.4.0.rst
@@ -89,6 +89,11 @@ Scalar and Aggregation Functions
   :ref:`blake3 <scalar-blake3>` scalar function for computing BLAKE3 checksums of
   strings.
 
+- `Bing O'Dowd <https://github.com/bodowd>`_ added the :ref:`largest triangle
+  three buckets <aggregation-largest-triangle-three-buckets>` aggregation
+  function for downsampling data using the Largest Triangle Three Buckets 
+  algorithm
+
 Performance and Resilience Improvements
 ---------------------------------------
 

--- a/docs/general/builtins/aggregation.rst
+++ b/docs/general/builtins/aggregation.rst
@@ -1018,6 +1018,91 @@ on the number of items and capacity. E.g. Processing 10,000 items with the
 with frequencies greater 4 will be included. Some items with frequencies below
 the threshold 4 may also appear in the result.
 
+.. _aggregation-largest-triangle-three-buckets:
+
+``lttb(column, column, threshhold)``
+------------------------------------
+
+The ``lttb`` aggregate function downsamples time series data while attempting to
+preserve the visual representation (shape) of the data by using the
+`Largest Triangle Three Buckets`_ algorithm. This algorithm was developed by Sveinn
+Steinarsson at the University of Iceland.
+
+The first argument is expected to be a reference to a timestamp column. The
+second argument can be :ref:`NUMERIC <type-numeric>`. During the aggregation,
+the values in this column will be implictly cast to :ref:`DOUBLE PRECISION <type-double-precision>`.
+The third argument is expected to be an ``integer`` representing
+the number of datapoints returned after downsampling.
+
+Note: ``lttb`` is a memory intensive operation because it will gather all 
+datapoints specified by the query into memory before downsampling
+
+``lttb`` returns an ``OBJECT`` of points selected by the algorithm
+in the following format::
+
+    {
+        "x": [<array of timestamps>],
+        "y": [<array of values>]
+    }
+
+``x`` contains an array of the timestamp portion of the selected points.
+``y`` contains an array of the values of the selected points as
+:ref:`DOUBLE PRECISION <type-double-precision>`.
+
+
+.. Hidden: create readings table
+
+    cr> CREATE TABLE readings (entered_at timestamp, reading double)
+    ... CLUSTERED INTO 1 SHARDS
+    ... WITH (number_of_replicas = 0);
+    CREATE OK, 1 row affected (... sec)
+
+.. Hidden: insert into readings table
+
+    cr> INSERT INTO readings (entered_at, reading)
+    ... VALUES ('2026-01-01 10:00:00'::timestamp, 21.0),
+    ... ('2026-01-01 10:01:00'::timestamp, 20.0),
+    ... ('2026-01-01 10:02:00'::timestamp, 25.0),
+    ... ('2026-01-01 10:03:00'::timestamp, 25.0),
+    ... ('2026-01-01 10:04:00'::timestamp, 90.0),
+    ... ('2026-01-01 10:05:00'::timestamp, 30.0),
+    ... ('2026-01-01 10:06:00'::timestamp, 27.0),
+    ... ('2026-01-01 10:07:00'::timestamp, 25.0),
+    ... ('2026-01-01 10:08:00'::timestamp, 23.0),
+    ... ('2026-01-01 10:09:00'::timestamp, 19.0),
+    ... ('2026-01-01 10:10:00'::timestamp, 20.0);
+    INSERT OK, 11 rows affected  (... sec)
+
+.. Hidden: refresh readings table
+
+    cr> REFRESH TABLE readings;
+    REFRESH OK, 1 row affected  (... sec)
+
+Example::
+
+    cr> WITH downsampled AS (
+    ... SELECT lttb(entered_at, reading, 5) AS lttb_data
+    ... FROM readings)
+    ... SELECT unnest((lttb_data).x) AS ts, unnest((lttb_data).y) as value
+    ... FROM downsampled;
+    +---------------+-------+
+    |            ts | value |
+    +---------------+-------+
+    | 1767261600000 |  21.0 |
+    | 1767261780000 |  25.0 |
+    | 1767261840000 |  90.0 |
+    | 1767262020000 |  25.0 |
+    | 1767262200000 |  20.0 |
+    +---------------+-------+
+    WITH 5 rows in set (... sec)
+
+
+.. Hidden: refresh readings table
+
+    cr> DROP TABLE readings;
+    DROP OK, 1 row affected (... sec)
+
+
 .. _aggregation-limitations:
 
 Limitations
@@ -1040,3 +1125,4 @@ Limitations
 .. _Variance: https://en.wikipedia.org/wiki/Variance
 .. _Frequency Sketch: https://datasketches.apache.org/docs/Frequency/FrequencySketches.html
 .. _Error Threshold Table: https://datasketches.apache.org/docs/Frequency/FrequentItemsErrorTable.html
+.. _Largest Triangle Three Buckets: https://skemman.is/bitstream/1946/15343/3/SS_MSthesis.pdf

--- a/extensions/functions/src/main/java/io/crate/module/ExtraFunctions.java
+++ b/extensions/functions/src/main/java/io/crate/module/ExtraFunctions.java
@@ -27,6 +27,7 @@ import io.crate.metadata.Functions.Builder;
 import io.crate.metadata.FunctionsProvider;
 import io.crate.metadata.settings.session.SessionSettingRegistry;
 import io.crate.operation.aggregation.HyperLogLogDistinctAggregation;
+import io.crate.operation.aggregation.LTTBAggregation;
 import io.crate.window.NthValueFunctions;
 import io.crate.window.OffsetValueFunctions;
 import io.crate.window.RankFunctions;
@@ -38,6 +39,7 @@ public class ExtraFunctions implements FunctionsProvider {
                              SessionSettingRegistry sessionSettingRegistry,
                              Builder builder) {
         HyperLogLogDistinctAggregation.register(builder);
+        LTTBAggregation.register(builder);
         NthValueFunctions.register(builder);
         OffsetValueFunctions.register(builder);
         RankFunctions.register(builder);

--- a/extensions/functions/src/main/java/io/crate/operation/aggregation/LTTBAggregation.java
+++ b/extensions/functions/src/main/java/io/crate/operation/aggregation/LTTBAggregation.java
@@ -1,0 +1,377 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.operation.aggregation;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.Version;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+
+import io.crate.Streamer;
+import io.crate.data.Input;
+import io.crate.data.breaker.RamAccounting;
+import io.crate.execution.engine.aggregation.AggregationFunction;
+import io.crate.memory.MemoryManager;
+import io.crate.metadata.FunctionType;
+import io.crate.metadata.Functions;
+import io.crate.metadata.Scalar;
+import io.crate.types.DataType;
+import io.crate.types.DataTypes;
+import io.crate.metadata.functions.BoundSignature;
+import io.crate.metadata.functions.Signature;
+
+public final class LTTBAggregation
+        extends
+        AggregationFunction<LTTBAggregation.LttbState, Map<String, List<? extends Number>>> {
+    static final String NAME = "lttb";
+
+    static {
+        DataTypes.register(LttbStateType.ID, _ -> LttbStateType.INSTANCE);
+    }
+
+    static final List<DataType<?>> SUPPORTED_X_TYPES = List.of(DataTypes.TIMESTAMP,
+            DataTypes.TIMESTAMPZ);
+
+    private final Signature signature;
+    private final BoundSignature boundSignature;
+
+    record Point(long timestamp, double value) {
+        public static final long SHALLOW_SIZE = RamUsageEstimator.shallowSizeOfInstance(Point.class);
+    }
+
+    private LTTBAggregation(Signature signature, BoundSignature boundSignature) {
+        this.signature = signature;
+        this.boundSignature = boundSignature;
+    }
+
+    public static void register(Functions.Builder builder) {
+        for (var supportedXType : SUPPORTED_X_TYPES) {
+            builder.add(
+                    Signature.builder(NAME, FunctionType.AGGREGATE)
+                            .argumentTypes(
+                                    supportedXType.getTypeSignature(),
+                                    DataTypes.DOUBLE.getTypeSignature(),
+                                    // Third argument is threshold (the number of points to be returned)
+                                    DataTypes.INTEGER.getTypeSignature())
+                            .returnType(DataTypes.UNTYPED_OBJECT.getTypeSignature())
+                            .features(Scalar.Feature.DETERMINISTIC)
+                            .build(),
+                    LTTBAggregation::new);
+        }
+    }
+
+    @Override
+    public LttbState reduce(RamAccounting ramAccounting, LttbState state1, LttbState state2) {
+        if (state1.isInitialized() == false) {
+            return state2;
+        }
+
+        if (state2.isInitialized()) {
+            state1.merge(ramAccounting, state2);
+        }
+        return state1;
+    }
+
+    @Override
+    public BoundSignature boundSignature() {
+        return boundSignature;
+    }
+
+    @Override
+    public Signature signature() {
+        return signature;
+    }
+
+    @Override
+    public DataType<?> partialType() {
+        return LttbStateType.INSTANCE;
+    }
+
+    @Override
+    public LttbState newState(RamAccounting ramAccounting,
+            Version minNodeInCluster,
+            MemoryManager memoryManager) {
+        ramAccounting.addBytes(LttbState.SHALLOW_SIZE);
+        return new LttbState();
+    }
+
+    @Override
+    public LttbState iterate(RamAccounting ramAccounting, MemoryManager memoryManager, LttbState state,
+            Input<?>... args) throws CircuitBreakingException {
+        if (args.length != 3) {
+            throw new IllegalArgumentException("lttb expects 3 arguments: timestamp, value, and threshold");
+        }
+
+        Long timestamp = (Long) args[0].value();
+        Double value = (Double) args[1].value();
+        Integer threshold = (Integer) args[2].value();
+
+        if (threshold == null) {
+            throw new IllegalArgumentException("lttb expects threshold not to be a null");
+        }
+
+        if (state.isInitialized() == false) {
+            state.init(ramAccounting, threshold);
+        }
+
+        if (timestamp != null && value != null) {
+            state.addPoint(ramAccounting, timestamp, value);
+        }
+        return state;
+    }
+
+    @Override
+    public Map<String, List<? extends Number>> terminatePartial(RamAccounting ramAccounting, LttbState state) {
+        List<Point> sampled = state.downsample();
+        List<Long> sampledX = new ArrayList<>(sampled.size());
+        List<Double> sampledY = new ArrayList<>(sampled.size());
+
+        for (Point p : sampled) {
+            sampledX.add(p.timestamp);
+            sampledY.add(p.value);
+        }
+        return Map.of("x", sampledX, "y", sampledY);
+    }
+
+    public static class LttbState implements Comparable<LttbState>, Writeable {
+        public static final long SHALLOW_SIZE = RamUsageEstimator.shallowSizeOfInstance(LttbState.class);
+
+        private List<Point> points;
+        private boolean initialized;
+        // The number of data points to be returned
+        private int threshold;
+
+        LttbState() {
+        }
+
+        LttbState(StreamInput in) throws IOException {
+            boolean isInitialized = in.readBoolean();
+            if (isInitialized) {
+                this.threshold = in.readVInt();
+                int size = in.readVInt();
+                this.points = new ArrayList<>(size);
+                for (int i = 0; i < size; i++) {
+                    long timestamp = in.readLong();
+                    double value = in.readDouble();
+                    this.points.add(new Point(timestamp, value));
+                }
+            }
+            this.initialized = isInitialized;
+
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeBoolean(initialized);
+            if (initialized) {
+                out.writeVInt(threshold);
+                out.writeVInt(points.size());
+                for (Point point : points) {
+                    out.writeLong(point.timestamp);
+                    out.writeDouble(point.value);
+                }
+            }
+        }
+
+        public List<Point> getPoints() {
+            return points;
+        }
+
+        public int getThreshold() {
+            return threshold;
+        }
+
+        void init(RamAccounting ramAccounting, Integer threshold) {
+            assert initialized == false : "LttbState was already initialized";
+            points = new ArrayList<>();
+            ramAccounting.addBytes(RamUsageEstimator.shallowSizeOfInstance(ArrayList.class));
+            this.threshold = threshold;
+            initialized = true;
+        }
+
+        boolean isInitialized() {
+            return initialized;
+        }
+
+        public void addPoint(RamAccounting ramAccounting, long timestamp, double value) {
+            assert initialized == true
+                    : "LttbState has not yet been initialized. It needs to be initialized before adding a point";
+            points.add(new Point(timestamp, value));
+            ramAccounting.addBytes(Point.SHALLOW_SIZE);
+        }
+
+        public LttbState merge(RamAccounting ramAccounting, LttbState other) {
+            if (other.threshold != this.threshold) {
+                throw new IllegalStateException("The thresholds between the two LttbStates do not match");
+            }
+            for (Point p : other.points) {
+                addPoint(ramAccounting, p.timestamp, p.value);
+            }
+            return this;
+        }
+
+        @Override
+        public int compareTo(LttbState o) {
+            // not necessary to compare one state to another in LTTB; we gather all data
+            // points
+            return 0;
+        }
+
+        public List<Point> downsample() {
+            points.sort(Comparator.comparingLong(p -> p.timestamp));
+
+            List<Point> sampled = new ArrayList<>();
+            int dataLength = points.size();
+
+            if (threshold >= dataLength || threshold == 0) {
+                return points;
+            }
+
+            // -2 to account for start and end data points
+            int bucketSize = (dataLength - 2) / (threshold - 2);
+
+            // There are three buckets: a, b, and c
+            //
+            // "b" is the bucket where we search each point
+            // to find the point that gives the largest area with points in buckets a and c
+            //
+            // "a" refers to the point in the previous bucket that was
+            // sampled.
+            //
+            // "c" refers to the bucket after bucket "b"
+            int a = 0;
+            sampled.add(points.get(a));
+
+            for (int cur = 0; cur < threshold - 2; cur++) {
+                // find the average point in the next bucket
+                long avgX = 0L; // NOTE: the current implementation expects a timestamp in the x axis
+                double avgY = 0.0D;
+
+                int cStart = (int) Math.floor((cur + 1) * bucketSize) + 1;
+                int cEnd = (int) Math.floor((cur + 2) * bucketSize) + 1;
+                cEnd = cEnd < dataLength ? cEnd : dataLength;
+
+                int cSize = cEnd - cStart;
+
+                for (int c = cStart; c < cEnd; c++) {
+                    Point point = points.get(c);
+                    avgX += point.timestamp;
+                    avgY += point.value;
+                }
+                avgX /= cSize;
+                avgY /= cSize;
+
+                // search the current bucket "b" to find the point that gives the largest
+                // triangle with the previous point in bucket "a" and the average point of
+                // bucket "c"
+                int bStart = (int) Math.floor((cur + 0) * bucketSize) + 1;
+                int bEnd = (int) Math.floor((cur + 1) * bucketSize) + 1;
+
+                long aX = points.get(a).timestamp;
+                double aY = points.get(a).value;
+                double maxArea = 0.0D;
+                int maxAreaPoint = a;
+
+                for (int b = bStart; b < bEnd; b++) {
+                    Point point = points.get(b);
+                    double area = Math.abs(
+                            (aX - avgX) * (point.value - aY) - (aX - point.timestamp) * (avgY - aY)) * 0.5;
+                    if (area > maxArea) {
+                        maxArea = area;
+                        maxAreaPoint = b;
+                    }
+                }
+                sampled.add(points.get(maxAreaPoint));
+                // this index will be the next bucket's "previous" value
+                a = maxAreaPoint;
+
+            }
+
+            // add the last point of the dataset
+            sampled.add(points.get(dataLength - 1));
+            return sampled;
+        }
+
+    }
+
+    public static class LttbStateType extends DataType<LTTBAggregation.LttbState>
+            implements Streamer<LTTBAggregation.LttbState> {
+        static final int ID = 18000;
+        static final LttbStateType INSTANCE = new LttbStateType();
+
+        @Override
+        public int id() {
+            return ID;
+        }
+
+        @Override
+        public Precedence precedence() {
+            return Precedence.CUSTOM;
+        }
+
+        @Override
+        public String getName() {
+            return "lttb_state";
+        }
+
+        @Override
+        public Streamer<LttbState> streamer() {
+            return this;
+        }
+
+        @Override
+        public LttbState sanitizeValue(Object value) {
+            return (LTTBAggregation.LttbState) value;
+        }
+
+        @Override
+        public int compare(LttbState val1, LttbState val2) {
+            // not necessary to compare one state to another in LTTB; we gather all data
+            // points
+            return 0;
+        }
+
+        @Override
+        public void writeValueTo(StreamOutput out, LttbState v) throws IOException {
+            v.writeTo(out);
+        }
+
+        @Override
+        public LttbState readValueFrom(StreamInput in) throws IOException {
+            return new LttbState(in);
+        }
+
+        @Override
+        public long valueBytes(LttbState value) {
+            throw new UnsupportedOperationException("valueSize is not implemented for LttbStateType");
+        }
+    }
+
+}

--- a/extensions/functions/src/test/java/io/crate/operation/aggregation/LTTBAggregationTest.java
+++ b/extensions/functions/src/test/java/io/crate/operation/aggregation/LTTBAggregationTest.java
@@ -1,0 +1,196 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements. See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership. Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.operation.aggregation;
+
+import static io.crate.testing.TestingHelpers.createNodeContext;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.InstanceOfAssertFactories.LIST;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import org.elasticsearch.Version;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.crate.data.breaker.RamAccounting;
+import io.crate.execution.engine.aggregation.AggregationFunction;
+import io.crate.expression.symbol.Literal;
+import io.crate.metadata.FunctionType;
+import io.crate.metadata.Scalar;
+import io.crate.metadata.SearchPath;
+import io.crate.metadata.functions.Signature;
+import io.crate.operation.aggregation.LTTBAggregation.LttbState;
+import io.crate.testing.PlainRamAccounting;
+import io.crate.types.DataType;
+import io.crate.types.DataTypes;
+
+public class LTTBAggregationTest extends AggregationTestCase {
+
+    @Before
+    public void prepareFunctions() {
+        nodeCtx = createNodeContext(null, null);
+    }
+
+    @SuppressWarnings("unchecked")
+    private AggregationFunction<LttbState, Map<String, List<? extends Number>>> getFunc() {
+        return (AggregationFunction<LttbState, Map<String, List<? extends Number>>>) nodeCtx
+                .functions().get(
+                        null,
+                        LTTBAggregation.NAME,
+                        List.of(Literal.of(1L), Literal.of(2.0), Literal.of(3)),
+                        SearchPath.pathWithPGCatalogAndDoc());
+    }
+
+    private Object executeAggregation(DataType<?> xType, Object[][] data) throws Exception {
+        return executeAggregation(
+                Signature.builder(LTTBAggregation.NAME, FunctionType.AGGREGATE)
+                        .argumentTypes(
+                                xType.getTypeSignature(),
+                                DataTypes.DOUBLE.getTypeSignature(),
+                                DataTypes.INTEGER.getTypeSignature())
+                        .returnType(DataTypes.UNTYPED_OBJECT.getTypeSignature())
+                        .features(Scalar.Feature.DETERMINISTIC)
+                        .build(),
+                data,
+                List.of());
+    }
+
+    private Object[][] createTestData(int numRows, Function<Integer, Long> timestampGenerator,
+            Function<Integer, Double> valueGenerator, int threshold) {
+        Object[][] data = new Object[numRows][3];
+        for (int i = 0; i < numRows; i++) {
+            data[i][0] = timestampGenerator.apply(i);
+            data[i][1] = valueGenerator.apply(i);
+            data[i][2] = threshold;
+        }
+        return data;
+    }
+
+    @Test
+    public void test_should_execute_with_timestamp() throws Exception {
+        Object[][] data = createTestData(1000, i -> System.currentTimeMillis() + (i * 1000),
+                i -> Math.sin(i * 0.1) * 100 + 50, 100);
+        Object result = executeAggregation(DataTypes.TIMESTAMP, data);
+        assertThat(result).extracting("x").asInstanceOf(LIST).hasSize(100);
+        assertThat(result).extracting("y").asInstanceOf(LIST).hasSize(100);
+    }
+
+    @Test
+    public void test_should_execute_with_timestampz() throws Exception {
+        Object[][] data = createTestData(1000, i -> System.currentTimeMillis() + (i * 1000),
+                i -> Math.sin(i * 0.1) * 100 + 50, 100);
+        Object result = executeAggregation(DataTypes.TIMESTAMPZ, data);
+        assertThat(result).extracting("x").asInstanceOf(LIST).hasSize(100);
+        assertThat(result).extracting("y").asInstanceOf(LIST).hasSize(100);
+    }
+
+    @Test
+    public void test_raise_if_x_type_is_not_timestamp() throws Exception {
+        Object[][] data = new Object[3][3];
+        data[0][0] = "invalid type - not a timestamp";
+        data[0][1] = 2.0;
+        data[0][2] = 1;
+        assertThatThrownBy(() -> executeAggregation(DataTypes.TIMESTAMP, data))
+                .isExactlyInstanceOf(ClassCastException.class);
+    }
+
+    @Test
+    public void test_raise_if_y_type_is_not_numeric() throws Exception {
+        Object[][] data = new Object[3][3];
+        data[0][0] = 20L;
+        data[0][1] = "invalid type - not numeric";
+        data[0][2] = 1;
+        assertThatThrownBy(() -> executeAggregation(DataTypes.TIMESTAMP, data))
+                .isExactlyInstanceOf(ClassCastException.class);
+    }
+
+    @Test
+    public void test_should_succeed_even_with_null_records() throws Exception {
+        Object[][] data = createTestData(10, i -> i == 1 ? null : System.currentTimeMillis() + (i * 1000),
+                i -> i == 5 ? null : Math.sin(i * 0.1) * 100 + 50, 5);
+        Object result = executeAggregation(DataTypes.TIMESTAMPZ, data);
+        assertThat(result).extracting("x").asInstanceOf(LIST).hasSize(5);
+        assertThat(result).extracting("y").asInstanceOf(LIST).hasSize(5);
+    }
+
+    @Test
+    public void test_should_not_downsample_if_threshold_zero() throws Exception {
+        Object[][] data = createTestData(10, i -> System.currentTimeMillis() + (i * 1000),
+                i -> Math.sin(i * 0.1) * 100 + 50, 0);
+        Object result = executeAggregation(DataTypes.TIMESTAMPZ, data);
+        assertThat(result).extracting("x").asInstanceOf(LIST).hasSize(10);
+        assertThat(result).extracting("y").asInstanceOf(LIST).hasSize(10);
+    }
+
+    @Test
+    public void test_should_not_downsample_if_threshold_larger_than_amount_of_data() throws Exception {
+        Object[][] data = createTestData(10, i -> System.currentTimeMillis() + (i * 1000),
+                i -> Math.sin(i * 0.1) * 100 + 50, 5000);
+        Object result = executeAggregation(DataTypes.TIMESTAMPZ, data);
+        assertThat(result).extracting("x").asInstanceOf(LIST).hasSize(10);
+        assertThat(result).extracting("y").asInstanceOf(LIST).hasSize(10);
+    }
+
+    @Test
+    public void test_should_select_points_that_form_largest_triangle() throws Exception {
+        List<Double> values = List.of(-10.0, 12.0, 50.0, 15.0, 11.0);
+        Object[][] data = createTestData(5, i -> System.currentTimeMillis() + (i * 1000),
+                i -> values.get(i), 3);
+        Object result = executeAggregation(DataTypes.TIMESTAMPZ, data);
+        assertThat(result).extracting("y").asInstanceOf(LIST).containsExactly(-10.0, 50.0, 11.0);
+
+    }
+
+    @Test
+    public void test_should_account_for_memory_when_creating_new_state() throws Exception {
+        AggregationFunction<LttbState, Map<String, List<? extends Number>>> func = getFunc();
+        RamAccounting ramAccounting = new PlainRamAccounting();
+        func.newState(ramAccounting, Version.CURRENT, memoryManager);
+        assertThat(ramAccounting.totalBytes()).isEqualTo(LttbState.SHALLOW_SIZE);
+    }
+
+    @Test
+    public void test_raises_when_memory_exceeds_threshold() throws Exception {
+        AggregationFunction<LttbState, Map<String, List<? extends Number>>> func = getFunc();
+        LttbState state = func.newState(
+                RamAccounting.NO_ACCOUNTING, Version.CURRENT, memoryManager);
+
+        // store the amount of memory used for one iteration
+        RamAccounting startRamAccounting = new PlainRamAccounting();
+        func.iterate(startRamAccounting, memoryManager, state, Literal.of(1L),
+                Literal.of(1.0), Literal.of(3));
+
+        // allow enough memory to be used for one more iteration, after which all
+        // allotted memory for this aggregation is used
+        RamAccounting limitRamAccounting = new PlainRamAccounting(startRamAccounting.totalBytes());
+        func.iterate(limitRamAccounting, memoryManager, state, Literal.of(1L),
+                Literal.of(1.0), Literal.of(3));
+
+        assertThatThrownBy(
+                () -> func.iterate(limitRamAccounting, memoryManager, state, Literal.of(1L), Literal.of(1.0),
+                        Literal.of(3)))
+                .isExactlyInstanceOf(RuntimeException.class);
+    }
+}

--- a/extensions/functions/src/test/java/io/crate/operation/aggregation/LttbStateTest.java
+++ b/extensions/functions/src/test/java/io/crate/operation/aggregation/LttbStateTest.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements. See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership. Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.operation.aggregation;
+
+import static io.crate.testing.TestingHelpers.createNodeContext;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.crate.data.breaker.RamAccounting;
+import io.crate.operation.aggregation.LTTBAggregation.LttbState;
+import io.crate.testing.PlainRamAccounting;
+
+public class LttbStateTest extends AggregationTestCase {
+
+    @Before
+    public void prepareFunctions() {
+        nodeCtx = createNodeContext(null, null);
+    }
+
+    @Test
+    public void test_should_reconstruct_state_when_streamed_from_one_state_to_another() throws Exception {
+        LttbState state1 = new LttbState();
+        RamAccounting ramAccounting = new PlainRamAccounting();
+        state1.init(ramAccounting, 10);
+        state1.addPoint(ramAccounting, 20L, 22.0);
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        state1.writeTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        LttbState state2 = new LttbState(in);
+
+        assertThat(state1.getThreshold()).isEqualTo(state2.getThreshold());
+        assertThat(state1.isInitialized()).isEqualTo(state2.isInitialized());
+
+        for (int i = 0; i < state1.getPoints().size(); i++) {
+            assertThat(state1.getPoints().get(i).timestamp()).isEqualTo(state2.getPoints().get(i).timestamp());
+            assertThat(state1.getPoints().get(i).value()).isEqualTo(state2.getPoints().get(i).value());
+        }
+    }
+
+    @Test
+    public void test_init_should_account_for_memory() throws Exception {
+        LttbState state = new LttbState();
+        RamAccounting ramAccounting = new PlainRamAccounting();
+        state.init(ramAccounting, 10);
+        assertThat(ramAccounting.totalBytes()).isEqualTo(RamUsageEstimator.shallowSizeOfInstance(ArrayList.class));
+    }
+
+    @Test
+    public void test_addPoint_should_account_for_memory() throws Exception {
+        LttbState state = new LttbState();
+        RamAccounting ramAccounting = new PlainRamAccounting();
+        state.init(ramAccounting, 10);
+        Long ramBefore = ramAccounting.totalBytes();
+        state.addPoint(ramAccounting, 1L, 0.1);
+        state.addPoint(ramAccounting, 2L, 0.1);
+        state.addPoint(ramAccounting, 3L, 0.1);
+        assertThat(ramAccounting.totalBytes())
+                .isEqualTo(ramBefore + LTTBAggregation.Point.SHALLOW_SIZE * 3);
+    }
+
+}


### PR DESCRIPTION
The Largest Triangle Three Buckets (LTTB) algorithm is a downsampling method designed to preserve the shape of the data while reducing its resolution [1, 2].

This commit implements LTTB as an aggregation function in CrateDB.

Some notes about this implementation:

- This implementation requires all data relevant to the query to be buffered in memory. Once the the data is gathered, then the LTTB algorithm can be run over that data.

- Downsampling is not done during the `reduce` phase of the aggregation because the aggregation function is still in the process of gathering all relevant data at that time. LTTB needs all the data available in order to run accurately.

- A simple experiment to downsample 1 million data points to 100 points on a locally run crate node shows the UDF implementation of LTTB from [2] completes in ~2 sec while the native implementation from this commit completes in about < 500 ms

[1]: https://skemman.is/bitstream/1946/15343/3/SS_MSthesis.pdf
[2]: https://community.cratedb.com/t/advanced-downsampling-with-the-lttb-algorithm/1287
