### PR TITLE
Fix `_blobs` endpoint privileges issue

### DIFF
--- a/docs/appendices/release-notes/6.2.8.rst
+++ b/docs/appendices/release-notes/6.2.8.rst
@@ -62,3 +62,5 @@ Fixes
 
 - Fixed an issue that could lead to an ``OutOfMemoryError`` when running a
   distributed query with aggregations or joins under memory pressure.
+
+- Fixed an authorization issue for ``_blobs`` HTTP endpoint.

--- a/docs/appendices/release-notes/6.3.2.rst
+++ b/docs/appendices/release-notes/6.3.2.rst
@@ -76,3 +76,5 @@ Fixes
 
 - Fixed an issue that could lead to an ``OutOfMemoryError`` when running a
   distributed query with aggregations or joins under memory pressure.
+
+- Fixed an authorization issue for ``_blobs`` HTTP endpoint.

--- a/server/src/main/java/io/crate/protocols/http/HttpBlobHandler.java
+++ b/server/src/main/java/io/crate/protocols/http/HttpBlobHandler.java
@@ -21,6 +21,7 @@
 
 package io.crate.protocols.http;
 
+import static io.crate.protocols.SSL.getSession;
 import static io.netty.handler.codec.http.HttpResponseStatus.CONTINUE;
 import static io.netty.handler.codec.http.HttpResponseStatus.PARTIAL_CONTENT;
 import static io.netty.handler.codec.http.HttpResponseStatus.TEMPORARY_REDIRECT;
@@ -34,9 +35,12 @@ import java.util.regex.Pattern;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.http.netty4.Netty4HttpServerTransport;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.jspecify.annotations.Nullable;
 
+import io.crate.auth.Protocol;
 import io.crate.blob.BlobService;
 import io.crate.blob.RemoteDigestBlob;
 import io.crate.blob.exceptions.DigestMismatchException;
@@ -46,6 +50,13 @@ import io.crate.blob.v2.BlobIndex;
 import io.crate.blob.v2.BlobShard;
 import io.crate.blob.v2.BlobsDisabledException;
 import io.crate.exceptions.RelationUnknown;
+import io.crate.protocols.postgres.ConnectionProperties;
+import io.crate.role.Permission;
+import io.crate.role.Privileges;
+import io.crate.role.Role;
+import io.crate.role.Roles;
+import io.crate.role.Securable;
+import io.crate.session.Sessions;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.channel.Channel;
@@ -55,7 +66,6 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelProgressiveFuture;
 import io.netty.channel.ChannelProgressiveFutureListener;
 import io.netty.channel.DefaultFileRegion;
-import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.DefaultHttpResponse;
 import io.netty.handler.codec.http.HttpChunkedInput;
@@ -71,7 +81,7 @@ import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.stream.ChunkedFile;
 import io.netty.util.ReferenceCountUtil;
 
