### PR TITLE
Fix stuck DROP SNAPSHOT and CREATE SNAPSHOT

### DIFF
--- a/docs/appendices/release-notes/6.2.9.rst
+++ b/docs/appendices/release-notes/6.2.9.rst
@@ -51,3 +51,6 @@ Fixes
 
 - Fixed an issue that caused nodes to fail to start when parsing persisted
   mappings for tables containing columns of type ``uuid``.
+
+- Fixed a regression introduced with :ref:`version_6.0.0`, leading to stuck
+  ``DROP SNAPSHOT`` and ``CREATE SNAPSHOT`` queries.

--- a/docs/appendices/release-notes/6.3.3.rst
+++ b/docs/appendices/release-notes/6.3.3.rst
@@ -69,3 +69,6 @@ Fixes
 
 - Fixed an issue that caused nodes to fail to start when parsing persisted
   mappings for tables containing columns of type ``uuid``.
+
+- Fixed a regression introduced with :ref:`version_6.0.0`, leading to stuck
+  ``DROP SNAPSHOT`` and ``CREATE SNAPSHOT`` queries.

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -930,27 +930,32 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
 
     private void executeOneStaleIndexDelete(BlockingQueue<Map.Entry<String, BlobContainer>> staleIndicesToDelete,
                                             ActionListener<Long> listener) throws InterruptedException {
+
         Map.Entry<String, BlobContainer> indexEntry = staleIndicesToDelete.poll(0L, TimeUnit.MILLISECONDS);
-        if (indexEntry != null) {
-            final String indexSnId = indexEntry.getKey();
-            threadPool.executor(ThreadPool.Names.SNAPSHOT).execute(ActionRunnable.supply(listener, () -> {
-                try {
-                    indexEntry.getValue().delete();
-                    LOGGER.debug("[{}] Cleaned up stale index [{}]", metadata.name(), indexSnId);
-                    executeOneStaleIndexDelete(staleIndicesToDelete, listener);
-                    return 1L;
-                } catch (IOException e) {
-                    LOGGER.warn(() -> new ParameterizedMessage(
-                        "[{}] index {} is no longer part of any snapshots in the repository, " +
-                            "but failed to clean up their index folders", metadata.name(), indexSnId), e);
-                    return 0L;
-                } catch (Exception e) {
-                    assert false : e;
-                    LOGGER.warn(new ParameterizedMessage("[{}] Exception during single stale index delete", metadata.name()), e);
-                    return 0L;
-                }
-            }));
+        if (indexEntry == null) {
+            return;
         }
+        final String indexSnId = indexEntry.getKey();
+        threadPool.executor(ThreadPool.Names.SNAPSHOT).execute(ActionRunnable.supply(listener, () -> {
+            try {
+                BlobContainer container = indexEntry.getValue();
+                container.delete();
+                LOGGER.debug("[{}] Cleaned up stale index [{}]", metadata.name(), indexSnId);
+                return 1L;
+            } catch (IOException e) {
+                LOGGER.warn(() -> new ParameterizedMessage(
+                    "[{}] index {} is no longer part of any snapshots in the repository, " +
+                        "but failed to clean up their index folders", metadata.name(), indexSnId), e);
+                return 0L;
+            } catch (Exception e) {
+                assert false : e;
+                LOGGER.warn(new ParameterizedMessage("[{}] Exception during single stale index delete", metadata.name()), e);
+                return 0L;
+            } finally {
+                // Must always continue to ensure listener is called the expected number of times
+                executeOneStaleIndexDelete(staleIndicesToDelete, listener);
+            }
+        }));
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/snapshots/ConcurrentSnapshotsIT.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/ConcurrentSnapshotsIT.java
@@ -22,7 +22,6 @@
 package org.elasticsearch.snapshots;
 
 import static io.crate.testing.Asserts.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.assertj.core.api.InstanceOfAssertFactories.THROWABLE;
 import static org.elasticsearch.snapshots.SnapshotsService.MAX_CONCURRENT_SNAPSHOT_OPERATIONS_SETTING;
@@ -97,6 +96,42 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
         return Settings.builder().put(super.nodeSettings(nodeOrdinal))
             .put(AbstractDisruptionTestCase.DEFAULT_SETTINGS)
             .build();
+    }
+
+
+    @Test
+    public void test_drop_snapshot_is_not_stuck_when_more_than_max_pool_size_tables_deleted() throws Exception {
+        String master = cluster().startMasterOnlyNode();
+        String dataNode = cluster().startDataOnlyNode();
+        // Processors number is set as builder.put(EsExecutors.PROCESSORS_SETTING.getKey(), 1 + random.nextInt(3)).
+        // To make reproduction stable, using max + 1 = halfProcMaxAt5 + 1,
+        // so that test fails regardless of processors count.
+        for (int i = 0; i < 6; i++) {
+            StringBuilder sb = new StringBuilder("CREATE TABLE t")
+                .append(i)
+                .append(" AS SELECT a, random() b FROM generate_series(1, 10, 1) as t(a)");
+            execute(sb.toString());
+        }
+
+        createRepo("repo", "mock");
+
+        execute("CREATE SNAPSHOT repo.test_snapshot ALL WITH (wait_for_completion=true)");
+
+        for (int i = 0; i < 6; i++) {
+            execute("DROP TABLE t" + i);
+        }
+        mockRepo("repo", master).setThrowOnDeletion(true);
+        execute("DROP SNAPSHOT repo.test_snapshot");
+        assertThat(response.rowCount()).isEqualTo(1L);
+
+        execute("select * from sys.snapshots where name = 'test_snapshot'");
+        assertThat(response.rowCount()).isEqualTo(0L);
+
+        // Make assertConsistency pass.
+        // Repository data is empty, because deletion of stale indices happens after writeIndexGen.
+        // Cluster state might have empty indices, while remote storage still have them because deletion failed.
+        // It's fine because stale indices cleanup is always re-tried on next deletion.
+        execute("DROP REPOSITORY repo");
     }
 
     @Test

--- a/server/src/testFixtures/java/org/elasticsearch/snapshots/mockstore/MockRepository.java
+++ b/server/src/testFixtures/java/org/elasticsearch/snapshots/mockstore/MockRepository.java
@@ -133,6 +133,8 @@ public class MockRepository extends FsRepository {
 
     private volatile boolean blockOnDeleteIndexN;
 
+    private volatile boolean throwOnDeletion = false;
+
     /**
      * Allows blocking on writing the index-N blob and subsequently failing it on unblock.
      * This is a way to enforce blocking the finalization of a snapshot, while permitting other IO operations to proceed unblocked.
@@ -249,6 +251,10 @@ public class MockRepository extends FsRepository {
 
     public void setFailReadsAfterUnblock(boolean failReadsAfterUnblock) {
         this.failReadsAfterUnblock = failReadsAfterUnblock;
+    }
+
+    public void setThrowOnDeletion(boolean throwOnDeletion) {
+        this.throwOnDeletion = throwOnDeletion;
     }
 
     public boolean blocked() {
@@ -400,6 +406,9 @@ public class MockRepository extends FsRepository {
 
             @Override
             public void delete() throws IOException {
+                if (throwOnDeletion) {
+                    throw new IOException("dummy");
+                }
                 for (BlobContainer child : children().values()) {
                     child.delete();
                 }


### PR DESCRIPTION
Relates to https://github.com/crate/support/issues/860
Supersedes https://github.com/crate/crate/pull/19430

Fixes a regression introduced with https://github.com/crate/crate/pull/17946
We schedule next cleanup only on successful delete
and in case of failures could end up with unfinsihed group listener.

To fix it, we continue deletions even if onde stale index deletion failed.



