### PR TITLE
Ensure mapping is null and unused on 6.4 IndexMetadata

### DIFF
--- a/server/src/main/java/io/crate/execution/ddl/tables/CreateTableRequest.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/CreateTableRequest.java
@@ -46,7 +46,7 @@ import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
 import io.crate.sql.tree.ColumnPolicy;
-import io.crate.types.DataTypes;
+import io.crate.types.DataTypesBwc;
 
 /**
  * Creates a table represented by an ES index or an ES template (partitioned table).
@@ -170,7 +170,7 @@ public class CreateTableRequest extends MasterNodeRequest<CreateTableRequest> im
                 Reference reference = columns.get(refIdx);
                 out.writeVInt(2);
                 out.writeString(column.fqn());
-                out.writeString(DataTypes.esMappingNameFrom(reference.valueType().id()));
+                out.writeString(DataTypesBwc.esMappingNameFrom(reference.valueType().id()));
             }
         }
     }

--- a/server/src/main/java/io/crate/execution/ddl/tables/MappingUtil.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/MappingUtil.java
@@ -105,7 +105,11 @@ public final class MappingUtil {
      * @param tableColumnPolicy has default value STRICT if not specified on a table creation.
      * On column addition it's NULL in order to not override an existing value.
      *
+     * @deprecated IndexMetadata since 6.4 doesn't contain a mapping anymore.
+     * Table schema is in {@link org.elasticsearch.cluster.metadata.RelationMetadata} instead.
+     * This is used for BWC - when communicating with older nodes.
      */
