### PR TITLE
Revert "Take query circuit breaker state into account when building distributed merge requests"

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/distribution/DistributingConsumer.java
+++ b/server/src/main/java/io/crate/execution/engine/distribution/DistributingConsumer.java
@@ -39,7 +39,6 @@ import java.util.function.BiConsumer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.bulk.BackoffPolicy;
-import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.threadpool.Scheduler.Cancellable;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -84,7 +83,6 @@ public class DistributingConsumer implements RowConsumer {
     private final ThreadPool threadPool;
 
     private final AtomicBoolean consuming = new AtomicBoolean(false);
-    private final CircuitBreaker queryCircuitBreaker;
 
     @VisibleForTesting
     final long maxBytes;
@@ -98,7 +96,6 @@ public class DistributingConsumer implements RowConsumer {
     private final String localNodeId;
 
     public DistributingConsumer(Executor responseExecutor,
-                                CircuitBreaker queryCircuitBreaker,
                                 UUID jobId,
                                 MultiBucketBuilder multiBucketBuilder,
                                 int targetPhaseId,
@@ -128,7 +125,6 @@ public class DistributingConsumer implements RowConsumer {
         for (String downstreamNodeId : downstreamNodeIds) {
             downstreams.add(new Downstream(downstreamNodeId));
         }
-        this.queryCircuitBreaker = queryCircuitBreaker;
         assert downstreams.size() > 0 : "Must always have at least one downstream";
         this.maxBytes = Math.max(Paging.MAX_PAGE_BYTES / downstreams.size(), 2 * 1024 * 1024);
     }
@@ -167,9 +163,7 @@ public class DistributingConsumer implements RowConsumer {
             try {
                 while (it.moveNext()) {
                     multiBucketBuilder.add(it.currentElement());
-                    if (multiBucketBuilder.size() >= pageSize
-                        || multiBucketBuilder.ramBytesUsed() >= maxBytes
-                        || multiBucketBuilder.ramBytesUsed() > queryCircuitBreaker.getFree() * 0.5) {
+                    if (multiBucketBuilder.size() >= pageSize || multiBucketBuilder.ramBytesUsed() >= maxBytes) {
                         forwardResults(it, false);
                         return;
                     }

--- a/server/src/main/java/io/crate/execution/engine/distribution/DistributingConsumerFactory.java
+++ b/server/src/main/java/io/crate/execution/engine/distribution/DistributingConsumerFactory.java
@@ -27,10 +27,8 @@ import java.util.UUID;
 import java.util.concurrent.Executor;
 
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
-import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.threadpool.ThreadPool;
 
@@ -56,7 +54,6 @@ public class DistributingConsumerFactory {
     private static final String RESPONSE_EXECUTOR_NAME = ThreadPool.Names.SEARCH;
 
     private final ClusterService clusterService;
-    private final CircuitBreaker queryCircuitBreaker;
     private final Executor responseExecutor;
     private final ActionExecutor<NodeRequest<DistributedResultRequest>, DistributedResultResponse> distributedResultAction;
     private final ActionExecutor<KillJobsNodeRequest, KillResponse> killNodeAction;
@@ -65,12 +62,10 @@ public class DistributingConsumerFactory {
 
     @Inject
     public DistributingConsumerFactory(ClusterService clusterService,
-                                       CircuitBreakerService circuitBreakerService,
                                        NodeContext nodeContext,
                                        ThreadPool threadPool,
                                        Node node) {
         this.clusterService = clusterService;
-        this.queryCircuitBreaker = circuitBreakerService.getBreaker(CircuitBreaker.QUERY);
         this.responseExecutor = threadPool.executor(RESPONSE_EXECUTOR_NAME);
         this.distributedResultAction = req -> node.client().execute(DistributedResultAction.INSTANCE, req);
         this.killNodeAction = req -> node.client().execute(KillJobsNodeAction.INSTANCE, req);
@@ -127,7 +122,6 @@ public class DistributingConsumerFactory {
 
         return new DistributingConsumer(
             responseExecutor,
-            queryCircuitBreaker,
             jobId,
             multiBucketBuilder,
             nodeOperation.downstreamExecutionPhaseId(),

--- a/server/src/test/java/io/crate/execution/engine/distribution/DistributingConsumerFactoryTest.java
+++ b/server/src/test/java/io/crate/execution/engine/distribution/DistributingConsumerFactoryTest.java
@@ -29,7 +29,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
-import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 import org.elasticsearch.node.Node;
 import org.junit.Before;
 import org.junit.Test;
@@ -58,7 +57,6 @@ public class DistributingConsumerFactoryTest extends CrateDummyClusterServiceUni
     public void prepare() {
         rowDownstreamFactory = new DistributingConsumerFactory(
             clusterService,
-            new NoneCircuitBreakerService(),
             TestingHelpers.createNodeContext(),
             THREAD_POOL,
             mock(Node.class)

--- a/server/src/test/java/io/crate/execution/engine/distribution/DistributingConsumerTest.java
+++ b/server/src/test/java/io/crate/execution/engine/distribution/DistributingConsumerTest.java
@@ -38,9 +38,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
-import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
-import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.junit.After;
@@ -87,7 +85,7 @@ public class DistributingConsumerTest extends ESTestCase {
             TestingRowConsumer collectingConsumer = new TestingRowConsumer();
             DistResultRXTask distResultRXTask = createPageDownstreamContext(streamers, collectingConsumer);
             TransportDistributedResultAction distributedResultAction = createFakeTransport(streamers, distResultRXTask);
-            DistributingConsumer distributingConsumer = createDistributingConsumer(streamers, distributedResultAction, new NoopCircuitBreaker(""));
+            DistributingConsumer distributingConsumer = createDistributingConsumer(streamers, distributedResultAction);
 
             BatchSimulatingIterator<Row> batchSimulatingIterator =
                 new BatchSimulatingIterator<>(TestingBatchIterators.range(0, 5),
@@ -113,76 +111,12 @@ public class DistributingConsumerTest extends ESTestCase {
     }
 
     @Test
-    public void test_querycb_usage_taken_into_account_for_sizing_requests() throws Exception {
-        try {
-            Streamer<?>[] streamers = {DataTypes.INTEGER.streamer()};
-            TestingRowConsumer collectingConsumer = new TestingRowConsumer();
-            DistResultRXTask distResultRXTask = createPageDownstreamContext(streamers, collectingConsumer);
-            TransportDistributedResultAction distributedResultAction = createFakeTransport(streamers, distResultRXTask);
-            CircuitBreaker breaker = new CircuitBreaker() {
-                @Override
-                public double addEstimateBytesAndMaybeBreak(long bytes, String label) throws CircuitBreakingException {
-                    return 0;
-                }
-
-                @Override
-                public long addWithoutBreaking(long bytes) {
-                    return 0;
-                }
-
-                @Override
-                public long getUsed() {
-                    return Integer.MAX_VALUE;
-                }
-
-                @Override
-                public long getLimit() {
-                    return 0;
-                }
-
-                @Override
-                public long getTrippedCount() {
-                    return 0;
-                }
-
-                @Override
-                public String getName() {
-                    return "";
-                }
-            };
-            DistributingConsumer distributingConsumer = createDistributingConsumer(streamers, distributedResultAction, breaker);
-
-            BatchSimulatingIterator<Row> batchSimulatingIterator =
-                new BatchSimulatingIterator<>(TestingBatchIterators.range(0, 5),
-                    2,
-                    3,
-                    executorService);
-            distributingConsumer.accept(batchSimulatingIterator, null);
-
-            List<Object[]> result = collectingConsumer.getResult();
-            assertThat(TestingHelpers.printedTable(new CollectionBucket(result))).isEqualTo(
-                "0\n" +
-                    "1\n" +
-                    "2\n" +
-                    "3\n" +
-                    "4\n");
-
-            // CB returns MAX_INT on getUsed, every iteration leads to a push.
-            // 3 batches with pageSize 2 gives 6 pushes in total.
-            verify(distributedResultAction, times(6)).execute(any());
-        } finally {
-            executorService.shutdown();
-            executorService.awaitTermination(10, TimeUnit.SECONDS);
-        }
-    }
-
-    @Test
     public void testDistributingConsumerForwardsFailure() throws Exception {
         Streamer<?>[] streamers = { DataTypes.INTEGER.streamer() };
         TestingRowConsumer collectingConsumer = new TestingRowConsumer();
         DistResultRXTask distResultRXTask = createPageDownstreamContext(streamers, collectingConsumer);
         TransportDistributedResultAction distributedResultAction = createFakeTransport(streamers, distResultRXTask);
-        DistributingConsumer distributingConsumer = createDistributingConsumer(streamers, distributedResultAction, new NoopCircuitBreaker(""));
+        DistributingConsumer distributingConsumer = createDistributingConsumer(streamers, distributedResultAction);
 
         distributingConsumer.accept(null, new CompletionException(new IllegalArgumentException("foobar")));
 
@@ -197,7 +131,7 @@ public class DistributingConsumerTest extends ESTestCase {
         TestingRowConsumer collectingConsumer = new TestingRowConsumer();
         DistResultRXTask distResultRXTask = createPageDownstreamContext(streamers, collectingConsumer);
         TransportDistributedResultAction distributedResultAction = createFakeTransport(streamers, distResultRXTask);
-        DistributingConsumer distributingConsumer = createDistributingConsumer(streamers, distributedResultAction, new NoopCircuitBreaker(""));
+        DistributingConsumer distributingConsumer = createDistributingConsumer(streamers, distributedResultAction);
 
         distributingConsumer.accept(FailingBatchIterator.failOnAllLoaded(), null);
 
@@ -211,7 +145,7 @@ public class DistributingConsumerTest extends ESTestCase {
         TestingRowConsumer collectingConsumer = new TestingRowConsumer();
         DistResultRXTask distResultRXTask = createPageDownstreamContext(streamers, collectingConsumer);
         TransportDistributedResultAction distributedResultAction = createFakeTransport(streamers, distResultRXTask);
-        DistributingConsumer distributingConsumer = createDistributingConsumer(streamers, distributedResultAction, new NoopCircuitBreaker(""));
+        DistributingConsumer distributingConsumer = createDistributingConsumer(streamers, distributedResultAction);
 
         BatchSimulatingIterator<Row> batchSimulatingIterator =
             new BatchSimulatingIterator<>(TestingBatchIterators.range(0, 5),
@@ -230,14 +164,11 @@ public class DistributingConsumerTest extends ESTestCase {
             .isExactlyInstanceOf(CircuitBreakingException.class);
     }
 
-    private DistributingConsumer createDistributingConsumer(Streamer<?>[] streamers,
-                                                            TransportDistributedResultAction distributedResultAction,
-                                                            CircuitBreaker breaker) {
+    private DistributingConsumer createDistributingConsumer(Streamer<?>[] streamers, TransportDistributedResultAction distributedResultAction) {
         int pageSize = 2;
         RowCollectExpression rowCollectExpression = new RowCollectExpression(0);
         return new DistributingConsumer(
             executorService,
-            breaker,
             UUID.randomUUID(),
             new ModuloBucketBuilder(streamers, 1, rowCollectExpression, List.of(rowCollectExpression), RamAccounting.NO_ACCOUNTING),
             1,


### PR DESCRIPTION


This reverts commit 92844d6b71e06bf384e1ac9970a2bd43bd9d71d5.


Will re-run https://github.com/crate/crate/pull/19284#issuecomment-4288711149 and also check `hash_joins`
