### PR TITLE
Fix incorrect release dates

### DIFF
--- a/docs/appendices/release-notes/5.3.6.rst
+++ b/docs/appendices/release-notes/5.3.6.rst
@@ -4,7 +4,7 @@
 Version 5.3.6
 =============
 
-Released on 2023-08-011.
+Released on 2023-08-01.
 
 .. NOTE::
 

--- a/docs/appendices/release-notes/6.2.0.rst
+++ b/docs/appendices/release-notes/6.2.0.rst
@@ -4,7 +4,7 @@
 Version 6.2.0
 =============
 
-Released on 2025-01-13.
+Released on 2026-01-13.
 
 .. WARNING::
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

While looking at something else, I noticed a couple of incorrect release dates.

## Checklist

 - [ ] ~Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes~
 - [ ] ~Updated documentation & `sql_features` table for user facing changes~
 - [ ] ~Touched code is covered by tests~
 - [ ] ~This does not contain breaking changes, or if it does:~
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
