### PR TITLE
Remove dead code from doDeleteShardSnapshots

### DIFF
--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -628,51 +628,36 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
     private void doDeleteShardSnapshots(Collection<SnapshotId> snapshotIds, long repositoryStateId, Map<String, BlobContainer> foundIndices,
                                         List<String> rootBlobs, RepositoryData repositoryData, Version repoMetaVersion,
                                         ActionListener<RepositoryData> listener) {
-
-        if (SnapshotsService.useShardGenerations(repoMetaVersion)) {
-            // First write the new shard state metadata (with the removed snapshot) and compute deletion targets
-            final StepListener<Collection<ShardSnapshotMetaDeleteResult>> writeShardMetaDataAndComputeDeletesStep = new StepListener<>();
-            writeUpdatedShardMetaDataAndComputeDeletes(snapshotIds, repositoryData, true, writeShardMetaDataAndComputeDeletesStep);
-            // Once we have put the new shard-level metadata into place, we can update the repository metadata as follows:
-            // 1. Remove the snapshots from the list of existing snapshots
-            // 2. Update the index shard generations of all updated shard folders
-            //
-            // Note: If we fail updating any of the individual shard paths, none of them are changed since the newly created
-            //       index-${gen_uuid} will not be referenced by the existing RepositoryData and new RepositoryData is only
-            //       written if all shard paths have been successfully updated.
-            final StepListener<RepositoryData> writeUpdatedRepoDataStep = new StepListener<>();
-            writeShardMetaDataAndComputeDeletesStep.whenComplete(deleteResults -> {
-                final ShardGenerations.Builder builder = ShardGenerations.builder();
-                for (ShardSnapshotMetaDeleteResult newGen : deleteResults) {
-                    builder.put(newGen.indexId, newGen.shardId, newGen.newGeneration);
-                }
-                final RepositoryData updatedRepoData = repositoryData.removeSnapshots(snapshotIds, builder.build());
-                writeIndexGen(updatedRepoData, repositoryStateId, repoMetaVersion, UnaryOperator.identity(),
-                    ActionListener.wrap(writeUpdatedRepoDataStep::onResponse, listener::onFailure));
-            }, listener::onFailure);
-            // Once we have updated the repository, run the clean-ups
-            writeUpdatedRepoDataStep.whenComplete(updatedRepoData -> {
-                // Run unreferenced blobs cleanup in parallel to shard-level snapshot deletion
-                final ActionListener<Void> afterCleanupsListener =
-                    MultiActionListener.of(2, ActionListener.wrap(() -> listener.onResponse(updatedRepoData)));
-                asyncCleanupUnlinkedRootAndIndicesBlobs(snapshotIds, foundIndices, rootBlobs, updatedRepoData, afterCleanupsListener);
-                asyncCleanupUnlinkedShardLevelBlobs(repositoryData, snapshotIds, writeShardMetaDataAndComputeDeletesStep.result(),
-                    afterCleanupsListener);
-            }, listener::onFailure);
-        } else {
-            // Write the new repository data first (with the removed snapshot), using no shard generations
-            final RepositoryData updatedRepoData = repositoryData.removeSnapshots(snapshotIds, ShardGenerations.EMPTY);
-            writeIndexGen(updatedRepoData, repositoryStateId, repoMetaVersion, UnaryOperator.identity(), ActionListener.wrap(newRepoData -> {
-                // Run unreferenced blobs cleanup in parallel to shard-level snapshot deletion
-                final ActionListener<Void> afterCleanupsListener = MultiActionListener.of(2, ActionListener.wrap(() -> listener.onResponse(newRepoData)));
-                asyncCleanupUnlinkedRootAndIndicesBlobs(snapshotIds, foundIndices, rootBlobs, newRepoData, afterCleanupsListener);
-                final StepListener<Collection<ShardSnapshotMetaDeleteResult>> writeMetaAndComputeDeletesStep = new StepListener<>();
-                writeUpdatedShardMetaDataAndComputeDeletes(snapshotIds, repositoryData, false, writeMetaAndComputeDeletesStep);
-                writeMetaAndComputeDeletesStep.whenComplete(deleteResults ->
-                        asyncCleanupUnlinkedShardLevelBlobs(repositoryData, snapshotIds, deleteResults, afterCleanupsListener),
-                    afterCleanupsListener::onFailure);
-            }, listener::onFailure));
-        }
+        assert SnapshotsService.useShardGenerations(repoMetaVersion) : "Versions without (<= 4.2) shardGenerations aren't supported";
+        // First write the new shard state metadata (with the removed snapshot) and compute deletion targets
+        final StepListener<Collection<ShardSnapshotMetaDeleteResult>> writeShardMetaDataAndComputeDeletesStep = new StepListener<>();
+        writeUpdatedShardMetaDataAndComputeDeletes(snapshotIds, repositoryData, true, writeShardMetaDataAndComputeDeletesStep);
+        // Once we have put the new shard-level metadata into place, we can update the repository metadata as follows:
+        // 1. Remove the snapshots from the list of existing snapshots
+        // 2. Update the index shard generations of all updated shard folders
+        //
+        // Note: If we fail updating any of the individual shard paths, none of them are changed since the newly created
+        //       index-${gen_uuid} will not be referenced by the existing RepositoryData and new RepositoryData is only
+        //       written if all shard paths have been successfully updated.
+        final StepListener<RepositoryData> writeUpdatedRepoDataStep = new StepListener<>();
+        writeShardMetaDataAndComputeDeletesStep.whenComplete(deleteResults -> {
+            final ShardGenerations.Builder builder = ShardGenerations.builder();
+            for (ShardSnapshotMetaDeleteResult newGen : deleteResults) {
+                builder.put(newGen.indexId, newGen.shardId, newGen.newGeneration);
+            }
+            final RepositoryData updatedRepoData = repositoryData.removeSnapshots(snapshotIds, builder.build());
+            writeIndexGen(updatedRepoData, repositoryStateId, repoMetaVersion, UnaryOperator.identity(),
+                ActionListener.wrap(writeUpdatedRepoDataStep::onResponse, listener::onFailure));
+        }, listener::onFailure);
+        // Once we have updated the repository, run the clean-ups
+        writeUpdatedRepoDataStep.whenComplete(updatedRepoData -> {
+            // Run unreferenced blobs cleanup in parallel to shard-level snapshot deletion
+            final ActionListener<Void> afterCleanupsListener =
+                MultiActionListener.of(2, ActionListener.wrap(() -> listener.onResponse(updatedRepoData)));
+            asyncCleanupUnlinkedRootAndIndicesBlobs(snapshotIds, foundIndices, rootBlobs, updatedRepoData, afterCleanupsListener);
+            asyncCleanupUnlinkedShardLevelBlobs(repositoryData, snapshotIds, writeShardMetaDataAndComputeDeletesStep.result(),
+                afterCleanupsListener);
+        }, listener::onFailure);
     }
 
     private void asyncCleanupUnlinkedRootAndIndicesBlobs(Collection<SnapshotId> deletedSnapshots, Map<String, BlobContainer> foundIndices,

--- a/server/src/test/java/org/elasticsearch/snapshots/CorruptedBlobStoreRepositoryIT.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/CorruptedBlobStoreRepositoryIT.java
@@ -24,7 +24,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
-import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -43,20 +42,17 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.unit.ByteSizeUnit;
-import org.elasticsearch.common.util.concurrent.FutureUtils;
 import org.elasticsearch.common.xcontent.DeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.repositories.IndexId;
-import org.elasticsearch.repositories.IndexMetaDataGenerations;
 import org.elasticsearch.repositories.RepositoriesService;
 import org.elasticsearch.repositories.Repository;
 import org.elasticsearch.repositories.RepositoryData;
 import org.elasticsearch.repositories.RepositoryException;
 import org.elasticsearch.repositories.ShardGenerations;
 import org.elasticsearch.repositories.blobstore.BlobStoreRepository;
-import org.elasticsearch.threadpool.ThreadPool;
 import org.junit.Test;
 
 import io.crate.concurrent.FutureActionListener;
@@ -193,67 +189,6 @@ public class CorruptedBlobStoreRepositoryIT extends AbstractSnapshotIntegTestCas
         logger.info("--> make sure snapshot doesn't exist");
         execute("select * from sys.snapshots where repository = 'test' and name = 'snapshot1'");
         assertThat(response.rowCount()).isEqualTo(0L);
-    }
-
-    @Test
-    public void testHandlingMissingRootLevelSnapshotMetadata() throws Exception {
-        Path repo = randomRepoPath();
-        final String repoName = "test";
-        logger.info("-->  creating repository at {}", repo.toAbsolutePath());
-
-        execute("CREATE REPOSITORY test TYPE fs with (location=?, compress=false, chunk_size=?)",
-                new Object[]{repo.toAbsolutePath().toString(), randomIntBetween(100, 1000) + ByteSizeUnit.BYTES.getSuffix()});
-
-        final String snapshotPrefix = "test-snap-";
-        final int snapshots = randomIntBetween(1, 2);
-        logger.info("--> creating [{}] snapshots", snapshots);
-        for (int i = 0; i < snapshots; ++i) {
-            // Workaround to simulate BwC situation: taking a snapshot without indices here so that we don't create any new version shard
-            // generations (the existence of which would short-circuit checks for the repo containing old version snapshots)
-            var createSnapshot = new CreateSnapshotRequest(repoName, snapshotPrefix + i).waitForCompletion(true);
-            var createSnapshotResponse = client().execute(TransportCreateSnapshot.ACTION, createSnapshot).get();
-            assertThat(createSnapshotResponse.getSnapshotInfo().successfulShards()).isEqualTo(0);
-            assertThat(createSnapshotResponse.getSnapshotInfo().successfulShards()).isEqualTo(createSnapshotResponse.getSnapshotInfo().totalShards());
-        }
-        final Repository repository = cluster().getCurrentMasterNodeInstance(RepositoriesService.class).repository(repoName);
-        final RepositoryData repositoryData = getRepositoryData(repository);
-
-        final SnapshotId snapshotToCorrupt = randomFrom(repositoryData.getSnapshotIds());
-        logger.info("--> delete root level snapshot metadata blob for snapshot [{}]", snapshotToCorrupt);
-        Files.delete(repo.resolve(String.format(Locale.ROOT, BlobStoreRepository.SNAPSHOT_NAME_FORMAT, snapshotToCorrupt.getUUID())));
-
-        logger.info("--> strip version information from index-N blob");
-        final RepositoryData withoutVersions = new RepositoryData(repositoryData.getGenId(),
-            repositoryData.getSnapshotIds().stream().collect(Collectors.toMap(
-                SnapshotId::getUUID, Function.identity())),
-            repositoryData.getSnapshotIds().stream().collect(Collectors.toMap(
-                SnapshotId::getUUID, repositoryData::getSnapshotState)),
-                Collections.emptyMap(), Collections.emptyMap(), ShardGenerations.EMPTY, IndexMetaDataGenerations.EMPTY);
-
-        Files.write(repo.resolve(BlobStoreRepository.INDEX_FILE_PREFIX + withoutVersions.getGenId()),
-            BytesReference.toBytes(BytesReference.bytes(withoutVersions.snapshotsToXContent(JsonXContent.builder(),
-                Version.CURRENT))), StandardOpenOption.TRUNCATE_EXISTING);
-
-        logger.info("--> verify that repo is assumed in old metadata format");
-        final SnapshotsService snapshotsService = cluster().getCurrentMasterNodeInstance(SnapshotsService.class);
-        final ThreadPool threadPool = cluster().getCurrentMasterNodeInstance(ThreadPool.class);
-        assertThat(
-            FutureUtils.get(threadPool.generic().submit(() ->
-                snapshotsService.minCompatibleVersion(Version.CURRENT, getRepositoryData(repository), null)
-            ))).isEqualTo(SnapshotsService.OLD_SNAPSHOT_FORMAT);
-
-        logger.info("--> verify that snapshot with missing root level metadata can be deleted");
-        execute("drop snapshot test.\"" + snapshotToCorrupt.getName() + "\"");
-
-        logger.info("--> verify that repository is assumed in new metadata format after removing corrupted snapshot");
-        assertThat(
-            FutureUtils.get(threadPool.generic().submit(() ->
-                snapshotsService.minCompatibleVersion(Version.CURRENT, getRepositoryData(repository), null)
-            ))).isEqualTo(Version.CURRENT);
-        final RepositoryData finalRepositoryData = getRepositoryData(repository);
-        for (SnapshotId snapshotId : finalRepositoryData.getSnapshotIds()) {
-            assertThat(finalRepositoryData.getVersion(snapshotId)).isEqualTo(Version.CURRENT);
-        }
     }
 
     @Test


### PR DESCRIPTION
CrateDB 6.4+ doesn't support reading snapshots created before CrateDB 4.2

Note that there are more `useShardGenerations` usages, including streaming it as a flag.

For now not touching streaming, only simplifying code related to https://github.com/crate/support/issues/860 