### PR TITLE
Fix broken ref in 5.9.5 release notes

### DIFF
--- a/docs/appendices/release-notes/5.9.5.rst
+++ b/docs/appendices/release-notes/5.9.5.rst
@@ -54,5 +54,5 @@ Fixes
 
 - Return a proper error message when using an invalid
   :ref:`sql-create-repo-azure-endpoint` or
-  :ref:`sql-create-repo-azure-secondary_endpoint` URI for defining an
-  :ref:`azure repository <sql-create-repo-azure>`.
+  ``sql-create-repo-azure-secondary_endpoint`` URI for defining an :ref:`azure
+  repository <sql-create-repo-azure>`.


### PR DESCRIPTION
The `sql-create-repo-azure-secondary_endpoint` reference was removed in:

https://github.com/crate/crate/pull/18997

Due to 6.3.x becoming stable the sphinx inventory no longer contains the
reference.
