### PR TITLE
Fix build warnings about compiler version, long files in tar

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -43,6 +43,7 @@
                     <descriptors>
                         <descriptor>src/assembly/src.xml</descriptor>
                     </descriptors>
+                    <tarLongFileMode>posix</tarLongFileMode>
                 </configuration>
                 <executions>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -301,8 +301,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.release>25</maven.compiler.release>
 
         <!-- see surefire plugin configuration for explanation -->
         <skipRunTests>false</skipRunTests>

--- a/server/src/main/java/org/elasticsearch/rest/RestStatus.java
+++ b/server/src/main/java/org/elasticsearch/rest/RestStatus.java
@@ -29,6 +29,7 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 /**
  * @deprecated Use {@link io.crate.rest.action.HttpErrorStatus} instead.
  */
+@Deprecated
 public enum RestStatus {
     /**
      * The client SHOULD continue with its request. This interim response is used to inform the client that the


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

* Using `maven.compiler.release` is safer: https://maven.apache.org/plugins/maven-compiler-plugin/examples/set-compiler-release.html
* There was a warning around long file names in the built tar file. The `posix` file format that is used is a more modern standard that handles this, and is readable by any POSIX-compatible tool.
 
## Checklist

 - [ ] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
