### PR TITLE
Don't recompute LuceneCollectorExpression in GenericFunctionQuery on each Weight creation

### DIFF
--- a/server/src/main/java/io/crate/lucene/GenericFunctionQuery.java
+++ b/server/src/main/java/io/crate/lucene/GenericFunctionQuery.java
@@ -23,6 +23,7 @@ package io.crate.lucene;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 
 import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.LeafReader;
@@ -43,15 +44,11 @@ import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.RamUsageEstimator;
 
 import io.crate.data.Input;
-import io.crate.execution.engine.collect.DocInputFactory;
 import io.crate.execution.engine.fetch.ReaderContext;
 import io.crate.expression.InputCondition;
-import io.crate.expression.InputFactory;
-import io.crate.expression.reference.doc.lucene.CollectorContext;
 import io.crate.expression.reference.doc.lucene.LuceneCollectorExpression;
 import io.crate.expression.symbol.Function;
 import io.crate.metadata.Reference;
-import io.crate.metadata.TransactionContext;
 
 /**
  * Query implementation which filters docIds by evaluating {@code condition} on each docId to verify if it matches.
@@ -61,22 +58,20 @@ import io.crate.metadata.TransactionContext;
 public class GenericFunctionQuery extends Query implements Accountable {
 
     private final Function function;
-    private final CollectorContext collectorContext;
-    private final DocInputFactory docInputFactory;
-    private final TransactionContext txnCtx;
+    private final LuceneCollectorExpression<?>[] expressions;
+    private final Input<Boolean> condition;
     private final Runnable raiseIfKilled;
     private final SmallCacheableQuery smallCacheableQuery;
 
     GenericFunctionQuery(Function function,
-                         CollectorContext collectorContext,
-                         DocInputFactory docInputFactory,
-                         TransactionContext txnCtx,
+                         Collection<? extends LuceneCollectorExpression<?>> expressions,
+                         Input<Boolean> condition,
                          Runnable raiseIfKilled) {
         this.function = function;
         this.smallCacheableQuery = new SmallCacheableQuery(function);
-        this.collectorContext = collectorContext;
-        this.docInputFactory = docInputFactory;
-        this.txnCtx = txnCtx;
+        // inner loop iterates over expressions - call toArray to avoid iterator allocations
+        this.expressions = expressions.toArray(new LuceneCollectorExpression[0]);
+        this.condition = condition;
         this.raiseIfKilled = raiseIfKilled;
     }
 
@@ -142,21 +137,6 @@ public class GenericFunctionQuery extends Query implements Accountable {
     @Override
     public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost) throws IOException {
         return new Weight(smallCacheableQuery) {
-            // Queries in the cache can end up retaining heavy objects,
-            // and prevent them being garbage collected.
-            // expressions can reference a heavy readers via expression.setNextReader(readerContext),
-            // hence we move expressions dependency out of the GenericFunctionQuery and re-create them per-weight.
-
-            final InputFactory.Context<? extends LuceneCollectorExpression<?>> ctx = docInputFactory.getCtx(txnCtx);
-            @SuppressWarnings("unchecked")
-            final Input<Boolean> condition = (Input<Boolean>) ctx.add(function);
-            final LuceneCollectorExpression<?>[] expressions = ctx.expressions().toArray(new LuceneCollectorExpression[0]);
-            {
-                for (LuceneCollectorExpression<?> expression: expressions) {
-                    expression.startCollect(collectorContext);
-                }
-
-            }
 
             @Override
             public boolean isCacheable(LeafReaderContext ctx) {

--- a/server/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
+++ b/server/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
@@ -24,6 +24,7 @@ package io.crate.lucene;
 import static io.crate.expression.eval.NullEliminator.eliminateNullsIfPossible;
 import static io.crate.metadata.DocReferences.inverseSourceLookup;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -47,8 +48,10 @@ import io.crate.data.Input;
 import io.crate.exceptions.UnsupportedFeatureException;
 import io.crate.exceptions.VersioningValidationException;
 import io.crate.execution.engine.collect.DocInputFactory;
+import io.crate.expression.InputFactory;
 import io.crate.expression.eval.EvaluatingNormalizer;
 import io.crate.expression.reference.doc.lucene.CollectorContext;
+import io.crate.expression.reference.doc.lucene.LuceneCollectorExpression;
 import io.crate.expression.reference.doc.lucene.LuceneReferenceResolver;
 import io.crate.expression.reference.doc.lucene.StoredRowLookup;
 import io.crate.expression.symbol.Function;
@@ -395,9 +398,16 @@ public class LuceneQueryBuilder {
         function = (Function) DocReferences.toDocLookup(function,
             r -> context.tableInfo().isIgnoredOrImmediateChildOfIgnored(r) || r.valueType() == DataTypes.GEO_POINT);
 
+        final InputFactory.Context<? extends LuceneCollectorExpression<?>> ctx = context.docInputFactory.getCtx(context.txnCtx);
+        @SuppressWarnings("unchecked")
+        final Input<Boolean> condition = (Input<Boolean>) ctx.add(function);
+        final Collection<? extends LuceneCollectorExpression<?>> expressions = ctx.expressions();
         final CollectorContext collectorContext
             = new CollectorContext(() -> StoredRowLookup.create(context.shardCreatedVersion, context.table, context.partitionValues));
-        return new GenericFunctionQuery(function, collectorContext, context.docInputFactory, context.txnCtx, context.raiseIfKilled);
+        for (LuceneCollectorExpression<?> expression : expressions) {
+            expression.startCollect(collectorContext);
+        }
+        return new GenericFunctionQuery(function, expressions, condition, context.raiseIfKilled);
     }
 
     private static void raiseUnsupported(Function function) {

--- a/server/src/test/java/io/crate/lucene/LikeQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/LikeQueryBuilderTest.java
@@ -30,7 +30,6 @@ import java.util.List;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.Query;
-import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.WildcardQuery;
 import org.assertj.core.api.Assertions;
@@ -201,19 +200,8 @@ public class LikeQueryBuilderTest extends LuceneQueryBuilderTest {
             .hasMessage("pattern '\\' must not end with escape character '\\'");
 
         // no index
-        Query query = convert("text_no_index like '\\'");
-        assertThat(query).isInstanceOf(GenericFunctionQuery.class);
-        GenericFunctionQuery genericFunctionQuery1 = (GenericFunctionQuery) query;
-        assertThatThrownBy(() -> genericFunctionQuery1.createWeight(null, ScoreMode.COMPLETE, 1))
-            .isExactlyInstanceOf(IllegalArgumentException.class)
-            .hasMessage("pattern '\\' must not end with escape character '\\'");
-
-        query = convert("text_no_index ilike '\\'");
-        assertThat(query).isInstanceOf(GenericFunctionQuery.class);
-        GenericFunctionQuery genericFunctionQuery2 = (GenericFunctionQuery) query;
-        assertThatThrownBy(() -> genericFunctionQuery2.createWeight(null, ScoreMode.COMPLETE, 1))
-            .isExactlyInstanceOf(IllegalArgumentException.class)
-            .hasMessage("pattern '\\' must not end with escape character '\\'");
+        assertThatThrownBy(() -> convert("text_no_index like '\\'"));
+        assertThatThrownBy(() -> convert("text_no_index ilike '\\'"));
     }
 
     /**


### PR DESCRIPTION
Reverts https://github.com/crate/crate/pull/18925/.

GenericFunctionQuery can have heavy dependencies
as we started passing only lightweight part to the cache in https://github.com/crate/crate/pull/19474

