### PR TITLE
Use LongMap in GroupByOptimizedIterator

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
@@ -49,7 +49,6 @@ import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.common.util.ObjectArray;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.shard.IndexShard;
@@ -89,6 +88,7 @@ import io.crate.metadata.RowGranularity;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.doc.SysColumns;
 import io.crate.types.DataTypes;
+import io.netty.util.collection.LongObjectHashMap;
 
 final class GroupByOptimizedIterator {
 
@@ -290,6 +290,7 @@ final class GroupByOptimizedIterator {
         final List<LeafReaderContext> leaves = indexSearcher.getTopReaderContext().leaves();
         Object[] nullStates = null;
 
+        LongObjectHashMap<Object[]> statesByOrd = new LongObjectHashMap<>();
         for (LeafReaderContext leaf: leaves) {
             raiseIfClosedOrKilled(killed);
             Scorer scorer = weight.scorer(leaf);
@@ -301,63 +302,63 @@ final class GroupByOptimizedIterator {
                 expressions.get(i).setNextReader(readerContext);
             }
             SortedSetDocValues values = DocValues.getSortedSet(leaf.reader(), keyColumnName);
-            try (ObjectArray<Object[]> statesByOrd = bigArrays.newObjectArray(values.getValueCount())) {
-                DocIdSetIterator docs = scorer.iterator();
-                Bits liveDocs = leaf.reader().getLiveDocs();
-                for (int doc = docs.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = docs.nextDoc()) {
-                    raiseIfClosedOrKilled(killed);
-                    if (docDeleted(liveDocs, doc)) {
-                        continue;
-                    }
-                    for (int i = 0, expressionsSize = expressions.size(); i < expressionsSize; i++) {
-                        expressions.get(i).setNextDocId(doc);
-                    }
-                    for (int i = 0, expressionsSize = aggExpressions.size(); i < expressionsSize; i++) {
-                        aggExpressions.get(i).setNextRow(inputRow);
-                    }
-                    if (values.advanceExact(doc)) {
-                        long ord = values.nextOrd();
-                        Object[] states = statesByOrd.get(ord);
-                        if (states == null) {
-                            statesByOrd.set(ord, initStates(aggregations, ramAccounting, memoryManager, minNodeVersion));
-                        } else {
-                            aggregateValues(aggregations, ramAccounting, memoryManager, states);
-                        }
-                        if (values.docValueCount() > 1) {
-                            throw new ArrayViaDocValuesUnsupportedException(keyColumnName);
-                        }
-                    } else {
-                        if (nullStates == null) {
-                            nullStates = initStates(aggregations, ramAccounting, memoryManager, minNodeVersion);
-                        } else {
-                            aggregateValues(aggregations, ramAccounting, memoryManager, nullStates);
-                        }
-                    }
+            DocIdSetIterator docs = scorer.iterator();
+            Bits liveDocs = leaf.reader().getLiveDocs();
+            for (int doc = docs.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = docs.nextDoc()) {
+                raiseIfClosedOrKilled(killed);
+                if (docDeleted(liveDocs, doc)) {
+                    continue;
                 }
-                for (long ord = 0; ord < statesByOrd.size(); ord++) {
-                    raiseIfClosedOrKilled(killed);
+                for (int i = 0, expressionsSize = expressions.size(); i < expressionsSize; i++) {
+                    expressions.get(i).setNextDocId(doc);
+                }
+                for (int i = 0, expressionsSize = aggExpressions.size(); i < expressionsSize; i++) {
+                    aggExpressions.get(i).setNextRow(inputRow);
+                }
+                if (values.advanceExact(doc)) {
+                    long ord = values.nextOrd();
                     Object[] states = statesByOrd.get(ord);
                     if (states == null) {
-                        continue;
-                    }
-                    BytesRef sharedKey = values.lookupOrd(ord);
-                    Object[] prevStates = statesByKey.get(sharedKey);
-                    if (prevStates == null) {
-                        ramAccounting.addBytes(BYTES_REF_SHALLOW_SIZE + sharedKey.length + HASH_MAP_ENTRY_OVERHEAD);
-                        statesByKey.put(BytesRef.deepCopyOf(sharedKey), states);
+                        statesByOrd.put(ord, initStates(aggregations, ramAccounting, memoryManager, minNodeVersion));
                     } else {
-                        for (int i = 0; i < aggregations.size(); i++) {
-                            AggregationContext aggregation = aggregations.get(i);
-                            //noinspection unchecked
-                            prevStates[i] = aggregation.function().reduce(
-                                ramAccounting,
-                                prevStates[i],
-                                states[i]
-                            );
-                        }
+                        aggregateValues(aggregations, ramAccounting, memoryManager, states);
+                    }
+                    if (values.docValueCount() > 1) {
+                        throw new ArrayViaDocValuesUnsupportedException(keyColumnName);
+                    }
+                } else {
+                    if (nullStates == null) {
+                        nullStates = initStates(aggregations, ramAccounting, memoryManager, minNodeVersion);
+                    } else {
+                        aggregateValues(aggregations, ramAccounting, memoryManager, nullStates);
                     }
                 }
             }
+            for (var entry : statesByOrd.entries()) {
+                raiseIfClosedOrKilled(killed);
+                long ord = entry.key();
+                Object[] states = entry.value();
+                if (states == null) {
+                    continue;
+                }
+                BytesRef sharedKey = values.lookupOrd(ord);
+                Object[] prevStates = statesByKey.get(sharedKey);
+                if (prevStates == null) {
+                    ramAccounting.addBytes(BYTES_REF_SHALLOW_SIZE + sharedKey.length + HASH_MAP_ENTRY_OVERHEAD);
+                    statesByKey.put(BytesRef.deepCopyOf(sharedKey), states);
+                } else {
+                    for (int i = 0; i < aggregations.size(); i++) {
+                        AggregationContext aggregation = aggregations.get(i);
+                        //noinspection unchecked
+                        prevStates[i] = aggregation.function().reduce(
+                            ramAccounting,
+                            prevStates[i],
+                            states[i]
+                        );
+                    }
+                }
+            }
+            statesByOrd.clear();
         }
         if (nullStates != null) {
             statesByKey.put(null, nullStates);


### PR DESCRIPTION
Hint for review: It's a lot easier to read with whitespace off in the diff

---

It used an array sized to the number of unique key values in a segment.
Given that the optimization was only used for low-cardinality cases this
was mostly okay, but with queries it could also be oversized

For example, on the uservisits dataset the following query has 95 unique
keys, the ordinals are all dense - ideal for the array:

    select "cCode", avg(duration), avg("adRevenue") from uservisits group by "cCode"

But if adding a filter like the following, there are only 2 unique keys
and the array was still sized to 95 records having lots of gaps:

    select "cCode", avg(duration), avg("adRevenue") from uservisits where "cCode" in ('AUT', 'GER') group by "cCode"

Benchmarks fluctuate a bit, but show that even the optimal case for the
array doesn't get much worse - in some runs it is even better:

    Q: select "cCode", avg(duration), avg("adRevenue") from uservisits group by "cCode"
    C: 1
    | Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
    |   V1    |       95.422 ±  111.462 |     54.198 |     59.229 |     63.022 |    412.485 |
    |   V2    |       93.235 ±  102.459 |     55.978 |     60.452 |     64.228 |    384.593 |
    ├---------┴-------------------------┴------------┴------------┴------------┴------------┘
    |               -   2.32%                           +   2.05%
    There is a 3.59% probability that the observed difference is not random, and the best estimate of that difference is 2.32%
    The test has no statistical significance

    Q: select "cCode", avg(duration), avg("adRevenue") from uservisits where "cCode" in ('AUT', 'GER') group by "cCode"
    C: 1
    | Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
    |   V1    |       19.629 ±    7.215 |     10.455 |     19.110 |     24.412 |     32.748 |
    |   V2    |       14.778 ±    6.400 |     10.447 |     11.299 |     17.945 |     29.381 |
    ├---------┴-------------------------┴------------┴------------┴------------┴------------┘
    |               -  28.20%                           -  51.37%
    There is a 87.09% probability that the observed difference is not random, and the best estimate of that difference is 28.20%
    The test has no statistical significance
