### PR TITLE
Add catalog_name to information_schema.schemata

### DIFF
--- a/docs/appendices/release-notes/6.4.0.rst
+++ b/docs/appendices/release-notes/6.4.0.rst
@@ -67,6 +67,9 @@ SQL Standard and PostgreSQL Compatibility
 
 - Added a :ref:`information_schema.collations <collations>` table.
 
+- Added a ``catalog_name`` column to :ref:`information_schema.schemata
+  <schemata>`.
+
 - `Dhruv Patel <https://github.com/DHRUV6029>`_ added the ``pg_catalog.pg_user``
   table for PostgreSQL compatibility, resolving issues with tools like
   DbVisualizer that query this table during schema introspection.

--- a/docs/general/information-schema.rst
+++ b/docs/general/information-schema.rst
@@ -854,18 +854,13 @@ schema is available after the first user table is created.
 
 .. rubric:: Schema
 
-+--------------+-----------+
-| Name         | Data Type |
-+==============+===========+
-| catalog_name | ``TEXT``  |
-+--------------+-----------+
-| schema_name  | ``TEXT``  |
-+--------------+-----------+
-
-:catalog_name:
-    Name of the catalog. This is always ``crate``.
-:schema_name:
-    Name of the schema.
++------------------+---------------------------------------+-----------+
+| Name             | Data Type                             |           |
++==================+=======================================+===========+
+| ``catalog_name`` | Name of the catalog. Always ``crate`` | ``TEXT``  |
++------------------+---------------------------------------+-----------+
+| ``schema_name``  | Name of the schema                    | ``TEXT``  |
++------------------+---------------------------------------+-----------+
 
 .. _sql_features:
 

--- a/docs/general/information-schema.rst
+++ b/docs/general/information-schema.rst
@@ -840,17 +840,32 @@ schema is available after the first user table is created.
 
 ::
 
-    cr> select schema_name from information_schema.schemata order by schema_name;
-    +--------------------+
-    | schema_name        |
-    +--------------------+
-    | blob               |
-    | doc                |
-    | information_schema |
-    | pg_catalog         |
-    | sys                |
-    +--------------------+
+    cr> select * from information_schema.schemata order by schema_name;
+    +--------------+--------------------+
+    | catalog_name | schema_name        |
+    +--------------+--------------------+
+    | crate        | blob               |
+    | crate        | doc                |
+    | crate        | information_schema |
+    | crate        | pg_catalog         |
+    | crate        | sys                |
+    +--------------+--------------------+
     SELECT 5 rows in set (... sec)
+
+.. rubric:: Schema
+
++--------------+-----------+
+| Name         | Data Type |
++==============+===========+
+| catalog_name | ``TEXT``  |
++--------------+-----------+
+| schema_name  | ``TEXT``  |
++--------------+-----------+
+
+:catalog_name:
+    Name of the catalog. This is always ``crate``.
+:schema_name:
+    Name of the schema.
 
 .. _sql_features:
 

--- a/server/src/main/java/io/crate/metadata/information/InformationSchemataTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/information/InformationSchemataTableInfo.java
@@ -23,6 +23,7 @@ package io.crate.metadata.information;
 
 import static io.crate.types.DataTypes.STRING;
 
+import io.crate.Constants;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.SystemTable;
@@ -35,6 +36,7 @@ public class InformationSchemataTableInfo {
 
     public static SystemTable<SchemaInfo> INSTANCE = SystemTable.<SchemaInfo>builder(IDENT)
         .add("schema_name", STRING, SchemaInfo::name)
+        .add("catalog_name", STRING, _ -> Constants.DB_NAME)
         .setPrimaryKeys(ColumnIdent.of("schema_name"))
         .build();
 }

