### PR TITLE
support for date and interval arithmetic

### DIFF
--- a/docs/appendices/release-notes/6.4.0.rst
+++ b/docs/appendices/release-notes/6.4.0.rst
@@ -83,6 +83,9 @@ Data Types
 Scalar and Aggregation Functions
 --------------------------------
 
+- Added support for adding or subtracting intervals to values of type :ref:`date
+  <type-date>`.
+
 - Added support for ``TH`` and ``th`` template patterns to the :ref:`to_char
   <scalar-to_char>` scalar function which can be used to add a ordinal suffix
   for numbers.

--- a/server/src/main/java/io/crate/execution/engine/window/ArithmeticOperatorsFactory.java
+++ b/server/src/main/java/io/crate/execution/engine/window/ArithmeticOperatorsFactory.java
@@ -26,6 +26,7 @@ import io.crate.expression.scalar.arithmetic.IntervalTimestampArithmeticScalar;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.types.ByteType;
 import io.crate.types.DataType;
+import io.crate.types.DateType;
 import io.crate.types.DoubleType;
 import io.crate.types.FloatType;
 import io.crate.types.IntegerType;
@@ -52,6 +53,7 @@ class ArithmeticOperatorsFactory {
     static BiFunction getAddFunction(DataType<?> fstArgDataType, DataType<?> sndArgDataType) {
         switch (fstArgDataType.id()) {
             case LongType.ID:
+            case DateType.ID:
             case TimestampType.ID_WITH_TZ:
             case TimestampType.ID_WITHOUT_TZ:
                 if (IntervalType.ID == sndArgDataType.id()) {
@@ -83,6 +85,7 @@ class ArithmeticOperatorsFactory {
     static BiFunction getSubtractFunction(DataType<?> fstArgDataType, DataType<?> sndArgDataType) {
         switch (fstArgDataType.id()) {
             case LongType.ID:
+            case DateType.ID:
             case TimestampType.ID_WITH_TZ:
             case TimestampType.ID_WITHOUT_TZ:
                 if (IntervalType.ID == sndArgDataType.id()) {

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/IntervalTimestampArithmeticScalar.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/IntervalTimestampArithmeticScalar.java
@@ -79,6 +79,53 @@ public class IntervalTimestampArithmeticScalar extends Scalar<Long, Object> impl
                     )
             );
         }
+
+        // DATE +/- INTERVAL (return TIMESTAMP per PostgreSQL spec: date + interval → timestamp)
+        module.add(
+            Signature.builder(ArithmeticFunctions.Names.ADD, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.INTERVAL.getTypeSignature(),
+                    DataTypes.DATE.getTypeSignature())
+                .returnType(DataTypes.TIMESTAMP.getTypeSignature())
+                .features(Feature.DETERMINISTIC)
+                .forbidCoercion()
+                .build(),
+            (signature, boundSignature) ->
+                new IntervalTimestampArithmeticScalar(
+                    "+",
+                    signature,
+                    boundSignature
+                )
+        );
+        module.add(
+            Signature.builder(ArithmeticFunctions.Names.ADD, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.DATE.getTypeSignature(),
+                    DataTypes.INTERVAL.getTypeSignature())
+                .returnType(DataTypes.TIMESTAMP.getTypeSignature())
+                .features(Feature.DETERMINISTIC)
+                .forbidCoercion()
+                .build(),
+            (signature, boundSignature) ->
+                new IntervalTimestampArithmeticScalar(
+                    "+",
+                    signature,
+                    boundSignature
+                )
+        );
+        module.add(
+            Signature.builder(ArithmeticFunctions.Names.SUBTRACT, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.DATE.getTypeSignature(),
+                    DataTypes.INTERVAL.getTypeSignature())
+                .returnType(DataTypes.TIMESTAMP.getTypeSignature())
+                .features(Feature.DETERMINISTIC)
+                .forbidCoercion()
+                .build(),
+            (signature, boundSignature) ->
+                new IntervalTimestampArithmeticScalar(
+                    "-",
+                    signature,
+                    boundSignature
+                )
+        );
     }
 
     public static Signature signatureFor(DataType<?> timestampType, String name) {

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/IntervalFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/IntervalFunctionTest.java
@@ -179,4 +179,35 @@ public class IntervalFunctionTest extends ScalarTestCase {
             .hasMessageStartingWith(
                 "Invalid arguments in: (cast('1 second' AS INTERVAL) - cast('86401000' AS TIMESTAMP WITH TIME ZONE)) with (interval, timestamp with time zone).");
     }
+
+    @Test
+    public void test_date_interval_add() {
+        assertEvaluate("interval '1 second' + '86400000'::date", 86401000L);
+        assertEvaluate("'86400000'::date + interval '1 second'", 86401000L);
+        assertEvaluate("'86400000'::date + interval '1 day'", 172800000L);
+        assertEvaluate("'86400000'::date + interval '-1 day'", 0L);
+    }
+
+    @Test
+    public void test_date_interval_subtract() {
+        assertEvaluate("'86401000'::date - interval '1 second'", 86399000L);
+        assertEvaluate("'86400000'::date - interval '1 day'", 0L);
+        assertEvaluate("'86400000'::date - interval '-1 day'", 172800000L);
+        assertEvaluate("'86400000'::date - interval '1000 years'", -31556822400000L);
+    }
+
+    @Test
+    public void test_date_interval_null() {
+        assertEvaluateNull("null + '86400000'::date");
+        assertEvaluateNull("'86400000'::date + null");
+    }
+
+    @Test
+    public void test_unallowed_interval_date_subtraction() {
+        assertThatThrownBy(
+            () -> assertEvaluate("interval '1 second' - '86401000'::date", 86400000L))
+            .isExactlyInstanceOf(UnsupportedFunctionException.class)
+            .hasMessageStartingWith(
+                "Invalid arguments in: (cast('1 second' AS INTERVAL) - cast('86401000' AS DATE)) with (interval, date).");
+    }
 }

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/IntervalFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/IntervalFunctionTest.java
@@ -200,10 +200,12 @@ public class IntervalFunctionTest extends ScalarTestCase {
     public void test_date_interval_null() {
         assertEvaluateNull("null + '86400000'::date");
         assertEvaluateNull("'86400000'::date + null");
+        assertEvaluateNull("null - '86400000'::date");
+        assertEvaluateNull("'86400000'::date - null");
     }
 
     @Test
-    public void test_unallowed_interval_date_subtraction() {
+    public void test_disallowed_interval_date_subtraction() {
         assertThatThrownBy(
             () -> assertEvaluate("interval '1 second' - '86401000'::date", 86400000L))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)

--- a/server/src/test/java/io/crate/integrationtests/WindowFunctionsIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/WindowFunctionsIntegrationTest.java
@@ -314,4 +314,23 @@ public class WindowFunctionsIntegrationTest extends IntegTestCase {
             "1| [1]",
             "2| [1]");
     }
+
+    @Test
+    public void testSumOverDateRangeIntervalOffset() {
+        // Window function with ts::date ORDER BY and RANGE BETWEEN INTERVAL offset.
+        execute("create table t (x int, ts timestamp)");
+        execute("insert into t values (1, 0), (2, 86400000), (3, 172800000), (4, 259200000)");
+        execute("refresh table t");
+
+        execute(
+            "SELECT sum(x) OVER(ORDER BY ts::date RANGE BETWEEN INTERVAL '1 day' PRECEDING AND CURRENT ROW) " +
+            "FROM t"
+        );
+        assertThat(response).hasRows(
+            "1",   // ts=0, only current row in 1-day window
+            "3",   // ts=1day, 1+2=3
+            "5",   // ts=2days, 2+3=5
+            "7"    // ts=3days, 3+4=7
+        );
+    }
 }


### PR DESCRIPTION
Fixes #15634 
## Summary

Adds support for DATE +/- INTERVAL arithmetic

This PR enables queries like:

SELECT CURRENT_DATE + INTERVAL '1 day';
SELECT CURRENT_DATE - INTERVAL '1 day';
SELECT INTERVAL '1 day' + CURRENT_DATE;


which previously failed with: UnsupportedFunctionException

## Changes

Added new scalar function registrations for:

(date, interval) -> timestamp
(interval, date) -> timestamp
(date, interval) subtraction -> timestamp

The implementation reuses the existing "IntervalTimestampArithmeticScalar" logic used for timestamp interval arithmetic.

## Behavior

The result type is `TIMESTAMP`, matching PostgreSQL semantics for:
DATE + INTERVAL -> TIMESTAMP

## Tests

Added tests covering:

DATE + INTERVAL
DATE - INTERVAL
INTERVAL + DATE
unsupported interval/date operations