### PR TITLE
Fix intermittent shard allocation failures during 6.0 > 6.1 rolling upgrades

### DIFF
--- a/docs/appendices/release-notes/6.1.5.rst
+++ b/docs/appendices/release-notes/6.1.5.rst
@@ -1,0 +1,51 @@
+.. _version_6.1.5:
+
+==========================
+Version 6.1.5 - Unreleased
+==========================
+
+.. comment 1. Remove the " - Unreleased" from the header above and adjust the ==
+.. comment 2. Remove the NOTE below and replace with: "Released on 20XX-XX-XX."
+.. comment    (without a NOTE entry, simply starting from col 1 of the line)
+.. NOTE::
+
+    In development. 6.1.5 isn't released yet. These are the release notes for
+    the upcoming release.
+
+.. NOTE::
+
+    If you are upgrading a cluster, you must be running CrateDB 5.0.0 or higher
+    before you upgrade to 6.1.5.
+
+    We recommend that you upgrade to the latest 6.0 release before moving to
+    6.1.5.
+
+    A rolling upgrade from >= 6.0.2 to 6.1.5 is supported.
+    Before upgrading, you should `back up your data`_.
+
+.. WARNING::
+
+    Tables that were created before CrateDB 5.x will not function with 6.x
+    and must be recreated before moving to 6.x.x.
+
+    You can recreate tables using ``COPY TO`` and ``COPY FROM`` or by
+    `inserting the data into a new table`_.
+
+.. _back up your data: https://cratedb.com/docs/crate/reference/en/latest/admin/snapshots.html
+.. _inserting the data into a new table: https://cratedb.com/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
+
+.. rubric:: Table of contents
+
+.. contents::
+   :local:
+
+
+See the :ref:`version_6.1.0` release notes for a full list of changes in the 6.1
+series.
+
+Fixes
+=====
+
+- Fixed intermittent shard allocation failures during rolling upgrades from
+  6.0.x to 6.1.x due to ``IllegalArgumentExceptions`` caused by unknown
+  ``index.name`` setting.

--- a/docs/appendices/release-notes/index.rst
+++ b/docs/appendices/release-notes/index.rst
@@ -66,6 +66,7 @@ Versions
 .. toctree::
     :maxdepth: 1
 
