### PR TITLE
Fix Vale action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,9 @@ jobs:
           persist-credentials: false
 
       - name: Install docutils
-        run: sudo apt-get install -y docutils
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y docutils
 
       - name: Run vale
         uses: vale-cli/vale-action@85f9f7f2c5f449ac0ae5b66662961bae3f77ca6a # 2.1.2


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Fixes Vale action failures like this: https://github.com/crate/crate/actions/runs/27273548977/job/80548865714?pr=19482.

See note in https://docs.github.com/en/actions/how-tos/manage-runners/github-hosted-runners/customize-runners about running `apt-get update` before `install`.

## Checklist

 - [ ] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
