### PR TITLE
tests: Fix a flaky test in EqualityExtractorTest

### DIFF
--- a/server/src/test/java/io/crate/analyze/where/EqualityExtractorTest.java
+++ b/server/src/test/java/io/crate/analyze/where/EqualityExtractorTest.java
@@ -609,10 +609,11 @@ public class EqualityExtractorTest extends CrateDummyClusterServiceUnitTest {
             this.maxChecks = maxChecks;
         }
 
-        public void check() {
+        @Override
+        public void check(String context) {
             checks++;
             if (timeout().nanos() > 0 && checks > maxChecks) {
-                throw JobKilledException.of("statement_timeout (" + timeout() + ")");
+                throw JobKilledException.of("statement_timeout (" + timeout() + "/" + context + ")");
             }
         }
     }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

On fast machines io.crate.analyze.where.EqualityExtractorTest.test_pk_extraction_interrupted_when_exceeds_timeout fails due to not running into a timeout. Overriding the correct base method to use the timeout correctly.
This was broken most probably since [6a8b1fa8655956e160b61c4f69a83e25e3b34110](https://github.com/crate/crate/commit/6a8b1fa8655956e160b61c4f69a83e25e3b34110)

## Checklist

N/A since it's a test fix
