### PR TITLE
Avoid updating local UDF registry during metadata upgrade

### DIFF
--- a/docs/appendices/release-notes/6.3.3.rst
+++ b/docs/appendices/release-notes/6.3.3.rst
@@ -58,3 +58,7 @@ Fixes
 - Fixed an issue that caused :ref:`RESTORE SNAPSHOT <sql-restore-snapshot>` to
   return ``RESTORE OK`` even if some shards failed to restore (for example, due
   to exceeded disk watermarks). It now fails with a ``SnapshotRestoreException``.
+
+- Fixed intermittent ``UDF`` resolution failures when upgrading metadata from a
+  remote cluster, for example during
+  :ref:`logical replication <administration-logical-replication>`.

--- a/server/src/main/java/io/crate/expression/udf/UserDefinedFunctionService.java
+++ b/server/src/main/java/io/crate/expression/udf/UserDefinedFunctionService.java
@@ -252,10 +252,10 @@ public class UserDefinedFunctionService extends AbstractLifecycleComponent imple
         if (!event.metadataChanged()) {
             return;
         }
-        updateImplementations(event.state().metadata());
+        nodeCtx.functions().setUDFs(buildUDFResolvers((event.state().metadata())));
     }
 
-    public void updateImplementations(Metadata newMetadata) {
+    public Map<FunctionName, List<FunctionProvider>> buildUDFResolvers(Metadata newMetadata) {
         final Map<FunctionName, List<FunctionProvider>> implementations = new HashMap<>();
         for (var schema : newMetadata.schemas().values()) {
             for (var udf : schema.udfs()) {
@@ -268,7 +268,7 @@ public class UserDefinedFunctionService extends AbstractLifecycleComponent imple
                 providers.add(provider);
             }
         }
-        nodeCtx.functions().setUDFs(implementations);
+        return implementations;
     }
 
     @Override

--- a/server/src/main/java/io/crate/metadata/Functions.java
+++ b/server/src/main/java/io/crate/metadata/Functions.java
@@ -122,6 +122,10 @@ public class Functions {
         udfFunctionImplementations = functions;
     }
 
+    public Functions copyOfBuiltIns() {
+        return new Functions(functionImplementations);
+    }
+
     @Nullable
     public Signature findFunctionSignatureByOid(int oid) {
         for (var signature : signatures()) {

--- a/server/src/main/java/io/crate/metadata/cluster/OpenTableClusterStateTaskExecutor.java
+++ b/server/src/main/java/io/crate/metadata/cluster/OpenTableClusterStateTaskExecutor.java
@@ -110,7 +110,12 @@ public class OpenTableClusterStateTaskExecutor extends DDLClusterStateTaskExecut
 
             // The index might be closed because we couldn't import it due to old incompatible version
             // We need to check that this index can be upgraded to the current version
-            updatedIndexMetadata = metadataIndexUpgradeService.upgradeIndexMetadata(updatedIndexMetadata, null, minIndexCompatibilityVersion);
+            updatedIndexMetadata = metadataIndexUpgradeService.upgradeIndexMetadata(
+                updatedIndexMetadata,
+                null,
+                minIndexCompatibilityVersion,
+                currentState.metadata()
+            );
             try {
                 indicesService.verifyIndexMetadata(updatedIndexMetadata, updatedIndexMetadata);
             } catch (Exception e) {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataUpgradeService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataUpgradeService.java
@@ -24,6 +24,7 @@ import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_VERSION_U
 import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
 
 import java.util.List;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.LogManager;
@@ -38,10 +39,10 @@ import org.elasticsearch.index.Index;
 import org.jspecify.annotations.Nullable;
 
 import io.crate.blob.v2.BlobIndex;
-import io.crate.common.annotations.VisibleForTesting;
 import io.crate.expression.udf.UserDefinedFunctionService;
 import io.crate.expression.udf.UserDefinedFunctionsMetadata;
 import io.crate.fdw.ForeignTablesMetadata;
+import io.crate.metadata.Functions;
 import io.crate.metadata.IndexName;
 import io.crate.metadata.IndexParts;
 import io.crate.metadata.NodeContext;
@@ -70,32 +71,31 @@ public class MetadataUpgradeService {
 
     private final IndexScopedSettings indexScopedSettings;
     private final MetadataIndexUpgrader indexUpgrader;
-    private final DocTableInfoFactory tableFactory;
-    private final UserDefinedFunctionService userDefinedFunctionService;
+    private final Function<Metadata, DocTableInfoFactory> metadataToDocTableInfoFactory;
 
     public MetadataUpgradeService(NodeContext nodeContext,
                                   IndexScopedSettings indexScopedSettings,
                                   UserDefinedFunctionService userDefinedFunctionService) {
-        this.tableFactory = new DocTableInfoFactory(nodeContext);
+        // Creates a DocTableInfoFactory for each upgrade invocation.
+        // Metadata can come from a foreign cluster, so the factory must be solely based on the metadata being upgraded.
+        this.metadataToDocTableInfoFactory = metadata -> {
+            Functions functions = nodeContext.functions().copyOfBuiltIns();
+            functions.setUDFs(userDefinedFunctionService.buildUDFResolvers(metadata));
+            return new DocTableInfoFactory(
+                new NodeContext(
+                    functions,
+                    nodeContext.roles(),
+                    _ -> nodeContext.schemas(),
+                    nodeContext.tableStats()
+                )
+            );
+        };
         this.indexScopedSettings = indexScopedSettings;
         this.indexUpgrader = new MetadataIndexUpgrader();
-        this.userDefinedFunctionService = userDefinedFunctionService;
     }
 
     public Metadata upgradeMetadata(Metadata metadata) {
-        final Metadata.Builder newMetadata = Metadata.builder(metadata);
-
-        UserDefinedFunctionsMetadata udfMetadata = metadata.custom(UserDefinedFunctionsMetadata.TYPE);
-        if (udfMetadata == null) {
-            userDefinedFunctionService.updateImplementations(metadata);
-        } else {
-            for (var udf : udfMetadata.functionsMetadata()) {
-                newMetadata.setUDF(udf);
-            }
-            newMetadata.removeCustom(UserDefinedFunctionsMetadata.TYPE);
-            userDefinedFunctionService.updateImplementations(newMetadata.build());
-        }
-
+        final Metadata.Builder newMetadata = Metadata.builder(upgradeUDFMetadata(metadata));
         ViewsMetadata viewsMetadata = metadata.custom(ViewsMetadata.TYPE);
         if (viewsMetadata != null) {
             for (var entry : viewsMetadata.views().entrySet()) {
@@ -111,6 +111,10 @@ public class MetadataUpgradeService {
             }
             newMetadata.removeCustom(ViewsMetadata.TYPE);
         }
+
+        // DocTableInfoFactory must have access to the UDF definitions from the given
+        // Metadata so table validation can resolve UDF dependencies.
+        DocTableInfoFactory tableInfoFactory = metadataToDocTableInfoFactory.apply(newMetadata.build());
 
         ForeignTablesMetadata foreignTablesMetadata = metadata.custom(ForeignTablesMetadata.TYPE);
         if (foreignTablesMetadata != null) {
@@ -134,7 +138,7 @@ public class MetadataUpgradeService {
             assert relation == null
                 : "If there is still a template present there shouldn't be any RelationMetadata";
 
-            DocTableInfo docTable = tableFactory.create(template, OID_UNASSIGNED);
+            DocTableInfo docTable = tableInfoFactory.create(template, OID_UNASSIGNED);
             Version versionCreated = getFixedVersionCreated(metadata, docTable);
 
             // versionCreated could be missing from the template settings and "calculated" afterwards
@@ -173,7 +177,8 @@ public class MetadataUpgradeService {
                 IndexName.isPartitioned(indexName)
                     ? newMetadata.getTemplate(PartitionName.templateName(indexName))
                     : null,
-                Version.CURRENT.minimumIndexCompatibilityVersion());
+                Version.CURRENT.minimumIndexCompatibilityVersion(),
+                tableInfoFactory);
             // Remove any existing metadata, registered by it's name, for the index
             newMetadata.remove(indexName);
             newMetadata.put(newIndexMetadata, false);
@@ -186,7 +191,7 @@ public class MetadataUpgradeService {
                 RelationName relationName = indexParts.toRelationName();
                 relation = newMetadata.getRelation(relationName);
                 if (!BlobIndex.isBlobIndex(indexName)) {
-                    tableInfo = tableFactory.create(newIndexMetadata, OID_UNASSIGNED);
+                    tableInfo = tableInfoFactory.create(newIndexMetadata, OID_UNASSIGNED);
                 }
             }
             if (relation == null) {
@@ -230,6 +235,18 @@ public class MetadataUpgradeService {
             }
         }
 
+        return newMetadata.build();
+    }
+
+    private static Metadata upgradeUDFMetadata(Metadata metadata) {
+        final Metadata.Builder newMetadata = Metadata.builder(metadata);
+        UserDefinedFunctionsMetadata udfMetadata = metadata.custom(UserDefinedFunctionsMetadata.TYPE);
+        if (udfMetadata != null) {
+            for (var udf : udfMetadata.functionsMetadata()) {
+                newMetadata.setUDF(udf);
+            }
+            newMetadata.removeCustom(UserDefinedFunctionsMetadata.TYPE);
+        }
         return newMetadata.build();
     }
 
@@ -286,7 +303,19 @@ public class MetadataUpgradeService {
      */
     public IndexMetadata upgradeIndexMetadata(IndexMetadata indexMetadata,
                                               @Nullable IndexTemplateMetadata indexTemplateMetadata,
-                                              Version minimumIndexCompatibilityVersion) {
+                                              Version minimumIndexCompatibilityVersion,
+                                              Metadata metadata) {
+        return upgradeIndexMetadata(
+            indexMetadata,
+            indexTemplateMetadata,
+            minimumIndexCompatibilityVersion,
+            metadataToDocTableInfoFactory.apply(upgradeUDFMetadata(metadata)));
+    }
+
+    private IndexMetadata upgradeIndexMetadata(IndexMetadata indexMetadata,
+                                               @Nullable IndexTemplateMetadata indexTemplateMetadata,
+                                               Version minimumIndexCompatibilityVersion,
+                                               DocTableInfoFactory tableInfoFactory) {
         if (isUpgraded(indexMetadata)) {
             return indexMetadata;
         }
@@ -298,7 +327,7 @@ public class MetadataUpgradeService {
         // with broken settings and fail in checkMappingsCompatibility
         newMetadata = archiveBrokenIndexSettings(newMetadata);
         newMetadata = indexUpgrader.upgrade(newMetadata, indexTemplateMetadata);
-        checkMappingsCompatibility(newMetadata);
+        checkMappingsCompatibility(newMetadata, tableInfoFactory);
         return markAsUpgraded(newMetadata);
     }
 
@@ -335,10 +364,9 @@ public class MetadataUpgradeService {
     /**
      * Checks the mappings for compatibility with the current version
      */
-    @VisibleForTesting
-    void checkMappingsCompatibility(IndexMetadata indexMetadata) {
+    private void checkMappingsCompatibility(IndexMetadata indexMetadata, DocTableInfoFactory tableInfoFactory) {
         try {
-            tableFactory.create(indexMetadata, OID_UNASSIGNED);
+            tableInfoFactory.create(indexMetadata, OID_UNASSIGNED);
 
             // We cannot instantiate real analysis server or similarity service at this point because the node
             // might not have been started yet. However, we don't really need real analyzers or similarities at

--- a/server/src/main/java/org/elasticsearch/gateway/LocalAllocateDangledIndices.java
+++ b/server/src/main/java/org/elasticsearch/gateway/LocalAllocateDangledIndices.java
@@ -154,7 +154,9 @@ public class LocalAllocateDangledIndices {
                                 IndexName.isPartitioned(indexName) ?
                                     currentState.metadata().templates().get(PartitionName.templateName(indexName)) :
                                     null,
-                                minIndexCompatibilityVersion);
+                                minIndexCompatibilityVersion,
+                                currentState.metadata()
+                            );
                             upgradedIndexMetadata = IndexMetadata.builder(upgradedIndexMetadata).settings(
                                 Settings.builder().put(upgradedIndexMetadata.getSettings()).put(
                                     IndexMetadata.SETTING_HISTORY_UUID, UUIDs.randomBase64UUID())).build();

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataUpgradeServiceTest.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataUpgradeServiceTest.java
@@ -45,14 +45,12 @@ import io.crate.expression.udf.UdfUnitTest;
 import io.crate.expression.udf.UserDefinedFunctionMetadata;
 import io.crate.expression.udf.UserDefinedFunctionsMetadata;
 import io.crate.metadata.ColumnIdent;
-import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.IndexName;
 import io.crate.metadata.IndexType;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.RowGranularity;
-import io.crate.metadata.SearchPath;
 import io.crate.metadata.SimpleReference;
 import io.crate.metadata.doc.SysColumns;
 import io.crate.metadata.upgrade.IndexTemplateUpgrader;
@@ -248,14 +246,7 @@ public class MetadataUpgradeServiceTest extends CrateDummyClusterServiceUnitTest
             .put(indexTemplateMetadata)
             .putCustom(UserDefinedFunctionsMetadata.TYPE, udfs)
             .build();
-        metadataUpgradeService.upgradeMetadata(metadata);
-        FunctionImplementation functionImplementation = e.nodeCtx.functions().get(
-            "custom",
-            "foo",
-            List.of(),
-            SearchPath.pathWithPGCatalogAndDoc()
-        );
-        assertThat(functionImplementation).isNotNull();
+        metadataUpgradeService.upgradeIndexMetadata(indexMetadata, indexTemplateMetadata, Version.V_5_7_0, metadata);
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Below failure was observed during rolling upgrade `6.3` > `latest-nightly`:
```
crate.client.exceptions.ProgrammingError: UnsupportedFeatureException[Function FunctionName{schema='doc', name='foo'}(integer) is not a scalar function.]
io.crate.exceptions.UnsupportedFeatureException: Function FunctionName{schema='doc', name='foo'}(integer) is not a scalar function.
	at io.crate.expression.BaseImplementationSymbolVisitor.visitFunction(BaseImplementationSymbolVisitor.java:70)
	at io.crate.expression.BaseImplementationSymbolVisitor.visitFunction(BaseImplementationSymbolVisitor.java:43)
	at io.crate.expression.symbol.Function.accept(Function.java:243)
	at io.crate.expression.InputFactory$Context.add(InputFactory.java:160)
	at io.crate.execution.dml.Indexer.<init>(Indexer.java:587)
	at io.crate.execution.dml.Indexer.<init>(Indexer.java:437)
```

To investigate, attached [logging on top of `6.3`](https://github.com/crate/crate/tree/jeeminso/debug-UDF-resolution-6.3-node) and performed the rolling upgrade test to `latest-nightly`:
```
[2026-05-18T17:21:40,800][WARN ][i.c.r.l.r.LogicalReplicationRepository] [C3Ea3fA2A8Ec-3] LR getRemoteClusterState upgrading remote metadata. subscription=s, relations=[doc.rx], remoteCluster=Cluster [DCbc134a5cB7], remoteSchemaUDFs=[]
[2026-05-18T17:21:40,814][WARN ][o.e.c.m.MetadataUpgradeService] [C3Ea3fA2A8Ec-3] Upgrading metadata on thread [cratedb[C3Ea3fA2A8Ec-3][netty-worker][T#11]]. schemaUDFs=0, legacyUDFs=0
[2026-05-18T17:21:40,814][WARN ][i.c.m.Functions          ] [C3Ea3fA2A8Ec-3] Replacing UDF function implementations on thread [cratedb[C3Ea3fA2A8Ec-3][netty-worker][T#11]]. old=[doc.foo=[FunctionName{schema='doc', name='foo'}(integer):integer]], new=[]
```
The logs show that logical replication upgraded metadata fetched from the remote cluster to the local cluster's version. Since the remote cluster had no UDFs, this emptied the local UDF registry as a side effect.

The remote metadata did not replace the local cluster metadata, but it temporarily cleared the local node's UDF implementations. The UDF registry was then restored by subsequent cluster state changes, which made the failure flaky.


## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
