### PR TITLE
Bump assertBusy timeout in ensureState to 20 seconds

### DIFF
--- a/server/src/testFixtures/java/io/crate/testing/SQLTransportExecutor.java
+++ b/server/src/testFixtures/java/io/crate/testing/SQLTransportExecutor.java
@@ -617,7 +617,7 @@ public class SQLTransportExecutor {
                 x -> assertThat(x).isEmpty(),
                 x -> assertThat(x).isEqualTo(List.of("STARTED"))
             );
-        });
+        }, 20, TimeUnit.SECONDS);
     }
 
     public interface ClientProvider {


### PR DESCRIPTION
Should fix https://wacklig.pipifein.dev/github/crate/crate/case/io.crate.integrationtests.FixCorruptedMetadataCommandITest/test_swap_table_partitioned_dotted_src_to_non_partitioned_dotted_target

```
>expected: 0L
 but was: 2L
		at io.crate.testing.SQLTransportExecutor.lambda$ensureState$0(SQLTransportExecutor.java:600)
		at org.elasticsearch.test.ESTestCase.assertBusy(ESTestCase.java:699)
```

and 

https://wacklig.pipifein.dev/github/crate/crate/case/io.crate.integrationtests.OpenCloseTableIntegrationTest/test_auto_expand_closed_tables

```
expected: 0L
 but was: 3L
	at __randomizedtesting.SeedInfo.seed([1A3132E947565CA1:A4ED0E1759580F37]:0)
	at io.crate.testing.SQLTransportExecutor.lambda$ensureState$0(SQLTransportExecutor.java:600)
```

and probably also https://wacklig.pipifein.dev/github/crate/crate/dfb877d0-187d-48b9-99b7-d035475145bb/ba7fb505-7515-46d5-9bd4-034e2507c2aa
```
expected: ["STARTED"]
 but was: ["UNASSIGNED", "STARTED"]
at SQLTransportExecutor.lambda$ensureState$4(SQLTransportExecutor.java:618)
		at io.crate.testing.SQLTransportExecutor.lambda$ensureState$0(SQLTransportExecutor.java:616)
```

which could have spent retry time on pending tasks and end up having not enough retry time to wait for shards having assigned state
