### PR TITLE
Enable query-then-fetch for filtered lookup joins under LIMIT

### DIFF
--- a/server/src/main/java/io/crate/planner/operators/Filter.java
+++ b/server/src/main/java/io/crate/planner/operators/Filter.java
@@ -21,6 +21,7 @@
 
 package io.crate.planner.operators;
 
+import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.SequencedCollection;
@@ -108,6 +109,20 @@ public final class Filter extends ForwardingLogicalPlan {
             return this;
         }
         return new Filter(newSource, query);
+    }
+
+    @Override
+    public FetchRewrite rewriteToFetch(Collection<Symbol> usedColumns) {
+        LinkedHashSet<Symbol> toKeep = new LinkedHashSet<>(usedColumns);
+        Symbols.intersection(query, source.outputs(), toKeep::add);
+        FetchRewrite fetchRewrite = source.rewriteToFetch(toKeep);
+        if (fetchRewrite == null) {
+            return null;
+        }
+        return new FetchRewrite(
+            fetchRewrite.replacedOutputs(),
+            new Filter(fetchRewrite.newPlan(), query)
+        );
     }
 
     @Override

--- a/server/src/test/java/io/crate/planner/SubQueryPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/SubQueryPlannerTest.java
@@ -76,10 +76,10 @@ public class SubQueryPlannerTest extends CrateDummyClusterServiceUnitTest {
         List<Projection> projections = collect.collectPhase().projections();
         assertThat(projections).satisfiesExactly(
             isLimitAndOffset(10, 0),
-            exactlyInstanceOf(FetchProjection.class),
             exactlyInstanceOf(FilterProjection.class),
             exactlyInstanceOf(OrderedLimitAndOffsetProjection.class),
-            isLimitAndOffset(3, 0)
+            isLimitAndOffset(3, 0),
+            exactlyInstanceOf(FetchProjection.class)
         );
     }
 

--- a/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
@@ -430,6 +430,41 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
     }
 
     @Test
