### PR TITLE
Fix node startup failure due to parsing UUID column type from Metadata

### DIFF
--- a/docs/appendices/release-notes/6.2.9.rst
+++ b/docs/appendices/release-notes/6.2.9.rst
@@ -1,0 +1,53 @@
+.. _version_6.2.9:
+
+==========================
+Version 6.2.9 - Unreleased
+==========================
+
+.. comment 1. Remove the " - Unreleased" from the header above and adjust the ==
+.. comment 2. Remove the NOTE below and replace with: "Released on 20XX-XX-XX."
+.. comment    (without a NOTE entry, simply starting from col 1 of the line)
+.. NOTE::
+
+    In development. 6.2.9 isn't released yet. These are the release notes for
+    the upcoming release.
+
+.. NOTE::
+
+    If you are upgrading a cluster, you must be running CrateDB 5.0.0 or higher
+    before you upgrade to 6.2.9.
+
+    We recommend that you upgrade to the latest 6.1 release before moving to
+    6.2.9.
+
+    A rolling upgrade from >= 6.1.2 to 6.2.9 is supported. Doing a rolling
+    upgrade from an earlier version than 6.1.2 can cause runtime errors when
+    executing statements relying on implicit casts.
+
+    Before upgrading, you should `back up your data`_.
+
+.. WARNING::
+
+    Tables that were created before CrateDB 5.x will not function with 6.x
+    and must be recreated before moving to 6.x.x.
+
+    You can recreate tables using ``COPY TO`` and ``COPY FROM`` or by
+    `inserting the data into a new table`_.
+
+.. _back up your data: https://cratedb.com/docs/crate/reference/en/latest/admin/snapshots.html
+.. _inserting the data into a new table: https://cratedb.com/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
+
+.. rubric:: Table of contents
+
+.. contents::
+   :local:
+
+
+See the :ref:`version_6.2.0` release notes for a full list of changes in the 6.2
+series.
+
+Fixes
+=====
+
+- Fixed an issue that caused nodes to fail to start when parsing persisted
+  mappings for tables containing columns of type ``uuid``.

--- a/docs/appendices/release-notes/6.3.3.rst
+++ b/docs/appendices/release-notes/6.3.3.rst
@@ -66,3 +66,6 @@ Fixes
 - Fixed intermittent ``UDF`` resolution failures when upgrading metadata from a
   remote cluster, for example during
   :ref:`logical replication <administration-logical-replication>`.
+
+- Fixed an issue that caused nodes to fail to start when parsing persisted
+  mappings for tables containing columns of type ``uuid``.

--- a/docs/appendices/release-notes/index.rst
+++ b/docs/appendices/release-notes/index.rst
@@ -47,6 +47,7 @@ Versions
 .. toctree::
     :maxdepth: 1
 
+    6.2.9
     6.2.8
     6.2.7
     6.2.6

--- a/server/src/main/java/io/crate/types/DataTypes.java
+++ b/server/src/main/java/io/crate/types/DataTypes.java
@@ -493,7 +493,8 @@ public final class DataTypes {
         entry("nested", UNTYPED_OBJECT),
         entry("interval", DataTypes.INTERVAL),
         entry(FloatVectorType.INSTANCE_ONE.getName(), FloatVectorType.INSTANCE_ONE),
-        entry("undefined", DataTypes.UNDEFINED)
+        entry("undefined", DataTypes.UNDEFINED),
+        entry(UUIDType.NAME, UUIDType.INSTANCE)
     );
 
     private static final Map<Integer, String> TYPE_IDS_TO_MAPPINGS = Map.ofEntries(

--- a/server/src/test/java/io/crate/metadata/doc/DocTableInfoFactoryTest.java
+++ b/server/src/test/java/io/crate/metadata/doc/DocTableInfoFactoryTest.java
@@ -51,6 +51,7 @@ import io.crate.metadata.NodeContext;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.RelationName;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.types.UUIDType;
 
 
 public class DocTableInfoFactoryTest extends CrateDummyClusterServiceUnitTest {
@@ -276,5 +277,35 @@ public class DocTableInfoFactoryTest extends CrateDummyClusterServiceUnitTest {
 
         assertThat(docTableInfo.indexColumn(ColumnIdent.of("text_ft")))
             .isNotNull();
+    }
+
+    @Test
+    public void test_uuid_column_from_mapping_is_parsed_as_uuid_type() {
+        RelationName tbl = new RelationName(randomSchema(), "tbl");
+        String mapping = """
+            {
+              "default": {
+                "properties": {
+                  "id": {
+                    "type": "uuid",
+                    "position": 1
+                  }
+                }
+              }
+            }
+            """;
+        IndexMetadata.Builder indexMetadataBuilder = IndexMetadata.builder(tbl.indexNameOrAlias())
+            .settings(Settings.builder().put("index.version.created", Version.CURRENT).build())
+            .numberOfReplicas(0)
+            .numberOfShards(5)
+            .putMapping(mapping);
+        Metadata metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED)
+            .put(indexMetadataBuilder)
+            .build();
+        metadata = metadataUpgradeService.upgradeMetadata(metadata);
+
+        DocTableInfo docTableInfo = new DocTableInfoFactory(nodeCtx).create(tbl, metadata);
+
+        assertThat(docTableInfo.getReference(ColumnIdent.of("id")).valueType()).isEqualTo(UUIDType.INSTANCE);
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Fixes https://github.com/crate/support/issues/877.

```
  |   | 2026-05-15 15:50:24.180 | at org.elasticsearch.cluster.metadata.MetadataUpgradeService.checkMappingsCompatibility(MetadataUpgradeService.java:305) |  
  |   | 2026-05-15 15:50:24.180 | at io.crate.metadata.doc.DocTableInfoFactory.create(DocTableInfoFactory.java:211) |  
  |   | 2026-05-15 15:50:24.180 | at io.crate.metadata.doc.DocTableInfoFactory.create(DocTableInfoFactory.java:273) |  
  |   | 2026-05-15 15:50:24.180 | at io.crate.metadata.doc.DocTableInfoFactory.parseColumns(DocTableInfoFactory.java:414) |  
  |   | 2026-05-15 15:50:24.180 | at io.crate.types.DataType.storageSupportSafe(DataType.java:318) |  
  |   | 2026-05-15 15:50:24.180 | Caused by: java.lang.UnsupportedOperationException: Type `NOT SUPPORTED` does not support storage |  
```
above exception was thrown during a node startup and is caused by parsing `"uuid"` into a `UUIDType`.


## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
