### PR TITLE
Optimize list partioning in ThreadPools.runWithAvailableThreads

### DIFF
--- a/server/src/main/java/io/crate/execution/support/ThreadPools.java
+++ b/server/src/main/java/io/crate/execution/support/ThreadPools.java
@@ -66,7 +66,9 @@ public class ThreadPools {
 
         int threadsToUse = availableThreads.getAsInt();
         if (threadsToUse < suppliers.size()) {
-            Iterable<List<Supplier<T>>> partitions = Iterables.partition(suppliers, suppliers.size() / threadsToUse);
+            Iterable<List<Supplier<T>>> partitions = suppliers instanceof List<Supplier<T>> supplierList
+                ? Lists.partition(supplierList, suppliers.size() / threadsToUse)
+                : Iterables.partition(suppliers, suppliers.size() / threadsToUse);
 
             ArrayList<CompletableFuture<List<T>>> futures = new ArrayList<>(threadsToUse + 1);
             for (List<Supplier<T>> partition : partitions) {


### PR DESCRIPTION
If the incoming `suppliers` Collection is a list we can use
`Lists.partition` which internally is based on indexing/sublists, to
avoid the array allocations that `Iterators.partition` has to do.
