### PR TITLE
Return EmptyQueryResponse for multiple empty statements in Pg wire protocol

### DIFF
--- a/docs/appendices/release-notes/6.3.3.rst
+++ b/docs/appendices/release-notes/6.3.3.rst
@@ -46,4 +46,7 @@ series.
 Fixes
 =====
 
-None
+- Fixed an issue that caused multiple empty statements like `;;` to result in a
+  parsing failure instead of returning empty statement results when executed via
+  the simple mode of the PostgreSQL wire protocol.
+

--- a/libs/sql-parser/src/main/antlr/io/crate/sql/parser/antlr/SqlBaseParser.g4
+++ b/libs/sql-parser/src/main/antlr/io/crate/sql/parser/antlr/SqlBaseParser.g4
@@ -24,7 +24,7 @@ parser grammar SqlBaseParser;
 options { tokenVocab=SqlBaseLexer; } // use tokens from SqlBaseLexer.g4
 
 statements
-    : statement? (SEMICOLON statement)* SEMICOLON? EOF
+    : statement? (SEMICOLON statement?)* EOF
     ;
 
 singleStatement

--- a/libs/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/libs/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -76,6 +76,7 @@ import io.crate.sql.tree.OptimizeStatement;
 import io.crate.sql.tree.ParameterExpression;
 import io.crate.sql.tree.QualifiedName;
 import io.crate.sql.tree.QualifiedNameReference;
+import io.crate.sql.tree.Query;
 import io.crate.sql.tree.RefreshStatement;
 import io.crate.sql.tree.ResetStatement;
 import io.crate.sql.tree.RestoreSnapshot;
@@ -113,6 +114,24 @@ public class TestStatementBuilder {
         statements = SqlParser.createStatementsForSimpleQuery("SET extra_float_digits = 3", str -> str);
         assertThat(statements).hasSize(1);
         assertThat(statements.get(0)).isExactlyInstanceOf(SetStatement.class);
+
+        assertThat(SqlParser.createStatementsForSimpleQuery("; select 1", x -> x))
+            .hasSize(1)
+            .hasOnlyElementsOfType(Query.class);
+
+        assertThat(SqlParser.createStatementsForSimpleQuery(";;; select 1", x -> x))
+            .hasSize(1)
+            .hasOnlyElementsOfType(Query.class);
+
+        assertThat(SqlParser.createStatementsForSimpleQuery("select 1;;;", x -> x))
+            .hasSize(1)
+            .hasOnlyElementsOfType(Query.class);
+
+        assertThat(SqlParser.createStatementsForSimpleQuery("; select 1; select 2;", x -> x))
+            .hasSize(2)
+            .hasOnlyElementsOfType(Query.class);
+
+        assertThat(SqlParser.createStatementsForSimpleQuery(";;;;", x -> x)).isEmpty();
     }
 
     @Test

--- a/server/src/main/java/io/crate/session/Session.java
+++ b/server/src/main/java/io/crate/session/Session.java
@@ -123,12 +123,12 @@ import io.crate.types.DataType;
  * sync()
  * </pre>
  * <p>
