### PR TITLE
Allow StmtEvent to be GCd earlier

### DIFF
--- a/server/src/main/java/io/crate/expression/reference/sys/job/JobContext.java
+++ b/server/src/main/java/io/crate/expression/reference/sys/job/JobContext.java
@@ -38,7 +38,9 @@ public class JobContext {
     private final long started;
     @Nullable
     private final Classification classification;
-    private final StmtEvent event;
+
+    @Nullable
+    private StmtEvent event;
 
     public JobContext(UUID id, int sessionId, String stmt, long started, Role user, @Nullable Classification classification) {
         this.id = id;
@@ -47,8 +49,9 @@ public class JobContext {
         this.started = started;
         this.username = user.name();
         this.classification = classification;
-        this.event = new StmtEvent();
+        StmtEvent event = new StmtEvent();
         if (event.shouldCommit()) {
+            this.event = event;
             event.id = id.toString();
             event.stmt = stmt;
             event.classification = classification == null ? null : classification.type().toString();
@@ -57,9 +60,10 @@ public class JobContext {
     }
 
     public void finish(long affectedRowCount) {
-        if (event.shouldCommit()) {
+        if (event != null && event.shouldCommit()) {
             event.affectedRowCount = affectedRowCount;
             event.commit();
+            event = null;
         }
     }
 


### PR DESCRIPTION
`JobContext` is referenced from `JobContextLog` which can be kept alive
a bit due to sys.jobs_log.
