### PR TITLE
Upgrade Netty to 4.2.15

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -327,7 +327,7 @@
         <versions.antlr>4.13.2</versions.antlr>
         <versions.quickcheck>1.0</versions.quickcheck>
         <versions.hppc>0.8.2</versions.hppc>
-        <versions.netty>4.2.14.Final</versions.netty>
+        <versions.netty>4.2.15.Final</versions.netty>
         <versions.lucene>10.4.0</versions.lucene>
         <versions.spatial4j>0.8</versions.spatial4j>
         <versions.jts>1.20.0</versions.jts>


### PR DESCRIPTION
https://netty.io/news/2026/06/01/4-2-15-Final.html

Porting to 6.3 because of multiple CVE-s
At least `netty-codec-http` looks relevant for us