### PR TITLE
Add session_id column to the sys.jobs table

### DIFF
--- a/docs/admin/system-information.rst
+++ b/docs/admin/system-information.rst
@@ -1372,6 +1372,10 @@ Table schema
 +------------------+--------------------------------------------------+------------------------------+
 | ``node['name']`` | The name of the node.                            | ``TEXT``                     |
 +------------------+--------------------------------------------------+------------------------------+
+| ``session_id``   | Id of a session that run this job. References    | ``INTEGER``                  |
+|                  | ``id`` column of the                             |                              |
+|                  | :ref:`sys.sessions <sys-sessions>` table.        |                              |
++------------------+--------------------------------------------------+------------------------------+
 | ``started``      | The point in time when the job started.          | ``TIMESTAMP WITH TIME ZONE`` |
 +------------------+--------------------------------------------------+------------------------------+
 | ``stmt``         | Shows the data query or manipulation statement   | ``TEXT``                     |
@@ -1395,6 +1399,22 @@ that is performing the query::
 
     If the user management module is not available, the ``username`` is
     given as ``crate``.
+
+The same session can be used to run different statements. They are scheduled
+and run one after another.
+``last_statement`` in the :ref:`sys.sessions <sys-sessions>` table shows only
+last scheduled statement.
+To get all statements currently running under specific session use query below.
+The first statement will be a statement that is currently running and other
+statements will be shown in scheduled order::
+
+    SELECT session_id, array_agg(stmt) AS job_ids
+        FROM (
+          SELECT session_id, stmt
+          FROM sys.jobs
+          ORDER BY started
+        ) ordered
+    GROUP BY session_id
 
 Every request that queries data or manipulates data is considered a "job" if it
 is a valid query. Requests that are not valid queries (for example, a request

--- a/docs/appendices/release-notes/6.4.0.rst
+++ b/docs/appendices/release-notes/6.4.0.rst
@@ -105,7 +105,7 @@ Performance and Resilience Improvements
 Administration and Operations
 -----------------------------
 
-None
+- Added ``session_id`` column to the :ref:`sys.jobs <sys-jobs>` table.
 
 Client interfaces
 -----------------

--- a/server/src/main/java/io/crate/execution/engine/collect/stats/JobsLogs.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/stats/JobsLogs.java
@@ -97,12 +97,12 @@ public class JobsLogs {
      * <p>
      * If {@link #isEnabled()} is false this method won't do anything.
      */
-    public void logExecutionStart(UUID jobId, String statement, Role user, StatementClassifier.Classification classification) {
+    public void logExecutionStart(UUID jobId, int sessionId, String statement, Role user, StatementClassifier.Classification classification) {
         activeRequests.increment();
         if (!isEnabled()) {
             return;
         }
-        jobsTable.put(jobId, new JobContext(jobId, statement, System.currentTimeMillis(), user, classification));
+        jobsTable.put(jobId, new JobContext(jobId, sessionId, statement, System.currentTimeMillis(), user, classification));
     }
 
     /**
@@ -139,14 +139,14 @@ public class JobsLogs {
 
     /**
      * Create a entry into `sys.jobs_log`
-     * This method can be used instead of {@link #logExecutionEnd(UUID, long, String)} if there was no {@link #logExecutionStart(UUID, String, User, StatementClassifier.Classification)}
+     * This method can be used instead of {@link #logExecutionEnd(UUID, long, String)} if there was no {@link #logExecutionStart(UUID, int, String, Role, StatementClassifier.Classification)}
      * Call because an error happened during parse, analysis or plan.
      * <p>
-     * {@link #logExecutionStart(UUID, String, Role, StatementClassifier.Classification)} is only called after a Plan has been created and execution starts.
+     * {@link #logExecutionStart(UUID, int, String, Role, StatementClassifier.Classification)} is only called after a Plan has been created and execution starts.
      */
-    public void logPreExecutionFailure(UUID jobId, String stmt, String errorMessage, Role user) {
+    public void logPreExecutionFailure(UUID jobId, int sessionId, String stmt, String errorMessage, Role user) {
         JobContextLog jobContextLog = new JobContextLog(
-            new JobContext(jobId, stmt, System.currentTimeMillis(), user, new StatementClassifier.Classification(UNDEFINED)), 0, errorMessage);
+            new JobContext(jobId, sessionId, stmt, System.currentTimeMillis(), user, new StatementClassifier.Classification(UNDEFINED)), 0, errorMessage);
         long stamp = jobsLogLock.readLock();
         try {
             jobsLog.add(jobContextLog);

--- a/server/src/main/java/io/crate/expression/reference/sys/job/JobContext.java
+++ b/server/src/main/java/io/crate/expression/reference/sys/job/JobContext.java
@@ -32,6 +32,7 @@ import io.crate.role.Role;
 public class JobContext {
 
     private final UUID id;
+    private final int sessionId;
     private final String username;
     private final String stmt;
     private final long started;
@@ -39,8 +40,9 @@ public class JobContext {
     private final Classification classification;
     private final StmtEvent event;
 
-    public JobContext(UUID id, String stmt, long started, Role user, @Nullable Classification classification) {
+    public JobContext(UUID id, int sessionId, String stmt, long started, Role user, @Nullable Classification classification) {
         this.id = id;
+        this.sessionId = sessionId;
         this.stmt = stmt;
         this.started = started;
         this.username = user.name();
@@ -63,6 +65,10 @@ public class JobContext {
 
     public UUID id() {
         return id;
+    }
+
+    public int sessionId() {
+        return sessionId;
     }
 
     public String stmt() {

--- a/server/src/main/java/io/crate/metadata/sys/SysJobsTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/sys/SysJobsTableInfo.java
@@ -21,6 +21,7 @@
 
 package io.crate.metadata.sys;
 
+import static io.crate.types.DataTypes.INTEGER;
 import static io.crate.types.DataTypes.STRING;
 import static io.crate.types.DataTypes.TIMESTAMPZ;
 
@@ -48,6 +49,7 @@ public class SysJobsTableInfo {
             .endObject()
             .add("stmt", STRING, JobContext::stmt)
             .add("started", TIMESTAMPZ, JobContext::started)
+            .add("session_id", INTEGER, JobContext::sessionId)
             .withRouting((state, routingProvider, sessionSettings) -> Routing.forTableOnAllNodes(IDENT, state.nodes()))
             .setPrimaryKeys(ColumnIdent.of("id"))
             .build();

--- a/server/src/main/java/io/crate/session/Session.java
+++ b/server/src/main/java/io/crate/session/Session.java
@@ -264,12 +264,12 @@ public class Session implements AutoCloseable {
         try {
             plan = planner.plan(analyzedStatement, plannerContext);
         } catch (Throwable t) {
-            jobsLogs.logPreExecutionFailure(jobId, statement, SQLExceptions.messageOf(t), sessionSettings.sessionUser());
+            jobsLogs.logPreExecutionFailure(jobId, id, statement, SQLExceptions.messageOf(t), sessionSettings.sessionUser());
             throw t;
         }
 
         StatementClassifier.Classification classification = StatementClassifier.classify(plan);
-        jobsLogs.logExecutionStart(jobId, statement, sessionSettings.sessionUser(), classification);
+        jobsLogs.logExecutionStart(jobId, id, statement, sessionSettings.sessionUser(), classification);
         JobsLogsUpdateListener jobsLogsUpdateListener = new JobsLogsUpdateListener(jobId, jobsLogs);
         if (!analyzedStatement.isWriteOperation()) {
             resultReceiver = new RetryOnFailureResultReceiver<>(
@@ -341,7 +341,7 @@ public class Session implements AutoCloseable {
         try {
             statement = SqlParser.createStatement(query);
         } catch (Throwable t) {
-            jobsLogs.logPreExecutionFailure(UUIDs.dirtyUUID(), query, SQLExceptions.messageOf(t), sessionSettings.sessionUser());
+            jobsLogs.logPreExecutionFailure(UUIDs.dirtyUUID(), id, query, SQLExceptions.messageOf(t), sessionSettings.sessionUser());
             throw t;
         }
         timeoutToken.check("parse");
@@ -357,7 +357,7 @@ public class Session implements AutoCloseable {
                 statementMaxLength,
                 query.length()
             );
-            jobsLogs.logPreExecutionFailure(UUIDs.dirtyUUID(), query, msg, sessionSettings.sessionUser());
+            jobsLogs.logPreExecutionFailure(UUIDs.dirtyUUID(), id, query, msg, sessionSettings.sessionUser());
             throw new IllegalArgumentException(msg);
         }
     }
@@ -382,6 +382,7 @@ public class Session implements AutoCloseable {
         } catch (Throwable t) {
             jobsLogs.logPreExecutionFailure(
                 UUIDs.dirtyUUID(),
+                id,
                 query == null ? statementName : query,
                 SQLExceptions.messageOf(t),
                 sessionSettings.sessionUser());
@@ -405,7 +406,7 @@ public class Session implements AutoCloseable {
         try {
             preparedStmt = getSafeStmt(statementName);
         } catch (Throwable t) {
-            jobsLogs.logPreExecutionFailure(UUIDs.dirtyUUID(), "", SQLExceptions.messageOf(t), sessionSettings.sessionUser());
+            jobsLogs.logPreExecutionFailure(UUIDs.dirtyUUID(), id, "", SQLExceptions.messageOf(t), sessionSettings.sessionUser());
             throw t;
         }
 
@@ -639,7 +640,7 @@ public class Session implements AutoCloseable {
                 )
             );
         } catch (Throwable t) {
-            jobsLogs.logPreExecutionFailure(UUIDs.dirtyUUID(), queryString, SQLExceptions.messageOf(t), sessionSettings.sessionUser());
+            jobsLogs.logPreExecutionFailure(UUIDs.dirtyUUID(), id, queryString, SQLExceptions.messageOf(t), sessionSettings.sessionUser());
             throw t;
         }
     }
@@ -749,6 +750,7 @@ public class Session implements AutoCloseable {
         } catch (Throwable t) {
             jobsLogs.logPreExecutionFailure(
                 jobId,
+                id,
                 firstPreparedStatement.rawStatement(),
                 SQLExceptions.messageOf(t),
                 sessionSettings.sessionUser());
@@ -756,6 +758,7 @@ public class Session implements AutoCloseable {
         }
         jobsLogs.logExecutionStart(
             jobId,
+            id,
             firstPreparedStatement.rawStatement(),
             sessionSettings.sessionUser(),
             StatementClassifier.classify(plan)
@@ -886,7 +889,7 @@ public class Session implements AutoCloseable {
         lastStmt = rawStatement;
         if (analyzedStmt == null) {
             String errorMsg = "Statement must have been analyzed: " + rawStatement;
-            jobsLogs.logPreExecutionFailure(jobId, rawStatement, errorMsg, sessionSettings.sessionUser());
+            jobsLogs.logPreExecutionFailure(jobId, id, rawStatement, errorMsg, sessionSettings.sessionUser());
             throw new IllegalStateException(errorMsg);
         }
         Plan plan;
@@ -894,7 +897,7 @@ public class Session implements AutoCloseable {
             plan = planner.plan(analyzedStmt, plannerContext);
             timeoutToken.check("singleExec:plan");
         } catch (Throwable t) {
-            jobsLogs.logPreExecutionFailure(jobId, rawStatement, SQLExceptions.messageOf(t), sessionSettings.sessionUser());
+            jobsLogs.logPreExecutionFailure(jobId, id, rawStatement, SQLExceptions.messageOf(t), sessionSettings.sessionUser());
             throw t;
         }
         if (!analyzedStmt.isWriteOperation()) {
@@ -918,7 +921,7 @@ public class Session implements AutoCloseable {
             );
         }
         jobsLogs.logExecutionStart(
-            jobId, rawStatement, sessionSettings.sessionUser(), StatementClassifier.classify(plan));
+            jobId, id, rawStatement, sessionSettings.sessionUser(), StatementClassifier.classify(plan));
         RowConsumerToResultReceiver consumer = new RowConsumerToResultReceiver(
             resultReceiver, maxRows, new JobsLogsUpdateListener(jobId, jobsLogs));
         portal.setActiveConsumer(consumer);

--- a/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -1953,6 +1953,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         assertThat(relation.outputs()).satisfiesExactly(
             isReference("id"),
             isReference("node"),
+            isReference("session_id"),
             isReference("started"),
             isReference("stmt"),
             isReference("username"));
@@ -1973,6 +1974,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         assertThat(relation.outputs()).satisfiesExactly(
             isField("id"),
             isField("node"),
+            isField("session_id"),
             isField("started"),
             isField("stmt"),
             isField("username"));

--- a/server/src/test/java/io/crate/execution/engine/collect/stats/JobsLogsTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/stats/JobsLogsTest.java
@@ -104,10 +104,11 @@ public class JobsLogsTest extends CrateDummyClusterServiceUnitTest {
         try (JobsLogService stats = new JobsLogService(settings, jobsLogs, clusterService, nodeCtx, breakerService)) {
             LogSink<JobContextLog> jobsLogSink = (LogSink<JobContextLog>) stats.get().jobsLog();
 
+            int sessionId = 123;
             jobsLogSink.add(new JobContextLog(
-                new JobContext(UUID.randomUUID(), "insert into", 10L, Role.CRATE_USER, null), 0, null, 20L));
+                new JobContext(UUID.randomUUID(), sessionId, "insert into", 10L, Role.CRATE_USER, null), 0, null, 20L));
             jobsLogSink.add(new JobContextLog(
-                new JobContext(UUID.randomUUID(), "select * from t1", 10L, Role.CRATE_USER, null), 0, null, 20L));
+                new JobContext(UUID.randomUUID(), sessionId, "select * from t1", 10L, Role.CRATE_USER, null), 0, null, 20L));
             assertThat(StreamSupport.stream(jobsLogSink.spliterator(), false).count()).isEqualTo(1L);
         }
     }
@@ -250,8 +251,9 @@ public class JobsLogsTest extends CrateDummyClusterServiceUnitTest {
             Classification classification =
                 new Classification(SELECT, Collections.singleton("Collect"));
 
+            int sessionId = 123;
             jobsLogSink.add(new JobContextLog(
-                new JobContext(UUID.randomUUID(), "select 1", 1L, Role.CRATE_USER, classification), 0, null));
+                new JobContext(UUID.randomUUID(), sessionId, "select 1", 1L, Role.CRATE_USER, classification), 0, null));
 
             clusterSettings.applySettings(Settings.builder()
                 .put(JobsLogService.STATS_ENABLED_SETTING.getKey(), true)
@@ -303,15 +305,16 @@ public class JobsLogsTest extends CrateDummyClusterServiceUnitTest {
             AtomicInteger numJobs = new AtomicInteger();
             int maxQueueSize = JobsLogService.STATS_JOBS_LOG_SIZE_SETTING.getDefault(Settings.EMPTY);
 
+            int sessionId = 123;
             executor.submit(() -> {
                 while (doInsertJobs.get() && numJobs.get() < maxQueueSize) {
                     UUID uuid = UUID.randomUUID();
                     int i = numJobs.getAndIncrement();
-                    jobsLogs.logExecutionStart(uuid, "select 1", Role.CRATE_USER, classification);
+                    jobsLogs.logExecutionStart(uuid, sessionId, "select 1", Role.CRATE_USER, classification);
                     if (i % 2 == 0) {
                         jobsLogs.logExecutionEnd(uuid, 0, null);
                     } else {
-                        jobsLogs.logPreExecutionFailure(uuid, "select 1", "failure", Role.CRATE_USER);
+                        jobsLogs.logPreExecutionFailure(uuid, sessionId, "select 1", "failure", Role.CRATE_USER);
                     }
                 }
                 latch.countDown();
@@ -338,8 +341,9 @@ public class JobsLogsTest extends CrateDummyClusterServiceUnitTest {
         Classification classification =
             new Classification(SELECT, Collections.singleton("Collect"));
 
-        JobContext jobContext = new JobContext(UUID.randomUUID(), "select 1", 1L, user, classification);
-        jobsLogs.logExecutionStart(jobContext.id(), jobContext.stmt(), user, classification);
+        int sessionId = 123;
+        JobContext jobContext = new JobContext(UUID.randomUUID(), sessionId, "select 1", 1L, user, classification);
+        jobsLogs.logExecutionStart(jobContext.id(), sessionId, jobContext.stmt(), user, classification);
         List<JobContext> jobsEntries = StreamSupport.stream(jobsLogs.activeJobs().spliterator(), false).toList();
 
         assertThat(jobsEntries).hasSize(1);
@@ -353,9 +357,9 @@ public class JobsLogsTest extends CrateDummyClusterServiceUnitTest {
     public void testExecutionFailure() {
         Role user = RolesHelper.userOf("arthur");
         Queue<JobContextLog> q = new BlockingEvictingQueue<>(1);
-
+        int sessionId = 123;
         jobsLogs.updateJobsLog(new QueueSink<>(q, () -> {}));
-        jobsLogs.logPreExecutionFailure(UUID.randomUUID(), "select foo", "stmt error", user);
+        jobsLogs.logPreExecutionFailure(UUID.randomUUID(), sessionId, "select foo", "stmt error", user);
 
         List<JobContextLog> jobsLogEntries = StreamSupport.stream(jobsLogs.jobsLog().spliterator(), false).toList();
         assertThat(jobsLogEntries).hasSize(1);
@@ -370,9 +374,9 @@ public class JobsLogsTest extends CrateDummyClusterServiceUnitTest {
     public void testExecutionFailureIsRecordedInMetrics() {
         Role user = RolesHelper.userOf("arthur");
         Queue<JobContextLog> q = new BlockingEvictingQueue<>(1);
-
+        int sessionId = 123;
         jobsLogs.updateJobsLog(new QueueSink<>(q, () -> {}));
-        jobsLogs.logPreExecutionFailure(UUID.randomUUID(), "select foo", "stmt error", user);
+        jobsLogs.logPreExecutionFailure(UUID.randomUUID(), sessionId, "select foo", "stmt error", user);
 
         List<MetricsView> metrics = StreamSupport.stream(jobsLogs.metrics().spliterator(), false).toList();
         assertThat(metrics).hasSize(1);
@@ -401,9 +405,9 @@ public class JobsLogsTest extends CrateDummyClusterServiceUnitTest {
             .build();
         try (JobsLogService stats = new JobsLogService(settings, jobsLogs, clusterService, nodeCtx, breakerService)) {
             LogSink<JobContextLog> jobsLogSink = (LogSink<JobContextLog>) stats.get().jobsLog();
-
+            int sessionId = 123;
             jobsLogSink.add(new JobContextLog(
-                new JobContext(UUID.randomUUID(), "insert into", 10L, Role.CRATE_USER, null), 0, null, 20L));
+                new JobContext(UUID.randomUUID(), sessionId, "insert into", 10L, Role.CRATE_USER, null), 0, null, 20L));
 
             assertThat(jobsLogSink).hasSize(1);
             assertThat(breaker.getUsed()).isEqualTo(96);

--- a/server/src/test/java/io/crate/execution/engine/collect/stats/RamAccountingQueueSinkTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/stats/RamAccountingQueueSinkTest.java
@@ -125,11 +125,12 @@ public class RamAccountingQueueSinkTest extends ESTestCase {
             scheduler,
             TimeValue.timeValueSeconds(1L)
         );
-        q.add(new JobContextLog(new JobContext(UUID.fromString("067e6162-3b6f-4ae2-a171-2470b63dff01"),
+        int sessionId = 123;
+        q.add(new JobContextLog(new JobContext(UUID.fromString("067e6162-3b6f-4ae2-a171-2470b63dff01"), sessionId,
             "select 1", 1L, Role.CRATE_USER, classification), 0, null, 2000L));
-        q.add(new JobContextLog(new JobContext(UUID.fromString("067e6162-3b6f-4ae2-a171-2470b63dff02"),
+        q.add(new JobContextLog(new JobContext(UUID.fromString("067e6162-3b6f-4ae2-a171-2470b63dff02"), sessionId,
             "select 1", 1L, Role.CRATE_USER, classification), 0, null, 4000L));
-        q.add(new JobContextLog(new JobContext(UUID.fromString("067e6162-3b6f-4ae2-a171-2470b63dff03"),
+        q.add(new JobContextLog(new JobContext(UUID.fromString("067e6162-3b6f-4ae2-a171-2470b63dff03"), sessionId,
             "select 1", 1L, Role.CRATE_USER, classification), 0, null, 7000L));
 
         TimeBasedQEviction.removeExpiredLogs(q, 10_000L, 5_000L);

--- a/server/src/test/java/io/crate/expression/reference/StaticTableDefinitionTest.java
+++ b/server/src/test/java/io/crate/expression/reference/StaticTableDefinitionTest.java
@@ -49,10 +49,11 @@ public class StaticTableDefinitionTest {
 
     @Test
     public void testTableDefinitionWithPredicate() throws ExecutionException, InterruptedException {
+        int sessionId = 123;
         List<JobContext> actual = List.of(
-            new JobContext(UUID.randomUUID(), "select 1", 1L, CRATE_USER, null),
-            new JobContext(UUID.randomUUID(), "select 2", 1L, CRATE_USER, null),
-            new JobContext(UUID.randomUUID(), "select 3", 1L, dummyUser, null));
+            new JobContext(UUID.randomUUID(), sessionId, "select 1", 1L, CRATE_USER, null),
+            new JobContext(UUID.randomUUID(), sessionId, "select 2", 1L, CRATE_USER, null),
+            new JobContext(UUID.randomUUID(), sessionId, "select 3", 1L, dummyUser, null));
 
         StaticTableDefinition<JobContext> tableDef = new StaticTableDefinition<>(
             () -> completedFuture(actual),

--- a/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -24,7 +24,6 @@ package io.crate.integrationtests;
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
 import static io.crate.testing.Asserts.assertThat;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Collections;
 import java.util.List;
@@ -582,7 +581,7 @@ public class InformationSchemaTest extends IntegTestCase {
     @Test
     public void testDefaultColumns() {
         execute("select * from information_schema.columns order by table_schema, table_name");
-        assertThat(response.rowCount()).isEqualTo(1106);
+        assertThat(response.rowCount()).isEqualTo(1107);
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/SysJobsTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SysJobsTest.java
@@ -48,9 +48,10 @@ public class SysJobsTest extends IntegTestCase {
         SQLResponse response = execute(stmt);
         List<String> statements = new ArrayList<>();
 
+        // SystemTable.build orders by fqn, hence mismatch with the declaration order in SysJobsTableInfo.
         for (Object[] objects : response.rows()) {
             assertThat(objects[0]).isNotNull();
-            statements.add((String) objects[3]);
+            statements.add((String) objects[4]);
         }
         assertThat(statements.contains(stmt)).isTrue();
     }


### PR DESCRIPTION
Popped up while looking into https://github.com/crate/support/issues/866 - I realized that session table's lastStatement actually has semantics of "last scheduled" and we don't have information about actually running under the session (and previously scheduled) stataments.
