### PR TITLE
feat: support for dropping multiple tables

### DIFF
--- a/libs/sql-parser/src/main/antlr/io/crate/sql/parser/antlr/SqlBaseParser.g4
+++ b/libs/sql-parser/src/main/antlr/io/crate/sql/parser/antlr/SqlBaseParser.g4
@@ -99,7 +99,7 @@ statement
 
 dropStmt
     : DROP BLOB TABLE (IF EXISTS)? table                                             #dropBlobTable
-    | DROP TABLE (IF EXISTS)? table                                                  #dropTable
+    | DROP TABLE (IF EXISTS)? table (',' table)*                                     #dropTable
     | DROP ALIAS qname                                                               #dropAlias
     | DROP REPOSITORY ident                                                          #dropRepository
     | DROP SNAPSHOT qname                                                            #dropSnapshot

--- a/libs/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
@@ -1398,7 +1398,13 @@ public final class SqlFormatter {
             if (node.dropIfExists()) {
                 builder.append("IF EXISTS ");
             }
-            node.table().accept(this, indent);
+            var tables = node.tables().iterator();
+            while (tables.hasNext()) {
+                tables.next().accept(this, indent);
+                if (tables.hasNext()) {
+                    builder.append(", ");
+                }
+            }
             return null;
         }
 

--- a/libs/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -833,8 +833,15 @@ class AstBuilder extends SqlBaseParserBaseVisitor<Node> {
     }
 
     @Override
+    @SuppressWarnings({"rawtypes", "unchecked"})
     public Node visitDropTable(SqlBaseParser.DropTableContext context) {
-        return new DropTable<>((Table<?>) visit(context.table()), context.EXISTS() != null);
+
+        List<Table> tables = context.table().stream()
+            .map(t -> (Table) visit(t))
+            .toList();
+
+        return new DropTable<Object>((List<Table<Object>>) (List<?>) tables, context.EXISTS() != null
+        );
     }
 
     @Override

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/DefaultTraversalVisitor.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/DefaultTraversalVisitor.java
@@ -337,7 +337,9 @@ public abstract class DefaultTraversalVisitor<R, C> extends AstVisitor<R, C> {
 
     @Override
     public R visitDropTable(DropTable<?> node, C context) {
-        node.table().accept(this, context);
+        for (Table nodeTable : node.tables()) {
+            nodeTable.accept(this, context);
+        }
         return super.visitDropTable(node, context);
     }
 

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/DropTable.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/DropTable.java
@@ -23,14 +23,15 @@ package io.crate.sql.tree;
 
 
 import java.util.Objects;
+import java.util.List;
 
 public class DropTable<T> extends Statement {
 
-    private final Table<T> table;
+    private final List<Table<T>> tables;
     private final boolean dropIfExists;
 
-    public DropTable(Table<T> table, boolean dropIfExists) {
-        this.table = table;
+    public DropTable(List<Table<T>> tables, boolean dropIfExists) {
+        this.tables = tables;
         this.dropIfExists = dropIfExists;
     }
 
@@ -38,8 +39,8 @@ public class DropTable<T> extends Statement {
         return dropIfExists;
     }
 
-    public Table<T> table() {
-        return table;
+    public List<Table<T>> tables() {
+        return tables;
     }
 
     @Override
@@ -57,19 +58,19 @@ public class DropTable<T> extends Statement {
         }
         DropTable<?> dropTable = (DropTable<?>) o;
         return dropIfExists == dropTable.dropIfExists &&
-               Objects.equals(table, dropTable.table);
+               Objects.equals(tables, dropTable.tables);
     }
 
     @Override
     public String toString() {
         return "DropTable{" +
-               "table=" + table +
+               "tables=" + tables +
                ", dropIfExists=" + dropIfExists +
                '}';
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(table, dropIfExists);
+        return Objects.hash(tables, dropIfExists);
     }
 }

--- a/libs/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/libs/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -351,6 +351,7 @@ public class TestStatementBuilder {
         printStatement("drop table test");
         printStatement("drop table if exists test");
         printStatement("drop table bar.foo");
+        printStatement("drop table test, bar.test, bar.foo");
     }
 
     @Test


### PR DESCRIPTION
closes #2036

## Implemented support for dropping multiple tables in a single statement

### Changes included:

- Extended SQL grammar to support `DROP TABLE t1, t2, ...`
- Updated AstBuilder to create a List<Table> of tables which needs to be dropped
- Updated SqlFormatter and DefaultTraversalVisitor to handle list of tables instead of single table
- Added relevant parser tests


This PR follows the implementation direction mentioned in the discussion, where handling postgresql-style transactional atomicity was considered optional for the initial PR. The implementation focuses on enabling multiple table drop support without adding rollback behavior if one of the table drops fails.