### PR TITLE
Reject restoring snapshots into closed tables

### DIFF
--- a/docs/appendices/release-notes/6.3.2.rst
+++ b/docs/appendices/release-notes/6.3.2.rst
@@ -78,3 +78,8 @@ Fixes
   distributed query with aggregations or joins under memory pressure.
 
 - Fixed an authorization issue for ``_blobs`` HTTP endpoint.
+
+- Fixed an issue where :ref:`RESTORE SNAPSHOT <sql-restore-snapshot>` allowed
+  restoring into existing closed tables, which is not a supported operation and
+  could leave the restored table empty or unavailable. CrateDB now rejects such
+  restores.

--- a/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -450,7 +450,6 @@ public class RestoreService implements ClusterStateApplier {
                             targetIndexName
                         );
                     }
-                    // Check that the index is closed or doesn't exist
                     IndexMetadata currentIndexMetadata = currentMetadata.getIndex(targetName, restoreIndex.partitionValues(), false, im -> im);
                     final Index renamedIndex;
                     final String newIndexUUID;
@@ -483,28 +482,11 @@ public class RestoreService implements ClusterStateApplier {
                         mdBuilder.put(updatedIndexMetadata, true);
                         renamedIndex = updatedIndexMetadata.getIndex();
                     } else {
-                        validateExistingIndex(targetName, currentIndexMetadata, snapshotIndexMetadata, targetIndexName);
-                        // Index exists and it's closed - open it in metadata and start recovery
-                        IndexMetadata.Builder indexMdBuilder = IndexMetadata.builder(snapshotIndexMetadata).state(IndexMetadata.State.OPEN);
-                        indexMdBuilder.version(Math.max(snapshotIndexMetadata.getVersion(), 1 + currentIndexMetadata.getVersion()));
-                        indexMdBuilder.mappingVersion(Math.max(snapshotIndexMetadata.getMappingVersion(), 1 + currentIndexMetadata.getMappingVersion()));
-                        indexMdBuilder.settingsVersion(Math.max(snapshotIndexMetadata.getSettingsVersion(), 1 + currentIndexMetadata.getSettingsVersion()));
-
-                        for (int shard = 0; shard < snapshotIndexMetadata.getNumberOfShards(); shard++) {
-                            indexMdBuilder.primaryTerm(shard, Math.max(snapshotIndexMetadata.primaryTerm(shard), currentIndexMetadata.primaryTerm(shard)));
+                        if (currentIndexMetadata.partitionValues().isEmpty()) {
+                            throw new RelationAlreadyExists(targetName);
+                        } else {
+                            throw new PartitionAlreadyExistsException(new PartitionName(targetName, PartitionName.encodeIdent(currentIndexMetadata.partitionValues())));
                         }
-
-                        newIndexUUID = currentIndexMetadata.getIndexUUID();
-                        newIndexUUIDs.add(newIndexUUID);
-                        indexMdBuilder.settings(
-                            Settings.builder()
-                                .put(snapshotIndexMetadata.getSettings())
-                                .put(IndexMetadata.SETTING_INDEX_UUID, newIndexUUID));
-                        IndexMetadata updatedIndexMetadata = indexMdBuilder.indexName(targetIndexName).build();
-                        rtBuilder.addAsRestore(updatedIndexMetadata, recoverySource);
-                        blocks.updateBlocks(updatedIndexMetadata);
-                        mdBuilder.put(updatedIndexMetadata, true);
-                        renamedIndex = updatedIndexMetadata.getIndex();
                     }
                     restoreIndexNames.add(renamedIndex.getName());
 
@@ -622,7 +604,7 @@ public class RestoreService implements ClusterStateApplier {
             }
 
             if (existingRelation instanceof RelationMetadata.Table existingTable) {
-                // restoring into existing closed tables is allowed
+                assert existingTable.state().equals(IndexMetadata.State.OPEN) : "Can only restore into open tables";
                 RelationMetadata.Table table = snapshotRelation instanceof RelationMetadata.Table snapshotTable
                     ? snapshotTable
                     : existingTable;
@@ -690,24 +672,6 @@ public class RestoreService implements ClusterStateApplier {
             // Make sure that index was fully snapshotted
             if (failed(snapshotInfo, index)) {
                 throw new SnapshotRestoreException(snapshot, "index [" + index + "] wasn't fully snapshotted - cannot " + "restore");
-            }
-        }
-
-        private void validateExistingIndex(RelationName targetName, IndexMetadata currentIndexMetadata, IndexMetadata snapshotIndexMetadata, String renamedIndex) {
-            // Index exist - checking that it's closed
-            if (currentIndexMetadata.getState() != IndexMetadata.State.CLOSE) {
-                // TODO: Enable restore for open indices
-                if (currentIndexMetadata.partitionValues().isEmpty()) {
-                    throw new RelationAlreadyExists(targetName);
-                } else {
-                    throw new PartitionAlreadyExistsException(new PartitionName(targetName, PartitionName.encodeIdent(currentIndexMetadata.partitionValues())));
-                }
-            }
-            // Make sure that the number of shards is the same. That's the only thing that we cannot change
-            if (currentIndexMetadata.getNumberOfShards() != snapshotIndexMetadata.getNumberOfShards()) {
-                throw new SnapshotRestoreException(snapshot, "cannot restore index [" + renamedIndex + "] with [" + currentIndexMetadata.getNumberOfShards() +
-                                                                "] shards from a snapshot of index [" + snapshotIndexMetadata.getIndex().getName() + "] with [" +
-                                                                snapshotIndexMetadata.getNumberOfShards() + "] shards");
             }
         }
 

--- a/server/src/test/java/io/crate/integrationtests/SnapshotRestoreIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SnapshotRestoreIntegrationTest.java
@@ -28,6 +28,7 @@ import static io.crate.testing.Asserts.assertThat;
 import static io.netty.handler.codec.http.HttpResponseStatus.CONFLICT;
 import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
 import java.io.IOException;
@@ -68,6 +69,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import io.crate.common.unit.TimeValue;
+import io.crate.exceptions.PartitionAlreadyExistsException;
 import io.crate.expression.udf.UserDefinedFunctionService;
 import io.crate.fdw.ForeignTablesMetadata;
 import io.crate.metadata.ColumnIdent;
@@ -83,6 +85,7 @@ import io.crate.role.metadata.UsersMetadata;
 import io.crate.role.metadata.UsersPrivilegesMetadata;
 import io.crate.testing.Asserts;
 import io.crate.testing.SQLResponse;
+import io.crate.testing.UseJdbc;
 import io.crate.testing.UseRandomizedSchema;
 import io.crate.types.DataTypes;
 
@@ -1373,5 +1376,20 @@ public class SnapshotRestoreIntegrationTest extends IntegTestCase {
         });
         latch.await();
         return repositoryData.get();
+    }
+
+    @UseJdbc(0)
+    @Test
+    public void test_restore_partition_into_partitioned_table_with_closed_partition() throws Exception {
+        createTableAndSnapshot("parted_table", SNAPSHOT_NAME, true);
+
+        execute("ALTER TABLE parted_table PARTITION (date='1970-01-01') CLOSE");
+
+        assertThatThrownBy(() -> execute("RESTORE SNAPSHOT " + snapshotName() +
+            " TABLE parted_table PARTITION (date='1970-01-01') WITH (" +
+            "ignore_unavailable=false, " +
+            "wait_for_completion=true)"))
+            .isExactlyInstanceOf(PartitionAlreadyExistsException.class)
+            .hasMessage("Partition '" + sqlExecutor.getCurrentSchema() + "..partitioned.parted_table.04130' already exists");
     }
 }

