### PR TITLE
Map Crate's byte type to Pg's smallint

### DIFF
--- a/docs/appendices/release-notes/6.4.0.rst
+++ b/docs/appendices/release-notes/6.4.0.rst
@@ -48,6 +48,17 @@ Breaking Changes
   the setting is present in the ``crate.yml`` CrateDB will refuse to start.
   Please remove it before updating.
 
+- The PostgreSQL type mapping of CrateDB's ``byte`` type changed from ``"char"``
+  (OID 18) to ``int2`` (OID 21). Clients now receive ``byte`` columns as
+  ``int2`` in both text and binary formats.
+
+  Most clients reading data determine the type of a column dynamically, and are
+  largely unaffected. With ``pgjdbc``, ``ResultSet``'s ``getString()`` and
+  ``getByte()`` return the same results as before. ``getObject()`` now returns a
+  ``Short`` instead of a ``String``.
+
+  The CrateDB JDBC driver is unaffected: ``getObject()`` returns an ``Integer``
+  as it did before.
 
 Deprecations
 ============

--- a/docs/interfaces/postgres.rst
+++ b/docs/interfaces/postgres.rst
@@ -202,7 +202,6 @@ table available in CrateDB::
     |  oid | typname      | typarray | typelem | typlen | typtype | typcategory |
     +------+--------------+----------+---------+--------+---------+-------------+
     |   16 | bool         |     1000 |       0 |      1 | b       | N           |
-    |   18 | char         |     1002 |       0 |      1 | b       | S           |
     |   19 | name         |       -1 |       0 |     64 | b       | S           |
     |   20 | int8         |     1016 |       0 |      8 | b       | N           |
     |   21 | int2         |     1005 |       0 |      2 | b       | N           |
@@ -218,7 +217,6 @@ table available in CrateDB::
     |  701 | float8       |     1022 |       0 |      8 | b       | N           |
     |  705 | unknown      |        0 |       0 |     -2 | p       | X           |
     | 1000 | _bool        |        0 |      16 |     -1 | b       | A           |
-    | 1002 | _char        |        0 |      18 |     -1 | b       | A           |
     | 1005 | _int2        |        0 |      21 |     -1 | b       | A           |
     | 1007 | _int4        |        0 |      23 |     -1 | b       | A           |
     | 1008 | _regproc     |        0 |      24 |     -1 | b       | A           |
@@ -254,7 +252,7 @@ table available in CrateDB::
     | 2950 | uuid         |     2951 |       0 |     16 | b       | U           |
     | 2951 | _uuid        |        0 |    2950 |     -1 | b       | A           |
     +------+--------------+----------+---------+--------+---------+-------------+
-    SELECT 52 rows in set (... sec)
+    SELECT 50 rows in set (... sec)
 
 .. NOTE::
 