+    @Deprecated
     public static Map<String, Object> createMapping(AllocPosition allocPosition,
                                                     @Nullable String pkConstraintName,
                                                     List<Reference> columns,

--- a/server/src/main/java/io/crate/execution/ddl/tables/MappingUtil.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/MappingUtil.java
@@ -42,7 +42,7 @@ import io.crate.metadata.table.TableInfo;
 import io.crate.sql.tree.ColumnPolicy;
 import io.crate.types.ArrayType;
 import io.crate.types.DataType;
-import io.crate.types.DataTypes;
+import io.crate.types.DataTypesBwc;
 import io.crate.types.ObjectType;
 
 public final class MappingUtil {
@@ -159,7 +159,7 @@ public final class MappingUtil {
 
     private static List<String> toPartitionMapping(Reference ref) {
         String fqn = ref.column().fqn();
-        String typeMappingName = DataTypes.esMappingNameFrom(ref.valueType().id());
+        String typeMappingName = DataTypesBwc.esMappingNameFrom(ref.valueType().id());
         return List.of(fqn, typeMappingName);
     }
 

--- a/server/src/main/java/io/crate/execution/ddl/tables/TransportOpenTable.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/TransportOpenTable.java
@@ -29,7 +29,6 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
-import org.elasticsearch.cluster.metadata.MetadataUpgradeService;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
@@ -62,7 +61,6 @@ public class TransportOpenTable extends AbstractDDLTransportAction<OpenTableRequ
                               ThreadPool threadPool,
                               AllocationService allocationService,
                               DDLClusterStateService ddlClusterStateService,
-                              MetadataUpgradeService metadataIndexUpgradeService,
                               IndicesService indexServices) {
         super(ACTION.name(),
             transportService,
@@ -75,7 +73,6 @@ public class TransportOpenTable extends AbstractDDLTransportAction<OpenTableRequ
         openExecutor = new OpenTableClusterStateTaskExecutor(
             allocationService,
             ddlClusterStateService,
-            metadataIndexUpgradeService,
             indexServices
         );
     }

--- a/server/src/main/java/io/crate/execution/dml/TranslogIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/TranslogIndexer.java
@@ -142,8 +142,8 @@ public class TranslogIndexer {
         Map<String, Object> docMap = sourceParser.parse(source, ignoreUnknownColumns == false);
         IndexDocumentBuilder docBuilder = new IndexDocumentBuilder(TranslogWriter.wrapBytes(source), _ -> null, Map.of(), shardCreatedVersion);
         for (var entry : docMap.entrySet()) {
-            var column = entry.getKey();
-            var indexer = indexers.get(column);
+            String columnName = entry.getKey();
+            var indexer = indexers.get(columnName);
             if (indexer == null) {
                 if (isEmpty(entry.getValue())) {
                     continue;

--- a/server/src/main/java/io/crate/metadata/SimpleReference.java
+++ b/server/src/main/java/io/crate/metadata/SimpleReference.java
@@ -46,6 +46,7 @@ import io.crate.sql.tree.ColumnPolicy;
 import io.crate.types.ArrayType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
+import io.crate.types.DataTypesBwc;
 import io.crate.types.ObjectType;
 import io.crate.types.StorageSupport;
 
@@ -378,7 +379,7 @@ public class SimpleReference implements Reference {
     public Map<String, Object> toMapping(int position) {
         DataType<?> innerType = ArrayType.unnest(type);
         Map<String, Object> mapping = new HashMap<>();
-        mapping.put("type", DataTypes.esMappingNameFrom(innerType.id()));
+        mapping.put("type", DataTypesBwc.esMappingNameFrom(innerType.id()));
         mapping.put("position", position);
         if (oid != OID_UNASSIGNED) {
             mapping.put("oid", oid);

--- a/server/src/main/java/io/crate/metadata/cluster/AlterTableClusterStateExecutor.java
+++ b/server/src/main/java/io/crate/metadata/cluster/AlterTableClusterStateExecutor.java
@@ -23,12 +23,10 @@ package io.crate.metadata.cluster;
 
 import static org.elasticsearch.common.settings.AbstractScopedSettings.ARCHIVED_SETTINGS_PREFIX;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.Set;
 
 import org.elasticsearch.action.ActionListener;
@@ -36,7 +34,6 @@ import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsRequest
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.AutoExpandReplicas;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
-import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.metadata.MetadataUpdateSettingsService;
 import org.elasticsearch.cluster.metadata.RelationMetadata;
@@ -45,11 +42,9 @@ import org.elasticsearch.common.settings.IndexScopedSettings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.Settings.Builder;
-import org.elasticsearch.index.Index;
-import org.jspecify.annotations.Nullable;
-import io.crate.common.annotations.VisibleForTesting;
 
 import io.crate.analyze.TableParameters;
+import io.crate.common.annotations.VisibleForTesting;
 import io.crate.execution.ddl.tables.AlterTableRequest;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.PartitionName;
@@ -122,12 +117,6 @@ public class AlterTableClusterStateExecutor extends DDLClusterStateTaskExecutor<
                 }
             }
         }
-        List<Index> concreteIndices = metadata.getIndices(
-            request.tableIdent(),
-            request.partitionValues(),
-            false,
-            IndexMetadata::getIndex
-        );
         List<PartitionName> partitions = partitions(request);
         if (request.isPartitioned()) {
             if (!request.partitionValues().isEmpty()) {
@@ -144,11 +133,9 @@ public class AlterTableClusterStateExecutor extends DDLClusterStateTaskExecutor<
                     supportedSettings.add(AutoExpandReplicas.SETTING);
 
                     currentState = updateSettings(currentState, filterSettings(settings, supportedSettings), partitions);
-                    currentState = updateMapping(currentState, concreteIndices, columnPolicy);
                 }
             }
         } else {
-            currentState = updateMapping(currentState, concreteIndices, columnPolicy);
             currentState = updateSettings(currentState, settings, partitions);
         }
 
@@ -166,30 +153,6 @@ public class AlterTableClusterStateExecutor extends DDLClusterStateTaskExecutor<
         } else {
             return List.of(new PartitionName(request.tableIdent(), List.of()));
         }
-    }
-
-    private ClusterState updateMapping(ClusterState currentState,
-                                       List<Index> concreteIndices,
-                                       @Nullable ColumnPolicy columnPolicy) throws IOException {
-        if (columnPolicy == null) {
-            return currentState;
-        }
-        Metadata.Builder metadataBuilder = Metadata.builder(currentState.metadata());
-        for (Index index : concreteIndices) {
-            final IndexMetadata indexMetadata = currentState.metadata().getIndexSafe(index);
-
-            Map<String, Object> indexMapping = indexMetadata.mapping().sourceAsMap();
-            String mappingValue = columnPolicy.toMappingValue();
-            if (indexMapping.get(ColumnPolicy.MAPPING_KEY).equals(mappingValue)) {
-                return currentState;
-            }
-            indexMapping.put(ColumnPolicy.MAPPING_KEY, mappingValue);
-            IndexMetadata.Builder imBuilder = IndexMetadata.builder(indexMetadata);
-            imBuilder.putMapping(new MappingMetadata(indexMapping)).mappingVersion(1 + imBuilder.mappingVersion());
-            metadataBuilder.put(imBuilder); // implicitly increments metadata version.
-        }
-
-        return ClusterState.builder(currentState).metadata(metadataBuilder).build();
     }
 
 

--- a/server/src/main/java/io/crate/metadata/cluster/OpenTableClusterStateTaskExecutor.java
+++ b/server/src/main/java/io/crate/metadata/cluster/OpenTableClusterStateTaskExecutor.java
@@ -24,13 +24,11 @@ package io.crate.metadata.cluster;
 import java.util.List;
 
 import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlocks;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexMetadata.State;
 import org.elasticsearch.cluster.metadata.Metadata;
-import org.elasticsearch.cluster.metadata.MetadataUpgradeService;
 import org.elasticsearch.cluster.metadata.RelationMetadata;
 import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
@@ -50,16 +48,13 @@ public class OpenTableClusterStateTaskExecutor extends DDLClusterStateTaskExecut
 
     private final AllocationService allocationService;
     private final DDLClusterStateService ddlClusterStateService;
-    private final MetadataUpgradeService metadataIndexUpgradeService;
     private final IndicesService indicesService;
 
     public OpenTableClusterStateTaskExecutor(AllocationService allocationService,
                                              DDLClusterStateService ddlClusterStateService,
-                                             MetadataUpgradeService metadataIndexUpgradeService,
                                              IndicesService indexServices) {
         this.allocationService = allocationService;
         this.ddlClusterStateService = ddlClusterStateService;
-        this.metadataIndexUpgradeService = metadataIndexUpgradeService;
         this.indicesService = indexServices;
     }
 
@@ -90,8 +85,6 @@ public class OpenTableClusterStateTaskExecutor extends DDLClusterStateTaskExecut
         }
         ClusterBlocks.Builder blocksBuilder = ClusterBlocks.builder()
             .blocks(currentState.blocks());
-        final Version minIndexCompatibilityVersion = currentState.nodes().getMaxNodeVersion()
-            .minimumIndexCompatibilityVersion();
         for (IndexMetadata closedMetadata : closedIndices) {
             final String indexUUID = closedMetadata.getIndex().getUUID();
             blocksBuilder.removeIndexBlockWithId(indexUUID, TransportCloseTable.INDEX_CLOSED_BLOCK_ID);
@@ -107,15 +100,6 @@ public class OpenTableClusterStateTaskExecutor extends DDLClusterStateTaskExecut
                 .settingsVersion(closedMetadata.getSettingsVersion() + 1)
                 .settings(updatedSettings)
                 .build();
-
-            // The index might be closed because we couldn't import it due to old incompatible version
-            // We need to check that this index can be upgraded to the current version
-            updatedIndexMetadata = metadataIndexUpgradeService.upgradeIndexMetadata(
-                updatedIndexMetadata,
-                null,
-                minIndexCompatibilityVersion,
-                currentState.metadata()
-            );
             try {
                 indicesService.verifyIndexMetadata(updatedIndexMetadata, updatedIndexMetadata);
             } catch (Exception e) {

--- a/server/src/main/java/io/crate/metadata/doc/DocTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocTableInfo.java
@@ -47,7 +47,6 @@ import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexMetadata.State;
-import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
@@ -67,8 +66,6 @@ import io.crate.common.StringUtils;
 import io.crate.common.collections.Lists;
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.exceptions.InvalidColumnNameException;
-import io.crate.execution.ddl.tables.MappingUtil;
-import io.crate.execution.ddl.tables.MappingUtil.AllocPosition;
 import io.crate.expression.symbol.DynamicReference;
 import io.crate.expression.symbol.RefReplacer;
 import io.crate.expression.symbol.Symbol;
@@ -1198,17 +1195,6 @@ public class DocTableInfo implements TableInfo, ShardedTable, StoredTable {
         for (var check : checkConstraints) {
             checkConstraintMap.put(check.name(), check.expressionStr());
         }
-        AllocPosition allocPosition = AllocPosition.forTable(this);
-        Map<String, Object> mapping = Map.of("default", MappingUtil.createMapping(
-            allocPosition,
-            pkConstraintName,
-            allColumns,
-            primaryKeys,
-            checkConstraintMap,
-            Lists.map(partitionedByColumns, Reference::column),
-            columnPolicy,
-            clusteredBy == SysColumns.ID.COLUMN ? null : clusteredBy
-        ));
         String[] concreteIndices = concreteIndices(metadata);
         ArrayList<String> indexUUIDs = new ArrayList<>(concreteIndices.length);
         for (String indexUUID : concreteIndices) {
@@ -1241,7 +1227,6 @@ public class DocTableInfo implements TableInfo, ShardedTable, StoredTable {
             }
             metadataBuilder.put(
                 IndexMetadata.builder(indexMetadata)
-                    .putMapping(new MappingMetadata(mapping))
                     .settings(settings)
                     .numberOfShards(indexNumberOfShards)
                     .mappingVersion(indexMetadata.getMappingVersion() + 1)

--- a/server/src/main/java/io/crate/metadata/doc/DocTableInfoFactory.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocTableInfoFactory.java
@@ -71,6 +71,7 @@ import io.crate.metadata.SimpleReference;
 import io.crate.metadata.TableInfoFactory;
 import io.crate.metadata.table.Operation;
 import io.crate.metadata.upgrade.IndexTemplateUpgrader;
+import io.crate.metadata.upgrade.MetadataIndexUpgrader;
 import io.crate.replication.logical.metadata.PublicationsMetadata;
 import io.crate.sql.parser.SqlParser;
 import io.crate.sql.tree.CheckConstraint;
@@ -80,6 +81,7 @@ import io.crate.types.BitStringType;
 import io.crate.types.CharacterType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
+import io.crate.types.DataTypesBwc;
 import io.crate.types.FloatVectorType;
 import io.crate.types.NumericType;
 import io.crate.types.ObjectType;
@@ -193,17 +195,25 @@ public class DocTableInfoFactory implements TableInfoFactory<DocTableInfo> {
      */
     @Deprecated
     @Nullable
-    public DocTableInfo create(IndexMetadata indexMetadata, int newTableOID) {
+    public DocTableInfo create(IndexMetadata indexMetadata, @Nullable IndexTemplateMetadata template, int newTableOID) {
         String indexName = indexMetadata.getIndex().getName();
         if (IndexName.isDangling(indexName)) {
             return null;
         }
+        if (indexMetadata.mapping() == null) {
+            // IndexMetadata upgraded to 6.4 has no mapping; only RelationMetadata.Table
+            // -> Must use DocTableInfo created from RelationMetadata.Table
+            return null;
+        }
+        MappingMetadata updatedIndexMetadata = MetadataIndexUpgrader.createUpdatedIndexMetadata(
+            indexMetadata.mapping(),
+            template
+        );
         RelationName relationName = RelationName.fromIndexName(indexName);
         Settings tableParameters = indexMetadata.getSettings();
         Version versionCreated = IndexMetadata.SETTING_INDEX_VERSION_CREATED.get(tableParameters);
         Version versionUpgraded = tableParameters.getAsVersion(IndexMetadata.SETTING_VERSION_UPGRADED, null);
-        MappingMetadata mapping = indexMetadata.mapping();
-        Map<String, Object> mappingSource = mapping == null ? Map.of() : mapping.sourceAsMap();
+        Map<String, Object> mappingSource = updatedIndexMetadata == null ? Map.of() : updatedIndexMetadata.sourceAsMap();
         return create(
             relationName,
             mappingSource,
@@ -728,7 +738,7 @@ public class DocTableInfoFactory implements TableInfoFactory<DocTableInfo> {
                 Integer dimensions = (Integer) columnProperties.get("dimensions");
                 yield new FloatVectorType(dimensions);
             }
-            default -> Objects.requireNonNullElse(DataTypes.ofMappingName(typeName), DataTypes.NOT_SUPPORTED);
+            default -> Objects.requireNonNullElse(DataTypesBwc.ofMappingName(typeName), DataTypes.NOT_SUPPORTED);
         };
     }
 }

--- a/server/src/main/java/io/crate/metadata/upgrade/MetadataIndexUpgrader.java
+++ b/server/src/main/java/io/crate/metadata/upgrade/MetadataIndexUpgrader.java
@@ -30,47 +30,51 @@ import java.util.List;
 import java.util.Map;
 
 import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.IndexMetadata.Builder;
 import org.elasticsearch.cluster.metadata.IndexTemplateMetadata;
 import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.jspecify.annotations.Nullable;
-import io.crate.common.annotations.VisibleForTesting;
 
 import io.crate.Constants;
+import io.crate.common.annotations.VisibleForTesting;
 import io.crate.common.collections.Maps;
 import io.crate.metadata.IndexName;
 import io.crate.metadata.IndexParts;
-import io.crate.metadata.PartitionName;
 import io.crate.server.xcontent.XContentHelper;
 import io.crate.types.ArrayType;
-import io.crate.types.DataTypes;
+import io.crate.types.DataTypesBwc;
 import io.crate.types.ObjectType;
 
 public class MetadataIndexUpgrader {
 
-    public IndexMetadata upgrade(IndexMetadata indexMetadata, @Nullable IndexTemplateMetadata indexTemplateMetadata) {
-        IndexMetadata upgraded = createUpdatedIndexMetadata(indexMetadata, indexTemplateMetadata);
-        upgraded = addPartitionValues(upgraded);
-        return upgraded;
+    private MetadataIndexUpgrader() {
     }
 
-    /**
-     * Purges any dynamic template from the index metadata because they might be out-dated and the general default
-     * template will apply any defaults for all indices.
-     */
-    private IndexMetadata createUpdatedIndexMetadata(IndexMetadata indexMetadata, @Nullable IndexTemplateMetadata indexTemplateMetadata) {
-        return IndexMetadata.builder(indexMetadata)
-            .putMapping(
-                createUpdatedIndexMetadata(
-                    indexMetadata.mapping(),
-                    indexTemplateMetadata
-                ))
-            .build();
+    /// Upgrade indexMetadata to 6.4 format:
+    /// - Remove mapping (must be using [org.elasticsearch.cluster.metadata.RelationMetadata])
+    /// - Add partitionValues
+    public static IndexMetadata upgrade(IndexMetadata indexMetadata) {
+        if (indexMetadata.mapping() == null && !indexMetadata.partitionValues().isEmpty()) {
+            return indexMetadata;
+        }
+        Builder builder = IndexMetadata.builder(indexMetadata)
+            .removeMapping();
+        if (indexMetadata.partitionValues().isEmpty() == false) {
+            return builder.build();
+        }
+        IndexParts indexParts = IndexName.decode(indexMetadata.getIndex().getName());
+        if (indexParts.isPartitioned() == false) {
+            return builder.build();
+        }
+        builder.partitionValues(indexParts.toPartitionName().values());
+        return builder.build();
     }
 
-    @VisibleForTesting
-    MappingMetadata createUpdatedIndexMetadata(MappingMetadata mappingMetadata, @Nullable IndexTemplateMetadata indexTemplateMetadata) {
+    public static MappingMetadata createUpdatedIndexMetadata(
+            MappingMetadata mappingMetadata,
+            @Nullable IndexTemplateMetadata indexTemplateMetadata) {
         if (mappingMetadata == null) { // blobs have no mappingMetadata
             return null;
         }
@@ -145,13 +149,13 @@ public class MetadataIndexUpgrader {
             if (ArrayType.NAME.equals(type)) {
                 Map<String, Object> innerMapping = Maps.get(columnProperties, "inner");
                 String innerType = Maps.get(innerMapping, "type");
-                if (innerType == null || ObjectType.UNTYPED.equals(DataTypes.ofMappingName(innerType))) {
+                if (innerType == null || ObjectType.UNTYPED.equals(DataTypesBwc.ofMappingName(innerType))) {
                     updated |= addIndexColumnSources(rootMapping, innerMapping, columnFQN);
                 }
             } else {
                 // ObjectMapper has logic to skip type if object has "properties" field (i.e has nested sub-column).
                 // Hence, type could be null and it indicates that it's an object column.
-                if (type == null || ObjectType.UNTYPED.equals(DataTypes.ofMappingName(type))) {
+                if (type == null || ObjectType.UNTYPED.equals(DataTypesBwc.ofMappingName(type))) {
                     updated |= addIndexColumnSources(rootMapping, columnProperties, columnFQN);
                 }
             }
@@ -191,7 +195,7 @@ public class MetadataIndexUpgrader {
      * @param defaultMap An index mapping that may contain duplicates or null positions.
      * @param indexTemplateMetadata if the table is partitioned, it should contain correct column positions.
      */
-    private void upgradeColumnPositions(Map<String, Object> defaultMap, @Nullable IndexTemplateMetadata indexTemplateMetadata) {
+    private static void upgradeColumnPositions(Map<String, Object> defaultMap, @Nullable IndexTemplateMetadata indexTemplateMetadata) {
         if (indexTemplateMetadata != null) {
             populateColumnPositionsFromMapping(defaultMap, indexTemplateMetadata.mapping());
         } else {
@@ -241,19 +245,5 @@ public class MetadataIndexUpgrader {
 
             populateColumnPositionsImpl(indexColumnProperties, templateColumnProperties);
         }
-    }
-
-    private IndexMetadata addPartitionValues(IndexMetadata indexMetadata) {
-        if (indexMetadata.partitionValues().isEmpty() == false) {
-            return indexMetadata;
-        }
-        IndexParts indexParts = IndexName.decode(indexMetadata.getIndex().getName());
-        if (indexParts.isPartitioned() == false) {
-            return indexMetadata;
-        }
-        PartitionName partitionName = indexParts.toPartitionName();
-        IndexMetadata.Builder builder = IndexMetadata.builder(indexMetadata);
-        builder.partitionValues(partitionName.values());
-        return builder.build();
     }
 }

--- a/server/src/main/java/io/crate/replication/logical/MetadataTracker.java
+++ b/server/src/main/java/io/crate/replication/logical/MetadataTracker.java
@@ -62,8 +62,8 @@ import org.elasticsearch.threadpool.Scheduler;
 import org.elasticsearch.threadpool.Scheduler.Cancellable;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.jspecify.annotations.Nullable;
-import io.crate.common.annotations.VisibleForTesting;
 
+import io.crate.common.annotations.VisibleForTesting;
 import io.crate.concurrent.CountdownFuture;
 import io.crate.exceptions.SQLExceptions;
 import io.crate.execution.support.RetryRunnable;
@@ -401,9 +401,14 @@ public final class MetadataTracker implements Closeable {
                 var subscriberIndexMetadata = subscriberIndices.get(publisherIndexMetadata.getIndexUUID());
                 if (subscriberIndexMetadata != null) {
                     var updatedIndexMetadataBuilder = IndexMetadata.builder(subscriberIndexMetadata);
-                    var updatedMapping = updateIndexMetadataMappings(publisherIndexMetadata, subscriberIndexMetadata);
+                    var updatedMapping = updateIndexMetadataMappings(
+                        publisherIndexMetadata,
+                        subscriberIndexMetadata
+                    );
                     if (updatedMapping != null) {
-                        updatedIndexMetadataBuilder.putMapping(updatedMapping).mappingVersion(publisherIndexMetadata.getMappingVersion());
+                        updatedIndexMetadataBuilder
+                            .putMapping(updatedMapping)
+                            .mappingVersion(publisherIndexMetadata.getMappingVersion());
                     }
                     var updatedSettings = updateSettings(
                         publisherIndexMetadata.getSettings(),

--- a/server/src/main/java/io/crate/replication/logical/MetadataTracker.java
+++ b/server/src/main/java/io/crate/replication/logical/MetadataTracker.java
@@ -401,25 +401,16 @@ public final class MetadataTracker implements Closeable {
                 var subscriberIndexMetadata = subscriberIndices.get(publisherIndexMetadata.getIndexUUID());
                 if (subscriberIndexMetadata != null) {
                     var updatedIndexMetadataBuilder = IndexMetadata.builder(subscriberIndexMetadata);
-                    var updatedMapping = updateIndexMetadataMappings(
-                        publisherIndexMetadata,
-                        subscriberIndexMetadata
-                    );
-                    if (updatedMapping != null) {
-                        updatedIndexMetadataBuilder
-                            .putMapping(updatedMapping)
-                            .mappingVersion(publisherIndexMetadata.getMappingVersion());
-                    }
                     var updatedSettings = updateSettings(
                         publisherIndexMetadata.getSettings(),
                         subscriberIndexMetadata.getSettings(),
                         indexScopedSettings
                     );
                     if (updatedSettings != null) {
-                        updatedIndexMetadataBuilder.settings(updatedSettings).settingsVersion(subscriberIndexMetadata.getSettingsVersion() + 1L);
-                    }
-                    if (updatedMapping != null || updatedSettings != null) {
-                        IndexMetadata indexMetadata = updatedIndexMetadataBuilder.build();
+                        IndexMetadata indexMetadata = updatedIndexMetadataBuilder
+                            .settings(updatedSettings)
+                            .settingsVersion(subscriberIndexMetadata.getSettingsVersion() + 1L)
+                            .build();
                         updatedMetadataBuilder.put(indexMetadata, true);
                         updateClusterState = true;
                     }

--- a/server/src/main/java/io/crate/replication/logical/metadata/Publication.java
+++ b/server/src/main/java/io/crate/replication/logical/metadata/Publication.java
@@ -179,6 +179,9 @@ public class Publication implements Writeable {
                         .put(REPLICATION_INDEX_ROUTING_ACTIVE.getKey(), false)
                 );
             }
+            // Add empty dummy mapping given that we're faking responses from
+            // old nodes which would have some mapping
+            publishedIndexMetadata.putMapping("{}");
             metadataBuilder.put(publishedIndexMetadata);
         }
     }

--- a/server/src/main/java/io/crate/replication/logical/metadata/SubscriptionsMetadata.java
+++ b/server/src/main/java/io/crate/replication/logical/metadata/SubscriptionsMetadata.java
@@ -54,11 +54,7 @@ public class SubscriptionsMetadata extends AbstractNamedDiffable<Metadata.Custom
     }
 
     public static SubscriptionsMetadata get(Metadata metadata) {
-        var subscriptionsMetadata = (SubscriptionsMetadata) metadata.custom(SubscriptionsMetadata.TYPE);
-        if (subscriptionsMetadata == null) {
-            return EMPTY;
-        }
-        return subscriptionsMetadata;
+        return (SubscriptionsMetadata) metadata.custom(SubscriptionsMetadata.TYPE, EMPTY);
     }
 
     private final Map<String, Subscription> subscriptionByName;

--- a/server/src/main/java/io/crate/types/DataTypes.java
+++ b/server/src/main/java/io/crate/types/DataTypes.java
@@ -480,62 +480,6 @@ public final class DataTypes {
         return TYPES_BY_NAME_OR_ALIAS.get(typeName);
     }
 
-    private static final Map<String, DataType<?>> MAPPING_NAMES_TO_TYPES = Map.ofEntries(
-        entry("date", DataTypes.TIMESTAMPZ),
-        entry("string", DataTypes.STRING),
-        entry("keyword", DataTypes.STRING),
-        entry("text", DataTypes.STRING),
-        entry("boolean", DataTypes.BOOLEAN),
-        entry("byte", DataTypes.BYTE),
-        entry("short", DataTypes.SHORT),
-        entry("integer", DataTypes.INTEGER),
-        entry("long", DataTypes.LONG),
-        entry("float", DataTypes.FLOAT),
-        entry("double", DataTypes.DOUBLE),
-        entry("ip", DataTypes.IP),
-        entry("geo_point", DataTypes.GEO_POINT),
-        entry("geo_shape", DataTypes.GEO_SHAPE),
-        entry("object", UNTYPED_OBJECT),
-        entry("nested", UNTYPED_OBJECT),
-        entry("interval", DataTypes.INTERVAL),
-        entry(FloatVectorType.INSTANCE_ONE.getName(), FloatVectorType.INSTANCE_ONE),
-        entry("undefined", DataTypes.UNDEFINED),
-        entry(UUIDType.NAME, UUIDType.INSTANCE)
-    );
-
-    private static final Map<Integer, String> TYPE_IDS_TO_MAPPINGS = Map.ofEntries(
-        entry(TIMESTAMPZ.id(), "date"),
-        entry(TIMESTAMP.id(), "date"),
-        entry(STRING.id(), "keyword"),
-        entry(CHARACTER.id(), "keyword"),
-        entry(BYTE.id(), "byte"),
-        entry(BOOLEAN.id(), "boolean"),
-        entry(IP.id(), "ip"),
-        entry(DOUBLE.id(), "double"),
-        entry(FLOAT.id(), "float"),
-        entry(SHORT.id(), "short"),
-        entry(INTEGER.id(), "integer"),
-        entry(LONG.id(), "long"),
-        entry(ObjectType.ID, "object"),
-        entry(GEO_SHAPE.id(), "geo_shape"),
-        entry(GEO_POINT.id(), "geo_point"),
-        entry(INTERVAL.id(), "interval"),
-        entry(BitStringType.ID, "bit"),
-        entry(NumericType.ID, "numeric"),
-        entry(FloatVectorType.ID, FloatVectorType.INSTANCE_ONE.getName()),
-        entry(UndefinedType.ID, UndefinedType.INSTANCE.getName()),
-        entry(UUIDType.ID, UUIDType.NAME)
-    );
-
-    @Nullable
-    public static String esMappingNameFrom(int typeId) {
-        return TYPE_IDS_TO_MAPPINGS.get(typeId);
-    }
-
-    @Nullable
-    public static DataType<?> ofMappingName(String name) {
-        return MAPPING_NAMES_TO_TYPES.get(name);
-    }
 
     /**
      * Checks if the {@link DataType} is a primitive data type.

--- a/server/src/main/java/io/crate/types/DataTypesBwc.java
+++ b/server/src/main/java/io/crate/types/DataTypesBwc.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.types;
+
+import static java.util.Map.entry;
+
+import java.util.Map;
+
+import org.jspecify.annotations.Nullable;
+
+public class DataTypesBwc {
+
+    private static final Map<String, DataType<?>> MAPPING_NAMES_TO_TYPES = Map.ofEntries(
+        entry("date", DataTypes.TIMESTAMPZ),
+        entry("string", DataTypes.STRING),
+        entry("keyword", DataTypes.STRING),
+        entry("text", DataTypes.STRING),
+        entry("boolean", DataTypes.BOOLEAN),
+        entry("byte", DataTypes.BYTE),
+        entry("short", DataTypes.SHORT),
+        entry("integer", DataTypes.INTEGER),
+        entry("long", DataTypes.LONG),
+        entry("float", DataTypes.FLOAT),
+        entry("double", DataTypes.DOUBLE),
+        entry("ip", DataTypes.IP),
+        entry("geo_point", DataTypes.GEO_POINT),
+        entry("geo_shape", DataTypes.GEO_SHAPE),
+        entry("object", DataTypes.UNTYPED_OBJECT),
+        entry("nested", DataTypes.UNTYPED_OBJECT),
+        entry("interval", DataTypes.INTERVAL),
+        entry(FloatVectorType.INSTANCE_ONE.getName(), FloatVectorType.INSTANCE_ONE),
+        entry("undefined", DataTypes.UNDEFINED),
+        entry(UUIDType.NAME, UUIDType.INSTANCE)
+    );
+
+    private static final Map<Integer, String> TYPE_IDS_TO_MAPPINGS = Map.ofEntries(
+        entry(DataTypes.TIMESTAMPZ.id(), "date"),
+        entry(DataTypes.TIMESTAMP.id(), "date"),
+        entry(DataTypes.STRING.id(), "keyword"),
+        entry(DataTypes.CHARACTER.id(), "keyword"),
+        entry(DataTypes.BYTE.id(), "byte"),
+        entry(DataTypes.BOOLEAN.id(), "boolean"),
+        entry(DataTypes.IP.id(), "ip"),
+        entry(DataTypes.DOUBLE.id(), "double"),
+        entry(DataTypes.FLOAT.id(), "float"),
+        entry(DataTypes.SHORT.id(), "short"),
+        entry(DataTypes.INTEGER.id(), "integer"),
+        entry(DataTypes.LONG.id(), "long"),
+        entry(ObjectType.ID, "object"),
+        entry(DataTypes.GEO_SHAPE.id(), "geo_shape"),
+        entry(DataTypes.GEO_POINT.id(), "geo_point"),
+        entry(DataTypes.INTERVAL.id(), "interval"),
+        entry(BitStringType.ID, "bit"),
+        entry(NumericType.ID, "numeric"),
+        entry(FloatVectorType.ID, FloatVectorType.INSTANCE_ONE.getName()),
+        entry(UndefinedType.ID, UndefinedType.INSTANCE.getName()),
+        entry(UUIDType.ID, UUIDType.NAME)
+    );
+
+    /// Returns the ES mapping name for a given DataType id.
+    /// Mappings are only used for indices from < 6.0.
+    ///
+    /// Upgraded indices contain their schema in [org.elasticsearch.cluster.metadata.RelationMetadata]
+    /// DataTypes added in >= 6.4 do not have a mapping name.
+    @Nullable
+    public static String esMappingNameFrom(int typeId) {
+        return TYPE_IDS_TO_MAPPINGS.get(typeId);
+    }
+
+    /// Returns a DataType by mapping name
+    /// Mappings are only used for indices from < 6.0.
+    ///
+    /// Upgraded indices contain their schema in [org.elasticsearch.cluster.metadata.RelationMetadata]
+    /// DataTypes added in >= 6.4 do not have a mapping name.
+    @Nullable
+    public static DataType<?> ofMappingName(String name) {
+        return MAPPING_NAMES_TO_TYPES.get(name);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/create/TransportCreatePartitions.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/create/TransportCreatePartitions.java
@@ -28,7 +28,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
@@ -46,7 +45,6 @@ import org.elasticsearch.cluster.ack.ClusterStateUpdateResponse;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
-import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.metadata.MetadataCreateIndexService;
 import org.elasticsearch.cluster.metadata.RelationMetadata;
@@ -72,7 +70,6 @@ import org.joda.time.DateTimeZone;
 
 import io.crate.common.annotations.VisibleForTesting;
 import io.crate.exceptions.RelationUnknown;
-import io.crate.execution.ddl.tables.MappingUtil;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.doc.DocTableInfo;
@@ -238,17 +235,6 @@ public class TransportCreatePartitions extends TransportMasterNodeAction<CreateP
 
             // "Probe" creation of the first index passed validation. Now add all indices to the cluster state metadata and update routing.
 
-            final MappingMetadata mapping = new MappingMetadata(Map.of("default", MappingUtil.createMapping(
-                MappingUtil.AllocPosition.forTable(docTableInfo),
-                table.pkConstraintName(),
-                table.columns(),
-                table.primaryKeys(),
-                table.checkConstraints(),
-                table.partitionedBy(),
-                table.columnPolicy(),
-                table.routingColumn()
-            )));
-
             RoutingTable.Builder routingTableBuilder = RoutingTable.builder(currentState.routingTable());
             ArrayList<String> indexUUIDs = new ArrayList<>(partitions.size());
             for (PartitionName partition : partitions) {
@@ -263,7 +249,6 @@ public class TransportCreatePartitions extends TransportMasterNodeAction<CreateP
                         .put(IndexMetadata.SETTING_INDEX_UUID, indexUUID)
                     );
 
-                indexMetadataBuilder.putMapping(mapping);
                 indexMetadataBuilder.state(IndexMetadata.State.OPEN);
 
                 final IndexMetadata indexMetadata;

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
@@ -290,10 +290,8 @@ public class IndexMetadata implements Diffable<IndexMetadata> {
 
     private final Settings settings;
 
-    /**
-     * @deprecated mapping is stored on table level via {@link RelationMetadata.Table}
-     **/
     @Deprecated
+    @Nullable
     private final MappingMetadata mapping;
 
     private final ImmutableOpenIntMap<Set<String>> inSyncAllocationIds;
@@ -458,10 +456,11 @@ public class IndexMetadata implements Diffable<IndexMetadata> {
         return partitionValues;
     }
 
-    /**
-     * Return the concrete mapping for this index or {@code null} if this index has no mappings at all.
-     */
+    /// Mapping for indices coming from old local state or old remote nodes
+    /// Null for 6.4 indices (upgraded using [MetadataUpgradeService] or newly created)
+    /// @deprecated Column info is stored in [RelationMetadata.Table] instead.
     @Nullable
+    @Deprecated
     public MappingMetadata mapping() {
         return mapping;
     }
@@ -1285,6 +1284,11 @@ public class IndexMetadata implements Diffable<IndexMetadata> {
             String indexUUID = builder.settings.get(SETTING_INDEX_UUID, INDEX_UUID_NA_VALUE);
             builder.indexUUID(indexUUID);
             return builder.build();
+        }
+
+        public Builder removeMapping() {
+            this.mapping = null;
+            return this;
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
@@ -86,8 +86,6 @@ import io.crate.common.collections.Lists;
 import io.crate.common.unit.TimeValue;
 import io.crate.execution.ddl.tables.CreateBlobTableRequest;
 import io.crate.execution.ddl.tables.CreateTableResponse;
-import io.crate.execution.ddl.tables.MappingUtil;
-import io.crate.metadata.DocReferences;
 import io.crate.metadata.IndexName;
 import io.crate.metadata.IndexReference;
 import io.crate.metadata.NodeContext;
@@ -95,7 +93,6 @@ import io.crate.metadata.PartitionName;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.blob.BlobSchemaInfo;
-import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.table.SchemaInfo;
 
 /**
@@ -290,7 +287,6 @@ public class MetadataCreateIndexService {
                     mdBuilder,
                     indexUUID,
                     indexMetadata,
-                    new MappingMetadata(Map.of()),
                     calculateNumRoutingShards(numShards, versionCreated)
                 );
                 // ensure table can be parsed
@@ -480,7 +476,6 @@ public class MetadataCreateIndexService {
                 metadataBuilder,
                 resizedIndexUUID,
                 indexService.getMetadata(),
-                sourceIndex.mapping(),
                 routingNumShards
             ));
         }
@@ -596,17 +591,6 @@ public class MetadataCreateIndexService {
         validateIndexSettings(indexName, concreteIndexSettings, true);
 
         Metadata.Builder metadataBuilder = Metadata.builder(metadata);
-        final MappingMetadata mapping = new MappingMetadata(Map.of("default", MappingUtil.createMapping(
-            MappingUtil.AllocPosition.forNewTable(),
-            table.pkConstraintName(),
-            DocReferences.applyOid(table.columns(), new DocTableInfo.OidSupplier(0)),
-            table.primaryKeys(),
-            table.checkConstraints(),
-            table.partitionedBy(),
-            table.columnPolicy(),
-            table.routingColumn()
-        )));
-
         Settings.Builder indexSettingsBuilder = Settings.builder()
             .put(table.settings())
             .put(concreteIndexSettings)
@@ -649,7 +633,6 @@ public class MetadataCreateIndexService {
                 metadataBuilder,
                 newIndexUUID,
                 tmpImd,
-                mapping,
                 routingNumShards
             );
             SchemaInfo docSchemaInfo = nodeContext.schemas().getOrCreateSchemaInfo(tableName.schema());
@@ -664,15 +647,13 @@ public class MetadataCreateIndexService {
                                          Metadata.Builder metadataBuilder,
                                          String indexUUID,
                                          IndexMetadata tmpImd,
-                                         MappingMetadata mapping,
                                          int routingNumShards) {
         final IndexMetadata.Builder indexMetadataBuilder = IndexMetadata.builder(indexUUID)
             .indexName(tmpImd.getIndex().getName())
             .settings(tmpImd.getSettings())
             .setRoutingNumShards(routingNumShards)
             .partitionValues(tmpImd.partitionValues())
-            .state(State.OPEN)
-            .putMapping(mapping);
+            .state(State.OPEN);
 
         for (int shardId = 0; shardId < tmpImd.getNumberOfShards(); shardId++) {
             indexMetadataBuilder.primaryTerm(shardId, tmpImd.primaryTerm(shardId));

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataUpgradeService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataUpgradeService.java
@@ -24,6 +24,7 @@ import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_VERSION_U
 import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.LogManager;
@@ -35,7 +36,6 @@ import org.elasticsearch.common.settings.AbstractScopedSettings;
 import org.elasticsearch.common.settings.IndexScopedSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.Index;
-import org.jspecify.annotations.Nullable;
 
 import io.crate.blob.v2.BlobIndex;
 import io.crate.expression.udf.UserDefinedFunctionService;
@@ -69,7 +69,6 @@ public class MetadataUpgradeService {
     private static final Logger LOGGER = LogManager.getLogger(MetadataUpgradeService.class);
 
     private final IndexScopedSettings indexScopedSettings;
-    private final MetadataIndexUpgrader indexUpgrader;
     private final UserDefinedFunctionService userDefinedFunctionService;
     private final NodeContext nodeContext;
 
@@ -79,7 +78,6 @@ public class MetadataUpgradeService {
         this.nodeContext = nodeContext;
         this.userDefinedFunctionService = userDefinedFunctionService;
         this.indexScopedSettings = indexScopedSettings;
-        this.indexUpgrader = new MetadataIndexUpgrader();
     }
 
     /// Creates a DocTableInfoFactory for each upgrade invocation.
@@ -177,11 +175,8 @@ public class MetadataUpgradeService {
             String indexName = indexMetadata.getIndex().getName();
             IndexMetadata newIndexMetadata = upgradeIndexMetadata(
                 indexMetadata,
-                IndexName.isPartitioned(indexName)
-                    ? newMetadata.getTemplate(PartitionName.templateName(indexName))
-                    : null,
-                Version.CURRENT.minimumIndexCompatibilityVersion(),
-                tableInfoFactory);
+                Version.CURRENT.minimumIndexCompatibilityVersion()
+            );
             // Remove any existing metadata, registered by it's name, for the index
             newMetadata.remove(indexName);
             newMetadata.put(newIndexMetadata, false);
@@ -194,7 +189,10 @@ public class MetadataUpgradeService {
                 RelationName relationName = indexParts.toRelationName();
                 relation = newMetadata.getRelation(relationName);
                 if (!BlobIndex.isBlobIndex(indexName)) {
-                    tableInfo = tableInfoFactory.create(newIndexMetadata, OID_UNASSIGNED);
+                    IndexTemplateMetadata template = IndexName.isPartitioned(indexName)
+                        ? newMetadata.getTemplate(PartitionName.templateName(indexName))
+                        : null;
+                    tableInfo = tableInfoFactory.create(indexMetadata, template, OID_UNASSIGNED);
                 }
             }
             if (relation == null) {
@@ -226,7 +224,12 @@ public class MetadataUpgradeService {
                         OID_UNASSIGNED
                     );
                 } else {
-                    throw new AssertionError("If the relation is missing we need a DocTableInfo instance or it must be a blob index");
+                    throw new AssertionError(String.format(
+                        Locale.ENGLISH,
+                        "RelationMetadata for indexName=%s uuid=%s is missing. Couldn't create DocTableInfo and it is not a blob index",
+                        indexName,
+                        indexUUID
+                    ));
                 }
             } else if (relation instanceof RelationMetadata.Table table) {
                 if (!table.indexUUIDs().contains(indexUUID)) {
@@ -296,29 +299,7 @@ public class MetadataUpgradeService {
         return versionCreated;
     }
 
-
-    /**
-     * Checks that the index can be upgraded to the current version of the master node.
-     *
-     * <p>
-     * If the index does not need upgrade it returns the index metadata unchanged, otherwise it returns a modified index metadata. If index
-     * cannot be updated the method throws an exception.
-     */
-    public IndexMetadata upgradeIndexMetadata(IndexMetadata indexMetadata,
-                                              @Nullable IndexTemplateMetadata indexTemplateMetadata,
-                                              Version minimumIndexCompatibilityVersion,
-                                              Metadata metadata) {
-        return upgradeIndexMetadata(
-            indexMetadata,
-            indexTemplateMetadata,
-            minimumIndexCompatibilityVersion,
-            createDocTableFactory(upgradeUDFMetadata(metadata)));
-    }
-
-    private IndexMetadata upgradeIndexMetadata(IndexMetadata indexMetadata,
-                                               @Nullable IndexTemplateMetadata indexTemplateMetadata,
-                                               Version minimumIndexCompatibilityVersion,
-                                               DocTableInfoFactory tableInfoFactory) {
+    private IndexMetadata upgradeIndexMetadata(IndexMetadata indexMetadata, Version minimumIndexCompatibilityVersion) {
         if (isUpgraded(indexMetadata)) {
             return indexMetadata;
         }
@@ -329,8 +310,7 @@ public class MetadataUpgradeService {
         // we have to run this first otherwise in we try to create IndexSettings
         // with broken settings and fail in checkMappingsCompatibility
         newMetadata = archiveBrokenIndexSettings(newMetadata);
-        newMetadata = indexUpgrader.upgrade(newMetadata, indexTemplateMetadata);
-        checkMappingsCompatibility(newMetadata, tableInfoFactory);
+        newMetadata = MetadataIndexUpgrader.upgrade(newMetadata);
         return markAsUpgraded(newMetadata);
     }
 
@@ -362,26 +342,6 @@ public class MetadataUpgradeService {
      */
     private static boolean isSupportedVersion(IndexMetadata indexMetadata, Version minimumIndexCompatibilityVersion) {
         return indexMetadata.getCreationVersion().onOrAfter(minimumIndexCompatibilityVersion);
-    }
-
-    /**
-     * Checks the mappings for compatibility with the current version
-     */
-    private void checkMappingsCompatibility(IndexMetadata indexMetadata, DocTableInfoFactory tableInfoFactory) {
-        try {
-            tableInfoFactory.create(indexMetadata, OID_UNASSIGNED);
-
-            // We cannot instantiate real analysis server or similarity service at this point because the node
-            // might not have been started yet. However, we don't really need real analyzers or similarities at
-            // this stage - so we can fake it using constant maps accepting every key.
-            // This is ok because all used similarities and analyzers for this index were known before the upgrade.
-            // Missing analyzers and similarities plugin will still trigger the appropriate error during the
-            // actual upgrade.
-
-        } catch (Exception ex) {
-            // Wrap the inner exception so we have the index name in the exception message
-            throw new IllegalStateException("unable to upgrade the mappings for the index [" + indexMetadata.getIndex() + "]", ex);
-        }
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/RelationMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/RelationMetadata.java
@@ -260,6 +260,12 @@ public sealed interface RelationMetadata extends Diffable<RelationMetadata>
 
             assert settings.hasValue(IndexMetadata.SETTING_VERSION_CREATED)
                 : "Must have version created setting";
+
+            assert columns.stream()
+                .map(ref -> ref.valueType().storageSupport())
+                .filter(x -> x == null)
+                .count() == 0
+                : "All column types must have storage support";
         }
 
 

--- a/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
+++ b/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
@@ -152,6 +152,8 @@ public final class NodeEnvironment implements Closeable {
     }
 
     private final Logger logger = LogManager.getLogger(NodeEnvironment.class);
+    private final Environment environment;
+    private final Settings settings;
     private final NodePath[] nodePaths;
     private final Path sharedDataPath;
     private final Lock[] locks;
@@ -239,6 +241,8 @@ public final class NodeEnvironment implements Closeable {
      * @param settings settings from elasticsearch.yml
      */
     public NodeEnvironment(Settings settings, Environment environment) throws IOException {
+        this.settings = settings;
+        this.environment = environment;
         if (!DiscoveryNode.nodeRequiresLocalStorage(settings)) {
             nodePaths = null;
             sharedDataPath = null;
@@ -299,6 +303,10 @@ public final class NodeEnvironment implements Closeable {
                 close();
             }
         }
+    }
+
+    public Environment environment() {
+        return environment;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/IndexService.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexService.java
@@ -49,6 +49,7 @@ import org.apache.lucene.search.QueryCache;
 import org.apache.lucene.store.AlreadyClosedException;
 import org.apache.lucene.store.Directory;
 import org.elasticsearch.Assertions;
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
@@ -92,10 +93,9 @@ import io.crate.metadata.IndexName;
 import io.crate.metadata.IndexReference;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
-import io.crate.metadata.RelationName;
-import io.crate.metadata.blob.BlobTableInfo;
+import io.crate.metadata.blob.BlobTableInfoFactory;
 import io.crate.metadata.doc.DocTableInfo;
-import io.crate.metadata.table.SchemaInfo;
+import io.crate.metadata.doc.DocTableInfoFactory;
 import io.crate.metadata.table.TableInfo;
 
 public class IndexService extends AbstractIndexComponent implements Iterable<IndexShard> {
@@ -399,7 +399,8 @@ public class IndexService extends AbstractIndexComponent implements Iterable<Ind
                 bigArrays,
                 indexingOperationListeners,
                 () -> globalCheckpointSyncer.accept(shardId),
-                retentionLeaseSyncer, circuitBreakerService
+                retentionLeaseSyncer,
+                circuitBreakerService
             );
             eventListener.indexShardStateChanged(indexShard, null, indexShard.state(), "shard created");
             eventListener.afterIndexShardCreated(indexShard);
@@ -494,7 +495,7 @@ public class IndexService extends AbstractIndexComponent implements Iterable<Ind
         return indexSettings;
     }
 
-    public void validateMapping(Metadata metadata, final IndexMetadata newIndexMetadata) {
+    public void updateMapping(Metadata metadata, final IndexMetadata newIndexMetadata) {
         Index index = newIndexMetadata.getIndex();
         String indexName = index.getName();
         if (IndexName.isDangling(indexName)) {
@@ -504,23 +505,16 @@ public class IndexService extends AbstractIndexComponent implements Iterable<Ind
         if (relation == null) {
             throw new IndexNotFoundException(index);
         }
-        RelationName relationName = relation.name();
-        SchemaInfo schemaInfo = nodeContext.schemas().getOrCreateSchemaInfo(relationName.schema());
-        var tableInfo = schemaInfo.create(relationName, metadata);
-        TranslogIndexer indexer = getTranslogIndexer(tableInfo);
+        Version indexVersionCreated = indexSettings.getIndexVersionCreated();
+        TranslogIndexer indexer = switch (relation) {
+            case RelationMetadata.Table table ->
+                new TranslogIndexer(new DocTableInfoFactory(nodeContext).create(table.name(), metadata), indexVersionCreated);
+            case RelationMetadata.BlobTable blobTable ->
+                new TranslogIndexer(new BlobTableInfoFactory(nodeEnv.environment()).create(blobTable.name(), metadata), indexVersionCreated);
+            default -> throw new UnsupportedFeatureException(
+                "Unsupported table type: " + relation.getClass().getSimpleName());
+        };
         this.getTranslogIndexer = () -> indexer;
-    }
-
-    private <T extends TableInfo> TranslogIndexer getTranslogIndexer(T tableInfo) {
-        TranslogIndexer indexer;
-        if (tableInfo instanceof DocTableInfo docTableInfo) {
-            indexer = new TranslogIndexer(docTableInfo, this.indexSettings.getIndexVersionCreated());
-        } else if (tableInfo instanceof BlobTableInfo blobTableInfo) {
-            indexer = new TranslogIndexer(blobTableInfo, this.indexSettings.getIndexVersionCreated());
-        } else {
-            throw new UnsupportedFeatureException("Unsupported table type: " + tableInfo.getClass().getName());
-        }
-        return indexer;
     }
 
     @VisibleForTesting

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -246,7 +246,8 @@ public class IndexShard extends AbstractIndexShardComponent {
             BigArrays bigArrays,
             List<IndexingOperationListener> listeners,
             Runnable globalCheckpointSyncer,
-            RetentionLeaseSyncer retentionLeaseSyncer, CircuitBreakerService circuitBreakerService) throws IOException {
+            RetentionLeaseSyncer retentionLeaseSyncer,
+            CircuitBreakerService circuitBreakerService) throws IOException {
         super(shardRouting.shardId(), indexSettings);
         assert shardRouting.initializing();
         this.shardRouting = shardRouting;

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -73,7 +73,6 @@ import org.elasticsearch.action.admin.indices.forcemerge.ForceMergeRequest;
 import org.elasticsearch.action.support.replication.PendingReplicationActions;
 import org.elasticsearch.action.support.replication.ReplicationResponse;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
-import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
 import org.elasticsearch.cluster.routing.RecoverySource;
 import org.elasticsearch.cluster.routing.RecoverySource.SnapshotRecoverySource;
@@ -149,7 +148,6 @@ import io.crate.exceptions.InvalidArgumentException;
 import io.crate.execution.dml.TranslogIndexer;
 import io.crate.execution.dml.TranslogMappingUpdateException;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.doc.DocTableInfoFactory;
 
 public class IndexShard extends AbstractIndexShardComponent {
 
@@ -233,8 +231,6 @@ public class IndexShard extends AbstractIndexShardComponent {
 
     private final Analyzer indexAnalyzer;
 
-    private final DocTableInfoFactory tableFactory;
-
     public IndexShard(
             NodeContext nodeContext,
             ShardRouting shardRouting,
@@ -269,7 +265,6 @@ public class IndexShard extends AbstractIndexShardComponent {
         state = IndexShardState.CREATED;
         this.path = path;
         this.circuitBreakerService = circuitBreakerService;
-        this.tableFactory = new DocTableInfoFactory(nodeContext);
         /* create engine config */
         logger.debug("state: [CREATED]");
 
@@ -1749,7 +1744,7 @@ public class IndexShard extends AbstractIndexShardComponent {
             // we are the first primary, recover from the gateway
             // if its post api allocation, the index should exists
             assert shardRouting.primary() : "recover from local shards only makes sense if the shard is a primary shard";
-            StoreRecovery storeRecovery = new StoreRecovery(shardId, logger, indexMetadata -> tableFactory.create(indexMetadata, Metadata.OID_UNASSIGNED));
+            StoreRecovery storeRecovery = new StoreRecovery(shardId, logger);
             storeRecovery.recoverFromLocalShards(this, snapshots, recoveryListener);
             success = true;
         } finally {
@@ -1764,16 +1759,16 @@ public class IndexShard extends AbstractIndexShardComponent {
         // if its post api allocation, the index should exists
         assert shardRouting.primary() : "recover from store only makes sense if the shard is a primary shard";
         assert shardRouting.initializing() : "can only start recovery on initializing shard";
-        StoreRecovery storeRecovery = new StoreRecovery(shardId, logger, indexMetadata -> tableFactory.create(indexMetadata, Metadata.OID_UNASSIGNED));
+        StoreRecovery storeRecovery = new StoreRecovery(shardId, logger);
         storeRecovery.recoverFromStore(this, listener);
     }
 
     public void restoreFromRepository(Repository repository, ActionListener<Boolean> listener) {
         try {
             assert shardRouting.primary() : "recover from store only makes sense if the shard is a primary shard";
-            assert recoveryState.getRecoverySource().getType() == RecoverySource.Type.SNAPSHOT : "invalid recovery type: " +
-                recoveryState.getRecoverySource();
-            StoreRecovery storeRecovery = new StoreRecovery(shardId, logger, indexMetadata -> tableFactory.create(indexMetadata, Metadata.OID_UNASSIGNED));
+            assert recoveryState.getRecoverySource().getType() == RecoverySource.Type.SNAPSHOT
+                : "invalid recovery type: " + recoveryState.getRecoverySource();
+            StoreRecovery storeRecovery = new StoreRecovery(shardId, logger);
             storeRecovery.recoverFromRepository(this, repository, listener);
         } catch (Exception e) {
             listener.onFailure(e);

--- a/server/src/main/java/org/elasticsearch/index/shard/StoreRecovery.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/StoreRecovery.java
@@ -27,7 +27,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.Logger;
@@ -70,12 +69,10 @@ final class StoreRecovery {
 
     private final Logger logger;
     private final ShardId shardId;
-    private final Consumer<IndexMetadata> validateSchema;
 
-    StoreRecovery(ShardId shardId, Logger logger, Consumer<IndexMetadata> validateSchema) {
+    StoreRecovery(ShardId shardId, Logger logger) {
         this.logger = logger;
         this.shardId = shardId;
-        this.validateSchema = validateSchema;
     }
 
     /**
@@ -124,7 +121,6 @@ final class StoreRecovery {
                 throw new IllegalArgumentException("can't add shards from more than one index");
             }
             IndexMetadata sourceMetadata = shards.get(0).getIndexMetadata();
-            validateSchema.accept(sourceMetadata);
 
             final boolean isSplit = sourceMetadata.getNumberOfShards() < indexShard.indexSettings().getNumberOfShards();
             ActionListener<Boolean> recoveryListener = recoveryListener(indexShard, listener);

--- a/server/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
+++ b/server/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
@@ -31,6 +31,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
@@ -49,6 +50,8 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateApplier;
 import org.elasticsearch.cluster.action.shard.ShardStateAction;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.metadata.RelationMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
@@ -64,6 +67,7 @@ import org.elasticsearch.common.util.concurrent.RejectableRunnable;
 import org.elasticsearch.env.ShardLockObtainFailedException;
 import org.elasticsearch.gateway.GatewayService;
 import org.elasticsearch.index.Index;
+import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.seqno.GlobalCheckpointSyncAction;
@@ -89,6 +93,7 @@ import io.crate.blob.v2.BlobIndicesService;
 import io.crate.common.exceptions.Exceptions;
 import io.crate.common.unit.TimeValue;
 import io.crate.execution.engine.collect.sources.ShardCollectSource;
+import io.crate.metadata.IndexName;
 import io.crate.replication.logical.ShardReplicationService;
 
 public class IndicesClusterStateService extends AbstractLifecycleComponent implements ClusterStateApplier {
@@ -458,7 +463,7 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
             IndexService indexService = null;
             try {
                 indexService = indicesService.createIndex(indexMetadata, buildInIndexListener, true);
-                indexService.validateMapping(state.metadata(), indexMetadata);
+                indexService.updateMapping(state.metadata(), indexMetadata);
             } catch (Exception e) {
                 final String failShardReason;
                 if (indexService == null) {
@@ -479,12 +484,23 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
             return;
         }
         final ClusterState state = event.state();
+        Metadata metadata = state.metadata();
         for (IndexService indexService : indicesService) {
             final Index index = indexService.index();
             final IndexMetadata currentIndexMetadata = indexService.getIndexSettings().getIndexMetadata();
-            final IndexMetadata newIndexMetadata = state.metadata().index(index);
+            final IndexMetadata newIndexMetadata = metadata.index(index);
             assert newIndexMetadata != null : "index " + index + " should have been removed by deleteIndices";
-            if (ClusterChangedEvent.indexMetadataChanged(currentIndexMetadata, newIndexMetadata)) {
+
+            RelationMetadata relation = metadata.getRelation(index.getUUID());
+            if (relation == null && !IndexName.isDangling(index.getName())) {
+                indicesService.removeIndex(indexService.index(), FAILURE, "removing index (RelationMetadata missing)");
+                failShards(state, index, "RelationMetadata missing", new IndexNotFoundException(index));
+                continue;
+            }
+            RelationMetadata oldRelation = event.previousState().metadata().getRelation(index.getUUID());
+
+            boolean indexMetadataChanged = ClusterChangedEvent.indexMetadataChanged(currentIndexMetadata, newIndexMetadata);
+            if (indexMetadataChanged || !Objects.equals(relation, oldRelation)) {
                 String reason = null;
                 try {
                     reason = "metadata update failed";
@@ -496,19 +512,24 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
                     }
 
                     reason = "mapping update failed";
-                    indexService.validateMapping(state.metadata(), newIndexMetadata);
+                    LOGGER.error("Updating mapping for {} {}", index, relation);
+                    indexService.updateMapping(metadata, newIndexMetadata);
                 } catch (Exception e) {
                     indicesService.removeIndex(indexService.index(), FAILURE, "removing index (" + reason + ")");
 
                     // fail shards that would be created or updated by createOrUpdateShards
-                    RoutingNode localRoutingNode = state.getRoutingNodes().node(state.nodes().getLocalNodeId());
-                    if (localRoutingNode != null) {
-                        for (final ShardRouting shardRouting : localRoutingNode) {
-                            if (shardRouting.index().equals(index) && failedShardsCache.containsKey(shardRouting.shardId()) == false) {
-                                sendFailShard(shardRouting, "failed to update index (" + reason + ")", e, state);
-                            }
-                        }
-                    }
+                    failShards(state, index, reason, e);
+                }
+            }
+        }
+    }
+
+    private void failShards(final ClusterState state, final Index index, String reason, Exception e) {
+        RoutingNode localRoutingNode = state.getRoutingNodes().node(state.nodes().getLocalNodeId());
+        if (localRoutingNode != null) {
+            for (final ShardRouting shardRouting : localRoutingNode) {
+                if (shardRouting.index().equals(index) && failedShardsCache.containsKey(shardRouting.shardId()) == false) {
+                    sendFailShard(shardRouting, "failed to update index (" + reason + ")", e, state);
                 }
             }
         }

--- a/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
@@ -85,6 +85,7 @@ import io.crate.testing.SQLExecutor;
 import io.crate.testing.TestingHelpers;
 import io.crate.types.ArrayType;
 import io.crate.types.DataTypes;
+import io.crate.types.DataTypesBwc;
 import io.crate.types.FloatVectorType;
 
 public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServiceUnitTest {
@@ -1590,7 +1591,7 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
                 assertThat(sProperties)
                     .containsEntry("doc_values", "false")
                     .containsEntry("position", 1)
-                    .containsEntry("type", DataTypes.esMappingNameFrom(dataType.id()));
+                    .containsEntry("type", DataTypesBwc.esMappingNameFrom(dataType.id()));
             } else if (dataType.storageSupport() != null) {
                 assertThatThrownBy(() -> analyze(stmt))
                     .isExactlyInstanceOf(IllegalArgumentException.class)

--- a/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
@@ -28,6 +28,7 @@ import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.TestingHelpers.printedTable;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
 

--- a/server/src/test/java/io/crate/metadata/SchemasTest.java
+++ b/server/src/test/java/io/crate/metadata/SchemasTest.java
@@ -24,9 +24,6 @@ package io.crate.metadata;
 import static io.crate.testing.TestingHelpers.createNodeContext;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_REPLICAS;
-import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_SHARDS;
-import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_VERSION_CREATED;
 import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
@@ -34,11 +31,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.elasticsearch.Version;
-import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.metadata.MetadataUpgradeService;
-import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.settings.IndexScopedSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.junit.Before;
@@ -105,41 +99,15 @@ public class SchemasTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testCurrentSchemas() throws Exception {
-        Metadata metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED)
-            .put(IndexMetadata.builder(UUIDs.randomBase64UUID())
-                .state(IndexMetadata.State.OPEN)
-                .settings(Settings.builder()
-                    .put(SETTING_NUMBER_OF_SHARDS, 1)
-                    .put(SETTING_NUMBER_OF_REPLICAS, 0)
-                    .put(SETTING_VERSION_CREATED, Version.CURRENT))
-                .indexName("doc.d1")
-                .build(), true)
-            .put(IndexMetadata.builder(UUIDs.randomBase64UUID())
-                .state(IndexMetadata.State.CLOSE)
-                .settings(Settings.builder()
-                    .put(SETTING_NUMBER_OF_SHARDS, 1)
-                    .put(SETTING_NUMBER_OF_REPLICAS, 0)
-                    .put(SETTING_VERSION_CREATED, Version.CURRENT))
-                .indexName("doc.d2")
-                .build(), true)
-            .put(IndexMetadata.builder(UUIDs.randomBase64UUID())
-                .state(IndexMetadata.State.CLOSE)
-                .settings(Settings.builder()
-                    .put(SETTING_NUMBER_OF_SHARDS, 1)
-                    .put(SETTING_NUMBER_OF_REPLICAS, 0)
-                    .put(SETTING_VERSION_CREATED, Version.CURRENT))
-                .indexName("foo.f1")
-                .build(), true)
-            .put(IndexMetadata.builder(UUIDs.randomBase64UUID())
-                .state(IndexMetadata.State.OPEN)
-                .settings(Settings.builder()
-                    .put(SETTING_NUMBER_OF_SHARDS, 1)
-                    .put(SETTING_NUMBER_OF_REPLICAS, 0)
-                    .put(SETTING_VERSION_CREATED, Version.CURRENT))
-                .indexName("foo.f2")
-                .build(), true)
-            .build();
-        metadata = metadataUpgradeService.upgradeMetadata(metadata);
+        SQLExecutor.of(clusterService)
+            .addTable("create table doc.d1 (x int)")
+            .addTable("create table doc.d2 (x int)")
+            .addTable("create table foo.f1 (x int)")
+            .addTable("create table foo.f2 (x int)")
+            .closeTable("d2")
+            .closeTable("f1");
+
+        Metadata metadata = clusterService.state().metadata();
         assertThat(Schemas.getNewCurrentSchemas(metadata)).containsExactly("foo", "doc");
     }
 

--- a/server/src/test/java/io/crate/metadata/upgrade/MetadataIndexUpgraderTest.java
+++ b/server/src/test/java/io/crate/metadata/upgrade/MetadataIndexUpgraderTest.java
@@ -50,9 +50,8 @@ public class MetadataIndexUpgraderTest extends ESTestCase {
 
     @Test
     public void testDynamicStringTemplateIsPurged() throws IOException {
-        MetadataIndexUpgrader metadataIndexUpgrader = new MetadataIndexUpgrader();
         MappingMetadata mappingMetadata = new MappingMetadata(createDynamicStringMappingTemplate());
-        MappingMetadata newMappingMetadata = metadataIndexUpgrader.createUpdatedIndexMetadata(mappingMetadata, null);
+        MappingMetadata newMappingMetadata = MetadataIndexUpgrader.createUpdatedIndexMetadata(mappingMetadata, null);
 
         Object dynamicTemplates = newMappingMetadata.sourceAsMap().get("dynamic_templates");
         assertThat(dynamicTemplates).isNull();
@@ -78,10 +77,7 @@ public class MetadataIndexUpgraderTest extends ESTestCase {
                 "}")
             .build();
 
-        MetadataIndexUpgrader metadataIndexUpgrader = new MetadataIndexUpgrader();
-        IndexMetadata updatedMetadata = metadataIndexUpgrader.upgrade(indexMetadata, null);
-
-        MappingMetadata mapping = updatedMetadata.mapping();
+        MappingMetadata mapping = MetadataIndexUpgrader.createUpdatedIndexMetadata(indexMetadata.mapping(), null);
         assertThat(mapping.source().string()).isEqualTo(
             "{\"default\":{\"properties\":{\"name\":{\"type\":\"keyword\",\"position\":1}}}}");
     }
@@ -105,10 +101,7 @@ public class MetadataIndexUpgraderTest extends ESTestCase {
                     "}")
             .build();
 
-        MetadataIndexUpgrader metadataIndexUpgrader = new MetadataIndexUpgrader();
-        IndexMetadata updatedMetadata = metadataIndexUpgrader.upgrade(indexMetadata, null);
-
-        MappingMetadata mapping = updatedMetadata.mapping();
+        MappingMetadata mapping = MetadataIndexUpgrader.createUpdatedIndexMetadata(indexMetadata.mapping(), null);
         assertThat(mapping.source().string()).isEqualTo(
             "{\"default\":{\"properties\":{\"name\":{\"type\":\"keyword\",\"position\":1}}}}");
     }
@@ -122,8 +115,7 @@ public class MetadataIndexUpgraderTest extends ESTestCase {
             .putMapping((MappingMetadata) null) // here
             .build();
 
-        MetadataIndexUpgrader metadataIndexUpgrader = new MetadataIndexUpgrader();
-        IndexMetadata updatedMetadata = metadataIndexUpgrader.upgrade(indexMetadata, null);
+        IndexMetadata updatedMetadata = MetadataIndexUpgrader.upgrade(indexMetadata);
 
         assertThat(updatedMetadata.mapping()).isNull();
     }
@@ -161,10 +153,7 @@ public class MetadataIndexUpgraderTest extends ESTestCase {
             .putMapping(MappingConstants.FULLTEXT_MAPPING_5_3)
             .build();
 
-        MetadataIndexUpgrader metadataIndexUpgrader = new MetadataIndexUpgrader();
-        IndexMetadata updatedMetadata = metadataIndexUpgrader.upgrade(indexMetadata, null);
-
-        MappingMetadata mapping = updatedMetadata.mapping();
+        MappingMetadata mapping = MetadataIndexUpgrader.createUpdatedIndexMetadata(indexMetadata.mapping(), null);
         assertThat(mapping.source().string())
             .isEqualTo(MappingConstants.FULLTEXT_MAPPING_EXPECTED_IN_5_4);
     }
@@ -299,8 +288,7 @@ public class MetadataIndexUpgraderTest extends ESTestCase {
             .build();
         assertThat(indexMetadata.partitionValues()).isEmpty();
 
-        MetadataIndexUpgrader metadataIndexUpgrader = new MetadataIndexUpgrader();
-        IndexMetadata updatedMetadata = metadataIndexUpgrader.upgrade(indexMetadata, null);
+        IndexMetadata updatedMetadata = MetadataIndexUpgrader.upgrade(indexMetadata);
         assertThat(updatedMetadata.partitionValues()).contains("2023-10-01");
     }
 }

--- a/server/src/test/java/io/crate/replication/logical/MetadataTrackerTest.java
+++ b/server/src/test/java/io/crate/replication/logical/MetadataTrackerTest.java
@@ -40,7 +40,6 @@ import org.elasticsearch.action.admin.cluster.snapshots.restore.TableOrPartition
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
-import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.metadata.RelationMetadata;
 import org.elasticsearch.cluster.routing.IndexRoutingTable;
@@ -131,10 +130,8 @@ public class MetadataTrackerTest extends ESTestCase {
         }
 
         private Builder addPartition(RelationMetadata.Table table, String indexUUID, PartitionName partitionName, Settings settings) throws IOException {
-            Map<String, Object> mapping = Map.of();
             var indexMetadata = IndexMetadata.builder(indexUUID)
                 .indexName(indexUUID)
-                .putMapping(new MappingMetadata(mapping))
                 .settings(settings(Version.CURRENT).put(settings))
                 .partitionValues(partitionName.values())
                 .numberOfShards(1)
@@ -420,7 +417,12 @@ public class MetadataTrackerTest extends ESTestCase {
             IndexMetadata syncedIndexMetadata = syncedSubscriberClusterState.metadata().index(indexUUID);
             String publisherIndexUUID = PUBLISHER_INDEX_UUID.get(syncedIndexMetadata.getSettings());
             IndexMetadata publisherIndexMetadata = updatedPublisherClusterState.metadata().index(publisherIndexUUID);
-            assertThat(syncedIndexMetadata.mapping()).isEqualTo(publisherIndexMetadata.mapping());
+            assertThat(syncedIndexMetadata.mapping())
+                .as("mapping is removed as part of the metadata upgrade. The RelationMetadata.Table is created instead")
+                .isNull();
+            assertThat(publisherIndexMetadata.mapping())
+                .as("Publisher retains mapping")
+                .isNotNull();
         }
     }
 

--- a/server/src/test/java/io/crate/replication/logical/MetadataTrackerTest.java
+++ b/server/src/test/java/io/crate/replication/logical/MetadataTrackerTest.java
@@ -421,8 +421,8 @@ public class MetadataTrackerTest extends ESTestCase {
                 .as("mapping is removed as part of the metadata upgrade. The RelationMetadata.Table is created instead")
                 .isNull();
             assertThat(publisherIndexMetadata.mapping())
-                .as("Publisher retains mapping")
-                .isNotNull();
+                .as("mapping is removed as part of the metadata upgrade. The RelationMetadata.Table is created instead")
+                .isNull();
         }
     }
 

--- a/server/src/test/java/io/crate/replication/logical/action/TransportAlterPublicationTest.java
+++ b/server/src/test/java/io/crate/replication/logical/action/TransportAlterPublicationTest.java
@@ -21,43 +21,22 @@
 
 package io.crate.replication.logical.action;
 
-import static io.crate.testing.TestingHelpers.createNodeContext;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
-import java.util.Set;
 
-import org.elasticsearch.Version;
-import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
-import org.elasticsearch.cluster.metadata.MetadataUpgradeService;
-import org.elasticsearch.common.settings.IndexScopedSettings;
-import org.elasticsearch.common.settings.Settings;
-import org.junit.Before;
 import org.junit.Test;
 
 import io.crate.exceptions.RelationUnknown;
-import io.crate.expression.udf.UserDefinedFunctionService;
-import io.crate.metadata.NodeContext;
 import io.crate.metadata.RelationName;
 import io.crate.replication.logical.metadata.Publication;
 import io.crate.sql.tree.AlterPublication;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.SQLExecutor;
 
 public class TransportAlterPublicationTest extends CrateDummyClusterServiceUnitTest {
-
-    private final NodeContext nodeCtx = createNodeContext();
-    private MetadataUpgradeService metadataUpgradeService;
-
-    @Before
-    public void setUpUpgradeService() throws Exception {
-        metadataUpgradeService = new MetadataUpgradeService(
-            nodeCtx,
-            new IndexScopedSettings(Settings.EMPTY, Set.of()),
-            new UserDefinedFunctionService(clusterService, nodeCtx)
-        );
-    }
 
     @Test
     public void test_unknown_table_raises_exception() {
@@ -74,48 +53,36 @@ public class TransportAlterPublicationTest extends CrateDummyClusterServiceUnitT
     }
 
     @Test
-    public void test_set_tables_on_existing_publication() {
+    public void test_set_tables_on_existing_publication() throws Exception {
         var oldPublication = new Publication("owner", false, List.of(RelationName.fromIndexName("t1")));
-        var metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED)
-            .put(IndexMetadata.builder("t2")
-                .settings(settings(Version.CURRENT))
-                .numberOfShards(1)
-                .numberOfReplicas(0)
-                .build(),
-                true
-            )
-            .build();
+
+        SQLExecutor.of(clusterService)
+            .addTable("create table t2 (x int)");
+        Metadata metadata = clusterService.state().metadata();
+
         var request = new TransportAlterPublication.Request(
             "pub1",
             AlterPublication.Operation.SET,
             List.of(RelationName.fromIndexName("t2"))
         );
 
-        metadata = metadataUpgradeService.upgradeMetadata(metadata);
         var newPublication = TransportAlterPublication.updatePublication(request, metadata, oldPublication);
         assertThat(newPublication).isNotEqualTo(oldPublication);
         assertThat(newPublication.tables()).containsExactly(RelationName.fromIndexName("t2"));
     }
 
     @Test
-    public void test_add_table_on_existing_publication() {
+    public void test_add_table_on_existing_publication() throws Exception {
         var oldPublication = new Publication("owner", false, List.of(RelationName.fromIndexName("t1")));
-        var metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED)
-            .put(IndexMetadata.builder("t2")
-                .settings(settings(Version.CURRENT))
-                .numberOfShards(1)
-                .numberOfReplicas(0)
-                .build(),
-                true
-            )
-            .build();
+        SQLExecutor.of(clusterService)
+            .addTable("create table t2 (x int)");
+        Metadata metadata = clusterService.state().metadata();
         var request = new TransportAlterPublication.Request(
             "pub1",
             AlterPublication.Operation.ADD,
             List.of(RelationName.fromIndexName("t2"))
         );
 
-        metadata = metadataUpgradeService.upgradeMetadata(metadata);
         var newPublication = TransportAlterPublication.updatePublication(request, metadata, oldPublication);
         assertThat(newPublication).isNotEqualTo(oldPublication);
         assertThat(newPublication.tables()).containsExactlyInAnyOrder(
@@ -123,28 +90,21 @@ public class TransportAlterPublicationTest extends CrateDummyClusterServiceUnitT
     }
 
     @Test
-    public void test_drop_table_from_existing_publication() {
+    public void test_drop_table_from_existing_publication() throws Exception {
         var oldPublication = new Publication(
             "owner",
             false,
             List.of(RelationName.fromIndexName("t1"), RelationName.fromIndexName("t2"))
         );
-        var metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED)
-            .put(IndexMetadata.builder("t2")
-                .settings(settings(Version.CURRENT))
-                .numberOfShards(1)
-                .numberOfReplicas(0)
-                .build(),
-                true
-            )
-            .build();
-
+        SQLExecutor.of(clusterService)
+            .addTable("create table t1 (x int)")
+            .addTable("create table t2 (x int)");
+        Metadata metadata = clusterService.state().metadata();
         var request = new TransportAlterPublication.Request(
             "pub1",
             AlterPublication.Operation.DROP,
             List.of(RelationName.fromIndexName("t2"))
         );
-        metadata = metadataUpgradeService.upgradeMetadata(metadata);
 
         var newPublication = TransportAlterPublication.updatePublication(request, metadata, oldPublication);
         assertThat(newPublication).isNotEqualTo(oldPublication);

--- a/server/src/test/java/io/crate/replication/logical/repository/LogicalReplicationRepositoryTest.java
+++ b/server/src/test/java/io/crate/replication/logical/repository/LogicalReplicationRepositoryTest.java
@@ -56,12 +56,14 @@ import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 public class LogicalReplicationRepositoryTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
+    @SuppressWarnings("deprecation")
     public void test_getRemoteClusterState_upgrades_indexMetadata() throws Exception {
         // This test basically checks RelationMetadata was created based on IndexMetadata, where RelationMetadata
         // was introduced to 6.0, which implicitly verifies the upgrade.
         Metadata metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED)
             .put(IndexMetadata.builder("test")
                 .settings(settings(Version.V_5_10_0))
+                .putMapping("{}")
                 .numberOfShards(1)
                 .numberOfReplicas(1))
             .build();
@@ -98,6 +100,7 @@ public class LogicalReplicationRepositoryTest extends CrateDummyClusterServiceUn
         );
 
         ClusterStateResponse responseFromOldNode = logicalReplicationRepository.getRemoteClusterState(false, false, List.of()).get();
+        logicalReplicationRepository.close();
         assertThat(responseFromOldNode
             .getState().metadata().relations("doc", RelationMetadata.Table.class)
             .getFirst().name().toString()

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/PublicationTransportHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/PublicationTransportHandlerTests.java
@@ -292,6 +292,7 @@ public class PublicationTransportHandlerTests extends ESTestCase {
         String indexUUID = UUIDs.randomBase64UUID();
         IndexMetadata indexMetadata = IndexMetadata.builder(indexUUID)
             .indexName(relationName.indexNameOrAlias())
+            .putMapping("{}")
             .settings(
                 Settings.builder()
                     .put(IndexMetadata.SETTING_INDEX_UUID, indexUUID)

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataUpgradeServiceTest.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataUpgradeServiceTest.java
@@ -246,7 +246,7 @@ public class MetadataUpgradeServiceTest extends CrateDummyClusterServiceUnitTest
             .put(indexTemplateMetadata)
             .putCustom(UserDefinedFunctionsMetadata.TYPE, udfs)
             .build();
-        metadataUpgradeService.upgradeIndexMetadata(indexMetadata, indexTemplateMetadata, Version.V_5_7_0, metadata);
+        metadataUpgradeService.upgradeMetadata(metadata);
     }
 
     @Test
@@ -349,11 +349,13 @@ public class MetadataUpgradeServiceTest extends CrateDummyClusterServiceUnitTest
     public void test_index_metadata_only_upgrade_when_not_on_current_version() {
         IndexMetadata indexMetadata = IndexMetadata.builder("old_index")
             .settings(settings(Version.V_5_7_0))
+            .putMapping("{}")
             .numberOfShards(1)
             .numberOfReplicas(1)
             .build();
         IndexMetadata indexMetadataAlreadyUpgraded = IndexMetadata.builder("already_upgraded")
             .settings(settings(Version.V_5_7_0).put(IndexMetadata.SETTING_VERSION_UPGRADED, Version.CURRENT))
+            .putMapping("{}")
             .numberOfShards(1)
             .numberOfReplicas(1)
             .build();
@@ -366,6 +368,21 @@ public class MetadataUpgradeServiceTest extends CrateDummyClusterServiceUnitTest
             .put(indexMetadata, false)
             .put(indexMetadataAlreadyUpgraded, false)
             .put(indexMetadataCreatedOnCurrentVersion, false)
+            .setTable(
+                new RelationName("doc", "created_on_current"),
+                List.of(),
+                indexMetadataCreatedOnCurrentVersion.getSettings(),
+                null,
+                ColumnPolicy.STRICT,
+                null,
+                Map.of(),
+                List.of(),
+                List.of(),
+                State.OPEN,
+                List.of(indexMetadataCreatedOnCurrentVersion.getIndexUUID()),
+                1,
+                1
+            )
             .build();
         Metadata upgrade = metadataUpgradeService.upgradeMetadata(metadata);
 
@@ -519,6 +536,7 @@ public class MetadataUpgradeServiceTest extends CrateDummyClusterServiceUnitTest
                 IndexMetadata.builder(indexUUID)
                     .settings(settings(Version.CURRENT))
                     .indexName(indexName)
+                    .putMapping("{}")
                     .numberOfReplicas(randomIntBetween(0, 3))
                     .numberOfShards(randomIntBetween(1, 5))
             );

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -151,7 +151,9 @@ import io.crate.common.collections.Tuple;
 import io.crate.common.exceptions.Exceptions;
 import io.crate.common.unit.TimeValue;
 import io.crate.concurrent.FutureActionListener;
+import io.crate.metadata.RelationName;
 import io.crate.metadata.doc.SysColumns;
+import io.crate.testing.SQLExecutor;
 
 /**
  * Simple unit-test IndexShard related operations.
@@ -2515,15 +2517,22 @@ public class IndexShardTests extends IndexShardTestCase {
     @Test
     public void testMinimumCompatVersion() throws IOException {
         Version versionCreated = VersionUtils.randomCompatibleVersion(random(), Version.CURRENT);
+        SQLExecutor.of(clusterService)
+            .addTable("create table doc.test (x int) clustered into 1 shards with (number_of_replicas = 0)");
+        IndexMetadata idm = clusterService.state().metadata().getIndex(
+            new RelationName("doc", "test"),
+            List.of(),
+            true,
+            x -> x
+        );
         Settings settings = Settings.builder()
+            .put(idm.getSettings())
             .put(IndexMetadata.SETTING_VERSION_CREATED, versionCreated.internalId)
-            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
-            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
             .build();
-        IndexMetadata metaData = IndexMetadata.builder("test")
+        idm = IndexMetadata.builder(idm)
             .settings(settings)
-            .primaryTerm(0, 1).build();
-        IndexShard test = newShard(new ShardId(metaData.getIndex(), 0), true, "n1", metaData, null);
+            .build();
+        IndexShard test = newShard(new ShardId(idm.getIndex(), 0), true, "n1", idm, null);
         recoverShardFromStore(test);
 
         indexDoc(test, "test");

--- a/server/src/testFixtures/java/io/crate/test/integration/CrateDummyClusterServiceUnitTest.java
+++ b/server/src/testFixtures/java/io/crate/test/integration/CrateDummyClusterServiceUnitTest.java
@@ -100,10 +100,12 @@ public class CrateDummyClusterServiceUnitTest extends ESTestCase {
         return EMPTY_CLUSTER_SETTINGS;
     }
 
-    protected ClusterService createClusterService(
-        Collection<Setting<?>> additionalClusterSettings,
-        Metadata metaData,
-        Version version) {
+    public static ClusterService createClusterService(
+            String clusterName,
+            ThreadPool threadPool,
+            Metadata metadata,
+            Version version,
+            Collection<Setting<?>> additionalClusterSettings) {
         Set<Setting<?>> clusterSettingsSet = new HashSet<>(ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
         clusterSettingsSet.addAll(additionalClusterSettings);
         ClusterSettings clusterSettings = new ClusterSettings(Settings.EMPTY, clusterSettingsSet);
@@ -113,7 +115,7 @@ public class CrateDummyClusterServiceUnitTest extends ESTestCase {
                 .put(Node.NODE_NAME_SETTING.getKey(), NODE_NAME)
                 .build(),
             clusterSettings,
-            THREAD_POOL
+            threadPool
         );
         clusterService.setNodeConnectionsService(createNoOpNodeConnectionsService());
         DiscoveryNode discoveryNode = new DiscoveryNode(
@@ -129,8 +131,8 @@ public class CrateDummyClusterServiceUnitTest extends ESTestCase {
             .localNodeId(NODE_ID)
             .masterNodeId(NODE_ID)
             .build();
-        ClusterState clusterState = ClusterState.builder(new ClusterName(this.getClass().getSimpleName()))
-            .nodes(nodes).metadata(metaData).blocks(ClusterBlocks.EMPTY_CLUSTER_BLOCK).build();
+        ClusterState clusterState = ClusterState.builder(new ClusterName(clusterName))
+            .nodes(nodes).metadata(metadata).blocks(ClusterBlocks.EMPTY_CLUSTER_BLOCK).build();
 
         ClusterApplierService clusterApplierService = clusterService.getClusterApplierService();
         clusterApplierService.setInitialState(clusterState);
@@ -141,5 +143,18 @@ public class CrateDummyClusterServiceUnitTest extends ESTestCase {
 
         clusterService.start();
         return clusterService;
+    }
+
+    protected ClusterService createClusterService(
+            Collection<Setting<?>> additionalClusterSettings,
+            Metadata metadata,
+            Version version) {
+        return createClusterService(
+            this.getClass().getSimpleName(),
+            THREAD_POOL,
+            metadata,
+            version,
+            additionalClusterSettings
+        );
     }
 }

--- a/server/src/testFixtures/java/org/elasticsearch/index/shard/IndexShardTestCase.java
+++ b/server/src/testFixtures/java/org/elasticsearch/index/shard/IndexShardTestCase.java
@@ -48,6 +48,7 @@ import org.elasticsearch.action.support.PlainFuture;
 import org.elasticsearch.action.support.replication.TransportReplicationAction;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.metadata.RelationMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
@@ -56,6 +57,7 @@ import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.ShardRoutingHelper;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.cluster.routing.TestShardRouting;
+import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.lucene.uid.Versions;
@@ -109,6 +111,7 @@ import io.crate.execution.dml.TranslogIndexer;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.doc.DocTableInfoFactory;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 
 /**
  * A base class for unit tests that need to create and shutdown {@link IndexShard} instances easily,
@@ -141,6 +144,7 @@ public abstract class IndexShardTestCase extends ESTestCase {
 
     protected ThreadPool threadPool;
     protected long primaryTerm;
+    protected ClusterService clusterService;
 
     @Override
     public void setUp() throws Exception {
@@ -148,6 +152,13 @@ public abstract class IndexShardTestCase extends ESTestCase {
         threadPool = setUpThreadPool();
         primaryTerm = randomIntBetween(1, 100); // use random but fixed term for creating shards
         failOnShardFailures();
+        clusterService = CrateDummyClusterServiceUnitTest.createClusterService(
+            this.getClass().getSimpleName(),
+            threadPool,
+            Metadata.EMPTY_METADATA,
+            Version.CURRENT,
+            Set.of()
+        );
     }
 
     protected ThreadPool setUpThreadPool() {
@@ -156,6 +167,7 @@ public abstract class IndexShardTestCase extends ESTestCase {
 
     @Override
     public void tearDown() throws Exception {
+        clusterService.stop();
         try {
             tearDownThreadPool();
         } finally {
@@ -242,7 +254,13 @@ public abstract class IndexShardTestCase extends ESTestCase {
         NodeContext nodeCtx = createNodeContext();
         DocTableInfoFactory tableFactory = new DocTableInfoFactory(nodeCtx);
         IndexMetadata indexMetadata = getIndexMetadata.get();
-        return tableFactory.create(indexMetadata, Metadata.OID_UNASSIGNED);
+        Metadata metadata = clusterService.state().metadata();
+        @Nullable
+        RelationMetadata relation = metadata.getRelation(indexMetadata.getIndexUUID());
+        if (relation == null) {
+            return tableFactory.create(indexMetadata, null, Metadata.OID_UNASSIGNED);
+        }
+        return tableFactory.create(relation.name(), metadata);
     }
 
     protected void assertDocCount(IndexShard shard, int docDount) throws IOException {


### PR DESCRIPTION
The full upgrade logic including the mapping upgrades always ran for all
indices, even those which had their mapping already in the
RelationMetadata.

Besides being a bit wasteful, this had the side effect that
`IndexMetadata` needed to retain the mapping, and that it required
mapping names for the data types.

This changes the logic to run the mapping upgrade logic only for indices which
do not yet have a RelationMetadata entry. It also removes the mapping during
the upgrade.


Relates to: https://github.com/crate/crate/pull/19416
Newly added types should no longer require mapping names - UUID was
added under that assumption (in 6.2)
