### PR TITLE
Restore order of ordinals in HttpErrorStatus; Make readFrom lenient

### DIFF
--- a/server/src/main/java/io/crate/rest/action/HttpErrorStatus.java
+++ b/server/src/main/java/io/crate/rest/action/HttpErrorStatus.java
@@ -23,10 +23,10 @@ package io.crate.rest.action;
 
 import java.io.IOException;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-
-import com.carrotsearch.hppc.IntObjectHashMap;
 
 import io.netty.handler.codec.http.HttpResponseStatus;
 
@@ -101,7 +101,6 @@ public enum HttpErrorStatus {
     USER_DEFINED_FUNCTION_WITH_SAME_SIGNATURE_EXISTS_ALREADY(HttpResponseStatus.CONFLICT,4098),
     USER_WITH_SAME_NAME_EXISTS_ALREADY(HttpResponseStatus.CONFLICT,4099),
     DUPLICATE_OBJECT(HttpResponseStatus.CONFLICT, 40910),
-    RESTORE_SCHEMA_INCOMPATIBLE(HttpResponseStatus.CONFLICT, 40911),
 
     TOO_MANY_REQUESTS(HttpResponseStatus.TOO_MANY_REQUESTS, 4290),
 
@@ -124,18 +123,14 @@ public enum HttpErrorStatus {
     NO_NODE_AVAILABLE(HttpResponseStatus.SERVICE_UNAVAILABLE, 5032),
     NO_SHARD_AVAILABLE(HttpResponseStatus.SERVICE_UNAVAILABLE, 5033),
     PROCESS_CLUSTER_EVENT_TIMEOUT(HttpResponseStatus.SERVICE_UNAVAILABLE, 5034),
-    STATE_NOT_RECOVERED(HttpResponseStatus.SERVICE_UNAVAILABLE, 5035);
+    STATE_NOT_RECOVERED(HttpResponseStatus.SERVICE_UNAVAILABLE, 5035),
 
-    private static final IntObjectHashMap<HttpErrorStatus> CODE_TO_STATUS;
 
-    static {
-        HttpErrorStatus[] values = values();
-        IntObjectHashMap<HttpErrorStatus> codeToStatus = new IntObjectHashMap<>(values.length);
-        for (HttpErrorStatus value : values) {
-            codeToStatus.put(value.errorCode, value);
-        }
-        CODE_TO_STATUS = codeToStatus;
-    }
+    RESTORE_SCHEMA_INCOMPATIBLE(HttpResponseStatus.CONFLICT, 40911),
+    ;
+
+    private static final HttpErrorStatus[] VALUES = values();
+    private static final Logger LOGGER = LogManager.getLogger(HttpErrorStatus.class);
 
     private final HttpResponseStatus httpResponseStatus;
     private final int errorCode;
@@ -155,7 +150,15 @@ public enum HttpErrorStatus {
     }
 
     public static HttpErrorStatus readFrom(StreamInput in) throws IOException {
-        return in.readEnum(HttpErrorStatus.class);
+        int ordinal = in.readVInt();
+        if (ordinal < 0 || ordinal >= VALUES.length) {
+            LOGGER.warn(
+                "Received out of range HttpErrorStatus. If the cluster is currently running with mixed nodes versions this is okay. If not, please report an issue",
+                ordinal
+            );
+            return HttpErrorStatus.UNHANDLED_SERVER_ERROR;
+        }
+        return VALUES[ordinal];
     }
 
     public static void writeTo(StreamOutput out, HttpErrorStatus status) throws IOException {


### PR DESCRIPTION
Follow up to: https://github.com/crate/crate/pull/19389
It broke streaming due to adding a new enum value somewhere in the
middle instead of at the end - causing existing ordinals to shift.

crate-qa broke because of it:

    Caused by: java.io.IOException: Unknown HttpErrorStatus ordinal [62]
        at org.elasticsearch.common.io.stream.StreamInput.readEnum(StreamInput.java:1125)
        at io.crate.rest.action.HttpErrorStatus.readFrom(HttpErrorStatus.java:157)
        at org.elasticsearch.cluster.block.ClusterBlock.<init>(ClusterBlock.java:56)
        at org.elasticsearch.common.io.stream.StreamInput.readSet(StreamInput.java:1101)
        at org.elasticsearch.cluster.block.ClusterBlockException.<init>(ClusterBlockException.java:43)
        at org.elasticsearch.ElasticsearchException.readException(ElasticsearchException.java:251)
        at org.elasticsearch.common.io.stream.StreamInput.readException(StreamInput.java:932)
        at org.elasticsearch.ElasticsearchException.<init>(ElasticsearchException.java:111)
        at org.elasticsearch.transport.TransportException.<init>(TransportException.java:33)
        at org.elasticsearch.transport.ActionTransportException.<init>(ActionTransportException.java:40)
        at org.elasticsearch.transport.RemoteTransportException.<init>(RemoteTransportException.java:45)
        at org.elasticsearch.ElasticsearchException.readException(ElasticsearchException.java:251)
        at org.elasticsearch.common.io.stream.StreamInput.readException(StreamInput.java:932)
        at org.elasticsearch.transport.InboundHandler.handlerResponseError(InboundHandler.java:360)

This moves RESTORE_SCHEMA_INCOMPATIBLE to the end and also makes
`readFrom` lenient - it will now fallback to UNHANDLED_SERVER_ERROR to
account for mixed clusters where a new node has additional error codes.
