### PR TITLE
Fix Numeric binary de-/ser for pg wire protocol

### DIFF
--- a/docs/appendices/release-notes/6.3.4.rst
+++ b/docs/appendices/release-notes/6.3.4.rst
@@ -46,5 +46,9 @@ series.
 Fixes
 =====
 
-- Fixed binary encoding and decoding of ``date`` values when using PostgreSQL
-  clients.
+- Fixed binary encoding and decoding of :ref:`DATE <type-date>` values when
+  using PostgreSQL clients.
+
+- Fixed and issue which caused wrong binary deserialization of
+  :ref:`NUMERIC <type-numeric>` types when using the
+  :ref:`PostgreSQL wire protocol <interface-postgresql>`.

--- a/server/src/main/java/io/crate/protocols/postgres/types/NumericType.java
+++ b/server/src/main/java/io/crate/protocols/postgres/types/NumericType.java
@@ -22,8 +22,11 @@
 package io.crate.protocols.postgres.types;
 
 import java.math.BigDecimal;
-import java.math.MathContext;
+import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+import org.postgresql.util.ByteConverter;
 
 import io.crate.metadata.RelationLookup;
 import io.crate.types.Regproc;
@@ -36,9 +39,18 @@ class NumericType extends PGType<BigDecimal> {
     private static final int TYPE_LEN = -1;
     private static final int TYPE_MOD = -1;
 
-    private static final short DEC_DIGITS = 4;
     private static final short NUMERIC_POS = 0x0000;
     private static final short NUMERIC_NEG = 0x4000;
+    private static final BigInteger[] BI_TEN_POWERS = new BigInteger[32];
+    private static final BigInteger BI_TEN_THOUSAND = BigInteger.valueOf(10000);
+    private static final BigInteger BI_MAX_LONG = BigInteger.valueOf(Long.MAX_VALUE);
+
+    static {
+        for (int i = 0; i < BI_TEN_POWERS.length; i++) {
+            BI_TEN_POWERS[i] = BigInteger.TEN.pow(i);
+        }
+    }
+
 
     public static final NumericType INSTANCE = new NumericType();
 
@@ -71,105 +83,155 @@ class NumericType extends PGType<BigDecimal> {
         return Regproc.of("numeric_recv");
     }
 
+    /**
+     * Copied from {@link ByteConverter#numeric(BigDecimal)} but use a {@link ByteBuf}
+     */
     @Override
     public int writeAsBinary(ByteBuf buffer, BigDecimal value) {
-        // Taken from https://github.com/cockroachdb/cockroach/blob/master/pkg/sql/pgwire/types.go#L336
-        // and https://github.com/postgres/postgres/blob/master/src/backend/utils/adt/numeric.c#L6760.
-        // The number is split into chunks of DEC_DIGITS short values while leading and trailing 0's are omitted.
-        // Examples:
-        //  * 01234       -> [1234]
-        //  * 1234567     -> [0123, 4567], scale 0
-        //  * 1.234500    -> [0001, 2345], scale 4
-        //  * 1234567.12  -> [0123, 4567, 1200], scale 1
-        //  * 1234.0      -> [1234], scale 1
-        //  * 0123.45     -> [0123, 4500], scale 2
-        var digits = value.unscaledValue().toString().toCharArray();
-        int start = 0;
-        int end = digits.length;
-        while (start < end && (digits[start] == '0' || digits[start] == '-')) {
-            start++;
+        final PositiveShorts shorts = new PositiveShorts();
+        BigInteger unscaled = value.unscaledValue().abs();
+        int scale = value.scale();
+        if (unscaled.equals(BigInteger.ZERO)) {
+            final byte[] bytes = new byte[]{0, 0, -1, -1, 0, 0, 0, 0};
+            ByteConverter.int2(bytes, 6, Math.max(0, scale));
+            buffer.writeInt(bytes.length);
+            buffer.writeBytes(bytes);
+            return INT32_BYTE_SIZE + bytes.length;
         }
-        int dWeight = end - start - value.scale() - 1;
-        while (start < end && digits[end - 1] == '0') {
-            end--;
-        }
-
-        int len = end - start;
-        short weight = 0;       // Max DEC_DIGIT block index before decimal point
-        int offset = 0;         // Offset inside the first block, e.g. 234.23 has and offset of 1
-        short nDigits = 0;      // Number of DEC_DIGIT blocks
-        if (len != 0) {
-            if (dWeight >= 0) {
-                weight = (short) ((dWeight + 1 + DEC_DIGITS - 1) / DEC_DIGITS - 1);
-            } else {
-                weight = (short) (-((-dWeight - 1) / DEC_DIGITS + 1));
+        int weight = -1;
+        if (scale <= 0) {
+            //this means we have an integer
+            //adjust unscaled and weight
+            if (scale < 0) {
+                scale = Math.abs(scale);
+                //weight value covers 4 digits
+                weight += scale / 4;
+                //whatever remains needs to be incorporated to the unscaled value
+                int mod = scale % 4;
+                unscaled = unscaled.multiply(tenPower(mod));
+                scale = 0;
             }
-            offset = (weight + 1) * DEC_DIGITS - (dWeight + 1);
-            nDigits = (short)((len + offset + DEC_DIGITS - 1) / DEC_DIGITS);
-        }
-        int typeLen = 2 * (4 + nDigits);
 
-        buffer.writeInt(typeLen);
-        buffer.writeShort(nDigits);
-        buffer.writeShort(weight);
-        if (value.signum() == -1) {
-            buffer.writeShort(NUMERIC_NEG);
+            while (unscaled.compareTo(BI_MAX_LONG) > 0) {
+                final BigInteger[] pair = unscaled.divideAndRemainder(BI_TEN_THOUSAND);
+                unscaled = pair[0];
+                final short shortValue = pair[1].shortValue();
+                if (shortValue != 0 || shorts.isNotEmpty()) {
+                    shorts.push(shortValue);
+                }
+                ++weight;
+            }
+            long unscaledLong = unscaled.longValueExact();
+            do {
+                final short shortValue = (short) (unscaledLong % 10000);
+                if (shortValue != 0 || shorts.isNotEmpty()) {
+                    shorts.push(shortValue);
+                }
+                unscaledLong = unscaledLong / 10000L;
+                ++weight;
+            } while (unscaledLong != 0);
         } else {
-            buffer.writeShort(NUMERIC_POS);
-        }
-        buffer.writeShort(value.scale());
+            final BigInteger[] split = unscaled.divideAndRemainder(tenPower(scale));
+            BigInteger decimal = split[1];
+            BigInteger wholes = split[0];
+            if (!BigInteger.ZERO.equals(decimal)) {
+                int mod = scale % 4;
+                int segments = scale / 4;
+                if (mod != 0) {
+                    decimal = decimal.multiply(tenPower(4 - mod));
+                    ++segments;
+                }
+                do {
+                    final BigInteger[] pair = decimal.divideAndRemainder(BI_TEN_THOUSAND);
+                    decimal = pair[0];
+                    final short shortValue = pair[1].shortValue();
+                    if (shortValue != 0 || shorts.isNotEmpty()) {
+                        shorts.push(shortValue);
+                    }
+                    --segments;
+                } while (!BigInteger.ZERO.equals(decimal));
 
-        int digitIdx = -offset + start;
-        while (nDigits-- > 0) {
-            short ndigit = 0;
-            // Encode 4 digits into a 16 bit short value
-            for (var nextDigitIdx = digitIdx + DEC_DIGITS; digitIdx < nextDigitIdx; digitIdx++) {
-                ndigit *= 10;
-                if (digitIdx >= start && digitIdx < end) {
-                    ndigit += (short) (digits[digitIdx] - '0');
+                //for the leading 0 shorts we either adjust weight (if no wholes)
+                // or push shorts
+                if (BigInteger.ZERO.equals(wholes)) {
+                    weight -= segments;
+                } else {
+                    //now add leading 0 shorts
+                    for (int i = 0; i < segments; i++) {
+                        shorts.push((short) 0);
+                    }
                 }
             }
-            buffer.writeShort(ndigit);
+
+            while (!BigInteger.ZERO.equals(wholes)) {
+                ++weight;
+                final BigInteger[] pair = wholes.divideAndRemainder(BI_TEN_THOUSAND);
+                wholes = pair[0];
+                final short shortValue = pair[1].shortValue();
+                if (shortValue != 0 || shorts.isNotEmpty()) {
+                    shorts.push(shortValue);
+                }
+            }
         }
 
-        return INT32_BYTE_SIZE + typeLen;
+        //8 bytes for "header" and then 2 for each short
+        final byte[] bytes = new byte[8 + (2 * shorts.size())];
+        int idx = 0;
+
+        //number of 2-byte shorts representing 4 decimal digits
+        ByteConverter.int2(bytes, idx, shorts.size());
+        idx += 2;
+        //0 based number of 4 decimal digits (i.e. 2-byte shorts) before the decimal
+        ByteConverter.int2(bytes, idx, weight);
+        idx += 2;
+        //indicates positive, negative or NaN
+        ByteConverter.int2(bytes, idx, value.signum() == -1 ? NUMERIC_NEG : NUMERIC_POS);
+        idx += 2;
+        //number of digits after the decimal
+        ByteConverter.int2(bytes, idx, scale);
+        idx += 2;
+
+        short s;
+        while ((s = shorts.pop()) != -1) {
+            ByteConverter.int2(bytes, idx, s);
+            idx += 2;
+        }
+
+        buffer.writeInt(bytes.length);
+        buffer.writeBytes(bytes);
+        return INT32_BYTE_SIZE + bytes.length;
     }
 
+    /**
+     * Simplified version of {@link org.postgresql.util.ByteConverter#numeric(byte[], int, int)}
+     *
+     * <p>The unscaled value is reconstructed arithmetically:
+     * <pre>
+     *   N = groups[0]*10000^(nDigits-1) + ... + groups[nDigits-1]
+     *   E = 4*(weight - nDigits + 1) + scale
+     *   unscaled = N * 10^E   (or N / 10^|E| when E < 0)
+     * </pre>
+     */
     @Override
     public BigDecimal readBinaryValue(ByteBuf buffer, int valueLength) {
-        // Number of DEC_DIGIT blocks
-        short nDigits = buffer.readShort();
-        // DEC_DIGIT blocks before decimal point
+        int nDigits = buffer.readShort() & 0xFFFF;
         short weight = buffer.readShort();
         short sign = buffer.readShort();
         short scale = buffer.readShort();
 
         if (nDigits == 0) {
-            return BigDecimal.ZERO;
+            return new BigDecimal(BigInteger.ZERO, scale);
         }
 
-        boolean has_dp = scale > 0;
-        int sizeOfBytes = (nDigits * DEC_DIGITS) + (has_dp ? 1 : 0);
-        char[] decDigits = new char[sizeOfBytes];
-
-        int decDigitsIdx = 0;
+        BigInteger bigInt = BigInteger.ZERO;
         for (int i = 0; i < nDigits; i++) {
-            int decDigit = buffer.readShort();
-            if (decDigit > 0) {
-                // Decode 4 digits from a 16 bit short
-                for (int j = 1000; j > 0 && decDigitsIdx < sizeOfBytes; j /= 10) {
-                    int d1 = (decDigit / j);
-                    decDigit -= d1 * j;
-                    decDigits[decDigitsIdx++] = (char) (d1 + '0');
-                }
-            }
-            if (has_dp && i == weight) {
-                decDigits[decDigitsIdx++] = '.';
-            }
+            bigInt = bigInt.multiply(BI_TEN_THOUSAND).add(BigInteger.valueOf(buffer.readShort() & 0xFFFF));
         }
 
-        var bd = new BigDecimal(decDigits)
-            .setScale(scale, MathContext.UNLIMITED.getRoundingMode());
+        int e = 4 * (weight - nDigits + 1) + scale;
+        BigInteger unscaled = e >= 0 ? bigInt.multiply(tenPower(e)) : bigInt.divide(tenPower(-e));
+
+        BigDecimal bd = new BigDecimal(unscaled, scale);
         return sign == NUMERIC_NEG ? bd.negate() : bd;
     }
 
@@ -181,5 +243,47 @@ class NumericType extends PGType<BigDecimal> {
     @Override
     BigDecimal decodeUTF8Text(byte[] bytes, RelationLookup relationLookup) {
         return new BigDecimal(new String(bytes, StandardCharsets.UTF_8));
+    }
+
+    private static BigInteger tenPower(int exponent) {
+        return BI_TEN_POWERS.length > exponent ? BI_TEN_POWERS[exponent] : BigInteger.TEN.pow(exponent);
+    }
+
+    /**
+     * Simple stack structure for non-negative {@code short} values.
+     */
+    private static final class PositiveShorts {
+        private short[] shorts = new short[8];
+        private int idx;
+
+        PositiveShorts() {
+        }
+
+        void push(short s) {
+            if (s < 0) {
+                throw new IllegalArgumentException("only non-negative values accepted: " + s);
+            }
+            if (idx == shorts.length) {
+                grow();
+            }
+            shorts[idx++] = s;
+        }
+
+        int size() {
+            return idx;
+        }
+
+        boolean isNotEmpty() {
+            return idx != 0;
+        }
+
+        short pop() {
+            return idx > 0 ? shorts[--idx] : -1;
+        }
+
+        private void grow() {
+            final int newSize = shorts.length <= 1024 ? shorts.length << 1 : (int) (shorts.length * 1.5);
+            shorts = Arrays.copyOf(shorts, newSize);
+        }
     }
 }

--- a/server/src/test/java/io/crate/protocols/postgres/types/NumericTypeTest.java
+++ b/server/src/test/java/io/crate/protocols/postgres/types/NumericTypeTest.java
@@ -24,10 +24,13 @@ package io.crate.protocols.postgres.types;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.math.MathContext;
+import java.nio.ByteBuffer;
 import java.util.List;
 
 import org.junit.Test;
+import org.postgresql.util.ByteConverter;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
@@ -38,15 +41,53 @@ public class NumericTypeTest extends BasePGTypeTest<BigDecimal> {
         super(NumericType.INSTANCE);
     }
 
+    // Tests copied from https://github.com/pgjdbc/pgjdbc/blob/master/pgjdbc/src/test/java/org/postgresql/util/BigDecimalByteConverterTest.java
     private static final List<BigDecimal> TEST_NUMBERS = List.of(
-        new BigDecimal(0),
-        new BigDecimal("-123"),
-        new BigDecimal("12345.1"),
-        new BigDecimal("-12.12"),
-        new BigDecimal("00123"),
-        new BigDecimal("12.123").setScale(2, MathContext.DECIMAL64.getRoundingMode()),
-        new BigDecimal("1234.0"),
-        new BigDecimal("1234.0000").setScale(1, MathContext.DECIMAL64.getRoundingMode())
+        new BigDecimal("0.1"),
+        new BigDecimal("0.10"),
+        new BigDecimal("0.01"),
+        new BigDecimal("0.001"),
+        new BigDecimal("0.0001"),
+        new BigDecimal("0.00001"),
+        new BigDecimal("1.0"),
+        new BigDecimal("0.000000000000000000000000000000000000000000000000000"),
+        new BigDecimal("0.100000000000000000000000000000000000000000000009900"),
+        new BigDecimal("-1.0"),
+        new BigDecimal("-1"),
+        new BigDecimal("1.2"),
+        new BigDecimal("-2.05"),
+        new BigDecimal("0.000000000000000000000000000990"),
+        new BigDecimal("-0.000000000000000000000000000990"),
+        new BigDecimal("10.0000000000099"),
+        new BigDecimal(".10000000000000"),
+        new BigDecimal("1.10000000000000"),
+        new BigDecimal("99999.2"),
+        new BigDecimal("99999"),
+        new BigDecimal("-99999.2"),
+        new BigDecimal("-99999"),
+        new BigDecimal("2147483647"),
+        new BigDecimal("-2147483648"),
+        new BigDecimal("2147483648"),
+        new BigDecimal("-2147483649"),
+        new BigDecimal("9223372036854775807"),
+        new BigDecimal("-9223372036854775808"),
+        new BigDecimal("9223372036854775808"),
+        new BigDecimal("-9223372036854775809"),
+        new BigDecimal("10223372036850000000"),
+        new BigDecimal("19223372036854775807"),
+        new BigDecimal("19223372036854775807.300"),
+        new BigDecimal("-19223372036854775807.300"),
+        new BigDecimal(BigInteger.valueOf(1234567890987654321L), -1),
+        new BigDecimal(BigInteger.valueOf(1234567890987654321L), -5),
+        new BigDecimal(BigInteger.valueOf(-1234567890987654321L), -3),
+        new BigDecimal(BigInteger.valueOf(6), -8),
+        new BigDecimal("30000"),
+        new BigDecimal("40000").setScale(15, MathContext.UNLIMITED.getRoundingMode()),
+        new BigDecimal("20000.000000000000000000"),
+        new BigDecimal("9990000").setScale(8, MathContext.UNLIMITED.getRoundingMode()),
+        new BigDecimal("1000000").setScale(31, MathContext.UNLIMITED.getRoundingMode()),
+        new BigDecimal("10000000000000000000000000000000000000").setScale(14, MathContext.UNLIMITED.getRoundingMode()),
+        new BigDecimal("90000000000000000000000000000000000000")
     );
 
     @Test
@@ -67,14 +108,49 @@ public class NumericTypeTest extends BasePGTypeTest<BigDecimal> {
     @Test
     public void test_read_and_write_numeric_binary_value() {
         for (var expected : TEST_NUMBERS) {
-            ByteBuf buffer = Unpooled.buffer();
+            ByteBuf crateDBBuffer = Unpooled.buffer(); // write and read using our NumericType
+
             try {
-                pgType.writeAsBinary(buffer, expected);
-                BigDecimal actual = pgType.readBinaryValue(buffer, buffer.readInt());
-                assertThat(actual.scale()).isEqualTo(expected.scale());
-                assertThat(actual.toString()).isEqualTo(expected.toString());
+                pgType.writeAsBinary(crateDBBuffer, expected);
+                BigDecimal actual = pgType.readBinaryValue(crateDBBuffer, crateDBBuffer.readInt());
+                if (expected.scale() >= 0) {
+                    assertThat(actual).isEqualTo(expected);
+                } else {
+                    assertThat(actual.toPlainString()).isEqualTo(expected.toPlainString());
+                }
             } finally {
-                buffer.release();
+                crateDBBuffer.release();
+            }
+        }
+    }
+
+    @Test
+    public void test_read_and_write_pg_compatibility() {
+        for (var expected : TEST_NUMBERS) {
+            ByteBuf crateDBBuffer = Unpooled.buffer(); // write and read using our NumericType
+
+            // Use pgjdbc to produce byte[]
+            byte[] tmp = ByteConverter.numeric(expected);
+            // Allocate a buffer with an extra int (4 bytes in the beginning)
+            byte[] pgjdbcBytes = new byte[tmp.length + 4];
+            // Write the length of the byte[] in the beginning
+            System.arraycopy(ByteBuffer.allocate(4).putInt(tmp.length).array(), 0, pgjdbcBytes, 0, 4);
+            // Write the actual bytes
+            System.arraycopy(tmp, 0, pgjdbcBytes, 4, tmp.length);
+            // Wrap into a ByteBuf to be able to read from our NumericType
+            ByteBuf pgjdbcBuffer = Unpooled.wrappedBuffer(pgjdbcBytes);
+
+            try {
+                pgType.writeAsBinary(crateDBBuffer, expected);
+                ByteBuf dupl = crateDBBuffer.slice(); // duplicate using the same byte[] but separate read index
+                BigDecimal actualReadByPgjdbc = (BigDecimal) ByteConverter.numeric(dupl.array(), 4, dupl.readInt());
+                BigDecimal actualFromCrateDB = pgType.readBinaryValue(crateDBBuffer, crateDBBuffer.readInt());
+                BigDecimal actualFromPgJdbc = pgType.readBinaryValue(pgjdbcBuffer, pgjdbcBuffer.readInt());
+                assertThat(actualFromCrateDB).isEqualTo(actualReadByPgjdbc);
+                assertThat(actualFromCrateDB).isEqualTo(actualFromPgJdbc);
+            } finally {
+                crateDBBuffer.release();
+                pgjdbcBuffer.release();
             }
         }
     }


### PR DESCRIPTION
Previously we used a char[] to reconstruct the number as string where
the logic of positioning the . to separate the integer from them decimal
digits was wrong. Use the code from pgjdbc `ByteConverter` but convert
it slightly to use `ByteBuf` instead of `byte[]`. Inherit the tests from
https://github.com/pgjdbc/pgjdbc/blob/master/pgjdbc/src/test/java/org/postgresql/util/BigDecimalByteConverterTest.java

Fixes: #19415