### PR TITLE
Support marking literal chars with double quotes in to_char

### DIFF
--- a/docs/appendices/release-notes/6.4.0.rst
+++ b/docs/appendices/release-notes/6.4.0.rst
@@ -90,6 +90,12 @@ Scalar and Aggregation Functions
   <scalar-to_char>` scalar function which can be used to add a ordinal suffix
   for numbers.
 
+- Added support for marking literal characters with double quotes in the
+  :ref:`to_char <scalar-to_char>` template pattern. Characters enclosed in
+  ``"..."`` are treated as literal text and not interpreted as formatting
+  tokens. Backslash escaping within double-quoted sections is also supported
+  (e.g., ``\"`` for a literal ``"``, ``\\`` for a literal ``\``).
+
 - `Robert Palmer <https://github.com/robd003>`_ added the
   :ref:`blake3 <scalar-blake3>` scalar function for computing BLAKE3 checksums of
   strings.

--- a/docs/general/builtins/scalar-functions.rst
+++ b/docs/general/builtins/scalar-functions.rst
@@ -1818,6 +1818,9 @@ The syntax for the ``format_string`` differs based the type of the
     * - ``TH`` / ``th``
       - Ordinal number suffix appended to the preceding numeric value
         (e.g., ``DDth`` produces ``15th``, ``1st``, ``2nd``, ``3rd``)
+    * - ``"..."``
+      - Marks characters enclosed in double quotes as literal text.
+        Backslashes can be used to escape characters within quoted text.
 
 Example::
 

--- a/server/src/main/java/io/crate/expression/scalar/formatting/PGDateTimeTemplates.java
+++ b/server/src/main/java/io/crate/expression/scalar/formatting/PGDateTimeTemplates.java
@@ -258,6 +258,36 @@ public class PGDateTimeTemplates {
 
             if (idx == pattern_to_consume.length()) {
                 nextTokenNode = null;
+                // PostgreSQL-compatible double-quote handling.
+                // - Backslash escapes the next character (including " and \)
+                // - Unescaped " ends the quoted section
+                // - Unmatched " consumes the rest of the pattern as literal text
+            } else if (idx == 0 && pattern_to_consume.charAt(0) == '"') {
+                StringBuilder sb = new StringBuilder();
+                int pos = 1;
+                boolean foundClosingQuote = false;
+                while (pos < pattern_to_consume.length()) {
+                    char c = pattern_to_consume.charAt(pos);
+                    if (c == '\\' && pos + 1 < pattern_to_consume.length()) {
+                        sb.append(pattern_to_consume.charAt(pos + 1));
+                        pos += 2;
+                    } else if (c == '"') {
+                        foundClosingQuote = true;
+                        break;
+                    } else {
+                        sb.append(c);
+                        pos++;
+                    }
+                }
+                tokens.add(new TemplateLiteral(sb.toString()));
+                if (foundClosingQuote) {
+                    pattern_to_consume = pattern_to_consume.substring(pos + 1);
+                } else {
+                    pattern_to_consume = "";
+                }
+                currentTokenNode = ROOT_TOKEN_NODE;
+                idx = 0;
+                continue;
             } else {
                 nextTokenNode = currentTokenNode.children.get(pattern_to_consume.charAt(idx));
             }

--- a/server/src/test/java/io/crate/expression/scalar/formatting/ToCharFunctionPostgresCompatabilityTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/formatting/ToCharFunctionPostgresCompatabilityTest.java
@@ -200,4 +200,11 @@ public class ToCharFunctionPostgresCompatabilityTest extends ScalarTestCase {
         assertEvaluate("to_char(timestamp '1970-01-01T17:31:12.12345', 'OF')", "");
     }
 
+    @Test
+    public void testPostgresDoubleQuotedLiteralCharacters() {
+        // In PostgreSQL, characters within double quotes in the template pattern are treated as literal text.
+        // This prevents pattern tokens like TH from being interpreted when they appear adjacent to each other.
+        assertEvaluate("to_char(timestamp '2005-05-28T20:57:00', 'YYYY-MM-DD\"T\"HH:MI:SSZ')","2005-05-28T08:57:00Z");
+        assertEvaluate("to_char(timestamp '2005-05-28T20:57:00', 'YYYY-MM-DD\"T\"HH24:MI:SSZ')","2005-05-28T20:57:00Z");
+    }
 }

