### PR TITLE
 FetchTask: maybeRefreshReaders must account for ShardNotFoundException

### DIFF
--- a/server/src/main/java/io/crate/execution/jobs/SharedShardContexts.java
+++ b/server/src/main/java/io/crate/execution/jobs/SharedShardContexts.java
@@ -34,6 +34,7 @@ import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.index.shard.ShardNotFoundException;
 import org.elasticsearch.indices.IndicesService;
 import io.crate.common.annotations.VisibleForTesting;
 
@@ -68,8 +69,9 @@ public class SharedShardContexts {
                 continue;
             }
             IndexMetadata indexMetadata = metadata.index(indexName);
+            boolean isPartitioned = IndexName.isPartitioned(indexName);
             if (indexMetadata == null) {
-                if (IndexName.isPartitioned(indexName)) {
+                if (isPartitioned) {
                     continue;
                 }
                 refreshActions.add(CompletableFuture.failedFuture(new IndexNotFoundException(indexName)));
@@ -77,14 +79,22 @@ public class SharedShardContexts {
             }
             IndexService indexService = indicesService.indexService(indexMetadata.getIndex());
             if (indexService == null) {
-                if (!IndexName.isPartitioned(indexName)) {
+                if (isPartitioned == false) {
                     refreshActions.add(CompletableFuture.failedFuture(new IndexNotFoundException(indexName)));
                 }
                 continue;
             }
             for (var shardCursor : entry.getValue()) {
                 int shardId = shardCursor.value;
-                IndexShard shard = indexService.getShard(shardId);
+                IndexShard shard;
+                try {
+                    shard = indexService.getShard(shardId);
+                } catch (ShardNotFoundException e) {
+                    if (isPartitioned == false) {
+                        refreshActions.add(CompletableFuture.failedFuture(e));
+                    }
+                    continue;
+                }
                 refreshActions.add(shard.awaitShardSearchActive());
             }
         }

--- a/server/src/test/java/io/crate/execution/jobs/SharedShardContextsTest.java
+++ b/server/src/test/java/io/crate/execution/jobs/SharedShardContextsTest.java
@@ -23,20 +23,30 @@ package io.crate.execution.jobs;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.index.shard.ShardNotFoundException;
 import org.elasticsearch.indices.IndicesService;
 import org.junit.Test;
+
+import com.carrotsearch.hppc.IntArrayList;
+import com.carrotsearch.hppc.IntIndexedContainer;
 
 public class SharedShardContextsTest {
 
@@ -117,5 +127,31 @@ public class SharedShardContextsTest {
         assertThatThrownBy(() -> sharedShardContexts.prepareContext(shardId, readerID + 1))
             .isExactlyInstanceOf(AssertionError.class)
             .hasMessageContaining("FetchTask cannot create 2 contexts with same shardId and different readerId");
+    }
+
+    @Test
+    public void test_maybeRefreshReaders_skips_missing_shard_for_partitioned_table() throws Exception {
+        IndicesService indicesService = mock(IndicesService.class);
+        IndexService indexService = mock(IndexService.class);
+        when(indicesService.indexService(any())).thenReturn(indexService);
+        when(indexService.getShard(anyInt()))
+            .thenThrow(new ShardNotFoundException(new ShardId("dummy", "uuid", 1)));
+        SharedShardContexts contexts = new SharedShardContexts(indicesService, null);
+
+        String partitionedIndex = ".partitioned.t.abc123";
+        IndexMetadata indexMetadata = mock(IndexMetadata.class);
+        when(indexMetadata.getIndex()).thenReturn(new Index(partitionedIndex, "uuid"));
+
+        Metadata metadata = mock(Metadata.class);
+        when(metadata.index(partitionedIndex)).thenReturn(indexMetadata);
+
+        IntIndexedContainer shards = new IntArrayList();
+        shards.add(1);
+
+        Map<String, IntIndexedContainer> shardsByIndex = Map.of(partitionedIndex, shards);
+        Map<String, Integer> bases = Map.of(partitionedIndex, 1);
+
+        CompletableFuture<Void> future = contexts.maybeRefreshReaders(metadata, shardsByIndex, bases);
+        assertThat(future).succeedsWithin(5, TimeUnit.SECONDS);
     }
 }


### PR DESCRIPTION
maybeRefreshReaders can throw, see for example 

https://wacklig.pipifein.dev/github/crate/crate/c51c5a85-752f-41ca-a943-b3bfa9a80934/18797c03-b254-456b-8105-e8c74f6cb2be

```
[hnxdzyznie.t/XXTO45fUTGCt8lGBZj1Fag][[hnxdzyznie.t/XXTO45fUTGCt8lGBZj1Fag][3]] org.elasticsearch.index.shard.ShardNotFoundException: no such shard
	at __randomizedtesting.SeedInfo.seed([28EC8CF3B2FFF084:5E775E3605C28CD1]:0)
	at org.elasticsearch.index.IndexService.getShard(IndexService.java:228)
	at io.crate.execution.jobs.SharedShardContexts.maybeRefreshReaders(SharedShardContexts.java:87)
	at io.crate.execution.engine.fetch.FetchTask.start(FetchTask.java:244)
	at io.crate.execution.jobs.RootTask.start(RootTask.java:220)
	at io.crate.execution.jobs.RootTask.start(RootTask.java:205)
	at io.crate.execution.jobs.transport.TransportJobAction.nodeOperation(TransportJobAction.java:152)
```

Follows https://github.com/crate/crate/pull/19485

BTW, this PR won't fix `test_insert_on_conflict_can_assign_object_column_containing_default_columns_to_null` as it's a regular table hitting fetch task on  `execute("select * from t order by c");`. 

Probably need to add `ensureGreen` to fix the flakiness but not sure