### PR TITLE
Allow restoring partitions into closed table

### DIFF
--- a/server/src/main/java/io/crate/metadata/table/Operation.java
+++ b/server/src/main/java/io/crate/metadata/table/Operation.java
@@ -61,7 +61,7 @@ public enum Operation {
     public static final EnumSet<Operation> SYS_READ_ONLY = EnumSet.of(READ);
     public static final EnumSet<Operation> READ_ONLY = EnumSet.of(READ, ALTER_BLOCKS);
     public static final EnumSet<Operation> CLOSED_OPERATIONS = EnumSet.of(ALTER_OPEN, ALTER_CLOSE, ALTER_TABLE_RENAME,
-        ALTER, ALTER_SET, ALTER_BLOCKS);
+        ALTER, ALTER_SET, ALTER_BLOCKS, RESTORE_SNAPSHOT);
     public static final EnumSet<Operation> BLOB_OPERATIONS = EnumSet.of(
         READ,
         OPTIMIZE,

--- a/server/src/test/java/io/crate/integrationtests/SnapshotRestoreIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SnapshotRestoreIntegrationTest.java
@@ -83,8 +83,10 @@ import io.crate.role.metadata.UsersMetadata;
 import io.crate.role.metadata.UsersPrivilegesMetadata;
 import io.crate.testing.Asserts;
 import io.crate.testing.SQLResponse;
+import io.crate.testing.UseJdbc;
 import io.crate.testing.UseRandomizedSchema;
 import io.crate.types.DataTypes;
+import io.crate.types.Regclass;
 
 @IntegTestCase.ClusterScope(numDataNodes = 1, numClientNodes = 0, supportsDedicatedMasters = false)
 public class SnapshotRestoreIntegrationTest extends IntegTestCase {
@@ -1373,5 +1375,76 @@ public class SnapshotRestoreIntegrationTest extends IntegTestCase {
         });
         latch.await();
         return repositoryData.get();
+    }
+
+    @UseJdbc(0)
+    @Test
+    public void test_restore_partition_into_closed_table_uses_closed_tables_oid() throws Exception {
+        createTable("parted_table", true);
+        execute("CREATE SNAPSHOT " + snapshotName() + " TABLE parted_table PARTITION (date='1970-01-01') WITH (wait_for_completion=true)");
+
+        // capture table oid in the snapshot
+        execute("select oid from pg_catalog.pg_class where relname = 'parted_table'");
+        int snapshotTableOid = ((Regclass) response.rows()[0][0]).oid();
+
+        // drop and recreate the original table such that the recreated table holds incremented oid
+        execute("DROP TABLE parted_table");
+        createTable("parted_table", true);
+
+        // capture table oid after re-creating the original table
+        execute("select oid from pg_catalog.pg_class where relname = 'parted_table'");
+        int recreatedTableOid = ((Regclass) response.rows()[0][0]).oid();
+
+        // confirm recreated table oid is 1 greater than the table oid that the snapshot holds
+        assertThat(recreatedTableOid).isEqualTo(snapshotTableOid + 1);
+
+        // prepare for restore - remove the partition to be restored and close the table
+        execute("DELETE FROM parted_table WHERE date = '1970-01-01'");
+        execute("ALTER TABLE parted_table CLOSE");
+
+        execute("RESTORE SNAPSHOT " + snapshotName() + " TABLE parted_table PARTITION (date = '1970-01-01') WITH (wait_for_completion=true)");
+
+        execute("ALTER TABLE parted_table OPEN");
+        execute("SELECT * FROM parted_table WHERE date = '1970-01-01'");
+        assertThat(response).hasRows("1| foo| 0| The quick brown fox jumps over the lazy dog.");
+
+        // confirm table oid is not impacted by the outdated snapshot's table oid
+        execute("select oid from pg_catalog.pg_class where relname = 'parted_table'");
+        int restoredTableOid = ((Regclass) response.rows()[0][0]).oid();
+        assertThat(restoredTableOid).isEqualTo(recreatedTableOid);
+    }
+
+    @UseJdbc(0)
+    @Test
+    public void test_restore_partition_into_non_existing_target_table_uses_next_oid() throws Exception {
+        createTable("parted_table", true);
+        execute("CREATE SNAPSHOT " + snapshotName() + " TABLE parted_table PARTITION (date='1970-01-01') WITH (wait_for_completion=true)");
+
+        // capture table oid in the snapshot
+        execute("select oid from pg_catalog.pg_class where relname = 'parted_table'");
+        int snapshotTableOid = ((Regclass) response.rows()[0][0]).oid();
+
+        // drop and recreate the original table such that the recreated table holds incremented oid
+        execute("DROP TABLE parted_table");
+        createTable("parted_table", true);
+
+        // capture table oid after re-creating the original table
+        execute("select oid from pg_catalog.pg_class where relname = 'parted_table'");
+        int recreatedTableOid = ((Regclass) response.rows()[0][0]).oid();
+
+        // confirm recreated table oid is 1 greater than the table oid that the snapshot holds
+        assertThat(recreatedTableOid).isEqualTo(snapshotTableOid + 1);
+
+        execute("DROP TABLE parted_table");
+
+        execute("RESTORE SNAPSHOT " + snapshotName() + " TABLE parted_table WITH (wait_for_completion=true)");
+
+        execute("SELECT * FROM parted_table WHERE date = '1970-01-01'");
+        assertThat(response).hasRows("1| foo| 0| The quick brown fox jumps over the lazy dog.");
+
+        // confirm the table created by restoring the partition holds table oid higher than both snapshotTableOid and recreatedTableOid
+        execute("select oid from pg_catalog.pg_class where relname = 'parted_table'");
+        int restoredTableOid = ((Regclass) response.rows()[0][0]).oid();
+        assertThat(restoredTableOid).isEqualTo(recreatedTableOid + 1);
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Resolves restoring partitions into closed table which was accidentally blocked:
```
cr> RESTORE SNAPSHOT repo.t_part3 TABLE t PARTITION (p = 'x');
OperationOnInaccessibleRelationException[The relation "doc.t" doesn't support or allow RESTORE SNAPSHOT operations, as it is currently closed.]
```
https://github.com/crate/crate/pull/18954#discussion_r2742325630.

On top of that, adding two tests for checking table oids after restoring:

https://github.com/crate/crate/blob/7d1ece5859139152e88e6cbec9da0d15c2e5b917/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java#L645

https://github.com/crate/crate/blob/7d1ece5859139152e88e6cbec9da0d15c2e5b917/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java#L665





## Checklist

 - [ ] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
