### PR TITLE
Don't add utc offset in pgwire timestamp text encoding

### DIFF
--- a/docs/appendices/release-notes/6.3.3.rst
+++ b/docs/appendices/release-notes/6.3.3.rst
@@ -46,6 +46,10 @@ series.
 Fixes
 =====
 
+- Changed the PostgreSQL wire format text encoding for ``TIMESTAMP WITHOUT TIME
+  ZONE`` to not include an UTC offset (``+00``) to match PostgreSQL and fix
+  compatibility issues with ``pgx``.
+
 - Fixed an issue where :ref:`RESTORE SNAPSHOT <sql-restore-snapshot>` of a
   partition into a table with an incompatible schema would silently succeed and
   produce unreadable data. CrateDB now rejects such restores with a clear

--- a/server/src/main/java/io/crate/protocols/postgres/types/TimestampType.java
+++ b/server/src/main/java/io/crate/protocols/postgres/types/TimestampType.java
@@ -58,8 +58,9 @@ final class TimestampType extends BaseTimestampType {
 
     private static final DateTimeFormatter ISO_FORMATTER = new DateTimeFormatterBuilder()
         .parseCaseInsensitive()
-        .appendPattern("yyyy-MM-dd HH:mm:ss.SSS+00")
-        .toFormatter(Locale.ENGLISH).withResolverStyle(ResolverStyle.STRICT);
+        .appendPattern("yyyy-MM-dd HH:mm:ss.SSS")
+        .toFormatter(Locale.ENGLISH)
+        .withResolverStyle(ResolverStyle.STRICT);
 
     private static final DateTimeFormatter ISO_FORMATTER_WITH_ERA = new DateTimeFormatterBuilder()
         .parseCaseInsensitive()

--- a/server/src/test/java/io/crate/protocols/postgres/types/TimestampTypeTest.java
+++ b/server/src/test/java/io/crate/protocols/postgres/types/TimestampTypeTest.java
@@ -53,8 +53,8 @@ public class TimestampTypeTest extends BasePGTypeTest<Long> {
 
     @Test
     public void testEncodeAsUTF8Text() {
-        assertThat(new String(TimestampType.INSTANCE.encodeAsUTF8Text(1467072000000L), UTF_8)).isEqualTo("2016-06-28 00:00:00.000+00");
-        assertThat(new String(TimestampType.INSTANCE.encodeAsUTF8Text(-93661920000000L), UTF_8)).isEqualTo("1000-12-22 00:00:00.000+00 BC");
+        assertThat(new String(TimestampType.INSTANCE.encodeAsUTF8Text(1467072000000L), UTF_8)).isEqualTo("2016-06-28 00:00:00.000");
+        assertThat(new String(TimestampType.INSTANCE.encodeAsUTF8Text(-93661920000000L), UTF_8)).isEqualTo("1000-12-22 00:00:00.000 BC");
     }
 
     @Test
@@ -67,6 +67,8 @@ public class TimestampTypeTest extends BasePGTypeTest<Long> {
     @Test
     public void test_decode_ts_string() throws Exception {
         assertThat(TimestampType.INSTANCE.decodeUTF8Text("2021-01-13T14:37:17.25988".getBytes(UTF_8), null))
+            .isEqualTo(1610548637259L);
+        assertThat(TimestampType.INSTANCE.decodeUTF8Text("2021-01-13 14:37:17.25988".getBytes(UTF_8), null))
             .isEqualTo(1610548637259L);
     }
 }


### PR DESCRIPTION
Including an UTC offset in the timestamp without time zone type in the
text encoding causes issues with clients like pgx.

This removes the UTC offset to match the PostgreSQL format:

    select now()::timestamp;
    +----------------------------+
    | now                        |
    |----------------------------|
    | 2026-05-27 10:30:35.680011 |
    +----------------------------+

Closes https://github.com/crate/crate/issues/19426