+    public void test_lookup_join_under_filter_and_limit_can_be_fetch_optimized() {
+        sqlExecutor.getSessionSettings().excludedOptimizerRules().remove(EquiJoinToLookupJoin.class);
+        TableInfo t1 = sqlExecutor.resolveTableInfo("t1");
+        TableInfo t2 = sqlExecutor.resolveTableInfo("t2");
+        sqlExecutor.updateTableStats(Map.of(
+            t1.ident(), new Stats(10_000, 0, Map.of()),
+            t2.ident(), new Stats(100, 0, Map.of())
+        ));
+
+        LogicalPlan plan = plan(
+            """
+            SELECT t1.i, t1.a, t2.i
+            FROM t1
+            JOIN t2 ON t1.i = t2.i
+            WHERE t1.x > t2.y
+            LIMIT 5
+            """
+        );
+
+        assertThat(plan).isEqualTo(
+            """
+            Eval[i, a, i]
+              └ Fetch[i, a, x, i, y]
+                └ Limit[5::bigint;0]
+                  └ Filter[(x > y)]
+                    └ HashJoin[INNER | (i = i)]
+                      ├ MultiPhase
+                      │  └ Collect[doc.t1 | [_fetchid, i, x] | (i = ANY((doc.t2)))]
+                      │  └ Collect[doc.t2 | [i] | true]
+                      └ Collect[doc.t2 | [i, y] | true]
+            """
+        );
+    }
+
+    @Test
     public void testPlanOfJoinedViewsHasBoundaryWithViewOutputs() {
         LogicalPlan plan = plan(
             """


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Follows https://github.com/crate/crate/pull/19447.

A slightly more complex lookup-join query that still cannot use query-then-fetch because `Filter.rewriteToFetch` is not implemented:

```
CREATE TABLE doc.t1 (
    id1 int,
    val1 int,
    payload text
) WITH (number_of_replicas = 0);

INSERT INTO doc.t1 (id1, val1, payload)
SELECT
    b,
    b % 100,
    gen_random_text_uuid() || gen_random_text_uuid() || gen_random_text_uuid() || gen_random_text_uuid()
FROM generate_series(1, 10000) AS a(b);

CREATE TABLE doc.t2 (
    id2 int,
    val2 int
) WITH (number_of_replicas = 0);

INSERT INTO doc.t2 (id2, val2)
SELECT
    b,
    b % 50
FROM generate_series(1, 100) AS a(b);

REFRESH TABLE doc.t1;
REFRESH TABLE doc.t2;
ANALYZE;

SET optimizer_equi_join_to_lookup_join = true;

EXPLAIN (COSTS FALSE)
SELECT t1.id1, t1.payload, t2.id2
FROM doc.t1
JOIN doc.t2 ON t1.id1 = t2.id2
WHERE t1.val1 > t2.val2
LIMIT 5;
```

The filter `WHERE t1.val1 > t2.val2` references columns from both sides of the join, so `MergeFilterAndCollect` cannot merge it with either collect. Then, the filter stays above the join and blocks query-then-fetch optimization, although `payload` is only needed in the final resultset and could be fetched later. See below query plans.

Before:
```
+-----------------------------------------------------------------------------+
| QUERY PLAN                                                                  |
+-----------------------------------------------------------------------------+
| Eval[id1, payload, id2]                                                     |
|   └ Limit[5::bigint;0]                                                      |
|     └ Filter[(val1 > val2)]                                                 |
|       └ HashJoin[INNER | (id1 = id2)]                                       |
|         ├ MultiPhase                                                        |
|         │  └ Collect[doc.t1 | [id1, payload, val1] | (id1 = ANY((doc.t2)))] |
|         │  └ Collect[doc.t2 | [id2] | true]                                 |
|         └ Collect[doc.t2 | [id2, val2] | true]                              |
+-----------------------------------------------------------------------------+
```
After:
```
+--------------------------------------------------------------------------------+
| QUERY PLAN                                                                     |
+--------------------------------------------------------------------------------+
| Eval[id1, payload, id2]                                                        |
|   └ Fetch[id1, payload, val1, id2, val2]                                       |
|     └ Limit[5::bigint;0]                                                       |
|       └ Filter[(val1 > val2)]                                                  |
|         └ HashJoin[INNER | (id1 = id2)]                                        |
|           ├ MultiPhase                                                         |
|           │  └ Collect[doc.t1 | [_fetchid, id1, val1] | (id1 = ANY((doc.t2)))] |
|           │  └ Collect[doc.t2 | [id2] | true]                                  |
|           └ Collect[doc.t2 | [id2, val2] | true]                               |
+--------------------------------------------------------------------------------+
```

## Performance improvements

Before:
```
$ cr8 run-spec specs/lookup_join_filter_fetch_limit.toml localhost:4200
# Running setUp
# Running benchmark

## Running Query:
   Statement:
     select t1.id1, t1.payload, t2.id2 from doc.t1 join doc.t2 on t1.id1 = t2.id2 where t1.val1 > t2.val2 limit 5
   Concurrency: 1
   Iterations: 100
100%|███████████████████████████████████████████████████████████████████████████████████████| 100/100 [00:16<00:00,  6.20 requests/s]
Runtime (in ms):
    mean:    160.005 ± 13.079
    min/max: 140.155 → 784.696
Percentile:
    50:   146.279 ± 66.727 (stdev)
    95:   182.864
    99.9: 784.696

## Running Query:
   Statement:
     select t1.id1, t1.payload, t2.id2 from doc.t1 join doc.t2 on t1.id1 = t2.id2 where t1.val1 > t2.val2 limit 1000
   Concurrency: 1
   Iterations: 100
100%|███████████████████████████████████████████████████████████████████████████████████████| 100/100 [00:14<00:00,  6.79 requests/s]
Runtime (in ms):
    mean:    145.517 ± 1.039
    min/max: 140.483 → 178.611
Percentile:
    50:   143.751 ± 5.303 (stdev)
    95:   156.173
    99.9: 178.611
# Running tearDown

```
After:
```
$ cr8 run-spec specs/lookup_join_filter_fetch_limit.toml localhost:4200
# Running setUp
# Running benchmark

## Running Query:
   Statement:
     select t1.id1, t1.payload, t2.id2 from doc.t1 join doc.t2 on t1.id1 = t2.id2 where t1.val1 > t2.val2 limit 5
   Concurrency: 1
   Iterations: 100
100%|███████████████████████████████████████████████████████████████████████████████████████| 100/100 [00:14<00:00,  6.94 requests/s]
Runtime (in ms):
    mean:    142.694 ± 14.524
    min/max: 126.158 → 836.779
Percentile:
    50:   130.882 ± 74.100 (stdev)
    95:   155.210
    99.9: 836.779

## Running Query:
   Statement:
     select t1.id1, t1.payload, t2.id2 from doc.t1 join doc.t2 on t1.id1 = t2.id2 where t1.val1 > t2.val2 limit 1000
   Concurrency: 1
   Iterations: 100
100%|███████████████████████████████████████████████████████████████████████████████████████| 100/100 [00:13<00:00,  7.27 requests/s]
Runtime (in ms):
    mean:    135.715 ± 1.814
    min/max: 127.134 → 185.337
Percentile:
    50:   132.869 ± 9.254 (stdev)
    95:   159.737
    99.9: 185.337
# Running tearDown
```
Shows up to 12% gain. As the payload gets larger, more improvements will be observed.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
