### PR TITLE
Fix IndexName decode error on sys.allocation queries

### DIFF
--- a/docs/appendices/release-notes/6.2.8.rst
+++ b/docs/appendices/release-notes/6.2.8.rst
@@ -49,6 +49,9 @@ series.
 Fixes
 =====
 
+- Fixed an issue that could cause queries against ``sys.allocations`` to fail if
+  concurrently resizing the shards of a table.
+
 - Fixed a performance regression introduced in 6.0.0 that could cause ``INSERT
   INTO <table> VALUES (...)`` bulk statements that hit many shards to be less
   aggressive than possible, taking longer than necessary.

--- a/docs/appendices/release-notes/6.3.2.rst
+++ b/docs/appendices/release-notes/6.3.2.rst
@@ -46,6 +46,9 @@ series.
 Fixes
 =====
 
+- Fixed an issue that could cause queries against ``sys.allocations`` to fail if
+  concurrently resizing the shards of a table.
+
 - Fixed a performance regression introduced in 6.0.0 that could cause ``INSERT
   INTO <table> VALUES (...)`` bulk statements that hit many shards to be less
   aggressive than possible, taking longer than necessary.

--- a/server/src/main/java/io/crate/execution/ddl/tables/AlterTableClient.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/AlterTableClient.java
@@ -75,8 +75,6 @@ import io.crate.sql.tree.GenericProperties;
 @Singleton
 public class AlterTableClient {
 
-    public static final String RESIZE_PREFIX = ".resized.";
-
     private static final Logger LOGGER = LogManager.getLogger(AlterTableClient.class);
 
     private final ClusterService clusterService;

--- a/server/src/main/java/io/crate/metadata/IndexName.java
+++ b/server/src/main/java/io/crate/metadata/IndexName.java
@@ -30,9 +30,9 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.indices.InvalidIndexNameException;
 import org.jspecify.annotations.Nullable;
-import io.crate.common.annotations.VisibleForTesting;
 
 import io.crate.blob.v2.BlobIndex;
+import io.crate.common.annotations.VisibleForTesting;
 import io.crate.metadata.blob.BlobSchemaInfo;
 import io.crate.metadata.doc.DocSchemaInfo;
 
@@ -42,6 +42,7 @@ public final class IndexName {
     private static final DeprecationLogger DEPRECATION_LOGGER = new DeprecationLogger(LOGGER);
     private static final String PARTITIONED_KEY_WORD = "partitioned";
 
+    public static final String RESIZE_PREFIX = ".resized.";
     public static final int MAX_INDEX_NAME_BYTES = 255;
 
     private IndexName() {}
@@ -120,7 +121,12 @@ public final class IndexName {
                 assertPartitionPrefix(parts[2]);
                 yield new IndexParts(parts[0], parts[3], parts[4]);
             }
-            default -> throw new IllegalArgumentException("Invalid index name: " + indexName);
+            default -> {
+                if (indexName.startsWith(RESIZE_PREFIX)) {
+                    yield decode(indexName.substring(RESIZE_PREFIX.length()));
+                }
+                throw new IllegalArgumentException("Invalid index name: " + indexName);
+            }
         };
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
@@ -84,11 +84,11 @@ import org.elasticsearch.indices.ShardLimitValidator;
 
 import io.crate.common.collections.Lists;
 import io.crate.common.unit.TimeValue;
-import io.crate.execution.ddl.tables.AlterTableClient;
 import io.crate.execution.ddl.tables.CreateBlobTableRequest;
 import io.crate.execution.ddl.tables.CreateTableResponse;
 import io.crate.execution.ddl.tables.MappingUtil;
 import io.crate.metadata.DocReferences;
+import io.crate.metadata.IndexName;
 import io.crate.metadata.IndexReference;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.PartitionName;
@@ -419,7 +419,7 @@ public class MetadataCreateIndexService {
                 }
             }
 
-            String resizedIndexName = AlterTableClient.RESIZE_PREFIX + sourceIndex.getIndex().getName();
+            String resizedIndexName = IndexName.RESIZE_PREFIX + sourceIndex.getIndex().getName();
             IndexMetadata.Builder tmpImdBuilder = IndexMetadata.builder(resizedIndexUUID)
                 .indexName(resizedIndexName)
                 .settings(indexSettingsBuilder)

--- a/server/src/test/java/io/crate/metadata/IndexPartsTest.java
+++ b/server/src/test/java/io/crate/metadata/IndexPartsTest.java
@@ -83,4 +83,12 @@ public class IndexPartsTest {
         assertThat(IndexName.isDangling(".shrinked.schema..partitioned.t.ident")).isTrue();
     }
 
+    @Test
+    public void test_can_decode_resized_index() throws Exception {
+        String indexName = IndexName.encode("s1", "tbl", "pident1");
+        IndexParts parts = IndexName.decode(IndexName.RESIZE_PREFIX + indexName);
+        assertThat(parts.schema()).isEqualTo("s1");
+        assertThat(parts.table()).isEqualTo("tbl");
+        assertThat(parts.partitionIdent()).isEqualTo("pident1");
+    }
 }


### PR DESCRIPTION
`testNumberOfShardsOfAPartitionCanBeIncreased` was flaky and could fail with:

    io.crate.exceptions.SQLParseException: Invalid index name: .resized.m..partitioned.tbl.04132
    [...]
    at java.base/java.lang.Thread.run(Thread.java:1516)
    Caused by: java.lang.IllegalArgumentException: Invalid index name: .resized.m..partitioned.tbl.04132
      at io.crate.metadata.IndexName.decode(IndexName.java:123)
      at io.crate.expression.reference.sys.shard.SysAllocations.createSysAllocations(SysAllocations.java:101)
      at io.crate.expression.reference.sys.shard.SysAllocations.lambda$iterator$0(SysAllocations.java:83)
