### PR TITLE
 Use postings for single-str-key group by optimization

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
@@ -33,11 +33,9 @@ import java.util.function.LongFunction;
 import java.util.function.Supplier;
 import java.util.stream.StreamSupport;
 
-import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.PostingsEnum;
-import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.index.Terms;
 import org.apache.lucene.index.TermsEnum;
@@ -51,6 +49,7 @@ import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.TotalHitCountCollectorManager;
 import org.apache.lucene.search.Weight;
+import org.apache.lucene.util.BitSet;
 import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.RamUsageEstimator;
@@ -74,7 +73,6 @@ import io.crate.data.CollectingBatchIterator;
 import io.crate.data.Row;
 import io.crate.data.RowN;
 import io.crate.data.breaker.RamAccounting;
-import io.crate.exceptions.ArrayViaDocValuesUnsupportedException;
 import io.crate.execution.dsl.phases.RoutedCollectPhase;
 import io.crate.execution.dsl.projection.GroupProjection;
 import io.crate.execution.dsl.projection.Projection;
@@ -105,7 +103,6 @@ import io.crate.metadata.RowGranularity;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.doc.SysColumns;
 import io.crate.types.DataTypes;
-import io.netty.util.collection.LongObjectHashMap;
 
 final class GroupByOptimizedIterator {
 
@@ -437,10 +434,10 @@ final class GroupByOptimizedIterator {
                                                                        Token killToken) throws IOException {
         final HashMap<BytesRef, Object[]> statesByKey = new HashMap<>();
         final Weight weight = indexSearcher.createWeight(indexSearcher.rewrite(query), ScoreMode.COMPLETE_NO_SCORES, 1f);
-        final List<LeafReaderContext> leaves = indexSearcher.getTopReaderContext().leaves();
+        final List<LeafReaderContext> leaves = indexSearcher.getLeafContexts();
         Object[] nullStates = null;
 
-        LongObjectHashMap<Object[]> statesByOrd = new LongObjectHashMap<>();
+        PostingsEnum postings = null;
         for (LeafReaderContext leaf: leaves) {
             killToken.raiseIfKilled();
             Scorer scorer = weight.scorer(leaf);
@@ -451,67 +448,45 @@ final class GroupByOptimizedIterator {
             for (int i = 0, expressionsSize = expressions.size(); i < expressionsSize; i++) {
                 expressions.get(i).setNextReader(readerContext);
             }
-            SortedSetDocValues values = DocValues.getSortedSet(leaf.reader(), keyColumnName);
+            LeafReader reader = leaf.reader();
+            // SortedSetDocValues values = DocValues.getSortedSet(reader, keyColumnName);
+
             DocIdSetIterator docs = scorer.iterator();
-            Bits liveDocs = leaf.reader().getLiveDocs();
-            for (int doc = docs.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = docs.nextDoc()) {
-                killToken.raiseIfKilled();
-                if (docDeleted(liveDocs, doc)) {
-                    continue;
+            BitSet matchedDocs = BitSet.of(docs, reader.maxDoc());
+            Bits liveDocs = reader.getLiveDocs();
+            Terms terms = reader.terms(keyColumnName);
+            if (terms == null) {
+                continue;
+            }
+            TermsEnum termsEnum = terms.iterator();
+            while (true) {
+                BytesRef sharedKey = termsEnum.next();
+                if (sharedKey == null) {
+                    break;
                 }
-                for (int i = 0, expressionsSize = expressions.size(); i < expressionsSize; i++) {
-                    expressions.get(i).setNextDocId(doc);
-                }
-                for (int i = 0, expressionsSize = aggExpressions.size(); i < expressionsSize; i++) {
-                    aggExpressions.get(i).setNextRow(inputRow);
-                }
-                if (values.advanceExact(doc)) {
-                    long ord = values.nextOrd();
-                    Object[] states = statesByOrd.get(ord);
+                postings = termsEnum.postings(postings, PostingsEnum.NONE);
+                int doc;
+                while ((doc = postings.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
+                    killToken.raiseIfKilled();
+                    if (docDeleted(liveDocs, doc) || !matchedDocs.get(doc)) {
+                        continue;
+                    }
+                    for (int i = 0, expressionsSize = expressions.size(); i < expressionsSize; i++) {
+                        expressions.get(i).setNextDocId(doc);
+                    }
+                    for (int i = 0, expressionsSize = aggExpressions.size(); i < expressionsSize; i++) {
+                        aggExpressions.get(i).setNextRow(inputRow);
+                    }
+                    Object[] states = statesByKey.get(sharedKey);
                     if (states == null) {
-                        statesByOrd.put(ord, initStates(aggregations, ramAccounting, memoryManager, minNodeVersion));
+                        ramAccounting.addBytes(BYTES_REF_SHALLOW_SIZE + sharedKey.length + HASH_MAP_ENTRY_OVERHEAD);
+                        states = initStates(aggregations, ramAccounting, memoryManager, minNodeVersion);
+                        statesByKey.put(BytesRef.deepCopyOf(sharedKey), states);
                     } else {
                         aggregateValues(aggregations, ramAccounting, memoryManager, states);
                     }
-                    if (values.docValueCount() > 1) {
-                        throw new ArrayViaDocValuesUnsupportedException(keyColumnName);
-                    }
-                } else {
-                    if (nullStates == null) {
-                        nullStates = initStates(aggregations, ramAccounting, memoryManager, minNodeVersion);
-                    } else {
-                        aggregateValues(aggregations, ramAccounting, memoryManager, nullStates);
-                    }
                 }
             }
-            for (var entry : statesByOrd.entries()) {
-                killToken.raiseIfKilled();
-                long ord = entry.key();
-                Object[] states = entry.value();
-                if (states == null) {
-                    continue;
-                }
-                BytesRef sharedKey = values.lookupOrd(ord);
-                Object[] prevStates = statesByKey.get(sharedKey);
-                if (prevStates == null) {
-                    ramAccounting.addBytes(BYTES_REF_SHALLOW_SIZE + sharedKey.length + HASH_MAP_ENTRY_OVERHEAD);
-                    statesByKey.put(BytesRef.deepCopyOf(sharedKey), states);
-                } else {
-                    for (int i = 0; i < aggregations.size(); i++) {
-                        AggregationContext aggregation = aggregations.get(i);
-                        //noinspection unchecked
-                        prevStates[i] = aggregation.function().reduce(
-                            ramAccounting,
-                            prevStates[i],
-                            states[i]
-                        );
-                    }
-                }
-            }
-            statesByOrd.clear();
-        }
-        if (nullStates != null) {
-            statesByKey.put(null, nullStates);
         }
         return statesByKey;
     }

--- a/server/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
@@ -38,19 +38,25 @@ import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.PostingsEnum;
 import org.apache.lucene.index.SortedSetDocValues;
+import org.apache.lucene.index.Term;
 import org.apache.lucene.index.Terms;
 import org.apache.lucene.index.TermsEnum;
+import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.FieldExistsQuery;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.search.TotalHitCountCollectorManager;
 import org.apache.lucene.search.Weight;
 import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.lucene.BytesRefs;
+import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.engine.Engine;
@@ -92,6 +98,7 @@ import io.crate.expression.symbol.Symbols;
 import io.crate.lucene.LuceneQueryBuilder;
 import io.crate.memory.MemoryManager;
 import io.crate.metadata.DocReferences;
+import io.crate.metadata.IndexType;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RowGranularity;
@@ -142,7 +149,7 @@ final class GroupByOptimizedIterator {
             : "Must have 1 key if getSingleStringKeyGroupProjection returned a projection";
 
         Reference docKeyRef = getKeyRef(collectPhase.toCollect(), groupProjection.keys().get(0));
-        if (docKeyRef == null || docKeyRef.isNullable()) {
+        if (docKeyRef == null) {
             return null; // group by on non-reference
         }
 
@@ -193,10 +200,10 @@ final class GroupByOptimizedIterator {
         };
         return () -> StreamSupport.stream(countsByKey.spliterator(), false)
             .map(cursor -> {
-                String key = cursor.key.utf8ToString();
+                BytesRef key = cursor.key;
                 long count = cursor.value;
                 // See GroupProjection.outputs(): keys always come first, aggregations second
-                cells[0] = key;
+                cells[0] = key == null ? null : key.utf8ToString();
                 cells[1] = wrapCount.apply(count);
                 return row;
             })
@@ -236,6 +243,18 @@ final class GroupByOptimizedIterator {
                     countsByKey.put(key, numDocs);
                 }
                 killToken.raiseIfKilled();;
+            }
+        }
+        if (keyRef.isNullable()) {
+            Query existsQuery = keyRef.hasDocValues() || keyRef.indexType() == IndexType.FULLTEXT
+                ? new FieldExistsQuery(keyStorageIdent)
+                : new ConstantScoreQuery(new TermQuery(new Term(SysColumns.FieldNames.NAME, keyStorageIdent)));
+            Query notNull = Queries.not(existsQuery);
+
+            TotalHitCountCollectorManager topHitCounts = new TotalHitCountCollectorManager(searcher.getSlices());
+            Integer count = searcher.search(notNull, topHitCounts);
+            if (count > 0) {
+                countsByKey.put(null, count);
             }
         }
         return countsByKey;


### PR DESCRIPTION
Just an experiment. Don't merge


Current implementation is buggy/incomplete, but looks like it could give a performance boost for cases where most documents match, but it in turns makes queries where few documents match much more expensive:

```
Q: select "cCode", avg(duration), avg("adRevenue") from uservisits where "cCode" in ('AUT', 'DEU') group by "cCode"
C: 1
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |        5.321 ±    9.486 |      2.218 |      3.389 |      4.314 |     83.009 |
|   V2    |       11.830 ±   31.769 |      5.496 |      7.559 |      8.893 |    320.743 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               +  75.90%                           +  76.18%   
There is a 94.90% probability that the observed difference is not random, and the best estimate of that difference is 75.90%
The test has no statistical significance

Q: select min("adRevenue") from uservisits group by "cCode"
C: 15
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |      204.284 ±  258.683 |     50.022 |     90.289 |    127.443 |    943.442 |
|   V2    |      153.656 ±  119.246 |     42.193 |    108.801 |    143.303 |    533.660 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -  28.29%                           +  18.60%   
There is a 92.30% probability that the observed difference is not random, and the best estimate of that difference is 28.29%
The test has no statistical significance

```

Not sure if worth continuing with this. One option could be to try and generalize the term-freq group-by path and use this if there is no query. 