### PR TITLE
Fix encoding and decoding of date values via pgwire

### DIFF
--- a/docs/appendices/release-notes/6.3.4.rst
+++ b/docs/appendices/release-notes/6.3.4.rst
@@ -46,4 +46,5 @@ series.
 Fixes
 =====
 
-None
+- Fixed binary encoding and decoding of ``date`` values when using PostgreSQL
+  clients.

--- a/docs/interfaces/postgres.rst
+++ b/docs/interfaces/postgres.rst
@@ -231,7 +231,7 @@ table available in CrateDB::
     | 1022 | _float8      |        0 |     701 |     -1 | b       | A           |
     | 1042 | bpchar       |     1014 |       0 |     -1 | b       | S           |
     | 1043 | varchar      |     1015 |       0 |     -1 | b       | S           |
-    | 1082 | date         |     1182 |       0 |      8 | b       | D           |
+    | 1082 | date         |     1182 |       0 |      4 | b       | D           |
     | 1114 | timestamp    |     1115 |       0 |      8 | b       | D           |
     | 1115 | _timestamp   |        0 |    1114 |     -1 | b       | A           |
     | 1182 | _date        |        0 |    1082 |     -1 | b       | A           |

--- a/server/src/main/java/io/crate/protocols/postgres/types/DateType.java
+++ b/server/src/main/java/io/crate/protocols/postgres/types/DateType.java
@@ -34,14 +34,20 @@ import java.util.Locale;
 
 import io.crate.metadata.RelationLookup;
 import io.crate.types.Regproc;
+import io.netty.buffer.ByteBuf;
 
 
-final class DateType extends BaseTimestampType {
+final class DateType extends PGType<Long> {
 
     public static final DateType INSTANCE = new DateType();
 
+    private static final int TYPE_LEN = 4;
     private static final int OID = 1082;
     private static final String NAME = "date";
+
+    /// Days between 1970-01-01 and 2000-01-01
+    private static final int EPOCH_DAY_DIFF = 10957;
+    private static final int DAY_TO_MS = 86400000;
 
     private static final DateTimeFormatter ISO_FORMATTER = new DateTimeFormatterBuilder()
         .parseCaseInsensitive()
@@ -54,7 +60,17 @@ final class DateType extends BaseTimestampType {
         .toFormatter(Locale.ENGLISH).withResolverStyle(ResolverStyle.STRICT);
 
     private DateType() {
-        super(OID, TYPE_LEN, TYPE_MOD, NAME);
+        super(OID, TYPE_LEN, -1, NAME);
+    }
+
+    @Override
+    public String typeCategory() {
+        return TypeCategory.DATETIME.code();
+    }
+
+    @Override
+    public String type() {
+        return Type.BASE.code();
     }
 
     @Override
@@ -70,6 +86,21 @@ final class DateType extends BaseTimestampType {
     @Override
     public Regproc typReceive() {
         return Regproc.of(NAME + "_recv");
+    }
+
+    @Override
+    public int writeAsBinary(ByteBuf buffer, Long msSince1970) {
+        buffer.writeInt(TYPE_LEN);
+        long daysSince1970 = msSince1970 / DAY_TO_MS;
+        buffer.writeInt((int) daysSince1970 - EPOCH_DAY_DIFF);
+        return INT32_BYTE_SIZE + TYPE_LEN;
+    }
+
+    @Override
+    public Long readBinaryValue(ByteBuf buffer, int valueLength) {
+        // https://github.com/postgres/postgres/blob/master/src/include/datatype/timestamp.h#L235
+        long numDaysSince2000 = (long) buffer.readInt();
+        return (numDaysSince2000 + EPOCH_DAY_DIFF) * DAY_TO_MS;
     }
 
     @Override

--- a/server/src/test/java/io/crate/protocols/postgres/types/DateTypeTest.java
+++ b/server/src/test/java/io/crate/protocols/postgres/types/DateTypeTest.java
@@ -54,6 +54,35 @@ public class DateTypeTest extends BasePGTypeTest<Long> {
     }
 
     @Test
+    public void test_binary_write_sends_days_since_2000_01_01() throws Exception {
+        ByteBuf buffer = Unpooled.buffer();
+        try {
+            // 2016-06-28
+            int written = pgType.writeAsBinary(buffer, 1467072000000L);
+            int length = buffer.readInt();
+            assertThat(written).isEqualTo(8);
+            assertThat(length).isEqualTo(4);
+
+            int daysSince2000 = buffer.readInt();
+            assertThat(daysSince2000).isEqualTo(6023);
+        } finally {
+            buffer.release();
+        }
+    }
+
+    @Test
+    public void test_binary_reads_value_as_days_since_2000_01_01() throws Exception {
+        ByteBuf buffer = Unpooled.buffer();
+        try {
+            buffer.writeInt(6023);
+            Long msSince1970 = pgType.readBinaryValue(buffer, 4);
+            assertThat(msSince1970).isEqualTo(1467072000000L);
+        } finally {
+            buffer.release();
+        }
+    }
+
+    @Test
     public void testEncodeAsUTF8Text() {
         assertThat(new String(DateType.INSTANCE.encodeAsUTF8Text(1467072000000L), UTF_8)).isEqualTo("2016-06-28");
         assertThat(new String(DateType.INSTANCE.encodeAsUTF8Text(-93661920000000L), UTF_8)).isEqualTo("1000-12-22");


### PR DESCRIPTION
The `DateType` implementation wrote/read the binary values in the same
format as the `Timestamp` implementations which was wrong.

`date` is encoded using the number of days since 2000-01-01 as int. See:

- https://github.com/postgres/postgres/blob/f58623faa856cfac67f1ff54b951f82f81fa1f59/src/backend/utils/adt/date.c#L205
- https://github.com/postgres/postgres/blob/master/src/include/datatype/timestamp.h#L235

This caused failures using clients where you can type the parameter.
For example using Haskell/hasql like this:

    selectDay :: Statement Day Day
    selectDay = preparable sql encoder decoder
      where
        sql = "select $1"
        encoder = Encoders.param (Encoders.nonNullable Encoders.date)
        decoder = Decoders.singleRow (Decoders.column (Decoders.nonNullable Decoders.date))

Failed with:

    ServerStatementError (ServerError "XX000" "readerIndex(21) + length(2) exceeds writerIndex(21)
