### PR TITLE
docs: Clarify SQL Handler's modes of communication

### DIFF
--- a/docs/concepts/clustering.rst
+++ b/docs/concepts/clustering.rst
@@ -50,11 +50,8 @@ The SQL Handler part of a node is responsible for three aspects:
     (`abstract syntax tree`_)
 
 The SQL Handler is the only of the four components that interfaces with the
-"outside world". CrateDB supports three protocols to handle client requests:
-
-(a) HTTP
-(b) a Binary Transport Protocol
-(c) the PostgreSQL Wire Protocol
+"outside world". This is done through :ref:`HTTP <interface-http>` or the
+:ref:`PostgreSQL wire protocol <interface-postgresql>`.
 
 A typical request contains a SQL statement and its corresponding arguments.
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Currently, all three protocols are mentioned in the SQL Handler section, which can make someone think that the SQL handler also accepts requests from the "outside world" via the binary transport protocol as well.

I'll update the diagram as soon as I find the source for it.

## Checklist

 - [ ] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
