### PR TITLE
tests: fix assertion to correctly check snapshot files removal

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/SnapshotRestoreIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SnapshotRestoreIntegrationTest.java
@@ -1438,7 +1438,7 @@ public class SnapshotRestoreIntegrationTest extends IntegTestCase {
         //Make sure the file location does not consist of any .dat file
         Files.walk(location.toPath())
             .filter(Files::isRegularFile)
-            .forEach(x -> assertThat(x.getFileName().endsWith(".dat")).isFalse());
+            .forEach(x -> assertThat(x.getFileName().toString().endsWith(".dat")).isFalse());
     }
 
     private RepositoryData getRepositoryData() throws Exception {


### PR DESCRIPTION
I will squash after the review, just wanted to show that without this change 
`assertAllRepoSnapshotFilesAreDeleted` is not catching anything and with this change it does 
(`testDropSnapshot` fails in the second commit)