### PR TITLE
Reject RESTORE TABLE with mismatching UDF dependencies

### DIFF
--- a/docs/appendices/release-notes/6.3.3.rst
+++ b/docs/appendices/release-notes/6.3.3.rst
@@ -62,3 +62,8 @@ Fixes
 - Fixed intermittent ``UDF`` resolution failures when upgrading metadata from a
   remote cluster, for example during
   :ref:`logical replication <administration-logical-replication>`.
+
+- Fixed an issue that caused :ref:`RESTORE SNAPSHOT <sql-restore-snapshot>` of
+  tables with ``UDF`` dependencies to accept a matching ``UDF`` signature with
+  a different definition, which led to unexpected generated values on
+  subsequent inserts.

--- a/server/src/main/java/io/crate/expression/udf/UserDefinedFunctionMetadata.java
+++ b/server/src/main/java/io/crate/expression/udf/UserDefinedFunctionMetadata.java
@@ -38,6 +38,10 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import io.crate.analyze.FunctionArgumentDefinition;
 import io.crate.common.collections.Lists;
 import io.crate.exceptions.UnhandledServerException;
+import io.crate.metadata.FunctionName;
+import io.crate.metadata.FunctionType;
+import io.crate.metadata.Scalar;
+import io.crate.metadata.functions.Signature;
 import io.crate.types.ArrayType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -129,8 +133,18 @@ public class UserDefinedFunctionMetadata implements Writeable {
         return specificName;
     }
 
