### PR TITLE
Remove misleading comment in GenericFunctionQuery#visit

### DIFF
--- a/server/src/main/java/io/crate/lucene/GenericFunctionQuery.java
+++ b/server/src/main/java/io/crate/lucene/GenericFunctionQuery.java
@@ -174,7 +174,6 @@ public class GenericFunctionQuery extends Query implements Accountable {
 
     @Override
     public void visit(QueryVisitor visitor) {
-        // Used by the RamUsageQueryVisitor.
         visitor.visitLeaf(this);
     }
 


### PR DESCRIPTION
The comment gives the impression that there's something special about
the ram usage case, but it is merely implementing `visit` according to
the interface and also used in other cases (e.g. to get the accurate
clauses count if used within a BooleanQuery).

And if the GenericFunctionQuery is the top-level query, ram accounting
via `RamUsageEstimator.sizeOf(Query)` isn't even hitting the visitor -
it's only used if GenericFunctionQuery is nested within other queries.