### PR TITLE
Update ScaCap/action-surefire-report

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Publish Test Report
         if: success() || failure()
-        uses: scacap/action-surefire-report@v1
+        uses: ScalableCapital/action-surefire-report@1e92f48016e566e4eed2d81560edbfe0f524cfb7 #v2.0.3
 
   forbiddenApis:
     name: forbiddenApis


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

From the GH action's repository [here](https://github.com/ScaCap/action-surefire-report):

> This repository now hosts the legacy ScaCap/action-surefire-report@v1 line. Active development and future releases have moved to [ScalableCapital/action-surefire-report@v2](https://github.com/ScalableCapital/action-surefire-report). New adopters should use v2, and existing v1 users should plan their migration before support ends on 2026-08-01.


## Checklist

 - [ ] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
