### PR TITLE
Add a change entry for https://github.com/crate/crate/pull/19284

### DIFF
--- a/docs/appendices/release-notes/6.2.8.rst
+++ b/docs/appendices/release-notes/6.2.8.rst
@@ -59,3 +59,6 @@ Fixes
 - Fixed an issue that lead to a ``NullPointerException`` error on selects from
   the :ref:`sys.snapshots <sys-snapshots>` table and simultaneously deleting
   tables or partitions and running ``CREATE SNAPSHOT``
+
+- Fixed an issue that could lead to an ``OutOfMemoryError`` when running a
+  distributed query with aggregations or joins under memory pressure.

--- a/docs/appendices/release-notes/6.3.2.rst
+++ b/docs/appendices/release-notes/6.3.2.rst
@@ -73,3 +73,6 @@ Fixes
 - Fixed an issue that lead to a ``NullPointerException`` error on selects from
   the :ref:`sys.snapshots <sys-snapshots>` table and simultaneously deleting
   tables or partitions and running ``CREATE SNAPSHOT``
+
+- Fixed an issue that could lead to an ``OutOfMemoryError`` when running a
+  distributed query with aggregations or joins under memory pressure.


### PR DESCRIPTION
Add a change entry for https://github.com/crate/crate/pull/19284

Benchmarks look fine. 
There were some suspicious results for couple of queries but turned out to be a red herring, 
see https://github.com/crate/crate/pull/19342#issuecomment-4419837987
