### PR TITLE
Count preparation phase must account for ShardNotFoundException

### DIFF
--- a/docs/appendices/release-notes/6.2.9.rst
+++ b/docs/appendices/release-notes/6.2.9.rst
@@ -57,3 +57,7 @@ Fixes
 
 - Fixed an issue causing cache to retain some heavy structures, potentially
   leading to an ``OutOfMemoryError``.
+
+- Fixed an issue causing ``COUNT`` queries on a partitioned table to fail with
+  ``ShardNotFoundException`` error if some partition shards were temporarily
+  unavailable.

--- a/docs/appendices/release-notes/6.3.3.rst
+++ b/docs/appendices/release-notes/6.3.3.rst
@@ -75,3 +75,7 @@ Fixes
 
 - Fixed an issue causing cache to retain some heavy structures, potentially
   leading to an ``OutOfMemoryError``.
+
+- Fixed an issue causing ``COUNT`` queries on a partitioned table to fail with
+  ``ShardNotFoundException`` error if some partition shards were temporarily
+  unavailable.

--- a/server/src/main/java/io/crate/execution/engine/collect/count/CountOperation.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/count/CountOperation.java
@@ -44,6 +44,7 @@ import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.shard.IllegalIndexShardStateException;
 import org.elasticsearch.index.shard.IndexShard;
+import org.elasticsearch.index.shard.ShardNotFoundException;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.threadpool.ThreadPool;
 import io.crate.common.annotations.VisibleForTesting;
@@ -124,16 +125,18 @@ public class CountOperation {
                                                              Symbol filter,
                                                              boolean onPartitionedTable) {
         IndexService indexService;
+        IndexShard indexShard;
         try {
             indexService = indicesService.indexServiceSafe(index);
-        } catch (IndexNotFoundException e) {
+            indexShard = indexService.getShard(shardId);
+        } catch (IndexNotFoundException | ShardNotFoundException e) {
             if (onPartitionedTable) {
                 return CompletableFuture.completedFuture(() -> 0L);
             } else {
                 return CompletableFuture.failedFuture(e);
             }
         }
-        IndexShard indexShard = indexService.getShard(shardId);
+
         CompletableFuture<Supplier<Long>> futureCount = new CompletableFuture<>();
         indexShard.awaitShardSearchActive(b -> {
             try {

--- a/server/src/test/java/io/crate/execution/engine/collect/count/CountOperationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/count/CountOperationTest.java
@@ -116,4 +116,23 @@ public class CountOperationTest extends IntegTestCase {
         );
         assertThat(count).isEqualTo(0);
     }
+
+    @Test
+    public void test_shard_not_found_on_partitioned_table_doesnt_cause_count_to_fail() throws Exception {
+        execute("create table doc.t (name string, p int) partitioned by (p) clustered into 1 shards with (number_of_replicas = 0)");
+        execute("insert into doc.t (name, p) values ('Foo', 1)");
+        execute("refresh table doc.t");
+        CoordinatorTxnCtx txnCtx = CoordinatorTxnCtx.systemTransactionContext();
+        Index index = resolveIndex("doc.t", List.of("1"));
+        CountOperation countOperation = cluster().getDataNodeInstance(CountOperation.class);
+
+        // CountOperation.count iterates over shards map
+        // and can fail on prepareGetCount, we need to pass non-empty map
+        IntArrayList shards = new IntArrayList(1);
+        shards.add(-1); // Ensure that ShardNotFoundException will be thrown by providing invalid id (normally must be positive number).
+        Map<String, IntIndexedContainer> indexShards = Map.of(index.getUUID(), shards);
+
+        CompletableFuture<Long> count = countOperation.count(txnCtx, indexShards, Literal.BOOLEAN_TRUE, true);
+        assertThat(count.get(5, TimeUnit.SECONDS)).isEqualTo(0L);
+    }
 }


### PR DESCRIPTION
https://wacklig.pipifein.dev/github/crate/crate/case/io.crate.integrationtests.OptimizeTableIntegrationTest/testOptimizeWithParams once failed with 

```
xigiijwtzysahbmerkem.test/4C0dFPAxTL63e7d4QJvOOQ][[xigiijwtzysahbmerkem.test/4C0dFPAxTL63e7d4QJvOOQ][3]] org.elasticsearch.index.shard.ShardNotFoundException: no such shard
	at __randomizedtesting.SeedInfo.seed([9BBC57E7EB0EC93D:67766D791223D3BB]:0)
	at org.elasticsearch.index.IndexService.getShard(IndexService.java:228)
	at io.crate.execution.engine.collect.count.CountOperation.prepareGetCount(CountOperation.java:136)
	at io.crate.execution.engine.collect.count.CountOperation.count(CountOperation.java:108)
	at io.crate.execution.jobs.CountTask.innerStart(CountTask.java:74)
	at io.crate.execution.jobs.AbstractTask.start(AbstractTask.java:61)
	at io.crate.execution.jobs.RootTask.start(RootTask.java:220)
	at io.crate.execution.jobs.RootTask.start(RootTask.java:205)
	at io.crate.execution.jobs.transport.TransportJobAction.nodeOperation(TransportJobAction.java:152)
```

`IndexService.getShard` can throw `ShardNotFoundException`, we need to catch it as well