### PR TITLE
Fix Numeric binary deserialisation for pg wire protocol

### DIFF
--- a/docs/appendices/release-notes/6.3.3.rst
+++ b/docs/appendices/release-notes/6.3.3.rst
@@ -69,3 +69,7 @@ Fixes
 
 - Fixed an issue that caused nodes to fail to start when parsing persisted
   mappings for tables containing columns of type ``uuid``.
+
+- Fixed and issue which caused wrong binary deserialization of
+  :ref:`NUMERIC <type-numeric>` types when using the
+  :ref:`PostgreSQL wire protocol <interface-postgresql>`.

--- a/server/src/main/java/io/crate/protocols/postgres/types/NumericType.java
+++ b/server/src/main/java/io/crate/protocols/postgres/types/NumericType.java
@@ -29,7 +29,7 @@ import io.crate.metadata.RelationLookup;
 import io.crate.types.Regproc;
 import io.netty.buffer.ByteBuf;
 
-class NumericType extends PGType<BigDecimal> {
+public class NumericType extends PGType<BigDecimal> {
 
     static final int OID = 1700;
 
@@ -95,29 +95,31 @@ class NumericType extends PGType<BigDecimal> {
         }
 
         int len = end - start;
-        short weight = 0;       // Max DEC_DIGIT block index before decimal point
+        int weight = 0;         // Max DEC_DIGIT block index before decimal point
         int offset = 0;         // Offset inside the first block, e.g. 234.23 has and offset of 1
         short nDigits = 0;      // Number of DEC_DIGIT blocks
         if (len != 0) {
             if (dWeight >= 0) {
-                weight = (short) ((dWeight + 1 + DEC_DIGITS - 1) / DEC_DIGITS - 1);
+                weight = (dWeight + 1 + DEC_DIGITS - 1) / DEC_DIGITS - 1;
             } else {
-                weight = (short) (-((-dWeight - 1) / DEC_DIGITS + 1));
+                weight = -((-dWeight - 1) / DEC_DIGITS + 1);
             }
             offset = (weight + 1) * DEC_DIGITS - (dWeight + 1);
             nDigits = (short)((len + offset + DEC_DIGITS - 1) / DEC_DIGITS);
         }
-        int typeLen = 2 * (4 + nDigits);
+        // Header: nDigits(2) + weight(4) + sign(2) + scale(4) = 12 bytes, plus 2 per digit group.
+        // weight and scale use int32 to support values outside the int16 range.
+        int typeLen = 12 + 2 * nDigits;
 
         buffer.writeInt(typeLen);
         buffer.writeShort(nDigits);
-        buffer.writeShort(weight);
+        buffer.writeInt(weight);
         if (value.signum() == -1) {
             buffer.writeShort(NUMERIC_NEG);
         } else {
             buffer.writeShort(NUMERIC_POS);
         }
-        buffer.writeShort(value.scale());
+        buffer.writeInt(value.scale());
 
         int digitIdx = -offset + start;
         while (nDigits-- > 0) {
@@ -139,38 +141,24 @@ class NumericType extends PGType<BigDecimal> {
     public BigDecimal readBinaryValue(ByteBuf buffer, int valueLength) {
         // Number of DEC_DIGIT blocks
         short nDigits = buffer.readShort();
-        // DEC_DIGIT blocks before decimal point
-        short weight = buffer.readShort();
+        // DEC_DIGIT blocks before decimal point (int32 to support values outside int16 range)
+        int weight = buffer.readInt();
         short sign = buffer.readShort();
-        short scale = buffer.readShort();
+        int scale = buffer.readInt();
 
         if (nDigits == 0) {
-            return BigDecimal.ZERO;
+            return BigDecimal.ZERO.setScale(scale, MathContext.UNLIMITED.getRoundingMode());
         }
 
-        boolean has_dp = scale > 0;
-        int sizeOfBytes = (nDigits * DEC_DIGITS) + (has_dp ? 1 : 0);
-        char[] decDigits = new char[sizeOfBytes];
-
-        int decDigitsIdx = 0;
+        // Reconstruct value as sum of digit[i] * 10000^(weight - i) for i in [0, nDigits).
+        BigDecimal result = BigDecimal.ZERO;
         for (int i = 0; i < nDigits; i++) {
-            int decDigit = buffer.readShort();
-            if (decDigit > 0) {
-                // Decode 4 digits from a 16 bit short
-                for (int j = 1000; j > 0 && decDigitsIdx < sizeOfBytes; j /= 10) {
-                    int d1 = (decDigit / j);
-                    decDigit -= d1 * j;
-                    decDigits[decDigitsIdx++] = (char) (d1 + '0');
-                }
-            }
-            if (has_dp && i == weight) {
-                decDigits[decDigitsIdx++] = '.';
-            }
+            int decDigit = buffer.readShort() & 0xFFFF;
+            int exponent = (weight - i) * DEC_DIGITS;
+            result = result.add(new BigDecimal(decDigit).scaleByPowerOfTen(exponent));
         }
-
-        var bd = new BigDecimal(decDigits)
-            .setScale(scale, MathContext.UNLIMITED.getRoundingMode());
-        return sign == NUMERIC_NEG ? bd.negate() : bd;
+        result = result.setScale(scale, MathContext.UNLIMITED.getRoundingMode());
+        return sign == NUMERIC_NEG ? result.negate() : result;
     }
 
     @Override

--- a/server/src/test/java/io/crate/protocols/postgres/types/NumericTypeTest.java
+++ b/server/src/test/java/io/crate/protocols/postgres/types/NumericTypeTest.java
@@ -24,6 +24,7 @@ package io.crate.protocols.postgres.types;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.math.MathContext;
 import java.util.List;
 
@@ -39,14 +40,53 @@ public class NumericTypeTest extends BasePGTypeTest<BigDecimal> {
     }
 
     private static final List<BigDecimal> TEST_NUMBERS = List.of(
-        new BigDecimal(0),
-        new BigDecimal("-123"),
-        new BigDecimal("12345.1"),
-        new BigDecimal("-12.12"),
-        new BigDecimal("00123"),
-        new BigDecimal("12.123").setScale(2, MathContext.DECIMAL64.getRoundingMode()),
-        new BigDecimal("1234.0"),
-        new BigDecimal("1234.0000").setScale(1, MathContext.DECIMAL64.getRoundingMode())
+        new BigDecimal("0.1"),
+        new BigDecimal("0.10"),
+        new BigDecimal("0.01"),
+        new BigDecimal("0.001"),
+        new BigDecimal("0.0001"),
+        new BigDecimal("0.00001"),
+        new BigDecimal("1.0"),
+        new BigDecimal("0.000000000000000000000000000000000000000000000000000"),
+        new BigDecimal("0.100000000000000000000000000000000000000000000009900"),
+        new BigDecimal("-1.0"),
+        new BigDecimal("-1"),
+        new BigDecimal("1.2"),
+        new BigDecimal("-2.05"),
+        new BigDecimal("0.000000000000000000000000000990"),
+        new BigDecimal("-0.000000000000000000000000000990"),
+        new BigDecimal("10.0000000000099"),
+        new BigDecimal(".10000000000000"),
+        new BigDecimal("1.10000000000000"),
+        new BigDecimal("99999.2"),
+        new BigDecimal("99999"),
+        new BigDecimal("-99999.2"),
+        new BigDecimal("-99999"),
+        new BigDecimal("2147483647"),
+        new BigDecimal("-2147483648"),
+        new BigDecimal("2147483648"),
+        new BigDecimal("-2147483649"),
+        new BigDecimal("9223372036854775807"),
+        new BigDecimal("-9223372036854775808"),
+        new BigDecimal("9223372036854775808"),
+        new BigDecimal("-9223372036854775809"),
+        new BigDecimal("10223372036850000000"),
+        new BigDecimal("19223372036854775807"),
+        new BigDecimal("19223372036854775807.300"),
+        new BigDecimal("-19223372036854775807.300"),
+        new BigDecimal(BigInteger.valueOf(1234567890987654321L), -1),
+        new BigDecimal(BigInteger.valueOf(1234567890987654321L), -5),
+        new BigDecimal(BigInteger.valueOf(-1234567890987654321L), -3),
+        new BigDecimal(BigInteger.valueOf(6), -8),
+        new BigDecimal("30000"),
+        new BigDecimal("40000").setScale(15, MathContext.UNLIMITED.getRoundingMode()),
+        new BigDecimal("20000.000000000000000000"),
+        new BigDecimal("9990000").setScale(8, MathContext.UNLIMITED.getRoundingMode()),
+        new BigDecimal("1000000").setScale(31, MathContext.UNLIMITED.getRoundingMode()),
+        new BigDecimal("10000000000000000000000000000000000000").setScale(14, MathContext.UNLIMITED.getRoundingMode()),
+        new BigDecimal("90000000000000000000000000000000000000"),
+        new BigDecimal(new BigInteger("3411016753891"), 123456789),
+        new BigDecimal(new BigInteger("3411016753891"), 123456789).negate()
     );
 
     @Test


### PR DESCRIPTION
Previously we used a `char[]` to reconstruct the number as string where the logic of positioning the `.` to separate the integer from them decimal digits was wrong.

Fixes: #19415

- Tested with the code provided in the issue (JDBC client -> CrateDB)
- Used values for unit tests from: https://github.com/pgjdbc/pgjdbc/blob/master/pgjdbc/src/test/java/org/postgresql/util/BigDecimalByteConverterTest.java
- Benchmarked against a solution with building a char[]: https://gist.github.com/matriv/6991f1af70e181280efc2276f347728f and the results are:
```
Benchmark                          Mode  Cnt      Score     Error  Units
NumericTypeTest.binaryCharMethod  thrpt   25  82079.308 ± 315.806  ops/s
NumericTypeTest.binaryMathMethod  thrpt   25  98930.308 ± 250.504  ops/s
```