### PR TITLE
Move global checkpoint sync to write threadpool

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/seqno/GlobalCheckpointSyncAction.java
+++ b/server/src/main/java/org/elasticsearch/index/seqno/GlobalCheckpointSyncAction.java
@@ -69,7 +69,7 @@ public class GlobalCheckpointSyncAction extends TransportReplicationAction<
                 shardStateAction,
                 Request::new,
                 Request::new,
-                ThreadPool.Names.MANAGEMENT);
+                ThreadPool.Names.WRITE);
     }
 
     @Override


### PR DESCRIPTION
It was running in the MANAGEMENT pool but checkpoints are more related
to write operations and having it in the management pool can interfere
with cluster state updates. Especially if disk IO is a bottleneck.

<img width="1994" height="1268" alt="image" src="https://github.com/user-attachments/assets/2872c89f-5c43-4495-91b3-e891640f1437" />
