### PR TITLE
Get back default max_retries for S3 repositories

### DIFF
--- a/plugins/es-repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3RepositorySettings.java
+++ b/plugins/es-repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3RepositorySettings.java
@@ -170,7 +170,7 @@ class S3RepositorySettings {
      */
     static final Setting<Integer> MAX_RETRIES_SETTING = Setting.intSetting(
         "max_retries",
-        25,
+        3,
         0,
         Setting.Property.NodeScope);
 


### PR DESCRIPTION
S3 default is 3, see https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/constant-values.html#com.amazonaws.retry.PredefinedRetryPolicies.DEFAULT_MAX_ERROR_RETRY

Relates to https://github.com/crate/crate/pull/18961#discussion_r3196121882

Not sure I need I test here - max_retries is passed deep inside opendal, would have to expose retry in BlobStore just for the sake of testing default value logic, I think not worth it for such a trivial change
