### PR TITLE
Fix close-connection handling on missing privilege response for blobs

### DIFF
--- a/server/src/main/java/io/crate/protocols/http/HttpBlobHandler.java
+++ b/server/src/main/java/io/crate/protocols/http/HttpBlobHandler.java
@@ -49,8 +49,11 @@ import io.crate.blob.exceptions.MissingHTTPEndpointException;
 import io.crate.blob.v2.BlobIndex;
 import io.crate.blob.v2.BlobShard;
 import io.crate.blob.v2.BlobsDisabledException;
+import io.crate.exceptions.MissingPrivilegeException;
 import io.crate.exceptions.RelationUnknown;
+import io.crate.exceptions.SchemaUnknownException;
 import io.crate.protocols.postgres.ConnectionProperties;
+import io.crate.rest.action.HttpErrorStatus;
 import io.crate.role.Permission;
 import io.crate.role.Privileges;
 import io.crate.role.Role;
@@ -76,6 +79,7 @@ import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpUtil;
+import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.stream.ChunkedFile;
@@ -187,7 +191,6 @@ public class HttpBlobHandler extends HttpHandler<Object> {
                 ctx.fireChannelRead(httpContent);
                 return;
             }
-
             handleBlobRequest(httpContent);
         } else {
             // Neither HttpMessage or HttpChunk
@@ -218,6 +221,18 @@ public class HttpBlobHandler extends HttpHandler<Object> {
             } else {
                 simpleResponse(HttpResponseStatus.METHOD_NOT_ALLOWED);
             }
+        } catch (MissingPrivilegeException | SchemaUnknownException | RelationUnknown e) {
+            String message = e.getMessage();
+            ByteBuf responseMsg = ByteBufUtil.writeUtf8(ctx.alloc(), message);
+            HttpErrorStatus httpErrorStatus = e.httpErrorStatus();
+            var response = new DefaultFullHttpResponse(
+                HttpVersion.HTTP_1_1,
+                httpErrorStatus.httpResponseStatus(),
+                responseMsg
+            );
+            HttpUtil.setContentLength(response, message.length());
+            maybeSetConnectionCloseHeader(response);
+            sendResponse(response);
         } finally {
             if (content != null) {
                 content.release();

--- a/server/src/test/java/io/crate/integrationtests/BlobPrivilegesIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/BlobPrivilegesIntegrationTest.java
@@ -46,18 +46,18 @@ public class BlobPrivilegesIntegrationTest extends BlobHttpIntegrationTest {
         String body = "a".repeat(1500);
 
         var response = get(uri, john);
-        assertThat(response.statusCode()).isEqualTo(500);
+        assertThat(response.statusCode()).isEqualTo(404);
         assertThat(response.body()).isEqualTo("Schema 'blob' unknown");
 
         var response2 = head(uri, john);
-        assertThat(response2.statusCode()).isEqualTo(500);
+        assertThat(response2.statusCode()).isEqualTo(404);
 
         var response3 = put(uri, body, john);
-        assertThat(response3.statusCode()).isEqualTo(500);
+        assertThat(response3.statusCode()).isEqualTo(404);
         assertThat(response3.body()).isEqualTo("Schema 'blob' unknown");
 
         var response4 = delete(uri, john);
-        assertThat(response4.statusCode()).isEqualTo(500);
+        assertThat(response4.statusCode()).isEqualTo(404);
     }
 }
 


### PR DESCRIPTION
Follow up to:

- https://github.com/crate/crate/commit/c8a0dccdbb3d01f1818190c2ed5cf6654f77eb6b
- https://github.com/crate/crate/pull/19361

Need to set the `CONNECTION: close` header and
`ChannelFutureListener.CLOSE` depending on the `isKeepAlive` value for
the response. With the default uncaughtException handler that returns
500 it can terminate the connection too early.

`BlobPrivilegesIntegrationTest.test_missing_privileges` was flaky,
failing with:

    HTTP/1.1 header parser received no bytes