--- a/server/src/test/java/io/crate/integrationtests/CustomSchemaIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/CustomSchemaIntegrationTest.java
@@ -155,7 +155,7 @@ public class CustomSchemaIntegrationTest extends IntegTestCase {
             .hasMessageContaining("Schema 'foobar' already exists");
         execute("create schema if not exists foobar");
 
-        execute("select * from information_schema.schemata order by 1");
+        execute("select schema_name from information_schema.schemata order by 1");
         assertThat(response).hasRows(
             "blob",
             "doc",
@@ -174,7 +174,7 @@ public class CustomSchemaIntegrationTest extends IntegTestCase {
 
         execute("drop table foobar.tbl");
 
-        execute("select * from information_schema.schemata order by 1");
+        execute("select schema_name from information_schema.schemata order by 1");
         assertThat(response).hasRows(
             "blob",
             "doc",
@@ -186,7 +186,7 @@ public class CustomSchemaIntegrationTest extends IntegTestCase {
         );
 
         execute("drop schema foobar, foo");
-        execute("select * from information_schema.schemata order by 1");
+        execute("select schema_name from information_schema.schemata order by 1");
         assertThat(response).hasRows(
             "blob",
             "doc",

--- a/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -582,7 +582,7 @@ public class InformationSchemaTest extends IntegTestCase {
     @Test
     public void testDefaultColumns() {
         execute("select * from information_schema.columns order by table_schema, table_name");
-        assertThat(response.rowCount()).isEqualTo(1109);
+        assertThat(response.rowCount()).isEqualTo(1110);
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -1223,13 +1223,13 @@ public class InformationSchemaTest extends IntegTestCase {
     @Test
     @UseRandomizedSchema(random = false)
     public void testSelectSchemata() throws Exception {
-        execute("select schema_name from information_schema.schemata order by schema_name asc");
+        execute("select * from information_schema.schemata order by schema_name asc");
         assertThat(response).hasRows(
-            "blob",
-            "doc",
-            "information_schema",
-            "pg_catalog",
-            "sys"
+            "crate| blob",
+            "crate| doc",
+            "crate| information_schema",
+            "crate| pg_catalog",
+            "crate| sys"
         );
 
         execute("create table t1 (col string) with (number_of_replicas=0)");

--- a/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
@@ -351,8 +351,17 @@ public class JoinIntegrationTest extends IntegTestCase {
     @Test
     public void testCrossJoinFromInformationSchemaTable() throws Exception {
         // sys table with doc granularity on single node
-        execute("select * from information_schema.schemata t1, information_schema.schemata t2 " +
-                "order by t1.schema_name, t2.schema_name");
+        execute("""
+            select
+                t1.schema_name,
+                t2.schema_name
+            from
+                information_schema.schemata t1,
+                information_schema.schemata t2
+            order by
+                t1.schema_name,
+                t2.schema_name
+            """);
         assertThat(response).hasRows(
                "blob| blob",
                "blob| doc",

--- a/server/src/test/java/io/crate/integrationtests/PrivilegesIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/PrivilegesIntegrationTest.java
@@ -662,7 +662,7 @@ public class PrivilegesIntegrationTest extends BaseRolesIntegrationTest {
         //make sure a new user has default accesses to pg tables with information and pg catalog schema related entries
         try (Session testUserSession = testUserSession()) {
             execute("select * from pg_catalog.pg_attribute order by attname", null, testUserSession);
-            assertThat(response).hasRowCount(615L);
+            assertThat(response).hasRowCount(616L);
 
             //create a table with an attribute that a new user is not privileged to access
             executeAsSuperuser("create table test_schema.my_table (my_col int)");


### PR DESCRIPTION
## Summary
- add `catalog_name` to `information_schema.schemata` using the existing database catalog name
- cover the PostgreSQL-compatible introspection query used by Harlequin
- update schema roundtrip assertions to avoid relying on `select *` column order

Fixes #19164

## Testing
- `JAVA_HOME=/Users/wonhyeonseob/.m2/jdks/jdk-26.0.1+8/Contents/Home ./mvnw test -pl server -Dtest=InformationSchemaTest -Dtests.method=testSelectSchemata -Dforbiddenapis.skip=true`
- `JAVA_HOME=/Users/wonhyeonseob/.m2/jdks/jdk-26.0.1+8/Contents/Home ./mvnw test -pl server -Dtest=CustomSchemaIntegrationTest -Dtests.method=test_create_and_drop_schema_roundtrip -Dforbiddenapis.skip=true`