### PR TITLE
Add AlterRepositoryPlanTest 

### DIFF
--- a/plugins/es-repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
+++ b/plugins/es-repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
@@ -146,7 +146,7 @@ public class S3Repository extends BlobStoreRepository {
         this.storageClass = STORAGE_CLASS_SETTING.get(metadata.settings());
 
         LOGGER.debug(
-            "using bucket [{}], chunk_size [{}], server_side_encryption [{}], buffer_size [{}], cannedACL [{}], storageClass [{}]",
+            "using bucket [{}], chunk_size [{}], server_side_encryption [{}], buffer_size [{}], storageClass [{}]",
             bucket,
             chunkSize,
             serverSideEncryption,

--- a/plugins/es-repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3RepositoryPluginAnalyzerTest.java
+++ b/plugins/es-repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3RepositoryPluginAnalyzerTest.java
@@ -105,7 +105,6 @@ public class S3RepositoryPluginAnalyzerTest extends CrateDummyClusterServiceUnit
         properties.put("base_path", "/data");
         properties.put("bucket", "myBucket");
         properties.put("buffer_size", "5mb");
-        properties.put("canned_acl", "cannedACL");
         properties.put("chunk_size", "4g");
         properties.put("compress", "true");
         properties.put("endpoint", "myEndpoint");

--- a/server/src/main/java/io/crate/analyze/repositories/RepositoryParamValidator.java
+++ b/server/src/main/java/io/crate/analyze/repositories/RepositoryParamValidator.java
@@ -44,6 +44,9 @@ public class RepositoryParamValidator {
     }
 
     public void validate(String type, GenericProperties<?> genericProperties, Settings settings) {
+        // make sure only supported keys are present
+        validateSupportedOnly(type, new GenericProperties<>(settings.getAsStructuredMap()));
+
         TypeSettings typeSettings = settingsForType(type);
         Map<String, Setting<?>> allSettings = typeSettings.all();
 
@@ -69,6 +72,22 @@ public class RepositoryParamValidator {
                     String.join(", ", missingRequiredSettings))
             );
         }
+    }
+
+    /**
+     * Validates that the provided {@code properties} contain only supported keys for the given {@code type}.
+     * The method is useful in contexts where an object is updated. To check if required properties are present
+     * use {@link #validate(String, GenericProperties, Settings)}.
+     *
+     * @param type          the type whose supported keys are checked against
+     * @param properties    the properties map to validate
+     * @throws IllegalArgumentException if unsupported properties are found
+     */
+    public void validateSupportedOnly(String type, GenericProperties<Object> properties) {
+        var supportedKeys = settingsForType(type)
+            .all()
+            .keySet();
+        properties.ensureContainsOnly(supportedKeys);
     }
 
     public TypeSettings settingsForType(String type) {

--- a/server/src/main/java/io/crate/planner/node/ddl/AlterRepositoryPlan.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/AlterRepositoryPlan.java
@@ -34,7 +34,6 @@ import org.elasticsearch.repositories.RepositoryMissingException;
 import io.crate.analyze.AnalyzedAlterRepository;
 import io.crate.analyze.SymbolEvaluator;
 import io.crate.analyze.repositories.RepositoryParamValidator;
-import io.crate.common.annotations.VisibleForTesting;
 import io.crate.data.Row;
 import io.crate.data.Row1;
 import io.crate.data.RowConsumer;
@@ -95,8 +94,7 @@ public class AlterRepositoryPlan implements Plan {
             .whenComplete(new OneRowActionListener<>(consumer, rCount -> new Row1(rCount == null ? -1 : rCount)));
     }
 
-    @VisibleForTesting
-    public static AlterRepositoryRequest createRequest(AnalyzedAlterRepository alterRepository,
+    private AlterRepositoryRequest createRequest(AnalyzedAlterRepository alterRepository,
                                                        CoordinatorTxnCtx txnCtx,
                                                        NodeContext nodeCtx,
                                                        Row parameters,
@@ -113,17 +111,14 @@ public class AlterRepositoryPlan implements Plan {
             subQueryResults
         );
 
+        // make sure that only supported keys are used
         var genericProperties = alterRepository.properties().map(eval);
         var repository = repositoryService.getRepository(alterRepository.name());
         if (repository == null) {
             throw new RepositoryMissingException(alterRepository.name());
         }
 
-        // make sure that only supported keys are used
-        var supportedKeys = repositoryParamValidator.settingsForType(repository.type())
-            .all()
-            .keySet();
-        genericProperties.ensureContainsOnly(supportedKeys);
+        repositoryParamValidator.validateSupportedOnly(repository.type(), genericProperties);
 
         // build and return request
         return new AlterRepositoryRequest(

--- a/server/src/main/java/io/crate/planner/node/ddl/CreateRepositoryPlan.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/CreateRepositoryPlan.java
@@ -21,11 +21,9 @@
 
 package io.crate.planner.node.ddl;
 
-import java.util.Map;
 import java.util.function.Function;
 
 import org.elasticsearch.action.admin.cluster.repositories.put.PutRepositoryRequest;
-import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 
 import io.crate.analyze.AnalyzedCreateRepository;
@@ -93,12 +91,9 @@ public class CreateRepositoryPlan implements Plan {
         );
 
         var genericProperties = createRepository.properties().map(eval);
-        Map<String, Setting<?>> supportedSettings = repositoryParamValidator.settingsForType(createRepository.type()).all();
-        genericProperties.ensureContainsOnly(supportedSettings.keySet());
         var settings = Settings.builder().put(genericProperties).build();
 
-        repositoryParamValidator.validate(
-            createRepository.type(), createRepository.properties(), settings);
+        repositoryParamValidator.validate(createRepository.type(), createRepository.properties(), settings);
 
         PutRepositoryRequest request = new PutRepositoryRequest(createRepository.name());
         request.type(createRepository.type());

--- a/server/src/main/java/org/elasticsearch/action/ActionType.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionType.java
@@ -59,4 +59,9 @@ public class ActionType<Response extends TransportResponse> {
     public int hashCode() {
         return name.hashCode();
     }
+
+    @Override
+    public String toString() {
+        return name;
+    }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/repositories/put/AlterRepositoryRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/repositories/put/AlterRepositoryRequest.java
@@ -23,6 +23,7 @@ import static org.elasticsearch.common.settings.Settings.readSettingsFromStream;
 import static org.elasticsearch.common.settings.Settings.writeSettingsToStream;
 
 import java.io.IOException;
+import java.util.Objects;
 
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -66,5 +67,24 @@ public class AlterRepositoryRequest extends AcknowledgedRequest<AlterRepositoryR
 
     public Settings settings() {
         return this.settings;
+    }
+
+    @Override
+    public String toString() {
+        return "AlterRepositoryRequest{" +
+            "name=" + name + ";" +
+            "settings=" + settings.toString() +
+            '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof AlterRepositoryRequest that)) return false;
+        return Objects.equals(name, that.name) && Objects.equals(settings, that.settings);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, settings);
     }
 }

--- a/server/src/test/java/io/crate/analyze/RepositoryParamValidatorTest.java
+++ b/server/src/test/java/io/crate/analyze/RepositoryParamValidatorTest.java
@@ -33,6 +33,7 @@ import org.junit.Test;
 
 import io.crate.analyze.repositories.RepositoryParamValidator;
 import io.crate.analyze.repositories.TypeSettings;
+import io.crate.expression.symbol.Literal;
 import io.crate.sql.tree.GenericProperties;
 
 public class RepositoryParamValidatorTest extends ESTestCase {
@@ -47,16 +48,49 @@ public class RepositoryParamValidatorTest extends ESTestCase {
     }
 
     @Test
-    public void testValidate() throws Exception {
+    public void test_validate_invalid_type() {
         assertThatThrownBy(() -> validator.validate("invalid_type", GenericProperties.empty(), Settings.EMPTY))
             .isExactlyInstanceOf(IllegalArgumentException.class)
             .hasMessage("Invalid repository type \"invalid_type\"");
     }
 
     @Test
-    public void testRequiredTypeIsMissing() throws Exception {
+    public void test_validate_required_param_missing() {
         assertThatThrownBy(() -> validator.validate("fs", GenericProperties.empty(), Settings.EMPTY))
             .isExactlyInstanceOf(IllegalArgumentException.class)
             .hasMessage("The following required parameters are missing to create a repository of type \"fs\": [location]");
+    }
+
+    @Test
+    public void test_validate_unsupported_setting() {
+        assertThatThrownBy(() -> validator.validate("fs", GenericProperties.empty(), Settings.builder().put("foo", "bar").build()))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Setting 'foo' is not supported");
+    }
+
+    @Test
+    public void test_validate_supported_only_with_unsupported_setting() {
+        assertThatThrownBy(() -> validator.validateSupportedOnly("fs", new GenericProperties<>(Map.of("foo", Literal.of("bar")))))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Setting 'foo' is not supported");
+    }
+
+    @Test
+    public void test_validate_supported_only_with_mandatory_only() {
+        validator.validateSupportedOnly(
+            "fs",
+            new GenericProperties<>(Map.of("location", Literal.of("/tmp/something")))
+        );
+    }
+
+    @Test
+    public void test_validate_supported_only_with_mandatory_and_optional() {
+        validator.validateSupportedOnly(
+            "fs",
+            new GenericProperties<>(Map.of(
+                "location", Literal.of("/tmp/something"),
+                "compress", Literal.of(false)
+            ))
+        );
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/SysRepositoriesServiceTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SysRepositoriesServiceTest.java
@@ -144,13 +144,6 @@ public class SysRepositoriesServiceTest extends IntegTestCase {
             .hasMessageContaining("[test-repo] missing");
     }
 
-    @Test
-    public void test_alter_repository_invalid_setting_name() {
-        assertSQLError(() -> execute("alter repository \"test-repo\" set (invalid_setting = true)"))
-            .hasHTTPError(STATEMENT_INVALID_OR_UNSUPPORTED_SYNTAX.httpResponseStatus(), STATEMENT_INVALID_OR_UNSUPPORTED_SYNTAX.errorCode())
-            .hasMessageContaining("Setting 'invalid_setting' is not supported");
-    }
-
     private void assertRepositorySettings(String repoName, Map<String, Object> expectedSettings) {
         execute("select settings from sys.repositories where name = ?", new Object[]{repoName});
         assertThat(response.rowCount()).isEqualTo(1L);

--- a/server/src/test/java/io/crate/planner/node/ddl/AlterRepositoryPlanTest.java
+++ b/server/src/test/java/io/crate/planner/node/ddl/AlterRepositoryPlanTest.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.node.ddl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.action.admin.cluster.repositories.put.AlterRepositoryRequest;
+import org.elasticsearch.action.admin.cluster.repositories.put.TransportAlterRepository;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.metadata.RepositoryMetadata;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.repositories.RepositoryMissingException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import io.crate.analyze.AnalyzedAlterRepository;
+import io.crate.analyze.repositories.RepositoryParamValidator;
+import io.crate.data.Row;
+import io.crate.data.testing.TestingRowConsumer;
+import io.crate.execution.ddl.RepositoryService;
+import io.crate.expression.symbol.Literal;
+import io.crate.planner.DependencyCarrier;
+import io.crate.planner.PlannerContext;
+import io.crate.planner.operators.SubQueryResults;
+import io.crate.sql.tree.GenericProperties;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AlterRepositoryPlanTest {
+    @Mock
+    RepositoryService repoService;
+    @Mock
+    RepositoryParamValidator repoParamValidator;
+    @Mock
+    Client client;
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    PlannerContext plannerCtx;
+    TestingRowConsumer rowConsumer;
+    @Mock
+    DependencyCarrier dependencyCarrier;
+
+    @Before
+    public void setUp() {
+        rowConsumer = new TestingRowConsumer();
+        when(dependencyCarrier.repositoryService()).thenReturn(repoService);
+        when(dependencyCarrier.repositoryParamValidator()).thenReturn(repoParamValidator);
+        when(dependencyCarrier.client()).thenReturn(client);
+    }
+
+    @Test
+    public void test_execute_or_fail() throws Exception {
+        var underTest = new AlterRepositoryPlan(
+            new AnalyzedAlterRepository(
+                "repo-name",
+                new GenericProperties<>(Map.of("location", Literal.of("/tmp/data")))
+            )
+        );
+
+        when(repoService.getRepository("repo-name"))
+            .thenReturn(new RepositoryMetadata("repo-name", "dummy-type", Settings.EMPTY));
+        when(client.execute(
+            TransportAlterRepository.ACTION, new AlterRepositoryRequest("repo-name", Settings.builder().put("location", "/tmp/data").build())
+        )).thenReturn(CompletableFuture.completedFuture(new AcknowledgedResponse(true)));
+
+        underTest.executeOrFail(dependencyCarrier, plannerCtx, rowConsumer, Row.EMPTY, SubQueryResults.EMPTY);
+
+        assertThat(rowConsumer.getResult()).hasSize(1);
+        assertThat(rowConsumer.getResult().getFirst()).hasSize(1);
+        // the number of rows changed
+        assertThat(rowConsumer.getResult().getFirst()[0]).isEqualTo(1L);
+    }
+
+    @Test
+    public void test_execute_or_fail_missing_repository() {
+        var underTest = new AlterRepositoryPlan(
+            new AnalyzedAlterRepository("repo-name", new GenericProperties<>(Map.of()))
+        );
+
+        assertThatThrownBy(() ->
+            underTest.executeOrFail(dependencyCarrier, plannerCtx, rowConsumer, Row.EMPTY, SubQueryResults.EMPTY)
+        ).isExactlyInstanceOf(RepositoryMissingException.class)
+            .hasMessageContaining("[repo-name]");
+    }
+
+    @Test
+    public void test_execute_or_fail_unsupported_property() {
+        var underTest = new AlterRepositoryPlan(
+            new AnalyzedAlterRepository("repo-name", new GenericProperties<>(Map.of()))
+        );
+
+        when(repoService.getRepository("repo-name"))
+            .thenReturn(new RepositoryMetadata("repo-name", "dummy-type", Settings.EMPTY));
+        doThrow(new IllegalArgumentException("invalid property"))
+            .when(repoParamValidator).validateSupportedOnly(any(), any());
+
+        assertThatThrownBy(() ->
+            underTest.executeOrFail(dependencyCarrier, plannerCtx, rowConsumer, Row.EMPTY, SubQueryResults.EMPTY)
+        ).isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("invalid property");
+    }
+
+    @Test
+    public void test_execute_or_fail_min_node_version() {
+        var underTest = new AlterRepositoryPlan(
+            new AnalyzedAlterRepository("repo-name", new GenericProperties<>(Map.of()))
+        );
+
+        when(plannerCtx.clusterState().nodes().getMinNodeVersion()).thenReturn(Version.V_6_3_2);
+
+        assertThatThrownBy(() ->
+            underTest.executeOrFail(dependencyCarrier, plannerCtx, rowConsumer, Row.EMPTY, SubQueryResults.EMPTY)
+        ).isExactlyInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("Cannot execute ALTER REPOSITORY while there are <6.4.0 nodes in the cluster");
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Follows: #19388.

AlterRepositoryPlan needs to validate if only supported settings are used. I added a helper method for that in `RepositoryParamValidator`, which makes it easier to test and is re-used in `RepositoryParamValidator` itself.

Additionally, `RepositoryParamValidator#validate` was only validating if required settings are provided, and not if only supported are used, which this PR fixes too.

## Checklist

 - [ ] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
