### PR TITLE
Enable query-then-fetch for lookup joins under LIMIT

### DIFF
--- a/docs/appendices/release-notes/6.4.0.rst
+++ b/docs/appendices/release-notes/6.4.0.rst
@@ -113,6 +113,11 @@ Performance and Resilience Improvements
   :ref:`max() <aggregation-max>` aggregations for columns of type :ref:`NUMERIC
   <data-types-numeric>`.
 
+- Improved query planning for lookup joins under ``LIMIT`` by deferring
+  collection of columns that are not needed during join execution until the
+  final fetch phase.
+
+
 Administration and Operations
 -----------------------------
 

--- a/server/src/main/java/io/crate/planner/operators/MultiPhase.java
+++ b/server/src/main/java/io/crate/planner/operators/MultiPhase.java
@@ -21,6 +21,7 @@
 
 package io.crate.planner.operators;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -33,6 +34,7 @@ import io.crate.common.collections.Maps;
 import io.crate.data.Row;
 import io.crate.execution.dsl.projection.builder.ProjectionBuilder;
 import io.crate.expression.symbol.SelectSymbol;
+import io.crate.expression.symbol.Symbol;
 import io.crate.planner.DependencyCarrier;
 import io.crate.planner.ExecutionPlan;
 import io.crate.planner.MultiPhasePlan;
@@ -86,6 +88,19 @@ public class MultiPhase extends ForwardingLogicalPlan {
     @Override
     public Map<LogicalPlan, SelectSymbol> dependencies() {
         return Maps.concat(source.dependencies(), subQueries);
+    }
+
+    @Override
+    public @Nullable FetchRewrite rewriteToFetch(Collection<Symbol> usedColumns) {
+        FetchRewrite fetchRewrite = source.rewriteToFetch(usedColumns);
+        if (fetchRewrite == null) {
+            return null;
+        }
+
+        return new FetchRewrite(
+            fetchRewrite.replacedOutputs(),
+            new MultiPhase(fetchRewrite.newPlan(), subQueries)
+        );
     }
 
     @Override

--- a/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
@@ -64,6 +64,7 @@ import io.crate.metadata.TransactionContext;
 import io.crate.metadata.table.TableInfo;
 import io.crate.planner.DependencyCarrier;
 import io.crate.planner.node.dql.QueryThenFetch;
+import io.crate.planner.optimizer.rule.EquiJoinToLookupJoin;
 import io.crate.statistics.ColumnStats;
 import io.crate.statistics.MostCommonValues;
 import io.crate.statistics.Stats;
@@ -394,6 +395,38 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
                   └ Rename[t2._fetchid, i] AS t2
                     └ Collect[doc.t2 | [_fetchid, i] | ((b > '100') AND (b > '10'))]
             """);
+    }
+
+    @Test
+    public void test_lookup_join_under_limit_can_be_fetch_optimized() {
+        sqlExecutor.getSessionSettings().excludedOptimizerRules().remove(EquiJoinToLookupJoin.class);
+        TableInfo t1 = sqlExecutor.resolveTableInfo("t1");
+        TableInfo t2 = sqlExecutor.resolveTableInfo("t2");
+        sqlExecutor.updateTableStats(Map.of(
+            t1.ident(), new Stats(10_000, 0, Map.of()),
+            t2.ident(), new Stats(100, 0, Map.of())
+        ));
+
+        LogicalPlan plan = plan(
+            """
+            SELECT t1.i, t1.a, t2.i
+            FROM t1
+            JOIN t2 ON t1.i = t2.i
+            LIMIT 5
+            """
+        );
+
+        assertThat(plan).isEqualTo(
+            """
+            Fetch[i, a, i]
+              └ Limit[5::bigint;0]
+                └ HashJoin[INNER | (i = i)]
+                  ├ MultiPhase
+                  │  └ Collect[doc.t1 | [_fetchid, i] | (i = ANY((doc.t2)))]
+                  │  └ Collect[doc.t2 | [i] | true]
+                  └ Collect[doc.t2 | [i] | true]
+            """
+        );
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Allow `MultiPhase` to forward `rewriteToFetch` to its source, enabling query-then-fetch optimization for lookup joins under `LIMIT` scenarios like below:

```
CREATE TABLE doc.t1 (id int, col1 int) WITH (number_of_replicas = 0);
INSERT INTO doc.t1 (id, col1) SELECT b, b FROM generate_series(1, 10000) AS a(b);

CREATE TABLE doc.t2 (id int, a int) WITH (number_of_replicas = 0);
INSERT INTO doc.t2 (id, a) SELECT b, b FROM generate_series(1, 100) AS a(b);

REFRESH TABLE doc.t1;
REFRESH TABLE doc.t2;
ANALYZE;

SET optimizer_equi_join_to_lookup_join = true;

EXPLAIN (COSTS FALSE)
SELECT t1.id, t1.col1, t2.id
FROM doc.t1
JOIN doc.t2 ON t1.id = t2.id
LIMIT 5;
```

Before:
```
+--------------------------------------------------------------+
| QUERY PLAN                                                   |
+--------------------------------------------------------------+
| Limit[5::bigint;0]                                           |
|   └ HashJoin[INNER | (id = id)]                              |
|     ├ MultiPhase                                             |  <-- returns `null` because Multiphase.rewriteToFetch is not implemented
|     │  └ Collect[doc.t1 | [id, col1] | (id = ANY((doc.t2)))] |
|     │  └ Collect[doc.t2 | [id] | true]                       |
|     └ Collect[doc.t2 | [id] | true]                          |
+--------------------------------------------------------------+
```
After:
```
+--------------------------------------------------------------------+
| QUERY PLAN                                                         |
+--------------------------------------------------------------------+
| Fetch[id, col1, id]                                                |
|   └ Limit[5::bigint;0]                                             |
|     └ HashJoin[INNER | (id = id)]                                  |
|       ├ MultiPhase                                                 |
|       │  └ Collect[doc.t1 | [_fetchid, id] | (id = ANY((doc.t2)))] |  <-- collecting `col1` is deferred and fetched later
|       │  └ Collect[doc.t2 | [id] | true]                           |
|       └ Collect[doc.t2 | [id] | true]                              |
+--------------------------------------------------------------------+
```

Resolves https://github.com/crate/crate/issues/18324. (Potentially, partially. Will continue to improve query planning for https://github.com/crate/crate/issues/18324 and https://github.com/crate/support/issues/864.)

Thanks @BaurzhanSakhariev for the initial investigation and reduced reproduction test.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
