### PR TITLE
Report snapshot restore shard failures during `RESTORE SNAPSHOT`

### DIFF
--- a/docs/appendices/release-notes/6.3.3.rst
+++ b/docs/appendices/release-notes/6.3.3.rst
@@ -50,3 +50,6 @@ Fixes
   parsing failure instead of returning empty statement results when executed via
   the simple mode of the PostgreSQL wire protocol.
 
+- Fixed an issue that caused :ref:`RESTORE SNAPSHOT <sql-restore-snapshot>` to
+  return ``RESTORE OK`` even if some shards failed to restore (for example, due
+  to exceeded disk watermarks). It now fails with a ``SnapshotRestoreException``.

--- a/server/src/main/java/io/crate/planner/node/ddl/RestoreSnapshotPlan.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/RestoreSnapshotPlan.java
@@ -32,6 +32,8 @@ import org.elasticsearch.action.admin.cluster.snapshots.restore.TableOrPartition
 import org.elasticsearch.action.admin.cluster.snapshots.restore.TransportRestoreSnapshot;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.snapshots.SnapshotRestoreException;
+
 import io.crate.common.annotations.VisibleForTesting;
 
 import io.crate.analyze.AnalyzedRestoreSnapshot;
@@ -127,7 +129,20 @@ public class RestoreSnapshotPlan implements Plan {
             stmt.globalSettings()
         );
         dependencies.client().execute(TransportRestoreSnapshot.ACTION, request)
-            .whenComplete(new OneRowActionListener<>(consumer, r -> new Row1(r == null ? -1L : 1L)));
+            .whenComplete(new OneRowActionListener<>(consumer, response -> {
+                if (response == null) {
+                    return new Row1(-1L);
+                }
+                var restoreInfo = response.getRestoreInfo();
+                if (restoreInfo != null && restoreInfo.failedShards() > 0) {
+                    throw new SnapshotRestoreException(
+                        restoreSnapshot.repository(),
+                        restoreSnapshot.snapshot(),
+                        "failed to restore " + restoreInfo.failedShards() + " of " + restoreInfo.totalShards() + " shards"
+                    );
+                }
+                return new Row1(1L);
+            }));
     }
 
     @VisibleForTesting

--- a/server/src/test/java/org/elasticsearch/snapshots/AbortedRestoreIT.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/AbortedRestoreIT.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.snapshots;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -105,7 +106,9 @@ public class AbortedRestoreIT extends AbstractSnapshotIntegTestCase {
         logger.info("--> unblocking repository [{}]", repositoryName);
         unblockAllDataNodes(repositoryName);
 
-        future.get();
+        assertThatThrownBy(future::get)
+            .hasCauseInstanceOf(SnapshotRestoreException.class)
+            .hasMessageContaining("[repo:snap1] failed to restore 1 of 1 shards");
 
         logger.info("--> waiting for snapshot thread pool to be empty");
         waitForMaxActiveSnapshotThreads(dataNode, 0);


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes https://github.com/crate/crate/issues/19336.

When `RESTORE SNAPSHOT` cannot allocate restored shards because disk threshold rejecting shard allocation, it must report the failure to the user instead of returning `RESTORE OK`:
```sql
RESTORE SNAPSHOT repo.snap ALL WITH (wait_for_completion = true);

SnapshotRestoreException[[repo:snap] failed to restore 8 of 8 shards]
```

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