+    public Signature signature() {
+        return Signature.builder(new FunctionName(schema, name), FunctionType.SCALAR)
+            .argumentTypes(Lists.map(argumentTypes, DataType::getTypeSignature))
+            .returnType(returnType.getTypeSignature())
+            .features(Scalar.Feature.DETERMINISTIC)
+            .build();
+    }
+
     public boolean sameSignature(String schema, String name, List<DataType<?>> types) {
-        return this.schema().equals(schema) && this.name().equals(name) && this.argumentTypes().equals(types);
+        Signature signature = signature();
+        return signature.getName().equals(new FunctionName(schema, name))
+            && signature.getArgumentDataTypes().equals(types);
     }
 
     static UserDefinedFunctionMetadata fromXContent(XContentParser parser) throws IOException {

--- a/server/src/main/java/io/crate/expression/udf/UserDefinedFunctionService.java
+++ b/server/src/main/java/io/crate/expression/udf/UserDefinedFunctionService.java
@@ -46,14 +46,12 @@ import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.jspecify.annotations.Nullable;
 
 import io.crate.common.annotations.VisibleForTesting;
-import io.crate.common.collections.Lists;
 import io.crate.common.unit.TimeValue;
 import io.crate.exceptions.UserDefinedFunctionAlreadyExistsException;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.FunctionName;
 import io.crate.metadata.FunctionProvider;
-import io.crate.metadata.FunctionType;
 import io.crate.metadata.GeneratedReference;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -190,12 +188,7 @@ public class UserDefinedFunctionService extends AbstractLifecycleComponent imple
 
     @Nullable
     public FunctionProvider buildFunctionResolver(UserDefinedFunctionMetadata udf) {
-        var functionName = new FunctionName(udf.schema(), udf.name());
-        var signature = Signature.builder(functionName, FunctionType.SCALAR)
-            .argumentTypes(Lists.map(udf.argumentTypes(), DataType::getTypeSignature))
-            .returnType(udf.returnType().getTypeSignature())
-            .features(Scalar.Feature.DETERMINISTIC)
-            .build();
+        Signature signature = udf.signature();
 
         final Scalar<?, ?> scalar;
         try {

--- a/server/src/main/java/io/crate/metadata/doc/AdHocDocTableInfoFactoryProvider.java
+++ b/server/src/main/java/io/crate/metadata/doc/AdHocDocTableInfoFactoryProvider.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.metadata.doc;
+
+import org.elasticsearch.cluster.metadata.Metadata;
+
+import io.crate.expression.udf.UserDefinedFunctionService;
+import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
+
+/**
+ * Creates {@link DocTableInfoFactory} instances based on the given metadata.
+ * Metadata can come from a foreign cluster, so table validation must use UDFs from that metadata
+ * instead of the local UDF registry.
+ */
+public class AdHocDocTableInfoFactoryProvider {
+
+    private final NodeContext nodeContext;
+    private final UserDefinedFunctionService userDefinedFunctionService;
+
+    public AdHocDocTableInfoFactoryProvider(NodeContext nodeContext,
+                                            UserDefinedFunctionService userDefinedFunctionService) {
+        this.nodeContext = nodeContext;
+        this.userDefinedFunctionService = userDefinedFunctionService;
+    }
+
+    public DocTableInfoFactory forMetadata(Metadata metadata) {
+        Functions functions = nodeContext.functions().copyOfBuiltIns();
+        functions.setUDFs(userDefinedFunctionService.buildUDFResolvers(metadata));
+        return new DocTableInfoFactory(
+            new NodeContext(
+                functions,
+                nodeContext.roles(),
+                _ -> nodeContext.schemas(),
+                nodeContext.tableStats()
+            )
+        );
+    }
+}

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataUpgradeService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataUpgradeService.java
@@ -24,7 +24,6 @@ import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_VERSION_U
 import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
 
 import java.util.List;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.LogManager;
@@ -42,7 +41,6 @@ import io.crate.blob.v2.BlobIndex;
 import io.crate.expression.udf.UserDefinedFunctionService;
 import io.crate.expression.udf.UserDefinedFunctionsMetadata;
 import io.crate.fdw.ForeignTablesMetadata;
-import io.crate.metadata.Functions;
 import io.crate.metadata.IndexName;
 import io.crate.metadata.IndexParts;
 import io.crate.metadata.NodeContext;
@@ -50,6 +48,7 @@ import io.crate.metadata.PartitionName;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.doc.DocTableInfoFactory;
+import io.crate.metadata.doc.AdHocDocTableInfoFactoryProvider;
 import io.crate.metadata.upgrade.IndexTemplateUpgrader;
 import io.crate.metadata.upgrade.MetadataIndexUpgrader;
 import io.crate.metadata.view.ViewMetadata;
@@ -71,25 +70,12 @@ public class MetadataUpgradeService {
 
     private final IndexScopedSettings indexScopedSettings;
     private final MetadataIndexUpgrader indexUpgrader;
-    private final Function<Metadata, DocTableInfoFactory> metadataToDocTableInfoFactory;
+    private final AdHocDocTableInfoFactoryProvider adHocDocTableInfoFactoryProvider;
 
     public MetadataUpgradeService(NodeContext nodeContext,
                                   IndexScopedSettings indexScopedSettings,
                                   UserDefinedFunctionService userDefinedFunctionService) {
-        // Creates a DocTableInfoFactory for each upgrade invocation.
-        // Metadata can come from a foreign cluster, so the factory must be solely based on the metadata being upgraded.
-        this.metadataToDocTableInfoFactory = metadata -> {
-            Functions functions = nodeContext.functions().copyOfBuiltIns();
-            functions.setUDFs(userDefinedFunctionService.buildUDFResolvers(metadata));
-            return new DocTableInfoFactory(
-                new NodeContext(
-                    functions,
-                    nodeContext.roles(),
-                    _ -> nodeContext.schemas(),
-                    nodeContext.tableStats()
-                )
-            );
-        };
+        this.adHocDocTableInfoFactoryProvider = new AdHocDocTableInfoFactoryProvider(nodeContext, userDefinedFunctionService);
         this.indexScopedSettings = indexScopedSettings;
         this.indexUpgrader = new MetadataIndexUpgrader();
     }
@@ -114,7 +100,7 @@ public class MetadataUpgradeService {
 
         // DocTableInfoFactory must have access to the UDF definitions from the given
         // Metadata so table validation can resolve UDF dependencies.
-        DocTableInfoFactory tableInfoFactory = metadataToDocTableInfoFactory.apply(newMetadata.build());
+        DocTableInfoFactory adHocTableInfoFactory = adHocDocTableInfoFactoryProvider.forMetadata(newMetadata.build());
 
         ForeignTablesMetadata foreignTablesMetadata = metadata.custom(ForeignTablesMetadata.TYPE);
         if (foreignTablesMetadata != null) {
@@ -138,7 +124,7 @@ public class MetadataUpgradeService {
             assert relation == null
                 : "If there is still a template present there shouldn't be any RelationMetadata";
 
-            DocTableInfo docTable = tableInfoFactory.create(template, OID_UNASSIGNED);
+            DocTableInfo docTable = adHocTableInfoFactory.create(template, OID_UNASSIGNED);
             Version versionCreated = getFixedVersionCreated(metadata, docTable);
 
             // versionCreated could be missing from the template settings and "calculated" afterwards
@@ -178,7 +164,7 @@ public class MetadataUpgradeService {
                     ? newMetadata.getTemplate(PartitionName.templateName(indexName))
                     : null,
                 Version.CURRENT.minimumIndexCompatibilityVersion(),
-                tableInfoFactory);
+                adHocTableInfoFactory);
             // Remove any existing metadata, registered by it's name, for the index
             newMetadata.remove(indexName);
             newMetadata.put(newIndexMetadata, false);
@@ -191,7 +177,7 @@ public class MetadataUpgradeService {
                 RelationName relationName = indexParts.toRelationName();
                 relation = newMetadata.getRelation(relationName);
                 if (!BlobIndex.isBlobIndex(indexName)) {
-                    tableInfo = tableInfoFactory.create(newIndexMetadata, OID_UNASSIGNED);
+                    tableInfo = adHocTableInfoFactory.create(newIndexMetadata, OID_UNASSIGNED);
                 }
             }
             if (relation == null) {
@@ -309,7 +295,7 @@ public class MetadataUpgradeService {
             indexMetadata,
             indexTemplateMetadata,
             minimumIndexCompatibilityVersion,
-            metadataToDocTableInfoFactory.apply(upgradeUDFMetadata(metadata)));
+            adHocDocTableInfoFactoryProvider.forMetadata(upgradeUDFMetadata(metadata)));
     }
 
     private IndexMetadata upgradeIndexMetadata(IndexMetadata indexMetadata,

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -676,6 +676,8 @@ public class Node implements Closeable {
                 clusterModule.getAllocationService(),
                 metadataCreateIndexService,
                 metadataIndexUpgradeService,
+                nodeContext,
+                udfService,
                 clusterService.getClusterSettings(),
                 shardLimitValidator
             );

--- a/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -94,13 +94,22 @@ import io.crate.common.unit.TimeValue;
 import io.crate.exceptions.PartitionAlreadyExistsException;
 import io.crate.exceptions.RelationAlreadyExists;
 import io.crate.exceptions.RelationUnknown;
+import io.crate.expression.symbol.Function;
+import io.crate.expression.symbol.Symbol;
+import io.crate.expression.udf.UserDefinedFunctionMetadata;
+import io.crate.expression.udf.UserDefinedFunctionService;
 import io.crate.expression.udf.UserDefinedFunctionsMetadata;
 import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.GeneratedReference;
 import io.crate.metadata.IndexName;
 import io.crate.metadata.IndexParts;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
+import io.crate.metadata.doc.AdHocDocTableInfoFactoryProvider;
+import io.crate.metadata.doc.DocTableInfo;
+import io.crate.sql.tree.CheckConstraint;
 
 /**
  * Service responsible for restoring snapshots
@@ -136,6 +145,8 @@ public class RestoreService implements ClusterStateApplier {
 
     private final MetadataUpgradeService metadataUpgradeService;
 
+    private final AdHocDocTableInfoFactoryProvider adHocDocTableInfoFactoryProvider;
+
     private final ClusterSettings clusterSettings;
 
     private final CleanRestoreStateTaskExecutor cleanRestoreStateTaskExecutor;
@@ -147,6 +158,8 @@ public class RestoreService implements ClusterStateApplier {
                           AllocationService allocationService,
                           MetadataCreateIndexService createIndexService,
                           MetadataUpgradeService metadataUpgradeService,
+                          NodeContext nodeContext,
+                          UserDefinedFunctionService userDefinedFunctionService,
                           ClusterSettings clusterSettings,
                           ShardLimitValidator shardLimitValidator) {
         this.clusterService = clusterService;
@@ -154,6 +167,7 @@ public class RestoreService implements ClusterStateApplier {
         this.allocationService = allocationService;
         this.createIndexService = createIndexService;
         this.metadataUpgradeService = metadataUpgradeService;
+        this.adHocDocTableInfoFactoryProvider = new AdHocDocTableInfoFactoryProvider(nodeContext, userDefinedFunctionService);
         if (DiscoveryNode.isMasterEligibleNode(clusterService.getSettings())) {
             clusterService.addStateApplier(this);
         }
@@ -417,6 +431,11 @@ public class RestoreService implements ClusterStateApplier {
             MapBuilder<ShardId, RestoreInProgress.ShardRestoreStatus> shardsBuilder = MapBuilder.newMapBuilder();
             boolean ignoreUnavailable = IGNORE_UNAVAILABLE.get(request.settings());
             HashSet<String> restoreIndexNames = new HashSet<>();
+            List<String> customMetadataTypes = Arrays.asList(request.customMetadataTypes());
+            boolean includeAll = customMetadataTypes.isEmpty();
+            boolean restoreSnapshotUDFs = request.includeCustomMetadata()
+                && (includeAll || customMetadataTypes.contains(UserDefinedFunctionsMetadata.TYPE));
+            boolean checkSnapshotTableUDFs = request.includeTables() && restoreSnapshotUDFs == false;
 
             for (Map.Entry<RelationName, RestoreRelation> entry : restoreRelations.entrySet()) {
                 RelationName relationName = entry.getKey();
@@ -499,7 +518,15 @@ public class RestoreService implements ClusterStateApplier {
                     }
                 }
 
-                restoreRelation(relationName, targetName, mdBuilder, currentMetadata, newIndexUUIDs, !ignoreUnavailable);
+                restoreRelation(
+                    relationName,
+                    targetName,
+                    mdBuilder,
+                    currentMetadata,
+                    newIndexUUIDs,
+                    checkSnapshotTableUDFs,
+                    !ignoreUnavailable
+                );
             }
 
 
@@ -558,10 +585,7 @@ public class RestoreService implements ClusterStateApplier {
 
             if (request.includeCustomMetadata() && snapshotMetadata.customs() != null) {
                 // CrateDB patch to only restore defined custom metadata types
-                List<String> customMetadataTypes = Arrays.asList(request.customMetadataTypes());
-                boolean includeAll = customMetadataTypes.isEmpty();
-
-                if (includeAll || customMetadataTypes.contains(UserDefinedFunctionsMetadata.TYPE)) {
+                if (restoreSnapshotUDFs) {
                     for (var schema : snapshotMetadata.schemas().values()) {
                         for (var udf : schema.udfs()) {
                             mdBuilder.setUDF(udf);
@@ -595,6 +619,7 @@ public class RestoreService implements ClusterStateApplier {
                                      Metadata.Builder mdBuilder,
                                      Metadata currentMetadata,
                                      List<String> indexUUIDs,
+                                     boolean checkSnapshotTableUDFs,
                                      boolean strict) {
             RelationMetadata existingRelation = currentMetadata.getRelation(targetName);
             RelationMetadata snapshotRelation = snapshotMetadata.getRelation(relationName);
@@ -611,6 +636,13 @@ public class RestoreService implements ClusterStateApplier {
                 RelationMetadata.Table table;
                 List<Reference> mergedColumns;
                 if (snapshotRelation instanceof RelationMetadata.Table snapshotTable) {
+                    if (checkSnapshotTableUDFs) {
+                        ensureSnapshotTableUDFsMatchCurrentMetadata(
+                            currentMetadata,
+                            snapshotMetadata,
+                            adHocDocTableInfoFactoryProvider.forMetadata(snapshotMetadata).create(snapshotTable.name(), snapshotMetadata)
+                        );
+                    }
                     table = snapshotTable;
                     SnapshotSchemaValidator.validate(snapshot, targetName, snapshotTable, existingTable);
                     Set<ColumnIdent> existingColumns = existingTable.columns().stream()
@@ -647,6 +679,13 @@ public class RestoreService implements ClusterStateApplier {
                 );
             } else if (existingRelation == null) {
                 if (snapshotRelation instanceof RelationMetadata.Table table) {
+                    if (checkSnapshotTableUDFs) {
+                        ensureSnapshotTableUDFsMatchCurrentMetadata(
+                            currentMetadata,
+                            snapshotMetadata,
+                            adHocDocTableInfoFactoryProvider.forMetadata(snapshotMetadata).create(table.name(), snapshotMetadata)
+                        );
+                    }
                     mdBuilder.setTable(
                         targetName,
                         Lists.map(
@@ -962,6 +1001,69 @@ public class RestoreService implements ClusterStateApplier {
             renamed = new RelationName(schema, table);
         }
         return renamed;
+    }
+
+    // RESTORE TABLE does not restore UDF metadata; UDFs referenced by snapshot tables
+    // must already exist in the current metadata with the same definition.
+    @VisibleForTesting
+    static void ensureSnapshotTableUDFsMatchCurrentMetadata(Metadata currentMetadata,
+                                                            Metadata snapshotMetadata,
+                                                            DocTableInfo snapshotTable) {
+        ArrayList<Symbol> expressions = new ArrayList<>();
+        RelationName tableName = snapshotTable.ident();
+        for (Reference column : snapshotTable.defaultExpressionColumns()) {
+            Symbol defaultExpression = column.defaultExpression();
+            if (defaultExpression != null) {
+                expressions.add(defaultExpression);
+            }
+        }
+        for (GeneratedReference generatedReference : snapshotTable.generatedColumns()) {
+            expressions.add(generatedReference.generatedExpression());
+        }
+        for (CheckConstraint<Symbol> checkConstraint : snapshotTable.checkConstraints()) {
+            expressions.add(checkConstraint.expression());
+        }
+
+        for (Symbol expression : expressions) {
+            expression.any(s -> {
+                if (s instanceof Function fn) {
+                    UserDefinedFunctionMetadata snapshotUdf = findUDF(snapshotMetadata, fn);
+                    if (snapshotUdf == null) {
+                        return false;
+                    }
+                    UserDefinedFunctionMetadata currentUdf = findUDF(currentMetadata, fn);
+                    if (currentUdf == null) {
+                        throw new IllegalArgumentException(
+                            "Cannot restore table " + tableName +
+                            " because it depends on UDF " + snapshotUdf.schema() + "." + snapshotUdf.specificName() +
+                            " which does not exist in the current metadata"
+                        );
+                    }
+                    if (currentUdf.equals(snapshotUdf) == false) {
+                        throw new IllegalArgumentException(
+                            "Cannot restore table " + tableName +
+                            " because it depends on UDF " + snapshotUdf.schema() + "." + snapshotUdf.specificName() +
+                            " but a different UDF with the same signature exists in the current metadata"
+                        );
+                    }
+                }
+                return false;
+            });
+        }
+    }
+
+    private static UserDefinedFunctionMetadata findUDF(Metadata metadata, Function function) {
+        var functionName = function.signature().getName();
+        var schemaMetadata = metadata.schemas().get(functionName.schema());
+        if (schemaMetadata == null) {
+            return null;
+        }
+        for (var udf : schemaMetadata.udfs()) {
+            if (udf.sameSignature(functionName.schema(), functionName.name(), function.signature().getArgumentDataTypes())) {
+                return udf;
+            }
+        }
+        return null;
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/snapshots/RestoreServiceTest.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/RestoreServiceTest.java
@@ -22,7 +22,9 @@
 package org.elasticsearch.snapshots;
 
 import static io.crate.analyze.SnapshotSettings.IGNORE_UNAVAILABLE;
+import static io.crate.expression.udf.UdfUnitTest.DUMMY_LANG;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.elasticsearch.snapshots.RestoreService.resolveRelations;
 import static org.elasticsearch.test.IntegTestCase.resolveIndex;
 
@@ -39,13 +41,121 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.Index;
 import org.junit.Test;
 
+import io.crate.analyze.FunctionArgumentDefinition;
+import io.crate.expression.udf.UserDefinedFunctionMetadata;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.doc.DocSchemaInfo;
+import io.crate.metadata.doc.DocTableInfo;
+import io.crate.metadata.doc.DocTableInfoFactory;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
+import io.crate.types.DataTypes;
 
 public class RestoreServiceTest extends CrateDummyClusterServiceUnitTest {
+
+    @Test
+    public void test_restore_table_with_udf_dependency_fails_if_udf_is_missing_in_current_metadata() throws Exception {
+        UserDefinedFunctionMetadata snapshotUdf = new UserDefinedFunctionMetadata(
+            "doc",
+            "foo",
+            List.of(FunctionArgumentDefinition.of("i", DataTypes.INTEGER)),
+            DataTypes.INTEGER,
+            DUMMY_LANG.name(),
+            "function foo(i) { return i + 1; }"
+        );
+        SQLExecutor e = SQLExecutor.builder(clusterService).build()
+            .addUDFLanguage(DUMMY_LANG)
+            .addUDF(snapshotUdf)
+            .addTable("create table doc.t (id int, gen as foo(id))");
+        Metadata snapshotMetadata = clusterService.state().metadata();
+        DocTableInfo table = new DocTableInfoFactory(e.nodeCtx).create(new RelationName("doc", "t"), snapshotMetadata);
+
+        assertThatThrownBy(() -> RestoreService.ensureSnapshotTableUDFsMatchCurrentMetadata(
+            Metadata.EMPTY_METADATA,
+            snapshotMetadata,
+            table
+        ))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Cannot restore table doc.t because it depends on UDF doc.foo(integer) " +
+                        "which does not exist in the current metadata");
+    }
+
+    @Test
+    public void test_restore_table_with_udf_dependency_fails_if_current_udf_has_different_definition() throws Exception {
+        UserDefinedFunctionMetadata snapshotUdf = new UserDefinedFunctionMetadata(
+            "doc",
+            "foo",
+            List.of(FunctionArgumentDefinition.of("i", DataTypes.INTEGER)),
+            DataTypes.INTEGER,
+            DUMMY_LANG.name(),
+            "function foo(i) { return i + 1; }"
+        );
+        UserDefinedFunctionMetadata currentUdf = new UserDefinedFunctionMetadata(
+            "doc",
+            "foo",
+            List.of(FunctionArgumentDefinition.of("i", DataTypes.INTEGER)),
+            DataTypes.INTEGER,
+            DUMMY_LANG.name(),
+            "function foo(i) { return i + 2; }"
+        );
+        SQLExecutor e = SQLExecutor.builder(clusterService).build()
+            .addUDFLanguage(DUMMY_LANG)
+            .addUDF(snapshotUdf)
+            .addTable("create table doc.t (id int, gen as foo(id))");
+        Metadata snapshotMetadata = clusterService.state().metadata();
+        DocTableInfo table = new DocTableInfoFactory(e.nodeCtx).create(new RelationName("doc", "t"), snapshotMetadata);
+        Metadata currentMetadata = Metadata.builder(Metadata.EMPTY_METADATA)
+            .setUDF(currentUdf)
+            .build();
+
+        assertThatThrownBy(() -> RestoreService.ensureSnapshotTableUDFsMatchCurrentMetadata(
+            currentMetadata,
+            snapshotMetadata,
+            table
+        ))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Cannot restore table doc.t because it depends on UDF doc.foo(integer) " +
+                        "but a different UDF with the same signature exists in the current metadata");
+    }
+
+    @Test
+    public void test_restore_table_with_udf_dependency_in_check_constraint_fails_if_current_udf_has_different_definition() throws Exception {
+        UserDefinedFunctionMetadata snapshotUdf = new UserDefinedFunctionMetadata(
+            "doc",
+            "foo",
+            List.of(FunctionArgumentDefinition.of("i", DataTypes.INTEGER)),
+            DataTypes.INTEGER,
+            DUMMY_LANG.name(),
+            "function foo(i) { return i + 1; }"
+        );
+        UserDefinedFunctionMetadata currentUdf = new UserDefinedFunctionMetadata(
+            "doc",
+            "foo",
+            List.of(FunctionArgumentDefinition.of("i", DataTypes.INTEGER)),
+            DataTypes.INTEGER,
+            DUMMY_LANG.name(),
+            "function foo(i) { return i + 2; }"
+        );
+        SQLExecutor e = SQLExecutor.builder(clusterService).build()
+            .addUDFLanguage(DUMMY_LANG)
+            .addUDF(snapshotUdf)
+            .addTable("create table doc.t (id int, constraint chk check (foo(id) > 0))");
+        Metadata snapshotMetadata = clusterService.state().metadata();
+        DocTableInfo table = new DocTableInfoFactory(e.nodeCtx).create(new RelationName("doc", "t"), snapshotMetadata);
+        Metadata currentMetadata = Metadata.builder(Metadata.EMPTY_METADATA)
+            .setUDF(currentUdf)
+            .build();
+
+        assertThatThrownBy(() -> RestoreService.ensureSnapshotTableUDFsMatchCurrentMetadata(
+            currentMetadata,
+            snapshotMetadata,
+            table
+        ))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Cannot restore table doc.t because it depends on UDF doc.foo(integer) " +
+                        "but a different UDF with the same signature exists in the current metadata");
+    }
 
     @Test
     public void resolve_indices_multiple_tables_specified() throws Exception {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Restoring a table with UDF dependencies only matched UDFs by signature, not by definition. If the current metadata contained a UDF with the same signature but a different definition, subsequent inserts could produce unexpected generated values.

```
-- Create snapshot with table depending on doc.foo(integer)
CREATE REPOSITORY repo TYPE fs
WITH (location = '/tmp/backups');

CREATE FUNCTION doc.foo(integer)
RETURNS integer
LANGUAGE JAVASCRIPT
AS 'function foo(x) { return x + 1; }';

CREATE TABLE doc.t (
    id integer,
    gen integer GENERATED ALWAYS AS doc.foo(id)
) CLUSTERED INTO 1 SHARDS WITH (number_of_replicas = 0);

INSERT INTO doc.t (id) VALUES (1);
REFRESH TABLE doc.t;

CREATE SNAPSHOT repo.snap ALL
WITH (wait_for_completion = true);

-- Replace current UDF with same signature but different definition
DROP TABLE doc.t;
DROP FUNCTION doc.foo(integer);

CREATE FUNCTION doc.foo(integer)
RETURNS integer
LANGUAGE JAVASCRIPT
AS 'function foo(x) { return x + 2; }';

-- Restore
RESTORE SNAPSHOT repo.snap TABLE doc.t
WITH (wait_for_completion = true);

-- Insert new row after restore
INSERT INTO doc.t (id) VALUES (2);
REFRESH TABLE doc.t;

-- Observe generated values
SELECT id, gen FROM doc.t ORDER BY id;
-- Before fix:
-- 1 | 2
-- 2 | 4
--
-- With fix:
-- RESTORE SNAPSHOT repo.snap TABLE doc.t is rejected.
```


## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