-public class HttpBlobHandler extends SimpleChannelInboundHandler<Object> {
+public class HttpBlobHandler extends HttpHandler<Object> {
 
     private static final String SCHEME_HTTP = "http://";
     private static final String SCHEME_HTTPS = "https://";
@@ -87,7 +97,6 @@ public class HttpBlobHandler extends SimpleChannelInboundHandler<Object> {
     private final Matcher blobsMatcher = BLOBS_PATTERN.matcher("");
     private final BlobService blobService;
 
-
     private HttpMethod method;
     private boolean is100ContinueExpected;
     private boolean isKeepAlive;
@@ -98,8 +107,8 @@ public class HttpBlobHandler extends SimpleChannelInboundHandler<Object> {
     private String index;
     private String digest;
 
-    public HttpBlobHandler(BlobService blobService) {
-        super(false);
+    public HttpBlobHandler(BlobService blobService, Settings settings, Sessions sessions, Roles roles) {
+        super(settings, sessions, roles);
         this.blobService = blobService;
     }
 
@@ -136,6 +145,16 @@ public class HttpBlobHandler extends SimpleChannelInboundHandler<Object> {
                 return;
             }
 
+            session = ensureSession(
+                new ConnectionProperties(
+                    null, // not used
+                    Netty4HttpServerTransport.getRemoteAddress(ctx.channel()),
+                    Protocol.HTTP,
+                    getSession(ctx.channel())
+                ),
+                request
+            );
+
             method = request.method();
             isKeepAlive = HttpUtil.isKeepAlive(request);
             is100ContinueExpected = HttpUtil.is100ContinueExpected(request);
@@ -157,15 +176,15 @@ public class HttpBlobHandler extends SimpleChannelInboundHandler<Object> {
                 LOGGER.trace("HTTPMessage:%n{}", request);
             }
             handleBlobRequest(null);
-        } else if (msg instanceof HttpContent) {
+        } else if (msg instanceof HttpContent httpContent) {
             if (method == null) {
                 // the chunk is probably from a regular non-blob request.
                 reset();
-                ctx.fireChannelRead(msg);
+                ctx.fireChannelRead(httpContent);
                 return;
             }
 
-            handleBlobRequest((HttpContent) msg);
+            handleBlobRequest(httpContent);
         } else {
             // Neither HttpMessage or HttpChunk
             reset();
@@ -173,19 +192,24 @@ public class HttpBlobHandler extends SimpleChannelInboundHandler<Object> {
         }
     }
 
-    private void handleBlobRequest(@Nullable HttpContent content) throws IOException {
+    private void handleBlobRequest(@Nullable HttpContent content) throws Exception {
         if (possibleRedirect(index, digest)) {
             return;
         }
 
+        Role user = session.sessionSettings().sessionUser();
         if (method.equals(HttpMethod.GET)) {
+            Privileges.ensureUserHasPrivilege(roles(), user, Permission.DQL, Securable.TABLE, index);
             get(index, digest);
             reset();
         } else if (method.equals(HttpMethod.HEAD)) {
+            Privileges.ensureUserHasPrivilege(roles(), user, Permission.DQL, Securable.TABLE, index);
             head(index, digest);
         } else if (method.equals(HttpMethod.PUT)) {
+            Privileges.ensureUserHasPrivilege(roles(), user, Permission.DML, Securable.TABLE, index);
             put(content, index, digest);
         } else if (method.equals(HttpMethod.DELETE)) {
+            Privileges.ensureUserHasPrivilege(roles(), user, Permission.DML, Securable.TABLE, index);
             delete(index, digest);
         } else {
             simpleResponse(HttpResponseStatus.METHOD_NOT_ALLOWED);
@@ -457,7 +481,7 @@ public class HttpBlobHandler extends SimpleChannelInboundHandler<Object> {
         }
 
         RemoteDigestBlob.Status status = digestBlob.addContent(input, last);
-        HttpResponseStatus exitStatus = null;
+        HttpResponseStatus exitStatus;
         switch (status) {
             case FULL:
                 exitStatus = HttpResponseStatus.CREATED;
@@ -481,7 +505,6 @@ public class HttpBlobHandler extends SimpleChannelInboundHandler<Object> {
                 throw new IllegalArgumentException("Unknown status: " + status);
         }
 
-        assert exitStatus != null : "exitStatus should not be null";
         LOGGER.trace("writeToFile exit status http:{} blob: {}", exitStatus, status);
         simpleResponse(exitStatus);
     }

--- a/server/src/main/java/io/crate/protocols/http/HttpHandler.java
+++ b/server/src/main/java/io/crate/protocols/http/HttpHandler.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.protocols.http;
+
+import static io.crate.auth.AuthSettings.AUTH_HOST_BASED_JWT_ISS_SETTING;
+
+import java.util.function.Predicate;
+
+import org.elasticsearch.common.settings.Settings;
+import org.jspecify.annotations.Nullable;
+
+import io.crate.auth.AuthSettings;
+import io.crate.auth.Credentials;
+import io.crate.auth.HttpAuthUpstreamHandler;
+import io.crate.common.annotations.VisibleForTesting;
+import io.crate.protocols.postgres.ConnectionProperties;
+import io.crate.role.Role;
+import io.crate.role.Roles;
+import io.crate.session.Session;
+import io.crate.session.Sessions;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpMessage;
+
+public abstract class HttpHandler<T> extends SimpleChannelInboundHandler<T> {
+
+    private static final String REQUEST_HEADER_SCHEMA = "Default-Schema";
+
+    private final Settings settings;
+    private final Sessions sessions;
+    private final Roles roles;
+    private final boolean checkJwtProperties;
+
+    @VisibleForTesting
+    Session session;
+
+    public HttpHandler(Settings settings,
+                       Sessions sessions,
+                       Roles roles) {
+        super(false);
+        this.settings = settings;
+        this.sessions = sessions;
+        this.roles = roles;
+        this.checkJwtProperties = settings.get(AUTH_HOST_BASED_JWT_ISS_SETTING.getKey()) == null;
+    }
+
+    protected Roles roles() {
+        return roles;
+    }
+
+    @Override
+    public void channelUnregistered(ChannelHandlerContext ctx) throws Exception {
+        if (session != null) {
+            session.close();
+            session = null;
+        }
+        super.channelUnregistered(ctx);
+    }
+
+    @VisibleForTesting
+    public Session ensureSession(ConnectionProperties connectionProperties, HttpMessage request) {
+        String defaultSchema = request.headers().get(REQUEST_HEADER_SCHEMA);
+        Role authenticatedUser = userFromAuthHeader(request.headers().get(HttpHeaderNames.AUTHORIZATION));
+        Session session = this.session;
+        if (session == null) {
+            session = sessions.newSession(connectionProperties, defaultSchema, authenticatedUser);
+        } else if (session.sessionSettings().authenticatedUser().equals(authenticatedUser) == false) {
+            session.close();
+            session = sessions.newSession(connectionProperties, defaultSchema, authenticatedUser);
+        }
+        this.session = session;
+        return session;
+    }
+
+    /**
+     * Doesn't do authentication as it's already done
+     * in {@link HttpAuthUpstreamHandler} which is registered before this handler
+     * Checks user existence and if not possible to resolve from header (basic or jwt),
+     * returns trusted user from configuration.
+     */
+    @VisibleForTesting
+    public Role userFromAuthHeader(@Nullable String authHeaderValue) {
+        try (Credentials credentials = Headers.extractCredentialsFromHttpAuthHeader(authHeaderValue)) {
+            Predicate<Role> rolePredicate = credentials.matchByToken(checkJwtProperties);
+            if (rolePredicate != null) {
+                Role role = roles.findUser(rolePredicate);
+                if (role != null) {
+                    credentials.setUsername(role.name());
+                }
+            }
+            String username = credentials.username();
+            // Fallback to trusted user from configuration
+            if (username == null || username.isEmpty()) {
+                username = AuthSettings.AUTH_TRUST_HTTP_DEFAULT_HEADER.get(settings);
+            }
+            return roles.findUser(username);
+        }
+    }
+}

--- a/server/src/main/java/io/crate/rest/action/SqlHttpHandler.java
+++ b/server/src/main/java/io/crate/rest/action/SqlHttpHandler.java
@@ -21,7 +21,6 @@
 
 package io.crate.rest.action;
 
-import static io.crate.auth.AuthSettings.AUTH_HOST_BASED_JWT_ISS_SETTING;
 import static io.crate.data.breaker.BlockBasedRamAccounting.MAX_BLOCK_SIZE_IN_BYTES;
 import static io.crate.protocols.SSL.getSession;
 import static io.crate.protocols.http.Headers.isCloseConnection;
@@ -35,7 +34,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
-import java.util.function.Predicate;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -50,9 +48,6 @@ import org.jspecify.annotations.Nullable;
 import io.crate.common.annotations.VisibleForTesting;
 
 import io.crate.auth.AccessControl;
-import io.crate.auth.AuthSettings;
-import io.crate.auth.Credentials;
-import io.crate.auth.HttpAuthUpstreamHandler;
 import io.crate.auth.Protocol;
 import io.crate.data.breaker.BlockBasedRamAccounting;
 import io.crate.data.breaker.RamAccounting;
@@ -61,8 +56,8 @@ import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.settings.CoordinatorSessionSettings;
 import io.crate.netty.AccountedByteBuf;
 import io.crate.protocols.http.Headers;
+import io.crate.protocols.http.HttpHandler;
 import io.crate.protocols.postgres.ConnectionProperties;
-import io.crate.role.Role;
 import io.crate.role.Roles;
 import io.crate.session.DescribeResult;
 import io.crate.session.ResultReceiver;
@@ -75,7 +70,6 @@ import io.netty.buffer.ByteBufOutputStream;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
-import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpHeaderNames;
@@ -83,16 +77,11 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.QueryStringDecoder;
 
-public class SqlHttpHandler extends SimpleChannelInboundHandler<FullHttpRequest> {
+public class SqlHttpHandler extends HttpHandler<FullHttpRequest> {
 
     private static final Logger LOGGER = LogManager.getLogger(SqlHttpHandler.class);
-    private static final String REQUEST_HEADER_SCHEMA = "Default-Schema";
 
-    private final Settings settings;
-    private final Sessions sessions;
     private final Function<String, CircuitBreaker> circuitBreakerProvider;
-    private final Roles roles;
-    private final boolean checkJwtProperties;
 
     @VisibleForTesting
     Session session;
@@ -101,12 +90,8 @@ public class SqlHttpHandler extends SimpleChannelInboundHandler<FullHttpRequest>
                           Sessions sessions,
                           Function<String, CircuitBreaker> circuitBreakerProvider,
                           Roles roles) {
-        super(false);
-        this.settings = settings;
-        this.sessions = sessions;
+        super(settings, sessions, roles);
         this.circuitBreakerProvider = circuitBreakerProvider;
-        this.roles = roles;
-        this.checkJwtProperties = settings.get(AUTH_HOST_BASED_JWT_ISS_SETTING.getKey()) == null;
     }
 
     @Override
@@ -162,15 +147,6 @@ public class SqlHttpHandler extends SimpleChannelInboundHandler<FullHttpRequest>
         return values != null && (values.equals(singletonList("")) || values.equals(singletonList("true")));
     }
 
-    @Override
-    public void channelUnregistered(ChannelHandlerContext ctx) throws Exception {
-        if (session != null) {
-            session.close();
-            session = null;
-        }
-        super.channelUnregistered(ctx);
-    }
-
     void sendResponse(CoordinatorSessionSettings sessionSettings,
                       ChannelHandlerContext ctx,
                       FullHttpRequest request,
@@ -188,7 +164,7 @@ public class SqlHttpHandler extends SimpleChannelInboundHandler<FullHttpRequest>
             // In case of partial success buffer can contain some data
             // Clearing buffer to ensure that error is not mixed with partial result.
             result.clear();
-            AccessControl accessControl = roles.getAccessControl(sessionSettings.authenticatedUser(), sessionSettings.sessionUser());
+            AccessControl accessControl = roles().getAccessControl(sessionSettings.authenticatedUser(), sessionSettings.sessionUser());
             var throwable = SQLExceptions.prepareForClientTransmission(accessControl, t);
             HttpError httpError = HttpError.fromThrowable(throwable);
             String mediaType;
@@ -246,20 +222,7 @@ public class SqlHttpHandler extends SimpleChannelInboundHandler<FullHttpRequest>
         }
     }
 
-    @VisibleForTesting
-    Session ensureSession(ConnectionProperties connectionProperties, FullHttpRequest request) {
-        String defaultSchema = request.headers().get(REQUEST_HEADER_SCHEMA);
-        Role authenticatedUser = userFromAuthHeader(request.headers().get(HttpHeaderNames.AUTHORIZATION));
-        Session session = this.session;
-        if (session == null) {
-            session = sessions.newSession(connectionProperties, defaultSchema, authenticatedUser);
-        } else if (session.sessionSettings().authenticatedUser().equals(authenticatedUser) == false) {
-            session.close();
-            session = sessions.newSession(connectionProperties, defaultSchema, authenticatedUser);
-        }
-        this.session = session;
-        return session;
-    }
+
 
     private CompletableFuture<XContentBuilder> executeSimpleRequest(Session session,
                                                                     ByteBuf resultBuffer,
@@ -313,7 +276,7 @@ public class SqlHttpHandler extends SimpleChannelInboundHandler<FullHttpRequest>
             }
         }
         var sessionSettings = session.sessionSettings();
-        AccessControl accessControl = roles.getAccessControl(sessionSettings.authenticatedUser(), sessionSettings.sessionUser());
+        AccessControl accessControl = roles().getAccessControl(sessionSettings.authenticatedUser(), sessionSettings.sessionUser());
         return session.sync(true)
             .thenApply(_ -> {
                 try {
@@ -330,30 +293,6 @@ public class SqlHttpHandler extends SimpleChannelInboundHandler<FullHttpRequest>
                     throw new RuntimeException(e);
                 }
             });
-    }
-
-    /**
-     * Doesn't do authentication as it's already done
-     * in {@link HttpAuthUpstreamHandler} which is registered before this handler
-     * Checks user existence and if not possible to resolve from header (basic or jwt),
-     * returns trusted user from configuration.
-     */
-    Role userFromAuthHeader(@Nullable String authHeaderValue) {
-        try (Credentials credentials = Headers.extractCredentialsFromHttpAuthHeader(authHeaderValue)) {
-            Predicate<Role> rolePredicate = credentials.matchByToken(checkJwtProperties);
-            if (rolePredicate != null) {
-                Role role = roles.findUser(rolePredicate);
-                if (role != null) {
-                    credentials.setUsername(role.name());
-                }
-            }
-            String username = credentials.username();
-            // Fallback to trusted user from configuration
-            if (username == null || username.isEmpty()) {
-                username = AuthSettings.AUTH_TRUST_HTTP_DEFAULT_HEADER.get(settings);
-            }
-            return roles.findUser(username);
-        }
     }
 
     private static boolean bothProvided(@Nullable List<Object> args, @Nullable List<List<Object>> bulkArgs) {

--- a/server/src/main/java/org/elasticsearch/http/netty4/Netty4HttpServerTransport.java
+++ b/server/src/main/java/org/elasticsearch/http/netty4/Netty4HttpServerTransport.java
@@ -600,7 +600,13 @@ public class Netty4HttpServerTransport extends AbstractLifecycleComponent implem
             aggregator.setMaxCumulationBufferComponents(transport.maxCompositeBufferComponents);
             pipeline.addLast("chunked", new ChunkedWriteHandler());
             pipeline.addLast("auth_handler", new HttpAuthUpstreamHandler(settings, authentication, roles));
-            pipeline.addLast("blob_handler", new HttpBlobHandler(blobService));
+            pipeline.addLast("blob_handler", new HttpBlobHandler(
+                blobService,
+                settings,
+                sessions,
+                roles
+            ));
+
             pipeline.addLast("aggregator", aggregator);
             if (transport.compression) {
                 pipeline.addLast("encoder_compress", new HttpContentCompressor(transport.compressionLevel));

--- a/server/src/test/java/io/crate/integrationtests/BlobHttpIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/BlobHttpIntegrationTest.java
@@ -33,6 +33,7 @@ import java.net.http.HttpRequest.BodyPublishers;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
@@ -49,6 +50,8 @@ import org.junit.Before;
 import io.crate.blob.BlobTransferStatus;
 import io.crate.blob.BlobTransferTarget;
 import io.crate.common.concurrent.CompletableFutures;
+import io.crate.role.Role;
+import io.netty.handler.codec.http.HttpHeaderNames;
 
 public abstract class BlobHttpIntegrationTest extends BlobIntegrationTestBase {
 
@@ -74,15 +77,21 @@ public abstract class BlobHttpIntegrationTest extends BlobIntegrationTestBase {
         Iterable<HttpServerTransport> transports = cluster().getDataNodeInstances(HttpServerTransport.class);
         Iterator<HttpServerTransport> httpTransports = transports.iterator();
         dataNode1 = httpTransports.next().boundAddress().publishAddress().address();
-        dataNode2 = httpTransports.next().boundAddress().publishAddress().address();
+        if (httpTransports.hasNext()) {
+            dataNode2 = httpTransports.next().boundAddress().publishAddress().address();
+        } else {
+            dataNode2 = dataNode1;
+        }
         execute("create blob table test clustered into 2 shards with (number_of_replicas = 0)");
         execute("create blob table test_blobs2 clustered into 2 shards with (number_of_replicas = 0)");
         execute("create table test_no_blobs (x int) clustered into 2 shards with (number_of_replicas = 0)");
+        execute("CREATE USER john with password 'passwd'");
         ensureGreen();
     }
 
     @After
     public void closeClient() throws Exception {
+        execute("DROP USER john");
         if (httpClient != null) {
             httpClient.close();
         }
@@ -120,7 +129,12 @@ public abstract class BlobHttpIntegrationTest extends BlobIntegrationTestBase {
     }
 
     protected HttpResponse<String> put(URI uri, String body) throws Exception {
+        return put(uri, body, Role.CRATE_USER);
+    }
+
+    protected HttpResponse<String> put(URI uri, String body, Role user) throws Exception {
         HttpRequest request = HttpRequest.newBuilder(uri)
+            .header(HttpHeaderNames.AUTHORIZATION.toString(), getAuth(user))
             .PUT(BodyPublishers.ofString(body))
             .build();
         HttpResponse<String> response = httpClient.send(request, BodyHandlers.ofString());
@@ -129,11 +143,17 @@ public abstract class BlobHttpIntegrationTest extends BlobIntegrationTestBase {
     }
 
     protected HttpResponse<String> get(String index, String digest) throws Exception {
-        return get(blobUri(index, digest));
+        return get(blobUri(index, digest), Role.CRATE_USER);
     }
 
     protected HttpResponse<String> get(URI uri) throws Exception {
+        return get(uri, Role.CRATE_USER);
+    }
+
+    protected HttpResponse<String> get(URI uri, Role user) throws Exception {
         HttpRequest request = HttpRequest.newBuilder(uri)
+            .header(HttpHeaderNames.AUTHORIZATION.toString(), getAuth(user))
+            .GET()
             .build();
         return httpClient.send(request, BodyHandlers.ofString());
     }
@@ -157,14 +177,23 @@ public abstract class BlobHttpIntegrationTest extends BlobIntegrationTestBase {
         }
     }
 
-
-    protected HttpResponse<Void> head(URI uri) throws Exception {
-        HttpRequest request = HttpRequest.newBuilder(uri).HEAD().build();
+    protected HttpResponse<Void> head(URI uri, Role user) throws Exception {
+        HttpRequest request = HttpRequest.newBuilder(uri)
+            .header(HttpHeaderNames.AUTHORIZATION.toString(), getAuth(user))
+            .HEAD()
+            .build();
         return httpClient.send(request, BodyHandlers.discarding());
     }
 
     protected HttpResponse<Void> delete(URI uri) throws Exception {
-        HttpRequest request = HttpRequest.newBuilder(uri).DELETE().build();
+        return delete(uri, Role.CRATE_USER);
+    }
+
+    protected HttpResponse<Void> delete(URI uri, Role user) throws Exception {
+        HttpRequest request = HttpRequest.newBuilder(uri)
+            .header(HttpHeaderNames.AUTHORIZATION.toString(), getAuth(user))
+            .DELETE()
+            .build();
         return httpClient.send(request, BodyHandlers.discarding());
     }
 
@@ -186,4 +215,10 @@ public abstract class BlobHttpIntegrationTest extends BlobIntegrationTestBase {
         return getRedirectLocations(httpClient, URI.create(url)).size();
     }
 
+    private static String getAuth(Role user) {
+        String secretKey = user.name() + ":passwd";
+        byte[] tokenBytes = secretKey.getBytes();
+        String token64 = Base64.getEncoder().encodeToString(tokenBytes);
+        return "Basic " + token64;
+    }
 }

--- a/server/src/test/java/io/crate/integrationtests/BlobIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/BlobIntegrationTest.java
@@ -54,6 +54,7 @@ import org.junit.Test;
 import io.crate.blob.v2.BlobIndicesService;
 import io.crate.blob.v2.BlobShard;
 import io.crate.metadata.RelationName;
+import io.crate.role.Role;
 import io.netty.handler.codec.http.HttpHeaderNames;
 
 @IntegTestCase.ClusterScope(scope = IntegTestCase.Scope.SUITE, numDataNodes = 2)
@@ -159,7 +160,7 @@ public class BlobIntegrationTest extends BlobHttpIntegrationTest {
     @Test
     public void testHeadRequest() throws Exception {
         String digest = uploadSmallBlob();
-        var res = head(blobUri(digest));
+        var res = head(blobUri(digest), Role.CRATE_USER);
         assertThat(res.headers().firstValue("Content-Length")).hasValue("1500");
         assertThat(res.headers().firstValue("Accept-Ranges")).hasValue("bytes");
         assertThat(res.headers().firstValue("Expires")).hasValue("Thu, 31 Dec 2037 23:59:59 GMT");

--- a/server/src/test/java/io/crate/integrationtests/BlobPrivilegesIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/BlobPrivilegesIntegrationTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.integrationtests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+
+import org.elasticsearch.test.IntegTestCase;
+import org.junit.Test;
+
+import io.crate.role.Role;
+import io.crate.role.metadata.RolesHelper;
+
+// Because of https://github.com/crate/crate/issues/19335 if more nodes exist in the cluster
+// a possible redirect will remove the basic auth headers and make the test flaky, as it leads
+// to using default "crate" user when no user is extracted from the headers
+@IntegTestCase.ClusterScope(scope = IntegTestCase.Scope.SUITE, numDataNodes = 1, supportsDedicatedMasters = false, numClientNodes = 0)
+@WindowsIncompatible
+public class BlobPrivilegesIntegrationTest extends BlobHttpIntegrationTest {
+
+    @Test
+    public void test_missing_privileges() throws Exception {
+        Role john = RolesHelper.userOf("john");
+        String digest = "c520e6109835c876fd98636efec43dd61634b7d3";
+        URI uri = blobUri("test", digest);
+        String body = "a".repeat(1500);
+
+        var response = get(uri, john);
+        assertThat(response.statusCode()).isEqualTo(500);
+        assertThat(response.body()).isEqualTo("Schema 'blob' unknown");
+
+        var response2 = head(uri, john);
+        assertThat(response2.statusCode()).isEqualTo(500);
+
+        var response3 = put(uri, body, john);
+        assertThat(response3.statusCode()).isEqualTo(500);
+        assertThat(response3.body()).isEqualTo("Schema 'blob' unknown");
+
+        var response4 = delete(uri, john);
+        assertThat(response4.statusCode()).isEqualTo(500);
+    }
+}
+

--- a/server/src/test/java/io/crate/protocols/http/HttpBlobHandlerTest.java
+++ b/server/src/test/java/io/crate/protocols/http/HttpBlobHandlerTest.java
@@ -31,8 +31,10 @@ import static org.mockito.Mockito.when;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 
-import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.common.settings.Settings;
+import org.jspecify.annotations.Nullable;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Answers;
@@ -42,6 +44,12 @@ import io.crate.blob.BlobService;
 import io.crate.blob.RemoteDigestBlob;
 import io.crate.blob.exceptions.MissingHTTPEndpointException;
 import io.crate.blob.v2.BlobShard;
+import io.crate.metadata.settings.CoordinatorSessionSettings;
+import io.crate.protocols.postgres.ConnectionProperties;
+import io.crate.role.Role;
+import io.crate.session.Session;
+import io.crate.session.Sessions;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
@@ -53,13 +61,13 @@ import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpVersion;
 
-public class HttpBlobHandlerTest extends ESTestCase {
+public class HttpBlobHandlerTest extends CrateDummyClusterServiceUnitTest {
 
     private static final String VALID_DIGEST = "a".repeat(40);
     private static final String BLOB_URI = "/_blobs/mytable/" + VALID_DIGEST;
 
     // An instance for cases where it returns some data and doesn't throw.
-    private BlobService blobService = mock(BlobService.class);
+    private final BlobService blobService = mock(BlobService.class);
     private EmbeddedChannel embeddedChannel;
 
     @Before
@@ -71,8 +79,7 @@ public class HttpBlobHandlerTest extends ESTestCase {
         BlobContainer container = new BlobContainer(tmpDirPath);
         when(blobService.localBlobShard(anyString(), anyString())).thenReturn(blobShard);
         when(blobShard.blobContainer()).thenReturn(container);
-
-        embeddedChannel = new EmbeddedChannel(new HttpBlobHandler(blobService));
+        embeddedChannel = createEmbeddedChannel(blobService);
     }
 
     @Test
@@ -90,7 +97,7 @@ public class HttpBlobHandlerTest extends ESTestCase {
         when(blobService.getRedirectAddress(anyString(), anyString()))
             .thenThrow(new MissingHTTPEndpointException("dummy"));
 
-        EmbeddedChannel channel = new EmbeddedChannel(new HttpBlobHandler(blobService));
+        EmbeddedChannel channel = createEmbeddedChannel(blobService);
         FullHttpRequest req = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, BLOB_URI);
         channel.writeInbound(req);
         assertThat(req.refCnt()).isEqualTo(0);
@@ -102,7 +109,7 @@ public class HttpBlobHandlerTest extends ESTestCase {
         when(blobService.getRedirectAddress(anyString(), anyString()))
             .thenReturn("dummy");
 
-        EmbeddedChannel channel = new EmbeddedChannel(new HttpBlobHandler(blobService));
+        EmbeddedChannel channel = createEmbeddedChannel(blobService);
         FullHttpRequest req = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, BLOB_URI);
         channel.writeInbound(req);
         assertThat(req.refCnt()).isEqualTo(0);
@@ -140,7 +147,7 @@ public class HttpBlobHandlerTest extends ESTestCase {
 
         FullHttpRequest req = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, BLOB_URI);
         req.headers().set(io.netty.handler.codec.http.HttpHeaderNames.RANGE, "bytes=1-3");
-        EmbeddedChannel channel = new EmbeddedChannel(new HttpBlobHandler(blobService));
+        EmbeddedChannel channel = createEmbeddedChannel(blobService);
         try {
             channel.writeInbound(req);
         } catch (Exception ignored) {
@@ -164,7 +171,7 @@ public class HttpBlobHandlerTest extends ESTestCase {
         when(blobService.localBlobShard(anyString(), anyString())).thenThrow(new RuntimeException("dummy"));
 
         FullHttpRequest req = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, BLOB_URI);
-        EmbeddedChannel channel = new EmbeddedChannel(new HttpBlobHandler(blobService));
+        EmbeddedChannel channel = createEmbeddedChannel(blobService);
         try {
             channel.writeInbound(req);
         } catch (Exception ignored) {
@@ -183,7 +190,7 @@ public class HttpBlobHandlerTest extends ESTestCase {
         when(blobShard.blobContainer().getFile(anyString()).length()).thenReturn(0L);
 
         FullHttpRequest req = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.HEAD, BLOB_URI);
-        EmbeddedChannel channel = new EmbeddedChannel(new HttpBlobHandler(blobService));
+        EmbeddedChannel channel = createEmbeddedChannel(blobService);
         channel.writeInbound(req);
         assertThat(req.refCnt()).isEqualTo(0);
     }
@@ -197,7 +204,7 @@ public class HttpBlobHandlerTest extends ESTestCase {
         when(blobShard.blobContainer().getFile(anyString()).length()).thenReturn(1L);
 
         FullHttpRequest req = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.HEAD, BLOB_URI);
-        EmbeddedChannel channel = new EmbeddedChannel(new HttpBlobHandler(blobService));
+        EmbeddedChannel channel = createEmbeddedChannel(blobService);
         channel.writeInbound(req);
         assertThat(req.refCnt()).isEqualTo(0);
     }
@@ -279,11 +286,39 @@ public class HttpBlobHandlerTest extends ESTestCase {
         assertThat(req.refCnt()).isEqualTo(0);
     }
 
-
     @Test
     public void test_unsupported_method_does_not_leak_request() throws Throwable {
         FullHttpRequest req = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.PATCH, BLOB_URI);
         embeddedChannel.writeInbound(req);
         assertThat(req.refCnt()).isEqualTo(0);
+    }
+
+    private EmbeddedChannel createEmbeddedChannel(BlobService blobService) {
+        Role crate = Role.CRATE_USER;
+        var sessionSettings = new CoordinatorSessionSettings(crate);
+        var mockedSessions = new Sessions(null, null, null, () -> null, null, Settings.EMPTY, clusterService, null) {
+            @Override
+            public Session newSession(ConnectionProperties connectionProperties, @Nullable String defaultSchema, Role authenticatedUser) {
+                return new Session(
+                    111,
+                    connectionProperties,
+                    null,
+                    null,
+                    null,
+                    false,
+                    null,
+                    sessionSettings,
+                    () -> {},
+                    1,
+                    100);
+            }
+        };
+
+        return new EmbeddedChannel(new HttpBlobHandler(
+            blobService,
+            Settings.EMPTY,
+            mockedSessions,
+            () -> List.of(Role.CRATE_USER)
+        ));
     }
 }


### PR DESCRIPTION
Although CREATE/DROP/SELECT statements for blob tables validate privileges, when accessing blobs through HTTP via `_blobs` endpoint no privileges check took place. Add an abstract HttpHandler class which extracts the authenticated user (basic auth or jwt) from the request and is used both for SQLHandler but now also for HttpBlobHandler to validate proper privileges are set to the user for the blob table.

(cherry picked from commit c8a0dccdbb3d01f1818190c2ed5cf6654f77eb6b)
