### PR TITLE
WIP - fix stuck drop snapshot, also causing many other problems with snapshots

### DIFF
--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -961,7 +961,6 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                             throw new IOException("dummy");
                         }
                         LOGGER.info("[{}] Cleaned up stale index [{}]", metadata.name(), indexSnId);
-                        executeOneStaleIndexDelete(staleIndicesToDelete, listener);
                         return 1L;
                     } catch (IOException e) {
                         LOGGER.warn(() -> new ParameterizedMessage(
@@ -972,6 +971,14 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                         assert false : e;
                         LOGGER.warn(new ParameterizedMessage("[{}] Exception during single stale index delete", metadata.name()), e);
                         return 0L;
+                    } finally {
+                        // Initial loop starts max_workers recursive calls.
+                        // When stale_indices > max_workers and ALL recursion trees fail because of a storage backend issue
+                        // (for example, rate limiting on S3),
+                        // we can end up with unfinished MultiActionListener
+                        // as it's decremented only when we schedule next stale delete.
+                        executeOneStaleIndexDelete(staleIndicesToDelete, listener);
+
                     }
                 }));
             } else {

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -932,7 +932,10 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                 ? ((ThreadPoolExecutor) executor).getMaximumPoolSize()
                 : 1;
             final int workers = Math.min(maximumPoolSize, staleIndicesToDelete.size());
+
+            LOGGER.info("workers number = {}, Runtime.getRuntime().availableProcessors() = {}", workers, Runtime.getRuntime().availableProcessors());
             for (int i = 0; i < workers; ++i) {
+                LOGGER.info("WORKER # " + i + " scheduling executeOneStaleIndexDelete");
                 executeOneStaleIndexDelete(staleIndicesToDelete, groupedListener);
             }
         } catch (Exception e) {
@@ -946,26 +949,36 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
 
     private void executeOneStaleIndexDelete(BlockingQueue<Map.Entry<String, BlobContainer>> staleIndicesToDelete,
                                             ActionListener<Long> listener) throws InterruptedException {
-        Map.Entry<String, BlobContainer> indexEntry = staleIndicesToDelete.poll(0L, TimeUnit.MILLISECONDS);
-        if (indexEntry != null) {
-            final String indexSnId = indexEntry.getKey();
-            threadPool.executor(ThreadPool.Names.SNAPSHOT).execute(ActionRunnable.supply(listener, () -> {
-                try {
-                    indexEntry.getValue().delete();
-                    LOGGER.debug("[{}] Cleaned up stale index [{}]", metadata.name(), indexSnId);
-                    executeOneStaleIndexDelete(staleIndicesToDelete, listener);
-                    return 1L;
-                } catch (IOException e) {
-                    LOGGER.warn(() -> new ParameterizedMessage(
-                        "[{}] index {} is no longer part of any snapshots in the repository, " +
-                            "but failed to clean up their index folders", metadata.name(), indexSnId), e);
-                    return 0L;
-                } catch (Exception e) {
-                    assert false : e;
-                    LOGGER.warn(new ParameterizedMessage("[{}] Exception during single stale index delete", metadata.name()), e);
-                    return 0L;
-                }
-            }));
+        try {
+            LOGGER.info("Before staleIndicesToDelete.poll");
+            Map.Entry<String, BlobContainer> indexEntry = staleIndicesToDelete.poll(0L, TimeUnit.MILLISECONDS);
+            LOGGER.info("after staleIndicesToDelete.poll");
+            if (indexEntry != null) {
+                final String indexSnId = indexEntry.getKey();
+                threadPool.executor(ThreadPool.Names.SNAPSHOT).execute(ActionRunnable.supply(listener, () -> {
+                    try {
+                        if (3 < 5) {
+                            throw new IOException("dummy");
+                        }
+                        LOGGER.info("[{}] Cleaned up stale index [{}]", metadata.name(), indexSnId);
+                        executeOneStaleIndexDelete(staleIndicesToDelete, listener);
+                        return 1L;
+                    } catch (IOException e) {
+                        LOGGER.warn(() -> new ParameterizedMessage(
+                            "[{}] index {} is no longer part of any snapshots in the repository, " +
+                                "but failed to clean up their index folders", metadata.name(), indexSnId), e);
+                        return 0L;
+                    } catch (Exception e) {
+                        assert false : e;
+                        LOGGER.warn(new ParameterizedMessage("[{}] Exception during single stale index delete", metadata.name()), e);
+                        return 0L;
+                    }
+                }));
+            } else {
+                LOGGER.info("staleIndicesToDelete.poll returned NULL, doing nothing");
+            }
+        } catch (Exception e) {
+            LOGGER.error(e);
         }
     }
 

--- a/server/src/test/java/io/crate/integrationtests/SnapshotRestoreIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SnapshotRestoreIntegrationTest.java
@@ -1181,6 +1181,32 @@ public class SnapshotRestoreIntegrationTest extends IntegTestCase {
         assertThat(response).hasRows("1| 1", "2| 2");
     }
 
+    @Test
+    public void debug() throws Exception {
+        // Processors number is set as builder.put(EsExecutors.PROCESSORS_SETTING.getKey(), 1 + random.nextInt(3)).
+        // To make reproduction stable, using max + 1 = halfProcMaxAt5 + 1,
+        // so that test fails regardless of processors count.
+        for (int i = 0; i < 6; i++) {
+            StringBuilder sb = new StringBuilder("CREATE TABLE t")
+                .append(i)
+                .append(" AS SELECT a, random() b FROM generate_series(1, 10, 1) as t(a)");
+            execute(sb.toString());
+        }
+        execute("CREATE SNAPSHOT my_repo.test_snapshot ALL WITH (wait_for_completion=true)");
+        for (int i = 0; i < 6; i++) {
+            execute("DROP TABLE t"+ i);
+        }
+
+        execute("DROP SNAPSHOT " + REPOSITORY_NAME + ".test_snapshot");
+        /*
+        assertThat(response.rowCount()).isEqualTo(1L);
+
+        execute("select * from sys.snapshots where name = 'test_snapshot'");
+        assertThat(response.rowCount()).isEqualTo(0L);
+        assertAllRepoSnapshotFilesAreDeleted(defaultRepositoryLocation);
+        */
+    }
+
     private void execute_statements_that_restore_tables_with_different_fqn(boolean partitioned) throws Exception {
         // One with doc schema and another with custom schema.
         createTable("source.my_table_1", partitioned);

--- a/server/src/test/java/io/crate/integrationtests/SnapshotRestoreIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SnapshotRestoreIntegrationTest.java
@@ -1198,13 +1198,14 @@ public class SnapshotRestoreIntegrationTest extends IntegTestCase {
         }
 
         execute("DROP SNAPSHOT " + REPOSITORY_NAME + ".test_snapshot");
-        /*
+
+
         assertThat(response.rowCount()).isEqualTo(1L);
 
         execute("select * from sys.snapshots where name = 'test_snapshot'");
         assertThat(response.rowCount()).isEqualTo(0L);
         assertAllRepoSnapshotFilesAreDeleted(defaultRepositoryLocation);
-        */
+
     }
 
     private void execute_statements_that_restore_tables_with_different_fqn(boolean partitioned) throws Exception {


### PR DESCRIPTION
In 6.0, we [ported](https://github.com/crate/crate/pull/17946)  OpenSearch change to speed up DROP SNAPSHOT.

It brought us 2 problems

1. Bug with not scheduling another one stale index deletion in non-happy path (say due to rate limiting on s3).
    Because scheduling here is also supposed to countdown `MultiActionListener` per each blob in the stale index, 
    not doing it caused wrapped listener (the whole chain of wrapped listeners) to be not finished.

    `CREATE SNAPSHOT` also uses `SNAPSHOT` thread pool, so eventually occupying all threads via one or more 
    stuck DROP-s, CREATE would also stuck.
    
    ---
    
    Current quick fix (second commit) - ensure that we keep recursively exhausting queue with stale indices to 
    countdown listener. 

    This is NOT a way to go, just a demo to prove the point about `MultiActionListener` not being reduced to zero.
    We can't go with this fix, as we would basically keep firing useless HTTP requests 
    (sometimes bound to fail due to rate limiting on blob storage side), it too inefficient.
    
     I have seen exceptions with 50K failed deletions  -> the bigger the table, 
     the more blobs it has, the more requests we will fire.
     
     --------
     
     A better fix - once we hit some exception, bail out and countdown listener to zero right away. 
     We might miss potential retry - but I think this should be a part of client as retryable exception is provider specific.   
     And in 6.3 we abstracted away with OpenDAL, don't think we can cover all provider differences.
     
 2. Overall parallelization leads to firing more HTTP requests concurrently and might hit rate limit for users using S3
      https://docs.aws.amazon.com/AmazonS3/latest/userguide/optimizing-performance.html
      
      >For example, your application can achieve at least 3,500 PUT/COPY/POST/DELETE or 5,500 GET/HEAD requests   
        per second per partitioned Amazon S3 prefix
        
      This is especially problematic for users who have many stale indices in snapshots -> 
       who often drop partitions or tables - we end up having to clean up many blobs, 
       each table or partition causes many blob deletion requests.

       Fix for "stuck DROP, also leading to stuck CREATE" won't help such users, 
        the only difference would be that DROP would fail properly and don't block threads in the pool but otherwise cleanup won't be successful + data will keep sitting in the backend storage.
        
       ------
        
     If we want to keep parallelization of DROP, we might want to at least split thread pools for CREATE/DROP, so that users who often delete data can cancel out parallelization for DROPS by tweaking DELETE_SNAPSHOT pool and NOT affect CREATE SNAPSHOT. Also, maybe think about retries, maybe add some generic, exception/provider agnostic limited exponential backoff - in any case, this can't be done as q quick fix.
     
     OpenSearch added dedicated deletion pool in https://github.com/opensearch-project/OpenSearch/pull/15568/c. In 
     
     ES it's same but metadata (sys.snapshots in our case) [has dedicated snapshot](https://github.com/elastic/elasticsearch/commit/da242856fdfc2af0176f123f85d39c36c7783cd2).
     
     Suggestion - revert https://github.com/crate/crate/pull/17946 (as a fix) to address both 1 and 2
     