--- a/server/src/test/java/io/crate/expression/scalar/formatting/ToCharFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/formatting/ToCharFunctionTest.java
@@ -246,4 +246,45 @@ public class ToCharFunctionTest extends ScalarTestCase {
         // Two standalone th followed by DD: both th should be literal
         assertEvaluate("to_char(timestamp '2024-01-15', 'ththDD')", "thth15");
     }
+
+    @Test
+    public void testDoubleQuotedLiteralCharacters() {
+        // Exact scenario from the issue 19291: T and HH should not be parsed as TH
+        assertEvaluate("to_char(timestamp '2005-05-28T20:57:00', 'YYYY-MM-DD\"T\"HH:MI:SSZ')","2005-05-28T08:57:00Z");
+        // Without double quotes, TH gets parsed as ordinal suffix
+        assertEvaluate("to_char(timestamp '2005-05-28T20:57:00', 'YYYY-MM-DDTHH:MI:SSZ')","2005-05-28THH:57:00Z");
+        // Empty quoted section: provides a no-op literal between patterns
+        assertEvaluate("to_char(timestamp '2024-01-15', 'DD\"\"MM')","1501");
+        // Multiple quoted sections in one pattern
+        assertEvaluate("to_char(timestamp '2024-01-15T14:30:45', '\"date:\" YYYY-MM-DD \"time:\" HH24:MI:SS')","date: 2024-01-15 time: 14:30:45");
+        // Unmatched quote: PostgreSQL consumes the rest as literal text
+        assertEvaluate("to_char(timestamp '2024-01-15', 'DD\"MM')","15MM");
+        // Quote at the very beginning of the pattern
+        assertEvaluate("to_char(timestamp '2024-01-15', '\"The date is\" DD/MM/YYYY')","The date is 15/01/2024");
+        // Quote at the very end of the pattern
+        assertEvaluate("to_char(timestamp '2024-01-15', 'DD/MM/YYYY\" is the date\"')","15/01/2024 is the date");
+        // Quoted literal that would otherwise be a valid pattern token
+        assertEvaluate("to_char(timestamp '2024-01-15', 'DD\"th\"')","15th");
+        // Quoted literal th after a non-numeric token (should not trigger th suffix lookup)
+        assertEvaluate("to_char(timestamp '2024-01-15', '\"th\"')","th");
+        // Mixed: quoted th followed by numeric th ordinal suffix
+        assertEvaluate("to_char(timestamp '2024-01-15', '\"th\"DDth')","th15th");
+        // Quoted MM (which is normally month number) should be literal
+        assertEvaluate("to_char(timestamp '2024-01-15', '\"MM\" MM')","MM 01");
+        // Only quoted text, no pattern tokens
+        assertEvaluate("to_char(timestamp '2024-01-15', '\"only quoted text\"')","only quoted text");
+        // Quoted text with special regex/sql characters
+        assertEvaluate("to_char(timestamp '2024-01-15', '\"YEAR:\" YYYY')","YEAR: 2024");
+        assertEvaluate("to_char(timestamp '2024-01-15', 'DD\"\\\"\"MM')","15\"01");
+        assertEvaluate("""
+            to_char(timestamp '2024-01-15', '"ab\\"cd"')""","ab\"cd");
+        assertEvaluate("""
+            to_char(timestamp '2024-01-15', '"a\\\\b"')""","a\\b");
+        assertEvaluate("""
+            to_char(timestamp '2024-01-15', '"\\T"')""","T");
+        assertEvaluate("""
+            to_char(timestamp '2024-01-15', 'DD"a\\"b"MM')""","15a\"b01");
+        assertEvaluate("""
+            to_char(timestamp '2024-01-15', '\\T')""","\\T");
+    }
 }


### PR DESCRIPTION
Closes #19291 

## Support postgresql-style double-quoted literal characters in `to_char` template patterns

Update `PGDateTimeTemplates.parse()` to treat content inside double quotes as literal text instead of interpreting it as formatting tokens.

Example:

`
SELECT TO_CHAR(
    timestamp '2026-05-27T20:00:00',
    'YYYY-MM-DD"T"HH:MI:SSZ'
);
`

Before:  2026-05-27"T"08:00:00Z

After:     2026-05-27T08:00:00Z


## Changes

Added support for parsing double-quoted literal sections in `PGDateTimeTemplates`
Added PostgreSQL compatibility tests for quoted literals in `to_char`

## Tests

quoted literal characters (`"T"`)
multiple quoted sections
quoted tokens such as `"MM"` and `"th"`
mixed literal + formatting patterns
