### PR TITLE
Use single string key group by optimization also on text cols with length

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
@@ -451,7 +451,7 @@ final class GroupByOptimizedIterator {
         if (!(shardProjection instanceof GroupProjection groupProjection)) {
             return null;
         }
-        if (groupProjection.keys().size() != 1 || groupProjection.keys().get(0).valueType() != DataTypes.STRING) {
+        if (groupProjection.keys().size() != 1 || groupProjection.keys().get(0).valueType().id() != DataTypes.STRING.id()) {
             return null;
         }
         return groupProjection;


### PR DESCRIPTION
If a text column is defined as "varchar" with a specific length, the
optimization wasn't used due to a identity check on the dataType
instance - comparing it with the STRING singleton

    Q: select "cCode", avg(duration), avg("adRevenue") from uservisits group by "cCode"
    C: 1
    | Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
    |   V1    |      142.166 ±   67.724 |    113.950 |    120.570 |    125.318 |    334.381 |
    |   V2    |       80.995 ±   99.602 |     28.487 |     29.275 |     85.286 |    322.538 |
    ├---------┴-------------------------┴------------┴------------┴------------┴------------┘
    |               -  54.82%                           - 121.85%
    There is a 87.43% probability that the observed difference is not random, and the best estimate of that difference is 54.82%
    The test has no statistical significance

    System/JVM Metrics (durations in ms, byte-values in MB)
        |    YOUNG GC            |       OLD GC           |      HEAP         |     ALLOC
        |  cnt      avg      max |  cnt      avg      max |  initial     used |     rate      total
     V1 |    3     2.24     2.37 |    0     0.00     0.00 |     2147      218 |  5406.86       1152
     V2 |    1     4.23     4.23 |    0     0.00     0.00 |     2147      599 |  1823.88        140
