### PR TITLE
docs: document the byte type in the data types reference

### DIFF
--- a/docs/general/ddl/data-types.rst
+++ b/docs/general/ddl/data-types.rst
@@ -52,6 +52,9 @@ CrateDB supports the following data types. Scroll down for more details.
     * - ``CHARACTER(n)`` and ``CHAR(n)``
       - A fixed-length, blank padded string of Unicode characters
       - ``'foobar'``
+    * - ``BYTE``
+      - A signed one-byte integer value
+      - ``127`` or ``-128``
     * - ``SMALLINT``, ``INTEGER`` and ``BIGINT``
       - A signed integer value
       - ``12345`` or ``-12345``
@@ -178,6 +181,10 @@ are likely to be larger due to additional metadata.
       - variable
       - Minimum length: 1. Maximum length: 2^31-1 (upper :ref:`integer <type-integer>` range). [#f1]_
       - Strings of fixed length, blank padded. All Unicode characters are allowed.
+    * - ``BYTE``
+      - 1 byte
+      - -128 to 127
+      - Tiny-range integer
     * - ``SMALLINT``
       - 2 bytes
       - -32,768 to 32,767
@@ -298,7 +305,7 @@ The following precedence order is used for data types (highest to lowest):
 21. :ref:`Time with time zone <type-time>`
 22. :ref:`Smallint <type-smallint>`
 23. :ref:`Boolean <type-boolean>`
-24. :ref:`"Char" <type-char>`
+24. :ref:`Byte <type-byte>` (also surfaced as :ref:`"Char" <type-char>`)
 25. :ref:`Text <type-text>`
 26. :ref:`Character <data-type-character>`
 27. :ref:`NULL <type-null>` (lowest)
@@ -909,6 +916,52 @@ CrateDB supports the following numeric types:
 
         cr> DROP TABLE my_table;
         DROP OK, 1 row affected (... sec)
+
+
+.. _type-byte:
+
+``BYTE``
+''''''''
+
+A one-byte integer.
+
+Limited to one byte, with a range from -128 to 127.
+
+Example::
+
+    cr> CREATE TABLE my_table (
+    ...     number BYTE
+    ... );
+    CREATE OK, 1 row affected (... sec)
+
+::
+
+    cr> INSERT INTO my_table (
+    ...     number
+    ... ) VALUES (
+    ...     127
+    ... );
+    INSERT OK, 1 row affected (... sec)
+
+.. HIDE:
+
+    cr> REFRESH TABLE my_table;
+    REFRESH OK, 1 row affected (... sec)
+
+::
+
+    cr> SELECT number FROM my_table;
+    +--------+
+    | number |
+    +--------+
+    | 127    |
+    +--------+
+    SELECT 1 row in set (... sec)
+
+.. HIDE:
+
+    cr> DROP TABLE my_table;
+    DROP OK, 1 row affected (... sec)
 
 
 .. _type-smallint:


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Documents the `byte` type (CrateDB's signed 8-bit integer) in the data-types reference at `docs/general/ddl/data-types.rst`. The reference previously jumped from BOOLEAN/CHAR straight to SMALLINT/INTEGER/BIGINT, and the byte-width table had no row for `byte`, so a documented user-facing type was missing from the page (#19491, filed by @hariso). This adds a summary-table row with an example, a byte-width/range row ("1 byte", -128..127), a `.. _type-byte:` anchor, and entries in the type-priority list and primitive-types section, mirroring the existing SMALLINT wording and cross-reference style. Documentation only; no code change.

## Checklist

- [x] Added an entry in the latest release notes for user facing changes — n/a, documentation-only fix (no behavior change)
- [x] Updated documentation for user facing changes (`docs/general/ddl/data-types.rst`)
- [x] Touched code is covered by tests — n/a, documentation only
- [x] This does not contain breaking changes

Closes #19491
