### PR TITLE
Bump JDK in workflows to 25.0.2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Maven Java
         uses: actions/setup-java@v5
         with:
-          java-version: "25.0.1"
+          java-version: "25.0.2"
           distribution: "temurin"
           cache: maven
 
@@ -65,7 +65,7 @@ jobs:
       - name: Setup Maven Java
         uses: actions/setup-java@v5
         with:
-          java-version: "25.0.1"
+          java-version: "25.0.2"
           distribution: "temurin"
           cache: maven
       - name: Run forbiddenapis:check
@@ -82,7 +82,7 @@ jobs:
       - name: Setup Maven Java
         uses: actions/setup-java@v5
         with:
-          java-version: "25.0.1"
+          java-version: "25.0.2"
           distribution: "temurin"
       - name: Run checkstyle
         run: mvn compile checkstyle:checkstyle

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Maven Java
         uses: actions/setup-java@v5
         with:
-          java-version: "25.0.1"
+          java-version: "25.0.2"
           distribution: "temurin"
           cache: maven
 


### PR DESCRIPTION
Follow up to https://github.com/crate/crate/commit/c9c0a031939d8346274e0165de9cc5b697444979

