### PR TITLE
Suppress transfer progress in Maven goals

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,6 @@ jobs:
           CRATE_TESTS_SQL_REQUEST_TIMEOUT: "20"
         run: |
           mvn test \
-            -B \
             -Dtests.crate.run-windows-incompatible=true \
             -DforkCount=2 \
             -DthreadCount=2 \

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,2 +1,3 @@
 -T1C
 -Djunit.vintage.discovery.issue.reporting.enabled=false
+--no-transfer-progress

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,7 +33,6 @@ pipeline {
             sh './mvnw compile'
             sh '''
               x=(~/.m2/jdks/jdk-$(./mvnw help:evaluate -Dexpression=versions.jdk -q -DforceStdout)*); JAVA_HOME="$x/" ./mvnw test \
-                -B \
                 -DforkCount=8 \
                 -DthreadCount=2 \
                 -Dcheckstyle.skip \


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Removes download progress for artifacts, e.g. lines like these:

```                 
Downloaded from central: https://repo.maven.apache.org/maven2/org/junit/junit-bom/6.1.0/junit-bom-6.1.0.pom (5.4 kB at 17 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-jlink-plugin/3.1.0/maven-jlink-plugin-3.1.0.pom
Progress (1): 764 B
Progress (1): 1.7 kB
Progress (1): 3.5 kB
Progress (1): 6.9 kB
Progress (1): 9.1 kB
Progress (1): 11 kB 
Progress (1): 12 kB
```

`--no-transfer-progress` is a better (more specific) way to disable the progress of download artifacts than `-B` (which we added in 3968a910b3eaf45740cdfda4f8ed9402c2703c84).

Additionally, this PR adds it to maven.config, so that it's used for any Maven goal run.

## Checklist

 - [ ] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
