### PR TITLE
Fix INSERT INTO perf regression; restore 5.10 backoff behavior

### DIFF
--- a/docs/appendices/release-notes/6.2.8.rst
+++ b/docs/appendices/release-notes/6.2.8.rst
@@ -49,4 +49,9 @@ series.
 Fixes
 =====
 
-None
+- Fixed a performance regression introduced in 6.0.0 that could cause ``INSERT
+  INTO <table> VALUES (...)`` bulk statements that hit many shards to be less
+  aggressive than possible, taking longer than necessary.
+
+  To mitigate the issue in earlier versions it is also possible to increase the
+  size of the :ref:`write thread pool <thread_pool.<name>.queue_size>`.

--- a/docs/appendices/release-notes/6.3.2.rst
+++ b/docs/appendices/release-notes/6.3.2.rst
@@ -46,6 +46,13 @@ series.
 Fixes
 =====
 
+- Fixed a performance regression introduced in 6.0.0 that could cause ``INSERT
+  INTO <table> VALUES (...)`` bulk statements that hit many shards to be less
+  aggressive than possible, taking longer than necessary.
+
+  To mitigate the issue in earlier versions it is also possible to increase the
+  size of the :ref:`write thread pool <thread_pool.<name>.queue_size>`.
+
 - Fixed an issue that caused the ``statement_timeout`` setting to expire a query
   if a PostgreSQL client was idling between creating a prepared statement
   (sending a ``parse`` message) and using the prepared statement (sending

--- a/server/src/main/java/org/elasticsearch/action/bulk/BackoffPolicy.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BackoffPolicy.java
@@ -47,7 +47,7 @@ public final class BackoffPolicy {
     }
 
     public static Iterable<TimeValue> limitedDynamic(ConcurrencyLimit concurrencyLimit) {
-        return () -> Stream.generate(() -> TimeValue.timeValueNanos(concurrencyLimit.getLastRtt(TimeUnit.NANOSECONDS)))
+        return () -> Stream.generate(() -> TimeValue.timeValueNanos(concurrencyLimit.getLongRtt(TimeUnit.NANOSECONDS)))
             .limit(DEFAULT_RETRY_LIMIT)
             .iterator();
     }


### PR DESCRIPTION
In 5.10 we've had two different back-off policy behaviors:

- unlimited: used `getLastRtt`
- limited: used `getLongRtt`

https://github.com/crate/crate/pull/17943 tried to unify this to:

- unlimited: used `getLongRtt`
- limited: used `getLongRtt`

But that caused some issues (unclear what exactly), leading to:

https://github.com/crate/crate/pull/18049

Which changed it to:

- unlimited: used `getLastRtt`
- limited: used `getLastRtt`

This caused the `specs/partitioned_bulk_insert.py` case from
crate-benchmarks to show a huge slowdown with linearly increasing
request times.

This restores the 5.10 behavior by changing the limited case which is
used in insert-from-values back to `getLongRtt` to address the
performance regression.

Before:

<img width="1170" height="840" alt="image" src="https://github.com/user-attachments/assets/ae308c6c-4ea5-43ab-a90c-f57b4a4127ef" />


After:

<img width="1184" height="850" alt="image" src="https://github.com/user-attachments/assets/07b1da70-607e-49f0-934f-1976b63860a1" />
