### PR TITLE
Increase write TP queue to 2000; tweak backoff policy/retries

### DIFF
--- a/docs/appendices/release-notes/6.4.0.rst
+++ b/docs/appendices/release-notes/6.4.0.rst
@@ -97,6 +97,12 @@ Scalar and Aggregation Functions
 Performance and Resilience Improvements
 ---------------------------------------
 
+- Increased the default queue size of the ``write`` search pool but lowered the
+  amount of internal retries for ``INSERT INTO <table> VALUES`` statements in
+  exchange. This should lower the load for bulk inserts into tables with many
+  shards at the expensive of potentially higher memory load before requests get
+  rejected if clients make single inserts with high concurrency/many
+  connections.
 
 - Improved the performance of the :ref:`min() <aggregation-min>` and
   :ref:`max() <aggregation-max>` aggregations for columns of type :ref:`NUMERIC

--- a/docs/config/cluster.rst
+++ b/docs/config/cluster.rst
@@ -1294,7 +1294,7 @@ settings.
 .. _thread_pool.<name>.queue_size:
 
 **thread_pool.<name>.queue_size**
-  | *Default write:*  ``200``
+  | *Default write:*  ``2000``
   | *Default search:* ``1000``
   | *Runtime:*  ``no``
 

--- a/server/src/main/java/org/elasticsearch/action/bulk/BackoffPolicy.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BackoffPolicy.java
@@ -39,10 +39,10 @@ public final class BackoffPolicy {
     private BackoffPolicy() {
     }
 
-    private static final int DEFAULT_RETRY_LIMIT = 10;
+    private static final int DEFAULT_RETRY_LIMIT = 3;
 
     public static Iterable<TimeValue> unlimitedDynamic(ConcurrencyLimit concurrencyLimit) {
-        return () -> Stream.generate(() -> TimeValue.timeValueNanos(concurrencyLimit.getLastRtt(TimeUnit.NANOSECONDS)))
+        return () -> Stream.generate(() -> TimeValue.timeValueNanos(concurrencyLimit.getLongRtt(TimeUnit.NANOSECONDS)))
             .iterator();
     }
 

--- a/server/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
+++ b/server/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
@@ -134,7 +134,7 @@ public class ThreadPool implements Scheduler {
 
         builders = List.of(
             new ScalingExecutorBuilder(Names.GENERIC, 4, genericThreadPoolMax, TimeValue.timeValueSeconds(30)),
-            new FixedExecutorBuilder(settings, Names.WRITE, availableProcessors, 200),
+            new FixedExecutorBuilder(settings, Names.WRITE, availableProcessors, 2000),
             new PrioFixedExecutorBuilder(settings, Names.SEARCH, searchThreadPoolSize(availableProcessors), 1000),
             new ScalingExecutorBuilder(Names.MANAGEMENT, 1, 5, TimeValue.timeValueMinutes(5)),
             // no queue athis means clients will need to handle rejections on listener queue even if the operation succeeded


### PR DESCRIPTION
Follow up to https://github.com/crate/crate/pull/19326

A bit of an experiment:

- Using `getLongRtt` again for unlimited. Rationale being that we don't
  want to overreact on outliers caused by GCs

- Increases the queue size and lowers internal retry to avoid retries
  altogether if possible. Sending requests back and forth is heavier
  than keeping more tasks in the tp queue.

Also relates to https://github.com/crate/crate/pull/19318

(Will keep an eye on nightly benchmarks to judge the impact of this - can revert or tweak if it causes problems)

```
Q: insert into part_bulk_insert (id, value) values (?, ?)
C: 1
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |      314.886 ±   37.557 |    266.525 |    306.176 |    314.147 |    497.619 |
|   V2    |      312.302 ±   36.437 |    276.539 |    305.510 |    315.476 |    508.815 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -   0.82%                           -   0.22%   
There is a 27.23% probability that the observed difference is not random, and the best estimate of that dif
ference is 0.82%
The test has no statistical significance
```

```
Q: insert into id_int_value_str (id, value) (select col1, col2 from unnest(?, ?))
C: 1
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |       35.470 ±    3.761 |     28.069 |     34.742 |     35.032 |     87.559 |
|   V2    |       35.625 ±    3.753 |     28.293 |     34.770 |     35.061 |     90.506 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               +   0.44%                           +   0.08%   
There is a 64.32% probability that the observed difference is not random, and the best estimate of that dif
ference is 0.44%
The test has no statistical significance

Q: insert into id_int_value_str (id, value) (select col1, col2 from unnest(?, ?))
C: 15
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |        2.754 ±    6.169 |      0.731 |      1.210 |      1.378 |     50.953 |
|   V2    |        2.473 ±    5.900 |      0.718 |      1.157 |      1.331 |     48.107 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -  10.75%                           -   4.46%   
There is a 70.18% probability that the observed difference is not random, and the best estimate of that dif
ference is 10.75%
The test has no statistical significance
```


