### PR TITLE
Store only small part of GenericFunctionQuery in the LRUQueryCache

### DIFF
--- a/docs/appendices/release-notes/6.2.9.rst
+++ b/docs/appendices/release-notes/6.2.9.rst
@@ -54,3 +54,6 @@ Fixes
 
 - Fixed a regression introduced with :ref:`version_6.0.0`, leading to stuck
   ``DROP SNAPSHOT`` and ``CREATE SNAPSHOT`` queries.
+
+- Fixed an issue causing cache to retain some heavy structures, potentially
+  leading to an ``OutOfMemoryError``.

--- a/docs/appendices/release-notes/6.3.3.rst
+++ b/docs/appendices/release-notes/6.3.3.rst
@@ -72,3 +72,6 @@ Fixes
 
 - Fixed a regression introduced with :ref:`version_6.0.0`, leading to stuck
   ``DROP SNAPSHOT`` and ``CREATE SNAPSHOT`` queries.
+
+- Fixed an issue causing cache to retain some heavy structures, potentially
+  leading to an ``OutOfMemoryError``.

--- a/server/src/main/java/io/crate/lucene/GenericFunctionQuery.java
+++ b/server/src/main/java/io/crate/lucene/GenericFunctionQuery.java
@@ -65,7 +65,7 @@ public class GenericFunctionQuery extends Query implements Accountable {
     private final DocInputFactory docInputFactory;
     private final TransactionContext txnCtx;
     private final Runnable raiseIfKilled;
-    private final long ramBytesUsed;
+    private final SmallCacheableQuery smallCacheableQuery;
 
     GenericFunctionQuery(Function function,
                          CollectorContext collectorContext,
@@ -73,18 +73,11 @@ public class GenericFunctionQuery extends Query implements Accountable {
                          TransactionContext txnCtx,
                          Runnable raiseIfKilled) {
         this.function = function;
+        this.smallCacheableQuery = new SmallCacheableQuery(function);
         this.collectorContext = collectorContext;
         this.docInputFactory = docInputFactory;
         this.txnCtx = txnCtx;
         this.raiseIfKilled = raiseIfKilled;
-        this.ramBytesUsed =
-            function.ramBytesUsed()
-            + RamUsageEstimator.shallowSizeOf(collectorContext)
-            + RamUsageEstimator.shallowSizeOf(docInputFactory)
-            + RamUsageEstimator.shallowSizeOf(txnCtx)
-            // raiseIfKilled references KillToken which has a link to Throwable.
-            + RamUsageEstimator.NUM_BYTES_OBJECT_HEADER + RamUsageEstimator.NUM_BYTES_OBJECT_REF
-            + 8; // ramBytesUsed
     }
 
     @Override
@@ -97,10 +90,58 @@ public class GenericFunctionQuery extends Query implements Accountable {
         return function.hashCode();
     }
 
+    /**
+     * @return memory usage of the part that is actually passed to the cache.
+     * LRUCache uses SmallCacheableQuery's memory accounting directly.
+     * This method is solely used by the RamUsageQueryVisitor.
+     */
+    @Override
+    public long ramBytesUsed() {
+        return smallCacheableQuery.ramBytesUsed();
+    }
+
+    static class SmallCacheableQuery extends Query implements Accountable {
+
+        private final Function function;
+        private final long ramBytesUsed;
+
+        private SmallCacheableQuery(Function function) {
+            this.function = function;
+            this.ramBytesUsed =
+                RamUsageEstimator.NUM_BYTES_OBJECT_HEADER
+                + RamUsageEstimator.NUM_BYTES_OBJECT_REF
+                + function.ramBytesUsed();
+        }
+
+        @Override
+        public String toString(String field) {
+            return function.toString();
+        }
+
+        @Override
+        public void visit(QueryVisitor visitor) {
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            return obj instanceof SmallCacheableQuery other && function.equals(other.function);
+        }
+
+        @Override
+        public int hashCode() {
+            return function.hashCode();
+        }
+
+        @Override
+        public long ramBytesUsed() {
+            return ramBytesUsed;
+        }
+    }
+
+
     @Override
     public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost) throws IOException {
-
-        return new Weight(this) {
+        return new Weight(smallCacheableQuery) {
             // Queries in the cache can end up retaining heavy objects,
             // and prevent them being garbage collected.
             // expressions can reference a heavy readers via expression.setNextReader(readerContext),
@@ -180,11 +221,6 @@ public class GenericFunctionQuery extends Query implements Accountable {
     @Override
     public String toString(String field) {
         return function.toString();
-    }
-
-    @Override
-    public long ramBytesUsed() {
-        return ramBytesUsed;
     }
 
     private static class FilteredTwoPhaseIterator extends TwoPhaseIterator {

--- a/server/src/test/java/io/crate/lucene/GenericFunctionQueryTest.java
+++ b/server/src/test/java/io/crate/lucene/GenericFunctionQueryTest.java
@@ -80,7 +80,7 @@ public class GenericFunctionQueryTest extends CrateDummyClusterServiceUnitTest {
         try (QueryTester tester = builder.build()) {
             var query = tester.toQuery("abs(a) * abs(b) = 1");
             assertThat(query).isInstanceOf(GenericFunctionQuery.class);
-            assertThat(CustomLRUQueryCache.getRamBytesUsed(query)).isEqualTo(1672L);
+            assertThat(CustomLRUQueryCache.getRamBytesUsed(query)).isEqualTo(1592L);
         }
     }
 
@@ -97,7 +97,7 @@ public class GenericFunctionQueryTest extends CrateDummyClusterServiceUnitTest {
         try (QueryTester tester = builder.build()) {
             var query = tester.toQuery("abs(a) = 1 AND abs(b) = 1");
             assertThat(query).isInstanceOf(BooleanQuery.class);
-            assertThat(CustomLRUQueryCache.getRamBytesUsed(query)).isEqualTo(1816L);
+            assertThat(CustomLRUQueryCache.getRamBytesUsed(query)).isEqualTo(1656L);
         }
     }
 }


### PR DESCRIPTION
We tried to remove heavy dependencies from GenericFunctionQuery in https://github.com/crate/crate/pull/18925 and https://github.com/crate/crate/pull/19091

However, it still has CollectContext and DocInputFactory dependencies, that are accounted only for shallow usage, while referencing quite some number of non-trivial structures.

Passing lightweight query to the cache allows it
to depend only on a lightweight Function object which also has precise memory accounting.

Thanks @mfussenegger for the idea!