- * (https://www.postgresql.org/docs/9.2/static/protocol-flow.html#PROTOCOL-FLOW-EXT-QUERY)
+ * See: <a href="https://www.postgresql.org/docs/9.2/protocol-flow.html#PROTOCOL-FLOW-EXT-QUERY">PostgreSQL: Extended Query Protocol</a>.
  */
 public class Session implements AutoCloseable {
 
     // Logger name should be SQLOperations here
-    private static final Logger LOGGER = LogManager.getLogger(Sessions.class);
+    private static final Logger LOGGER = LogManager.getLogger(Session.class);
 
     public static final String UNNAMED = "";
     private final DependencyCarrier executor;
@@ -329,6 +329,11 @@ public class Session implements AutoCloseable {
         return sessionSettings;
     }
 
+    /**
+     * Parses the input query string into a statement and saves it under the given statement name
+     * (if parsing was successful).
+     * The method expects a single statement in the provided query string.
+     */
     public void parse(String statementName, String query, List<DataType<?>> paramTypes) {
         TimeoutToken timeoutToken = newTimeoutToken();
         if (LOGGER.isDebugEnabled()) {

--- a/server/src/test/java/io/crate/integrationtests/PostgresITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PostgresITest.java
@@ -917,8 +917,24 @@ public class PostgresITest extends IntegTestCase {
                               "create table t (id int);" +
                               "insert into t values (42);" +
                               "refresh table t");
+
+            // Test simple select
             statement = conn.createStatement();
             ResultSet resultSet = statement.executeQuery("select * from hoschi.t");
+            resultSet.next();
+            assertThat(resultSet.getInt(1)).isEqualTo(42);
+            assertThat(resultSet.isLast()).isTrue();
+
+            // Test with empty statement added to the query
+            statement = conn.createStatement();
+            resultSet = statement.executeQuery("select * from hoschi.t;;");
+            resultSet.next();
+            assertThat(resultSet.getInt(1)).isEqualTo(42);
+            assertThat(resultSet.isLast()).isTrue();
+
+            // Test with empty statement prepended to the query
+            statement = conn.createStatement();
+            resultSet = statement.executeQuery(";; select * from hoschi.t");
             resultSet.next();
             assertThat(resultSet.getInt(1)).isEqualTo(42);
             assertThat(resultSet.isLast()).isTrue();

--- a/server/src/test/java/io/crate/integrationtests/RestSQLActionIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/RestSQLActionIntegrationTest.java
@@ -23,7 +23,6 @@ package io.crate.integrationtests;
 
 import static io.crate.execution.engine.indexing.ShardingUpsertExecutor.BULK_RESPONSE_MAX_ERRORS_PER_SHARD;
 import static io.crate.testing.Asserts.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.OutputStream;
 import java.net.Socket;
@@ -376,6 +375,23 @@ public class RestSQLActionIntegrationTest extends SQLHttpIntegrationTest {
         assertThat(response.body()).contains(
             """
             {"cols":[],"rows":[[]],"rowcount":1,"duration":
+            """.stripIndent().stripTrailing()
+        );
+    }
+
+    @Test
+    public void test_only_single_statements_allowed() throws Exception {
+        String body =
+            """
+            {
+                "stmt": "select 1; select 2;"
+            }
+            """;
+        var response = post(body);
+        assertThat(response.statusCode()).isEqualTo(400);
+        assertThat(response.body()).contains(
+            """
+            "error":{"message":"SQLParseException[line 1:11: mismatched input 'select' expecting <EOF>]","code":4000}
             """.stripIndent().stripTrailing()
         );
     }

--- a/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
@@ -28,7 +28,6 @@ import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.TestingHelpers.printedTable;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
 

--- a/server/src/test/java/io/crate/session/SessionTest.java
+++ b/server/src/test/java/io/crate/session/SessionTest.java
@@ -24,7 +24,6 @@ package io.crate.session;
 import static io.crate.session.Session.UNNAMED;
 import static io.crate.testing.Asserts.assertThat;
 import static java.util.concurrent.CompletableFuture.completedFuture;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -75,12 +74,23 @@ import io.crate.planner.PlannerContext;
 import io.crate.planner.operators.SubQueryResults;
 import io.crate.protocols.postgres.FormatCodes.FormatCode;
 import io.crate.protocols.postgres.Portal;
+import io.crate.sql.parser.ParsingException;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 
 public class SessionTest extends CrateDummyClusterServiceUnitTest {
+
+    @Test
+    public void test_parse_fails_with_multiple_statements() {
+        SQLExecutor sqlExecutor = SQLExecutor.builder(clusterService).build();
+        try (Session session = sqlExecutor.createSession()) {
+            assertThatThrownBy(() -> session.parse("S_1", "select 1; select 2;", Collections.emptyList()))
+                .isExactlyInstanceOf(ParsingException.class)
+                .hasMessage("line 1:11: mismatched input 'select' expecting <EOF>");
+        }
+    }
 
     @Test
     public void test_out_of_bounds_getParamType_fails() throws Exception {
@@ -137,7 +147,6 @@ public class SessionTest extends CrateDummyClusterServiceUnitTest {
         assertThat(session.deferredExecutionsByStmt).hasSize(0);
         assertThat(session.activeExecution).isNull();
     }
-
 
     @Test
     public void test_flush_triggers_deferred_executions_and_sets_active_execution() throws Exception {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Fixes #19337 .

Currently, our grammar doesn't allow multiple empty statements separated with semicolons. This PR changes our grammar so that it's allowed.

This is also how PostgreSQL's grammar is defined in the Antlr project: https://github.com/antlr/grammars-v4/blob/master/sql/postgresql/PostgreSQLParser.g4#L42-L44.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [ ] (not needed) Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
