### PR TITLE
gha: Run vale only on PRs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,9 +4,6 @@ on:
   pull_request:
     paths:
       - '**.rst'
-  push:
-    branches:
-      - master
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Latest vale-action update has changed the behavior a bit, causing
failures and we've still quite a few false positive alerts - so this
removes the check on push, to only have the checks on PRs which are
diff-based.
