### PR TITLE
tests: Add annotation to ease SqlLogic debugging

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/SQLLogicITest.java
+++ b/server/src/test/java/io/crate/integrationtests/SQLLogicITest.java
@@ -28,15 +28,18 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import org.elasticsearch.test.IntegTestCase;
+import org.jspecify.annotations.Nullable;
 import org.junit.Test;
 
 import io.crate.test.integration.SQLLogicParser;
 import io.crate.test.integration.SQLLogicParser.Cmd;
 import io.crate.test.integration.SQLLogicParser.QueryCmd;
 import io.crate.test.integration.SQLLogicParser.StatementCmd;
+import io.crate.testing.SqlLogic;
 import io.crate.testing.UseJdbc;
 
 /**
@@ -45,7 +48,7 @@ import io.crate.testing.UseJdbc;
 @IntegTestCase.ClusterScope(numDataNodes = 1, numClientNodes = 0, supportsDedicatedMasters = false)
 public class SQLLogicITest extends IntegTestCase {
 
-    private void runFile(Path file) {
+    private void runFile(Path file, @Nullable String testName) {
         String schema = "doc";
         try (var cmds = SQLLogicParser.parse(file)) {
             boolean dmlDone = false;
@@ -63,12 +66,14 @@ public class SQLLogicITest extends IntegTestCase {
                         }
                     }
                     case QueryCmd query -> {
-                        if (!dmlDone) {
-                            dmlDone = true;
-                            refreshTables(schema);
+                        if (testName == null || query.testName().equals(testName)) {
+                            if (!dmlDone) {
+                                dmlDone = true;
+                                refreshTables(schema);
+                            }
+                            var response = execute(query.getQuery(), schema);
+                            query.validate(response);
                         }
-                        var response = execute(query.getQuery(), schema);
-                        query.validate(response);
                     }
                 }
             }
@@ -82,11 +87,23 @@ public class SQLLogicITest extends IntegTestCase {
     @Test
     @UseJdbc(1)
     public void testFiles() throws Exception {
+        Predicate<Path> fileFilter = path -> path.toString().endsWith(".test");
+        final String[] testName = new String[] {null};
+        SqlLogic annotation = getTestAnnotation(SqlLogic.class);
+        if (annotation != null) {
+            if (annotation.file().isEmpty() == false) {
+                fileFilter = path -> annotation.file().equals(path.getFileName().toString());
+            }
+            if (annotation.testName().isEmpty() == false) {
+                testName[0] = annotation.testName();
+            }
+        }
+
         Path testsLocation = getDataPath("/integtests");
         try (Stream<Path> files = Files.list(testsLocation)) {
             files
-                .filter(path -> path.toString().endsWith(".test"))
-                .forEach(this::runFile);
+                .filter(fileFilter)
+                .forEach(path -> runFile(path, testName[0]));
         }
     }
 

--- a/server/src/testFixtures/java/io/crate/test/integration/SQLLogicParser.java
+++ b/server/src/testFixtures/java/io/crate/test/integration/SQLLogicParser.java
@@ -181,7 +181,7 @@ public final class SQLLogicParser {
         @Nullable
         private final List<String> rawExpected;
         private final String filename;
-        private final String testname;
+        private final String testName;
 
         QueryCmd(List<NumberedLine> lines, String filename) {
             this.filename = filename;
@@ -192,7 +192,7 @@ public final class SQLLogicParser {
             String[] header = first.line().split("\\s+");
             String formatsStr = header[1];
             String sortStr = header[2];
-            this.testname = header[3];
+            this.testName = header[3];
 
             for (char c : formatsStr.toCharArray()) {
                 if (c != 'I' && c != 'R' && c != 'T') {
@@ -233,14 +233,14 @@ public final class SQLLogicParser {
                 if (m.matches()) {
                     int expectedValues = Integer.parseInt(m.group(1));
                     String expectedHash = m.group(2);
-                    validateHash(response, expectedValues, expectedHash, filename, lnum);
+                    validateHash(response, expectedValues, expectedHash, filename, testName, lnum);
                     return;
                 }
             }
             List<Object> expected = (sort == SortMode.ROWS)
                 ? formatExpectedRows(rawExpected)
                 : formatExpectedFlat(rawExpected);
-            validateCmpResult(response, expected, query, filename, testname, lnum);
+            validateCmpResult(response, expected, query, filename, testName, lnum);
         }
 
         private void validateCmpResult(SQLResponse response,
@@ -334,6 +334,10 @@ public final class SQLLogicParser {
             return out;
         }
 
+        public String testName() {
+            return testName;
+        }
+
         @Override
         public String getQuery() {
             return query;
@@ -375,6 +379,7 @@ public final class SQLLogicParser {
                                      int expectedValues,
                                      String expectedHash,
                                      String filename,
+                                     String testname,
                                      int lnum) {
         long got = response.rowCount();
         if (got != expectedValues) {
@@ -396,9 +401,10 @@ public final class SQLLogicParser {
             if (!digest.equals(expectedHash)) {
                 throw new IncorrectResultException(String.format(
                     Locale.ENGLISH,
-                    "[%s:d] Expected values hashing to %s. Got: %s\n%s",
+                    "[%s:%d][%s] Expected values hashing to %s:. Got: %s running %s",
                     filename,
                     lnum,
+                    testname,
                     expectedHash,
                     digest,
                     response
@@ -431,7 +437,7 @@ public final class SQLLogicParser {
     public static Stream<Cmd> parse(Path file) throws IOException {
         AtomicInteger lnum = new AtomicInteger(0);
         Gatherer<NumberedLine, List<NumberedLine>, Cmd> gatherCmds = Gatherer.ofSequential(
-            () -> new ArrayList<NumberedLine>(),
+            ArrayList::new,
             (state, element, downstream) -> {
                 String line = element.line();
                 if (!line.isEmpty()) {

--- a/server/src/testFixtures/java/io/crate/testing/SqlLogic.java
+++ b/server/src/testFixtures/java/io/crate/testing/SqlLogic.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.testing;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Filter for specific sqllogic file and specific test within the file
+ * e.g.:
+ * {@code
+ *
+ *     @Test
+ *     @UseJdbc(1)
+ *     @SqlLogic(file="arithmetic.test", testName="floating-point-arithmetic")
+ *     public void testFiles() throws Exception {
+ *     ...
+ *     }
+ * }
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Inherited
+public @interface SqlLogic {
+
+    String file() default "";
+    String testName() default "";
+}

--- a/server/src/testFixtures/java/org/elasticsearch/test/IntegTestCase.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/IntegTestCase.java
@@ -1881,7 +1881,7 @@ public abstract class IntegTestCase extends ESTestCase {
      * @return the annotation if one is present or null otherwise
      */
     @Nullable
-    private <T extends Annotation> T getTestAnnotation(Class<T> annotationClass) {
+    protected <T extends Annotation> T  getTestAnnotation(Class<T> annotationClass) {
         try {
             Class<?> clazz = this.getClass();
             String testMethodName = testName.getMethodName();


### PR DESCRIPTION
Add an annotation which can be used to filter for specific sqllogic file and a specific test query within that.