--- a/server/src/test/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
@@ -578,7 +578,7 @@ public class IndexRecoveryIT extends IntegTestCase {
         execute("SELECT state FROM sys.snapshots WHERE name = '" + SNAP_NAME + "'");
         assertThat(response).hasRows("SUCCESS");
 
-        execute("ALTER TABLE " + INDEX_NAME + " CLOSE");
+        execute("DROP TABLE " + INDEX_NAME);
 
         logger.info("--> restore");
         execute("RESTORE SNAPSHOT " + snapshotName + " ALL WITH (wait_for_completion=true)");


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Continues from https://github.com/crate/crate/pull/19310. As suggested by @mfussenegger (https://github.com/crate/crate/pull/19310#issuecomment-4369458033), rejecting restore into closed tables is more consistent with the current write operations to closed tables. Also, restore into closed tables does not appear to work reliably today:

```sql
SET GLOBAL cluster.routing.allocation.disk.threshold_enabled = false;

DROP TABLE IF EXISTS t;
DROP SNAPSHOT r.s;
DROP REPOSITORY r;

CREATE TABLE t (a int);

INSERT INTO t VALUES (1), (2);
REFRESH TABLE t;

CREATE REPOSITORY r
TYPE fs
WITH (location = '/tmp/backups');

CREATE SNAPSHOT r.s TABLE t
WITH (wait_for_completion = true);

DROP TABLE t;

CREATE TABLE t (a int);

ALTER TABLE t CLOSE;

RESTORE SNAPSHOT r.s ALL
WITH (wait_for_completion = true);

SELECT * FROM t;
```
Observed:
```
RESTORE OK, 1 row affected (1.591 sec)

+---+
| a |
+---+
+---+
SELECT 0 rows in set (0.044 sec)
=> expected rows 1 and 2, but the result is empty

[2026-05-08T15:57:09,871][INFO ][o.e.r.RepositoriesService] [Pizzo del Ramulazz S] put repository [r]
[2026-05-08T15:57:10,098][INFO ][o.e.s.SnapshotsService   ] [Pizzo del Ramulazz S] snapshot [r:s/aMlzRPsCQ6KV33_AeYJAjg] started
[2026-05-08T15:57:10,988][INFO ][o.e.s.SnapshotsService   ] [Pizzo del Ramulazz S] snapshot [r:s/aMlzRPsCQ6KV33_AeYJAjg] completed with state [SUCCESS]
[2026-05-08T15:57:10,991][INFO ][o.e.c.m.MetadataDeleteIndexService] [Pizzo del Ramulazz S] [t/lnt8oYjBT1m2-rt2DlYw6A] deleting index
[2026-05-08T15:57:11,208][INFO ][o.e.c.m.MetadataCreateIndexService] [Pizzo del Ramulazz S] [t/st4yiTNFSRWcHgWHM3XHdg] creating index, cause [create-table], shards [4]/[0]
[2026-05-08T15:57:12,717][INFO ][o.e.c.r.a.AllocationService] [Pizzo del Ramulazz S] Cluster health status changed from [YELLOW] to [GREEN] (reason: [shards started [[t/st4yiTNFSRWcHgWHM3XHdg][2], [t/st4yiTNFSRWcHgWHM3XHdg][3], [t/st4yiTNFSRWcHgWHM3XHdg][0]]]).
[2026-05-08T15:57:13,063][INFO ][i.c.e.d.t.TransportCloseTable] [Pizzo del Ramulazz S] completed closing of indices [t]
[2026-05-08T15:57:13,839][INFO ][o.e.c.r.a.AllocationService] [Pizzo del Ramulazz S] Cluster health status changed from [RED] to [GREEN] (reason: [shards started [[t/st4yiTNFSRWcHgWHM3XHdg][2], [t/st4yiTNFSRWcHgWHM3XHdg][3], [t/st4yiTNFSRWcHgWHM3XHdg][0]]]).
[2026-05-08T15:57:14,219][WARN ][o.e.i.c.IndicesClusterStateService] [Pizzo del Ramulazz S] [t/lnt8oYjBT1m2-rt2DlYw6A][1] marking and sending shard failed due to [failed to update mapping for index]
org.elasticsearch.index.IndexNotFoundException: no such index [t/lnt8oYjBT1m2-rt2DlYw6A]
	at org.elasticsearch.index.IndexService.validateMapping(IndexService.java:504)
	at org.elasticsearch.indices.cluster.IndicesClusterStateService.createIndices(IndicesClusterStateService.java:461)
	at org.elasticsearch.indices.cluster.IndicesClusterStateService.applyClusterState(IndicesClusterStateService.java:205)
	at org.elasticsearch.cluster.service.ClusterApplierService.callClusterStateAppliers(ClusterApplierService.java:508)
	at org.elasticsearch.cluster.service.ClusterApplierService.callClusterStateAppliers(ClusterApplierService.java:498)
	at org.elasticsearch.cluster.service.ClusterApplierService.applyChanges(ClusterApplierService.java:475)
	at org.elasticsearch.cluster.service.ClusterApplierService.runTask(ClusterApplierService.java:422)
	at org.elasticsearch.cluster.service.ClusterApplierService$UpdateTask.run(ClusterApplierService.java:166)
	at org.elasticsearch.common.util.concurrent.PrioritizedEsThreadPoolExecutor$TieBreakingPrioritizedRunnable.runAndClean(PrioritizedEsThreadPoolExecutor.java:208)
	at org.elasticsearch.common.util.concurrent.PrioritizedEsThreadPoolExecutor$TieBreakingPrioritizedRunnable.run(PrioritizedEsThreadPoolExecutor.java:171)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
	at java.base/java.lang.Thread.run(Thread.java:1474)

[2026-05-08T15:57:14,227][WARN ][o.e.c.r.a.AllocationService] [Pizzo del Ramulazz S] failing shard [failed shard, shard [t][1], node[iDft1Z1VQx6TDvAeFQIHHQ], [P], recovery_source[snapshot recovery [x1rTNCZQRVipKAeVUBohLw] from r:s/aMlzRPsCQ6KV33_AeYJAjg], s[INITIALIZING], a[id=omovDnuQRTeHvd9v57gyxQ], unassigned_info[[reason=EXISTING_INDEX_RESTORED], at[2026-05-08T19:57:13.972Z], delayed=false, details[restore_source[r/s]], allocation_status[fetching_shard_data]], expected_shard_size[5928], message [failed to update mapping for index], markAsStale [true], failure [[t/lnt8oYjBT1m2-rt2DlYw6A] org.elasticsearch.index.IndexNotFoundException: no such index [t/lnt8oYjBT1m2-rt2DlYw6A]
	at org.elasticsearch.index.IndexService.validateMapping(IndexService.java:504)
	at org.elasticsearch.indices.cluster.IndicesClusterStateService.createIndices(IndicesClusterStateService.java:461)
	at org.elasticsearch.indices.cluster.IndicesClusterStateService.applyClusterState(IndicesClusterStateService.java:205)
	at org.elasticsearch.cluster.service.ClusterApplierService.callClusterStateAppliers(ClusterApplierService.java:508)
	at org.elasticsearch.cluster.service.ClusterApplierService.callClusterStateAppliers(ClusterApplierService.java:498)
	at org.elasticsearch.cluster.service.ClusterApplierService.applyChanges(ClusterApplierService.java:475)
	at org.elasticsearch.cluster.service.ClusterApplierService.runTask(ClusterApplierService.java:422)
	at org.elasticsearch.cluster.service.ClusterApplierService$UpdateTask.run(ClusterApplierService.java:166)
	at org.elasticsearch.common.util.concurrent.PrioritizedEsThreadPoolExecutor$TieBreakingPrioritizedRunnable.runAndClean(PrioritizedEsThreadPoolExecutor.java:208)
	at org.elasticsearch.common.util.concurrent.PrioritizedEsThreadPoolExecutor$TieBreakingPrioritizedRunnable.run(PrioritizedEsThreadPoolExecutor.java:171)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
	at java.base/java.lang.Thread.run(Thread.java:1474)
]]
```
The above scenario, together with https://github.com/crate/crate/issues/19336, suggests supporting restore into closed tables may involve more edge cases than expected.

I think it would be better to clean up the implicitly defined behaviour now, and handle restore into closed tables as a dedicated feature request if we want to support it later.


## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
