### PR TITLE
tests: Fix SqlLogicITest to return an xml report for failures

### DIFF
--- a/server/src/testFixtures/java/io/crate/test/integration/SQLLogicParser.java
+++ b/server/src/testFixtures/java/io/crate/test/integration/SQLLogicParser.java
@@ -55,8 +55,8 @@ public final class SQLLogicParser {
 
     SQLLogicParser() {}
 
-    /** Thrown when the actual cursor result does not match the expected one. */
-    public static final class IncorrectResultException extends RuntimeException {
+    /** Thrown when the actual result does not match the expected one. */
+    public static final class IncorrectResultException extends AssertionError {
 
         public IncorrectResultException(String message) {
             super(message);


### PR DESCRIPTION
Change `IncorrectResultException` to extend `AssertionError` which is recognized by surefire test report plugin.
