### PR TITLE
Ensure `createPartitionsRequestOngoing` flag is always reset

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/indexing/ShardingUpsertExecutor.java
+++ b/server/src/main/java/io/crate/execution/engine/indexing/ShardingUpsertExecutor.java
@@ -168,13 +168,15 @@ public class ShardingUpsertExecutor
         if (requests.itemsByMissingPartition.isEmpty()) {
             return execRequests(requests, upsertResults);
         }
+        CreatePartitionsRequest request = CreatePartitionsRequest.of(
+            tableOID,
+            requests.itemsByMissingPartition.keySet()
+        );
         createPartitionsRequestOngoing = true;
-        return elasticsearchClient.execute(
-            TransportCreatePartitions.ACTION,
-                CreatePartitionsRequest.of(tableOID, requests.itemsByMissingPartition.keySet()))
+        return elasticsearchClient.execute(TransportCreatePartitions.ACTION, request)
+            .whenComplete((_, _) -> createPartitionsRequestOngoing = false)
             .thenCompose(_ -> {
                 grouper.reResolveShardLocations(requests, tableOID);
-                createPartitionsRequestOngoing = false;
                 return execRequests(requests, upsertResults);
             });
     }


### PR DESCRIPTION
Shouldn't be an issue in practice - it's used for the `shouldPause`
condition but the `BatchIteratorBackpressureExecutor` aborts on failures
anyway.
Mostly changing it to make it clearer that it's working
