### PR TITLE
Compile scalar in check of generated column only once for bulk inserts

### DIFF
--- a/docs/appendices/release-notes/6.4.0.rst
+++ b/docs/appendices/release-notes/6.4.0.rst
@@ -97,6 +97,9 @@ Scalar and Aggregation Functions
 Performance and Resilience Improvements
 ---------------------------------------
 
+- Improved the performance of bulk insert operations against tables that use
+  user defined functions in a generated column which also has check constraints.
+
 - Increased the default queue size of the ``write`` search pool but lowered the
   amount of internal retries for ``INSERT INTO <table> VALUES`` statements in
   exchange. This should lower the load for bulk inserts into tables with many

--- a/server/src/main/java/io/crate/execution/dml/Indexer.java
+++ b/server/src/main/java/io/crate/execution/dml/Indexer.java
@@ -59,8 +59,6 @@ import io.crate.expression.InputFactory.Context;
 import io.crate.expression.reference.Doc;
 import io.crate.expression.reference.ReferenceResolver;
 import io.crate.expression.symbol.DynamicReference;
-import io.crate.expression.symbol.Literal;
-import io.crate.expression.symbol.RefReplacer;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.Symbols;
 import io.crate.metadata.ColumnIdent;
@@ -144,12 +142,18 @@ public class Indexer {
         private final List<Reference> targetColumns;
         private final DocTableInfo table;
         private final SymbolEvaluator symbolEval;
+        private final InputFactory inputFactory;
+        private final TransactionContext txnCtx;
 
-        private RefResolver(SymbolEvaluator symbolEval,
+        private RefResolver(InputFactory inputFactory,
+                            SymbolEvaluator symbolEval,
+                            TransactionContext txnCtx,
                             List<String> partitionValues,
                             List<Reference> targetColumns,
                             DocTableInfo table) {
+            this.inputFactory = inputFactory;
             this.symbolEval = symbolEval;
+            this.txnCtx = txnCtx;
             this.partitionValues = partitionValues;
             this.targetColumns = targetColumns;
             this.table = table;
@@ -216,9 +220,7 @@ public class Indexer {
                 Symbol defaultExpression = ref.defaultExpression();
                 if (defaultExpression == null) {
                     if (ref instanceof GeneratedReference generated) {
-                        return NestableCollectExpression.forFunction(
-                            item -> fromGenerated(generated, item)
-                        );
+                        return fromGenerated(generated);
                     }
                     return NestableCollectExpression.constant(null);
                 }
@@ -238,14 +240,18 @@ public class Indexer {
             if (rootIndex == -1) {
                 return NestableCollectExpression.constant(null);
             }
+            CollectExpression<IndexItem, Object> fromGenerated = ref instanceof GeneratedReference generated
+                ? fromGenerated(generated)
+                : null;
             Function<IndexItem, Object> getValue = item -> {
                 Object val = Maps.getByPath(item.insertValues()[rootIndex], column.path());
                 if (val == null) {
                     Symbol defaultExpression = ref.defaultExpression();
                     if (defaultExpression != null) {
                         val = defaultExpression.accept(symbolEval, Row.EMPTY).value();
-                    } else if (ref instanceof GeneratedReference generated) {
-                        return fromGenerated(generated, item);
+                    } else if (fromGenerated != null) {
+                        fromGenerated.setNextRow(item);
+                        return fromGenerated.value();
                     }
                 }
                 return val;
@@ -253,14 +259,24 @@ public class Indexer {
             return NestableCollectExpression.forFunction(getValue);
         }
 
-        private Object fromGenerated(GeneratedReference generated, IndexItem item) {
-            Symbol generatedExpression = RefReplacer.replaceRefs(generated.generatedExpression(), x -> {
-                var collectExpression = getImplementation(x);
-                collectExpression.setNextRow(item);
-                return Literal.ofUnchecked(x.valueType(), collectExpression.value());
-            });
-            Input<?> accept = generatedExpression.accept(symbolEval, Row.EMPTY);
-            return accept.value();
+        private CollectExpression<IndexItem, Object> fromGenerated(GeneratedReference generated) {
+            Context<CollectExpression<IndexItem, Object>> ctx = inputFactory.ctxForRefs(txnCtx, this);
+            final List<CollectExpression<IndexItem, Object>> expressions = ctx.expressions();
+            final Input<?> input = ctx.add(generated.generatedExpression());
+            return new CollectExpression<>() {
+
+                @Override
+                public Object value() {
+                    return input.value();
+                }
+
+                @Override
+                public void setNextRow(IndexItem row) {
+                    for (var expr : expressions) {
+                        expr.setNextRow(row);
+                    }
+                }
+            };
         }
     }
 
@@ -498,7 +514,7 @@ public class Indexer {
         this.getRef = table::getReference;
         InputFactory inputFactory = new InputFactory(nodeCtx);
         SymbolEvaluator symbolEval = new SymbolEvaluator(txnCtx, nodeCtx, SubQueryResults.EMPTY);
-        var referenceResolver = new RefResolver(symbolEval, partitionValues, columns, table);
+        var referenceResolver = new RefResolver(inputFactory, symbolEval, txnCtx, partitionValues, columns, table);
         Context<CollectExpression<IndexItem, Object>> ctxForRefs = inputFactory.ctxForRefs(
             txnCtx,
             referenceResolver
@@ -1059,7 +1075,7 @@ public class Indexer {
                                                             List<Reference> targetColumns) {
         var symbolEval = new SymbolEvaluator(txnCtx, nodeCtx, SubQueryResults.EMPTY);
         InputFactory inputFactory = new InputFactory(nodeCtx);
-        var referenceResolver = new RefResolver(symbolEval, partitionValues, targetColumns, table);
+        var referenceResolver = new RefResolver(inputFactory, symbolEval, txnCtx, partitionValues, targetColumns, table);
         Context<CollectExpression<IndexItem, Object>> ctxForRefs = inputFactory.ctxForRefs(
             txnCtx,
             referenceResolver


### PR DESCRIPTION
In a case like:

    create table udf_gen (
      id int primary key,
      value bigint,
      x generated always as foo(value) check (foo(x) > 0)
    ) with (number_of_replicas = 0)

We used `SymbolEvaluator` to evaluate the UDF in INSERT INTO statements - this caused the scalar
instance to be created and compiled once per row. Creating the Polyglot
context is rather expensive.

This changes the generated ref evaluation to use the `InputFactory` to
allow re-using the compiled scalar instance across rows.

    Q: insert into udf_gen ("id", "value") values ($1, $2)
    C: 1
    | Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
    |   V1    |      166.488 ±   98.442 |     66.030 |    133.647 |    246.452 |    709.610 |
    |   V2    |        4.325 ±    5.804 |      2.548 |      3.371 |      4.022 |    157.190 |
    ├---------┴-------------------------┴------------┴------------┴------------┴------------┘
    |               - 189.87%                           - 190.16%
    There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 189.87%
    The test has statistical significance

    System/JVM Metrics (durations in ms, byte-values in MB)
        |    YOUNG GC            |       OLD GC           |      HEAP         |     ALLOC
        |  cnt      avg      max |  cnt      avg      max |  initial     used |     rate      total
     V1 |  438    16.10    16.41 |  125   178.52   223.91 |     2147     1748 |  1458.28     112436
     V2 |    9    15.43    12.85 |    1     8.98     8.98 |     2147      261 |  1533.59       9884