--- a/server/src/main/java/io/crate/protocols/postgres/types/PGTypes.java
+++ b/server/src/main/java/io/crate/protocols/postgres/types/PGTypes.java
@@ -45,14 +45,22 @@ import io.crate.types.UUIDType;
 
 public class PGTypes {
 
+    /**
+     * Maps each CrateDB type to the Pg type clients see for it.
+     * <p>
+     * Several CrateDB types can map to the same pg type (e.g. string and ip -> varchar,
+     * short and byte -> int2). Insertion order then decides the reverse (pg -> CrateDB)
+     * mapping: {@link #PG_TYPES_TO_CRATE_TYPE} is built first-wins per oid, so the
+     * CrateDB type that should represent the pg type must be inserted first.
+     */
     private static final Map<DataType<?>, PGType<?>> CRATE_TO_PG_TYPES = MapBuilder.<DataType<?>, PGType<?>>newLinkedHashMapBuilder()
-        .put(DataTypes.BYTE, CharType.INSTANCE)
         .put(DataTypes.STRING, VarCharType.INSTANCE)
         .put(DataTypes.CHARACTER, CharacterType.INSTANCE)
         .put(DataTypes.BOOLEAN, BooleanType.INSTANCE)
         .put(DataTypes.UNTYPED_OBJECT, JsonType.INSTANCE)
         .put(RowType.EMPTY, RecordType.EMPTY_RECORD)
         .put(DataTypes.SHORT, SmallIntType.INSTANCE)
+        .put(DataTypes.BYTE, SmallIntType.INSTANCE)
         .put(DataTypes.INTEGER, IntegerType.INSTANCE)
         .put(DataTypes.LONG, BigIntType.INSTANCE)
         .put(DataTypes.FLOAT, RealType.INSTANCE)
@@ -72,8 +80,8 @@ public class PGTypes {
         .put(DataTypes.REGCLASS, RegclassType.INSTANCE)
         .put(BitStringType.INSTANCE_ONE, BitType.INSTANCE)
         .put(UUIDType.INSTANCE, PgUUIDType.INSTANCE)
-        .put(new ArrayType<>(DataTypes.BYTE), PGArray.CHAR_ARRAY)
         .put(new ArrayType<>(DataTypes.SHORT), PGArray.INT2_ARRAY)
+        .put(new ArrayType<>(DataTypes.BYTE), PGArray.INT2_ARRAY)
         .put(new ArrayType<>(DataTypes.INTEGER), PGArray.INT4_ARRAY)
         .put(new ArrayType<>(DataTypes.LONG), PGArray.INT8_ARRAY)
         .put(new ArrayType<>(DataTypes.FLOAT), PGArray.FLOAT4_ARRAY)

--- a/server/src/main/java/io/crate/protocols/postgres/types/SmallIntType.java
+++ b/server/src/main/java/io/crate/protocols/postgres/types/SmallIntType.java
@@ -25,7 +25,6 @@ package io.crate.protocols.postgres.types;
 import java.nio.charset.StandardCharsets;
 
 import io.crate.metadata.RelationLookup;
-import io.crate.types.DataTypes;
 import io.netty.buffer.ByteBuf;
 
 /**
@@ -63,13 +62,13 @@ class SmallIntType extends PGType<Number> {
     @Override
     public int writeAsBinary(ByteBuf buffer, Number value) {
         buffer.writeInt(TYPE_LEN);
-        buffer.writeShort(DataTypes.SHORT.implicitCast(value));
+        buffer.writeShort(value.shortValue());
         return INT32_BYTE_SIZE + TYPE_LEN;
     }
 
     @Override
     protected byte[] encodeAsUTF8Text(Number value) {
-        return Short.toString(DataTypes.SHORT.implicitCast(value)).getBytes(StandardCharsets.UTF_8);
+        return Short.toString(value.shortValue()).getBytes(StandardCharsets.UTF_8);
     }
 
     @Override

--- a/server/src/main/java/io/crate/protocols/postgres/types/SmallIntType.java
+++ b/server/src/main/java/io/crate/protocols/postgres/types/SmallIntType.java
@@ -25,9 +25,15 @@ package io.crate.protocols.postgres.types;
 import java.nio.charset.StandardCharsets;
 
 import io.crate.metadata.RelationLookup;
+import io.crate.types.DataTypes;
 import io.netty.buffer.ByteBuf;
 
-class SmallIntType extends PGType<Short> {
+/**
+ * Accepts any {@link Number} on the write paths because both CrateDB's
+ * {@code smallint} (Short) and {@code byte} (Byte) map to pg's int2.
+ * The read paths always produce {@link Short}.
+ */
+class SmallIntType extends PGType<Number> {
 
     public static final SmallIntType INSTANCE = new SmallIntType();
     static final int OID = 21;
@@ -55,15 +61,15 @@ class SmallIntType extends PGType<Short> {
     }
 
     @Override
-    public int writeAsBinary(ByteBuf buffer, Short value) {
+    public int writeAsBinary(ByteBuf buffer, Number value) {
         buffer.writeInt(TYPE_LEN);
-        buffer.writeShort(value);
+        buffer.writeShort(DataTypes.SHORT.implicitCast(value));
         return INT32_BYTE_SIZE + TYPE_LEN;
     }
 
     @Override
-    protected byte[] encodeAsUTF8Text(Short value) {
-        return Short.toString(value).getBytes(StandardCharsets.UTF_8);
+    protected byte[] encodeAsUTF8Text(Number value) {
+        return Short.toString(DataTypes.SHORT.implicitCast(value)).getBytes(StandardCharsets.UTF_8);
     }
 
     @Override

--- a/server/src/test/java/io/crate/integrationtests/AnyIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/AnyIntegrationTest.java
@@ -79,20 +79,20 @@ public class AnyIntegrationTest extends IntegTestCase {
 
         execute("select b from t where b = ANY([1, 2, 4]) order by b");
         assertThat(response).hasRowCount(2);
-        assertThat(response.rows()[0][0]).isEqualTo((byte) 1);
-        assertThat(response.rows()[1][0]).isEqualTo((byte) 2);
+        assertThat(response.rows()[0][0]).isEqualTo(byteOrShort(1));
+        assertThat(response.rows()[1][0]).isEqualTo(byteOrShort(2));
 
         execute("select * from t where b != ANY([1, 2, 4]) order by b");
         assertThat(response).hasRowCount(3); // all rows does not contain at least one of the array elements
 
         execute("select b from t where b <= ANY([-1, 0, 1])");
         assertThat(response).hasRowCount(1);
-        assertThat(response.rows()[0][0]).isEqualTo((byte) 1);
+        assertThat(response.rows()[0][0]).isEqualTo(byteOrShort(1));
 
         execute("select b from t where s like ANY(['%ar', 'go%']) order by b DESC");
         assertThat(response).hasRowCount(2);
-        assertThat(response.rows()[0][0]).isEqualTo((byte) 2);
-        assertThat(response.rows()[1][0]).isEqualTo((byte) 1);
+        assertThat(response.rows()[0][0]).isEqualTo(byteOrShort(2));
+        assertThat(response.rows()[1][0]).isEqualTo(byteOrShort(1));
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/AnyIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/AnyIntegrationTest.java
@@ -79,20 +79,20 @@ public class AnyIntegrationTest extends IntegTestCase {
 
         execute("select b from t where b = ANY([1, 2, 4]) order by b");
         assertThat(response).hasRowCount(2);
-        assertThat(response.rows()[0][0]).isEqualTo(byteOrShort(1));
-        assertThat(response.rows()[1][0]).isEqualTo(byteOrShort(2));
+        assertThat(response.rows()[0][0]).isEqualTo((short) 1);
+        assertThat(response.rows()[1][0]).isEqualTo((short) 2);
 
         execute("select * from t where b != ANY([1, 2, 4]) order by b");
-        assertThat(response).hasRowCount(3); // all rows does not contain at least one of the array elements
+        assertThat(response).hasRowCount(3); // no row contains any of the array elements
 
         execute("select b from t where b <= ANY([-1, 0, 1])");
         assertThat(response).hasRowCount(1);
-        assertThat(response.rows()[0][0]).isEqualTo(byteOrShort(1));
+        assertThat(response.rows()[0][0]).isEqualTo((short) 1);
 
         execute("select b from t where s like ANY(['%ar', 'go%']) order by b DESC");
         assertThat(response).hasRowCount(2);
-        assertThat(response.rows()[0][0]).isEqualTo(byteOrShort(2));
-        assertThat(response.rows()[1][0]).isEqualTo(byteOrShort(1));
+        assertThat(response.rows()[0][0]).isEqualTo((short) 2);
+        assertThat(response.rows()[1][0]).isEqualTo((short) 1);
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/CastIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/CastIntegrationTest.java
@@ -63,7 +63,7 @@ public class CastIntegrationTest extends IntegTestCase {
         assertThat(response).hasRowCount(2L);
         assertThat(response.rows()[0][0]).isEqualTo(1);
         assertThat((response.rows()[0][1])).isNull();
-        assertThat((List<Object>) response.rows()[0][2]).containsExactly((byte) 1, (byte) 2);
+        assertThat((List<Object>) response.rows()[0][2]).containsExactly(byteOrShort(1), byteOrShort(2));
         assertThat(response.rows()[1][0]).isEqualTo(2);
         assertThat(response.rows()[1][1]).isNull();
         assertThat(response.rows()[1][2]).isNull();

--- a/server/src/test/java/io/crate/integrationtests/CastIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/CastIntegrationTest.java
@@ -63,7 +63,7 @@ public class CastIntegrationTest extends IntegTestCase {
         assertThat(response).hasRowCount(2L);
         assertThat(response.rows()[0][0]).isEqualTo(1);
         assertThat((response.rows()[0][1])).isNull();
-        assertThat((List<Object>) response.rows()[0][2]).containsExactly(byteOrShort(1), byteOrShort(2));
+        assertThat((List<Object>) response.rows()[0][2]).containsExactly((short) 1, (short) 2);
         assertThat(response.rows()[1][0]).isEqualTo(2);
         assertThat(response.rows()[1][1]).isNull();
         assertThat(response.rows()[1][2]).isNull();

--- a/server/src/test/java/io/crate/integrationtests/CorrelatedSubqueryITest.java
+++ b/server/src/test/java/io/crate/integrationtests/CorrelatedSubqueryITest.java
@@ -23,7 +23,6 @@ package io.crate.integrationtests;
 
 
 import static io.crate.testing.Asserts.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.sql.DriverManager;
@@ -441,7 +440,7 @@ public class CorrelatedSubqueryITest extends IntegTestCase {
                 EXISTS (
                     SELECT 1 FROM pg_catalog.pg_type el WHERE el.oid = t.typelem);
             """);
-        assertThat(response).hasRowCount(25L);
+        assertThat(response).hasRowCount(24L);
     }
 
     /**

--- a/server/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
@@ -519,8 +519,7 @@ public class PartitionedTableIntegrationTest extends IntegTestCase {
         execute("select id, type, content from stuff where id=2 and type=126");
         assertThat(response.rowCount()).isEqualTo(1L);
         assertThat((Integer) response.rows()[0][0]).isEqualTo(2);
-        byte b = 126;
-        assertThat((Byte) response.rows()[0][1]).isEqualTo(b);
+        assertThat(response.rows()[0][1]).isEqualTo(byteOrShort(126));
         assertThat((String) response.rows()[0][2]).isEqualTo("Time is an illusion. Lunchtime doubly so");
 
         // multiget
@@ -528,11 +527,11 @@ public class PartitionedTableIntegrationTest extends IntegTestCase {
         assertThat(response.rowCount()).isEqualTo(2L);
 
         assertThat((Integer) response.rows()[0][0]).isEqualTo(2);
-        assertThat((Byte) response.rows()[0][1]).isEqualTo(b);
+        assertThat(response.rows()[0][1]).isEqualTo(byteOrShort(126));
         assertThat((String) response.rows()[0][2]).isEqualTo("Time is an illusion. Lunchtime doubly so");
 
         assertThat((Integer) response.rows()[1][0]).isEqualTo(3);
-        assertThat((Byte) response.rows()[1][1]).isEqualTo(b);
+        assertThat(response.rows()[1][1]).isEqualTo(byteOrShort(126));
         assertThat((String) response.rows()[1][2]).isEqualTo("Now panic");
     }
 

--- a/server/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
@@ -519,7 +519,7 @@ public class PartitionedTableIntegrationTest extends IntegTestCase {
         execute("select id, type, content from stuff where id=2 and type=126");
         assertThat(response.rowCount()).isEqualTo(1L);
         assertThat((Integer) response.rows()[0][0]).isEqualTo(2);
-        assertThat(response.rows()[0][1]).isEqualTo(byteOrShort(126));
+        assertThat(response.rows()[0][1]).isEqualTo((short) 126);
         assertThat((String) response.rows()[0][2]).isEqualTo("Time is an illusion. Lunchtime doubly so");
 
         // multiget
@@ -527,11 +527,11 @@ public class PartitionedTableIntegrationTest extends IntegTestCase {
         assertThat(response.rowCount()).isEqualTo(2L);
 
         assertThat((Integer) response.rows()[0][0]).isEqualTo(2);
-        assertThat(response.rows()[0][1]).isEqualTo(byteOrShort(126));
+        assertThat(response.rows()[0][1]).isEqualTo((short) 126);
         assertThat((String) response.rows()[0][2]).isEqualTo("Time is an illusion. Lunchtime doubly so");
 
         assertThat((Integer) response.rows()[1][0]).isEqualTo(3);
-        assertThat(response.rows()[1][1]).isEqualTo(byteOrShort(126));
+        assertThat(response.rows()[1][1]).isEqualTo((short) 126);
         assertThat((String) response.rows()[1][2]).isEqualTo("Now panic");
     }
 

--- a/server/src/test/java/io/crate/integrationtests/PostgresITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PostgresITest.java
@@ -374,20 +374,20 @@ public class PostgresITest extends IntegTestCase {
         try (Connection conn = DriverManager.getConnection(url(RW), properties)) {
             conn.createStatement().executeUpdate(
                 "CREATE TABLE t (" +
-                "   chars array(byte)," +
+                "   bytes array(byte)," +
                 "   strings array(text)) " +
                 "WITH (number_of_replicas = 0)");
 
             PreparedStatement preparedStatement = conn.prepareStatement(
-                "INSERT INTO t (chars, strings) VALUES (?, ?)");
-            preparedStatement.setArray(1, conn.createArrayOf("char", new Byte[]{'c', '3'}));
+                "INSERT INTO t (bytes, strings) VALUES (?, ?)");
+            preparedStatement.setArray(1, conn.createArrayOf("int2", new Short[]{99, 51}));
             preparedStatement.setArray(2, conn.createArrayOf("varchar", new String[]{"fo,o", "bar"}));
             preparedStatement.executeUpdate();
             conn.createStatement().execute("REFRESH TABLE t");
 
-            ResultSet resultSet = conn.createStatement().executeQuery("SELECT chars, strings FROM t");
+            ResultSet resultSet = conn.createStatement().executeQuery("SELECT bytes, strings FROM t");
             assertThat(resultSet.next()).isTrue();
-            assertThat(resultSet.getArray(1).getArray()).isEqualTo(new String[]{"99", "51"});
+            assertThat(resultSet.getArray(1).getArray()).isEqualTo(new Short[]{99, 51});
             assertThat(resultSet.getArray(2).getArray()).isEqualTo(new String[]{"fo,o", "bar"});
             assertThat(resultSet.next()).isFalse();
         } catch (BatchUpdateException e) {

--- a/server/src/test/java/io/crate/integrationtests/SQLTypeMappingTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SQLTypeMappingTest.java
@@ -25,7 +25,6 @@ import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
 import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.TestingHelpers.printedTable;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 import java.util.Locale;
@@ -93,12 +92,12 @@ public class SQLTypeMappingTest extends IntegTestCase {
         assertThat(response.rows()[0][0]).isEqualTo(1);
         assertThat(response.rows()[0][1]).isEqualTo("With");
         assertThat(response.rows()[0][2]).isEqualTo(0L);
-        assertThat(response.rows()[0][3]).isEqualTo((byte) 127);
+        assertThat(response.rows()[0][3]).isEqualTo(byteOrShort(127));
 
         assertThat(response.rows()[1][0]).isEqualTo(2);
         assertThat(response.rows()[1][1]).isEqualTo("Without");
         assertThat(response.rows()[1][2]).isEqualTo(3600000L);
-        assertThat(response.rows()[1][3]).isEqualTo((byte) -128);
+        assertThat(response.rows()[1][3]).isEqualTo(byteOrShort(-128));
     }
 
     public void setUpObjectTable() throws Exception {
@@ -229,7 +228,7 @@ public class SQLTypeMappingTest extends IntegTestCase {
                                        "object_field, ip_field from t1 where id=0");
         assertThat(response.rowCount()).isEqualTo(1);
         assertThat(response.rows()[0][0]).isEqualTo(0);
-        assertThat(response.rows()[0][1]).isEqualTo((byte) 127);
+        assertThat(response.rows()[0][1]).isEqualTo(byteOrShort(127));
         assertThat(response.rows()[0][2]).isEqualTo((short) -32768);
         assertThat(response.rows()[0][3]).isEqualTo(0x7fffffff);
         assertThat(response.rows()[0][4]).isEqualTo(Long.MIN_VALUE + 1);

--- a/server/src/test/java/io/crate/integrationtests/SQLTypeMappingTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SQLTypeMappingTest.java
@@ -92,12 +92,12 @@ public class SQLTypeMappingTest extends IntegTestCase {
         assertThat(response.rows()[0][0]).isEqualTo(1);
         assertThat(response.rows()[0][1]).isEqualTo("With");
         assertThat(response.rows()[0][2]).isEqualTo(0L);
-        assertThat(response.rows()[0][3]).isEqualTo(byteOrShort(127));
+        assertThat(response.rows()[0][3]).isEqualTo((short) 127);
 
         assertThat(response.rows()[1][0]).isEqualTo(2);
         assertThat(response.rows()[1][1]).isEqualTo("Without");
         assertThat(response.rows()[1][2]).isEqualTo(3600000L);
-        assertThat(response.rows()[1][3]).isEqualTo(byteOrShort(-128));
+        assertThat(response.rows()[1][3]).isEqualTo((short) -128);
     }
 
     public void setUpObjectTable() throws Exception {
@@ -157,7 +157,7 @@ public class SQLTypeMappingTest extends IntegTestCase {
         response = execute("select object_field['created'], object_field['size'], " +
                            "no_dynamic_field['dynamic_again']['field'] from test12");
         assertThat(response.rows()[0][0]).isEqualTo(1384819200000L);
-        assertThat(response.rows()[0][1]).isEqualTo((byte) 127);
+        assertThat(response.rows()[0][1]).isEqualTo((short) 127);
         assertThat(response.rows()[0][2]).isEqualTo(1384790145289L);
     }
 
@@ -228,7 +228,7 @@ public class SQLTypeMappingTest extends IntegTestCase {
                                        "object_field, ip_field from t1 where id=0");
         assertThat(response.rowCount()).isEqualTo(1);
         assertThat(response.rows()[0][0]).isEqualTo(0);
-        assertThat(response.rows()[0][1]).isEqualTo(byteOrShort(127));
+        assertThat(response.rows()[0][1]).isEqualTo((short) 127);
         assertThat(response.rows()[0][2]).isEqualTo((short) -32768);
         assertThat(response.rows()[0][3]).isEqualTo(0x7fffffff);
         assertThat(response.rows()[0][4]).isEqualTo(Long.MIN_VALUE + 1);

--- a/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
@@ -1921,8 +1921,16 @@ public class TransportSQLActionTest extends IntegTestCase {
                 Object x1 = map.get("x");
                 hasPrecisionChange = x1 instanceof Map<?, ?> innerMap && innerMap.containsKey("coordinates");
             }
+
+            // Byte values are normalized to short values,
+            // since both bytes and shorts map to the same Pg type (int2).
+            if (DataTypes.BYTE.equals(type)) {
+                type = DataTypes.SHORT;
+                val1 = ((Byte) val1).shortValue();
+            }
+
             if (!hasPrecisionChange) {
-                assertThat(((DataType) type).compare(x, val1))
+                assertThat(((DataType<Object>) type).compare(x, val1))
                     .as("inserted value must match selected value for type " + type + ": val=" + val1 + " response=" + x)
                     .isEqualTo(0);
             }

--- a/server/src/test/java/io/crate/protocols/postgres/types/PGTypesTest.java
+++ b/server/src/test/java/io/crate/protocols/postgres/types/PGTypesTest.java
@@ -79,6 +79,19 @@ public class PGTypesTest extends ESTestCase {
 
     }
 
+    @Test
+    public void test_byte_is_mapped_to_int2() {
+        assertThat(PGTypes.get(DataTypes.BYTE)).isExactlyInstanceOf(SmallIntType.class);
+        assertThat(PGTypes.get(DataTypes.BYTE).oid()).isEqualTo(SmallIntType.OID);
+        assertThat(PGTypes.get(new ArrayType<>(DataTypes.BYTE)).oid()).isEqualTo(PGArray.INT2_ARRAY.oid());
+    }
+
+    @Test
+    public void test_pg_int2_resolves_to_short() {
+        assertThat(PGTypes.fromOID(SmallIntType.OID)).isEqualTo(DataTypes.SHORT);
+        assertThat(PGTypes.fromOID(PGArray.INT2_ARRAY.oid())).isEqualTo(new ArrayType<>(DataTypes.SHORT));
+    }
+
     @SuppressWarnings({"unchecked", "rawtypes"})
     @Test
     public void test_undefined_type_can_stream_non_string_values() {
@@ -117,7 +130,6 @@ public class PGTypesTest extends ESTestCase {
 
     @Test
     public void testPgArray2CrateType() {
-        assertThat(PGTypes.fromOID(PGArray.CHAR_ARRAY.oid())).isExactlyInstanceOf(ArrayType.class);
         assertThat(PGTypes.fromOID(PGArray.INT2_ARRAY.oid())).isExactlyInstanceOf(ArrayType.class);
         assertThat(PGTypes.fromOID(PGArray.INT4_ARRAY.oid())).isExactlyInstanceOf(ArrayType.class);
         assertThat(PGTypes.fromOID(PGArray.INT8_ARRAY.oid())).isExactlyInstanceOf(ArrayType.class);

--- a/server/src/test/java/io/crate/protocols/postgres/types/PGTypesTest.java
+++ b/server/src/test/java/io/crate/protocols/postgres/types/PGTypesTest.java
@@ -82,7 +82,6 @@ public class PGTypesTest extends ESTestCase {
     @Test
     public void test_byte_is_mapped_to_int2() {
         assertThat(PGTypes.get(DataTypes.BYTE)).isExactlyInstanceOf(SmallIntType.class);
-        assertThat(PGTypes.get(DataTypes.BYTE).oid()).isEqualTo(SmallIntType.OID);
         assertThat(PGTypes.get(new ArrayType<>(DataTypes.BYTE)).oid()).isEqualTo(PGArray.INT2_ARRAY.oid());
     }
 

--- a/server/src/test/java/io/crate/protocols/postgres/types/SmallIntTypeTest.java
+++ b/server/src/test/java/io/crate/protocols/postgres/types/SmallIntTypeTest.java
@@ -21,19 +21,52 @@
 
 package io.crate.protocols.postgres.types;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import java.nio.charset.StandardCharsets;
 
 import org.junit.Test;
 
-public class SmallIntTypeTest extends BasePGTypeTest<Short> {
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+
+public class SmallIntTypeTest extends BasePGTypeTest<Number> {
 
     public SmallIntTypeTest() {
         super(SmallIntType.INSTANCE);
     }
 
     @Test
-    public void testWriteValue() throws Exception {
+    public void test_write_read_short_value() throws Exception {
         assertBytesWritten(Short.MIN_VALUE, new byte[]{0, 0, 0, 2, -128, 0});
+        assertBytesReadBinary(new byte[]{-128, 0}, Short.MIN_VALUE);
+    }
+
+    @Test
+    public void test_write_read_byte_value() {
+        byte[] expected = {0, 0, 0, 2, -1, -128};
+        assertBytesWritten((byte) -128, expected);
+        assertBytesReadBinary(new byte[]{-1, -128}, (short) -128);
+    }
+
+    @Test
+    public void test_encode_byte_value_as_text() {
+        byte[] textBytes = "42".getBytes(StandardCharsets.UTF_8);
+        assertThat(pgType.encodeAsUTF8Text((byte) 42)).isEqualTo(textBytes);
+        assertBytesReadText(textBytes, (short) 42);
+    }
+
+    @Test
+    public void test_write_out_of_range_value_throws() {
+        ByteBuf buffer = Unpooled.buffer();
+        try {
+            assertThatThrownBy(() -> pgType.writeAsBinary(buffer, 70000))
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("short value out of range: 70000");
+        } finally {
+            buffer.release();
+        }
     }
 
     @Test

--- a/server/src/test/java/io/crate/protocols/postgres/types/SmallIntTypeTest.java
+++ b/server/src/test/java/io/crate/protocols/postgres/types/SmallIntTypeTest.java
@@ -22,14 +22,10 @@
 package io.crate.protocols.postgres.types;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.nio.charset.StandardCharsets;
 
 import org.junit.Test;
-
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
 
 public class SmallIntTypeTest extends BasePGTypeTest<Number> {
 
@@ -55,18 +51,6 @@ public class SmallIntTypeTest extends BasePGTypeTest<Number> {
         byte[] textBytes = "42".getBytes(StandardCharsets.UTF_8);
         assertThat(pgType.encodeAsUTF8Text((byte) 42)).isEqualTo(textBytes);
         assertBytesReadText(textBytes, (short) 42);
-    }
-
-    @Test
-    public void test_write_out_of_range_value_throws() {
-        ByteBuf buffer = Unpooled.buffer();
-        try {
-            assertThatThrownBy(() -> pgType.writeAsBinary(buffer, 70000))
-                .isExactlyInstanceOf(IllegalArgumentException.class)
-                .hasMessage("short value out of range: 70000");
-        } finally {
-            buffer.release();
-        }
     }
 
     @Test

--- a/server/src/testFixtures/java/io/crate/testing/SQLResponse.java
+++ b/server/src/testFixtures/java/io/crate/testing/SQLResponse.java
@@ -25,7 +25,9 @@ import java.util.Arrays;
 
 import org.jspecify.annotations.Nullable;
 
+import io.crate.types.ArrayType;
 import io.crate.types.DataType;
+import io.crate.types.DataTypes;
 
 public final class SQLResponse {
 
@@ -39,10 +41,40 @@ public final class SQLResponse {
                 DataType<?>[] colTypes,
                 long rowCount) {
         assert cols.length == colTypes.length : "cols and colTypes differ";
+        // Convert byte->short to normalize result between Session/jdbc. In PGTypes byte is mapped to int2.
+        // Can't convert the PG version using `executeAndConvertResult` / `ResultSetParser`
+        // because from ResultSetMetadata alone it isn't known if the type was byte/int2.
+        for (int i = 0; i < colTypes.length; i++) {
+            for (Object[] row : rows) {
+                row[i] = normalizeByteValue(row[i], colTypes[i]);
+            }
+        }
         this.cols = cols;
         this.colTypes = colTypes;
         this.rows = rows;
         this.rowCount = rowCount;
+    }
+
+    private static Object normalizeByteValue(Object val, DataType<?> type) {
+        if (val == null) {
+            return null;
+        }
+
+        var normalizedType = normalizeType(type);
+        if (type.equals(normalizedType)) {
+            return val;
+        }
+
+        return normalizedType.implicitCast(val);
+    }
+
+    private static DataType<?> normalizeType(DataType<?> type) {
+        int dimensions = ArrayType.dimensions(type);
+        DataType<?> innerType = ArrayType.unnest(type);
+        if (innerType.id() == DataTypes.BYTE.id()) {
+            return ArrayType.makeArray(DataTypes.SHORT, dimensions);
+        }
+        return type;
     }
 
     public String[] cols() {

--- a/server/src/testFixtures/java/io/crate/testing/SQLTransportExecutor.java
+++ b/server/src/testFixtures/java/io/crate/testing/SQLTransportExecutor.java
@@ -469,17 +469,8 @@ public class SQLTransportExecutor {
             while (resultSet.next()) {
                 Object[] row = new Object[metadata.getColumnCount()];
                 for (int i = 0; i < row.length; i++) {
-                    Object value;
                     String typeName = metadata.getColumnTypeName(i + 1);
-                    value = getObject(resultSet, i, typeName);
-                    if (typeName.equals("char") && value != null) {
-                        // ResultSetParser is dedicated to deal with Postgres specific "char" type which can be single ASCII character.
-                        // This code is also used in tests to get results via JDBC which is not necessarily bound to PG logic.
-                        // Hence, cancel PG specific logic here.
-                        assert value instanceof String;
-                        value = Byte.parseByte((String) value);
-                    }
-                    row[i] = value;
+                    row[i] = getObject(resultSet, i, typeName);
                 }
                 rows.add(row);
             }

--- a/server/src/testFixtures/java/org/elasticsearch/test/IntegTestCase.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/IntegTestCase.java
@@ -322,7 +322,6 @@ public abstract class IntegTestCase extends ESTestCase {
     public TestName testName = new TestName();
 
     protected final SQLTransportExecutor sqlExecutor;
-    protected TestExecutionConfig testExecutionConfig;
 
     @BeforeClass
     public static void beforeClass() throws Exception {
@@ -1537,8 +1536,7 @@ public abstract class IntegTestCase extends ESTestCase {
      */
     public SQLResponse execute(String stmt, Object[] args) {
         try {
-            this.testExecutionConfig = testExecutionConfig();
-            SQLResponse response = sqlExecutor.exec(this.testExecutionConfig, stmt, args);
+            SQLResponse response = sqlExecutor.exec(testExecutionConfig(), stmt, args);
             this.response = response;
             return response;
         } catch (ElasticsearchTimeoutException e) {
@@ -1558,8 +1556,7 @@ public abstract class IntegTestCase extends ESTestCase {
      */
     public SQLResponse execute(String stmt, Object[] args, TimeValue timeout) throws SQLException {
         try {
-            this.testExecutionConfig = testExecutionConfig();
-            SQLResponse response = sqlExecutor.exec(this.testExecutionConfig, stmt, args, timeout);
+            SQLResponse response = sqlExecutor.exec(testExecutionConfig(), stmt, args, timeout);
             this.response = response;
             return response;
         } catch (ElasticsearchTimeoutException e) {
@@ -1904,14 +1901,6 @@ public abstract class IntegTestCase extends ESTestCase {
         } catch (NoSuchMethodException e) {
             return null;
         }
-    }
-
-    protected Number byteOrShort(int n) {
-        if (testExecutionConfig.isJdbcEnabled()) {
-            return (short) n;
-        }
-
-        return (byte) n;
     }
 
     /**

--- a/server/src/testFixtures/java/org/elasticsearch/test/IntegTestCase.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/IntegTestCase.java
@@ -322,6 +322,7 @@ public abstract class IntegTestCase extends ESTestCase {
     public TestName testName = new TestName();
 
     protected final SQLTransportExecutor sqlExecutor;
+    protected TestExecutionConfig testExecutionConfig;
 
     @BeforeClass
     public static void beforeClass() throws Exception {
@@ -1536,7 +1537,8 @@ public abstract class IntegTestCase extends ESTestCase {
      */
     public SQLResponse execute(String stmt, Object[] args) {
         try {
-            SQLResponse response = sqlExecutor.exec(testExecutionConfig(), stmt, args);
+            this.testExecutionConfig = testExecutionConfig();
+            SQLResponse response = sqlExecutor.exec(this.testExecutionConfig, stmt, args);
             this.response = response;
             return response;
         } catch (ElasticsearchTimeoutException e) {
@@ -1556,7 +1558,8 @@ public abstract class IntegTestCase extends ESTestCase {
      */
     public SQLResponse execute(String stmt, Object[] args, TimeValue timeout) throws SQLException {
         try {
-            SQLResponse response = sqlExecutor.exec(testExecutionConfig(), stmt, args, timeout);
+            this.testExecutionConfig = testExecutionConfig();
+            SQLResponse response = sqlExecutor.exec(this.testExecutionConfig, stmt, args, timeout);
             this.response = response;
             return response;
         } catch (ElasticsearchTimeoutException e) {
@@ -1901,6 +1904,14 @@ public abstract class IntegTestCase extends ESTestCase {
         } catch (NoSuchMethodException e) {
             return null;
         }
+    }
+
+    protected Number byteOrShort(int n) {
+        if (testExecutionConfig.isJdbcEnabled()) {
+            return (short) n;
+        }
+
+        return (byte) n;
     }
 
     /**


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