+    6.1.5
     6.1.4
     6.1.3
     6.1.2

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
@@ -204,7 +204,6 @@ public class IndexMetadata implements Diffable<IndexMetadata> {
         new Setting<>(SETTING_DATA_PATH, "", Function.identity(), DataTypes.STRING, Property.IndexScope);
     public static final String INDEX_UUID_NA_VALUE = "_na_";
 
-    public static final String SETTING_INDEX_NAME = "index.name";
     public static final String INDEX_NAME_NA_VALUE = "_na_";
 
     public static final String INDEX_ROUTING_REQUIRE_GROUP_PREFIX = "index.routing.allocation.require";
@@ -1050,11 +1049,10 @@ public class IndexMetadata implements Diffable<IndexMetadata> {
 
             final MapBuilder<String, AliasMetadata> tmpAliases = aliases;
             indexName = indexName == null ? indexUUID : indexName;
-            final Settings tmpSettings = Settings.builder()
+            final Settings.Builder tmpSettings = Settings.builder()
                 .put(settings)
-                .put(SETTING_INDEX_NAME, indexName)
-                .put(SETTING_INDEX_UUID, indexUUID)
-                .build();
+                .put(SETTING_INDEX_UUID, indexUUID);
+            tmpSettings.remove("index.name");
 
             Integer maybeNumberOfShards = settings.getAsInt(SETTING_NUMBER_OF_SHARDS, null);
             if (maybeNumberOfShards == null) {
@@ -1142,7 +1140,7 @@ public class IndexMetadata implements Diffable<IndexMetadata> {
                 state,
                 numberOfShards,
                 numberOfReplicas,
-                tmpSettings,
+                tmpSettings.build(),
                 mapping,
                 tmpAliases.immutableMap(),
                 partitionValues,

--- a/server/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
@@ -152,7 +152,6 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
             case MergePolicyConfig.INDEX_MERGE_ENABLED:
             case IndexMetadata.INDEX_RESIZE_SOURCE_UUID_KEY:
             case IndexMetadata.INDEX_RESIZE_SOURCE_NAME_KEY:
-            case IndexMetadata.SETTING_INDEX_NAME:
                 return true;
             default:
                 return IndexMetadata.INDEX_ROUTING_INITIAL_RECOVERY_GROUP_SETTING.getRawKey().match(key);

--- a/server/src/test/java/io/crate/cluster/commands/FixCorruptedMetadataCommandTest.java
+++ b/server/src/test/java/io/crate/cluster/commands/FixCorruptedMetadataCommandTest.java
@@ -210,8 +210,6 @@ public class FixCorruptedMetadataCommandTest {
         IndexMetadata fixedIndexMetadata = upgradedMetadata.get(indexUUID);
         assertThat(fixedIndexMetadata.getIndex().getName()).isEqualTo("m7..partitioned.s7.08000");
         assertThat(fixedIndexMetadata.mapping().source()).isEqualTo(corruptedMetadata.mapping().source());
-        assertThat(fixedIndexMetadata.getSettings().filter(s -> s.equals(IndexMetadata.SETTING_INDEX_NAME) == false).getAsStructuredMap())
-            .isEqualTo(corruptedMetadata.getSettings().filter(s -> s.equals(IndexMetadata.SETTING_INDEX_NAME) == false).getAsStructuredMap());
 
         // Also indexTemplateMetadata is created accordingly.
         IndexTemplateMetadata convertedFromIndexMetadata = upgradedMetadata.getTemplate("m7..partitioned.s7.");
@@ -258,8 +256,6 @@ public class FixCorruptedMetadataCommandTest {
         IndexMetadata fixedIndexMetadata = upgradedMetadata.get(indexUUID);
         assertThat(fixedIndexMetadata.getIndex().getName()).isEqualTo("m7..partitioned.s7.08000");
         assertThat(fixedIndexMetadata.mapping().source()).isEqualTo(corruptedMetadata.mapping().source());
-        assertThat(fixedIndexMetadata.getSettings().filter(s -> s.equals(IndexMetadata.SETTING_INDEX_NAME) == false).getAsStructuredMap())
-            .isEqualTo(corruptedMetadata.getSettings().filter(s -> s.equals(IndexMetadata.SETTING_INDEX_NAME) == false).getAsStructuredMap());
 
         // Also indexTemplateMetadata is created accordingly -- this help verifies that the existing template is overwritten
         IndexTemplateMetadata convertedFromIndexMetadata = upgradedMetadata.getTemplate(existingTemplateName);
@@ -303,7 +299,7 @@ public class FixCorruptedMetadataCommandTest {
         assertThat(afterFix).isNotNull();
         assertThat(afterFix.mapping().source()).hasToString(mappingForNonPartitioned);
         assertThat(afterFix.getSettings().filter(k -> !k.equals(SETTING_INDEX_UUID)).getAsStructuredMap())
-            .hasToString("{index={name=m7.s7, number_of_shards=1, number_of_replicas=1, version={created=" +
+            .hasToString("{index={number_of_shards=1, number_of_replicas=1, version={created=" +
                          Version.CURRENT.internalId + "}}}");
 
         // indexMetadata named 'm7.s7' and indexTemplateMetadata 'm7..partitioned.s7.' cannot co-exist.


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Intermittent shard allocation failures were observed during rolling upgrades from 6.0.x to 6.1.x (https://github.com/crate/crate-alerts/issues/891).

The failures occurred while executing a table swap added in (https://github.com/crate/crate-qa/pull/391). When a 6.1.x node was the master, it transmitted `index.name` setting(newly added to 6.1) to 6.0.x nodes. Since 6.0.x nodes do not recognize this setting, `IllegalArgumentExceptions` were thrown.
```
[2026-06-08T18:11:26,909][WARN ][o.e.c.r.a.AllocationService] [Piz Timun] failing shard [failed shard, shard [.partitioned.t1.04136][2], node[5akRq1ILRiW_oPFGIHG-uw], [P], recovery_source[existing store recovery; bootstrap_history_uuid=false], s[INITIALIZING], a[id=GCuQfuRPTbOiBtvru-JIGQ], unassigned_info[[reason=NODE_LEFT], at[2026-06-08T22:11:08.044Z], delayed=true, details[node_left [5akRq1ILRiW_oPFGIHG-uw]], allocation_status[fetching_shard_data]], message [failed to create index], markAsStale [true], failure [java.lang.IllegalArgumentException: unknown setting [index.name] please check that any required plugins are installed, or check the breaking changes documentation for removed settings
        at org.elasticsearch.common.settings.AbstractScopedSettings.validate(AbstractScopedSettings.java:421)
        at org.elasticsearch.common.settings.AbstractScopedSettings.validate(AbstractScopedSettings.java:362)
        at org.elasticsearch.common.settings.AbstractScopedSettings.validate(AbstractScopedSettings.java:333)
        at org.elasticsearch.indices.IndicesService.createIndexService(IndicesService.java:437)
        at org.elasticsearch.indices.IndicesService.createIndex(IndicesService.java:364)
        at org.elasticsearch.indices.IndicesService.createIndex(IndicesService.java:123)
        at org.elasticsearch.indices.cluster.IndicesClusterStateService.createIndices(IndicesClusterStateService.java:503)
        at org.elasticsearch.indices.cluster.IndicesClusterStateService.applyClusterState(IndicesClusterStateService.java:248)
        at org.elasticsearch.cluster.service.ClusterApplierService.callClusterStateAppliers(ClusterApplierService.java:502)
        at org.elasticsearch.cluster.service.ClusterApplierService.callClusterStateAppliers(ClusterApplierService.java:492)
        at org.elasticsearch.cluster.service.ClusterApplierService.applyChanges(ClusterApplierService.java:469)
        at org.elasticsearch.cluster.service.ClusterApplierService.runTask(ClusterApplierService.java:416)
        at org.elasticsearch.cluster.service.ClusterApplierService$UpdateTask.run(ClusterApplierService.java:163)
        at org.elasticsearch.common.util.concurrent.PrioritizedEsThreadPoolExecutor$TieBreakingPrioritizedRunnable.runAndClean(PrioritizedEsThreadPoolExecutor.java:208)
        at org.elasticsearch.common.util.concurrent.PrioritizedEsThreadPoolExecutor$TieBreakingPrioritizedRunnable.run(PrioritizedEsThreadPoolExecutor.java:171)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1095)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:619)
        at java.lang.Thread.run(Thread.java:1447)
]]
```

This PR filters the `index.name` setting unknown to pre-6.1 nodes.

## Checklist

 - [ ] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
