### PR TITLE
Ensure that failure of a query within DECLARE is forwarded to the consumer

### DIFF
--- a/docs/appendices/release-notes/6.3.4.rst
+++ b/docs/appendices/release-notes/6.3.4.rst
@@ -52,3 +52,6 @@ Fixes
 - Fixed and issue which caused wrong binary deserialization of
   :ref:`NUMERIC <type-numeric>` types when using the
   :ref:`PostgreSQL wire protocol <interface-postgresql>`.
+
+- Fixed and issue causing :ref:`DECLARE <sql-declare>` statements to get stuck
+  if query within the ``DECLARE`` statement failed on initial run.

--- a/server/src/main/java/io/crate/planner/DeclarePlan.java
+++ b/server/src/main/java/io/crate/planner/DeclarePlan.java
@@ -23,6 +23,8 @@ package io.crate.planner;
 
 import java.util.concurrent.CompletableFuture;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.jspecify.annotations.Nullable;
 
@@ -41,6 +43,8 @@ import io.crate.sql.tree.Declare;
 import io.crate.sql.tree.Declare.Hold;
 
 public class DeclarePlan implements Plan {
+
+    private static final Logger LOGGER = LogManager.getLogger(DeclarePlan.class);
 
     private final AnalyzedDeclare declare;
     private final Plan queryPlan;
@@ -81,6 +85,17 @@ public class DeclarePlan implements Plan {
         );
         cursors.add(declareStmt.cursorName(), cursor);
         Plan.execute(queryPlan, dependencies, plannerContext, cursorRowConsumer, params, subQueryResults);
+        cursorRowConsumer.consumer()
+            .completionFuture()
+            .whenComplete((_, err) -> {
+                if (err != null) {
+                    // DECLARE failed and cursor is unusable as next FETCH will fail anyway.
+                    // We can release resources eagerly and also clean up pg_cursors entry
+                    // and don't wait until end of transaction/connection.
+                    cursors.close(declareStmt.cursorName());
+                }
+            });
+
     }
 
     private static class CursorRowConsumer implements RowConsumer {
@@ -93,9 +108,17 @@ public class DeclarePlan implements Plan {
             this.consumer = consumer;
         }
 
+        public RowConsumer consumer() {
+            return consumer;
+        }
+
         @Override
         public void accept(BatchIterator<Row> iterator, @Nullable Throwable failure) {
             if (failure != null) {
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.debug("Declare query failed", failure);
+                }
+                consumer.accept(null, failure);
                 declareResult.completeExceptionally(failure);
             } else {
                 // The result of DECLARE itself, not of the query

--- a/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
@@ -63,6 +63,7 @@ import io.crate.metadata.RowGranularity;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.table.TableInfo;
 import io.crate.planner.DependencyCarrier;
+import io.crate.planner.Plan;
 import io.crate.planner.node.dql.QueryThenFetch;
 import io.crate.planner.optimizer.rule.EquiJoinToLookupJoin;
 import io.crate.statistics.ColumnStats;
@@ -904,6 +905,41 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
         // Before 5.10.13, circuit breaker memory was not released
         // if multiphased execution failed on sub-query and addWithoutBreaking() was never called.
         verify(circuitBreaker, times(1)).addWithoutBreaking(anyLong());
+    }
+
+    @Test
+    public void test_declare_forwards_query_failure_to_consumer_and_closes_cursor() throws Exception {
+        Plan declarePlan = sqlExecutor.plan(
+            "declare c1 no scroll cursor with hold for select * from generate_series(1, 10)");
+
+        // Setup some dummy failure for a query in DECLARE.
+        DependencyCarrier dependencies = sqlExecutor.dependencyMock;
+        PhasesTaskFactory phasesTaskFactory = mock(PhasesTaskFactory.class);
+        when(dependencies.phasesTaskFactory()).thenReturn(phasesTaskFactory);
+        JobLauncher jobLauncher = new JobLauncher(
+            UUID.randomUUID(),
+            clusterService,
+            Mockito.mock(JobSetup.class),
+            Mockito.mock(TasksService.class),
+            Mockito.mock(IndicesService.class),
+            null,
+            null,
+            List.of(),
+            false
+        ) {
+            @Override
+            public void execute(RowConsumer consumer, TransactionContext txnCtx) {
+                consumer.accept(null, new RuntimeException("dummy"));
+            }
+        };
+        when(phasesTaskFactory.create(any(), any(), anyBoolean())).thenReturn(jobLauncher);
+        var consumer = sqlExecutor.execute(declarePlan);
+        assertThat(consumer.completionFuture().isDone()).isTrue();
+
+        var plannerContext = sqlExecutor.getPlannerContext();
+        assertThat(plannerContext.cursors()).isEmpty();
+
+
     }
 
     /**


### PR DESCRIPTION
Relates to https://github.com/crate/support/issues/880

Ignore failures with `not a sys query, under load with full queue can be rejected` - expected to fail as we intentionally throw (realistic to happen in prod) exception.

See full logs: https://jenkins.crate.io/job/CrateDB/job/crate_on_pr/5053/consoleFull, such entries as:

1. `"not reset to 0"` - no entries, I think because `finalResult` is completed eventually is `cursor.close`, see also https://github.com/crate/crate/pull/19541#discussion_r3397518260

2. `"Open jobs"` (shows query from  `test_declare_without_hold_does_not_survive_transaction`)

```
java.lang.AssertionError: Open jobs:
JobContext{id=8c27bec6-83f9-492b-d928-2d964dafda10, username='crate', stmt='declare c1 no scroll cursor for select * from generate_series(1, 10)', started=1781195516011, classification=Classification{type=SELECT, labels=[]}}
JobContext{id=e5161666-b52b-00ac-fe7d-a81d505a43b4, username='crate', stmt='declare c1 no scroll cursor without hold for select * from generate_series(1, 10)', started=1781195694905, classification=Classification{type=SELECT, labels=[]}}
```
3. `Active tasks:`, relates to DeclarePlan$CursorRowConsumer
```
## node: node_sd4
{8c27bec6-83f9-492b-d928-2d964dafda10=Task{id=8c27bec6-83f9-492b-d928-2d964dafda10, tasks=[CollectTask{id=0, sharedContexts=SharedShardContexts{allocatedShards=[]}, consumer=InterceptingRowConsumer{initTracker=InitializationTracker{CountdownFuture{counter=0, lastFailure=null}}, jobId=8c27bec6-83f9-492b-d928-2d964dafda10, consumer=io.crate.planner.DeclarePlan$CursorRowConsumer@45a76c99}, searchContexts=[], batchIterator=io.crate.data.InMemoryBatchIterator@1d3a2fa4, finished=false}], closed=true, participating=[]}}
## node: node_sm0
{e5161666-b52b-00ac-fe7d-a81d505a43b4=Task{id=e5161666-b52b-00ac-fe7d-a81d505a43b4, tasks=[CollectTask{id=0, sharedContexts=SharedShardContexts{allocatedShards=[]}, consumer=InterceptingRowConsumer{initTracker=InitializationTracker{CountdownFuture{counter=0, lastFailure=null}}, jobId=e5161666-b52b-00ac-fe7d-a81d505a43b4, consumer=io.crate.planner.DeclarePlan$CursorRowConsumer@2f218a09}, searchContexts=[], batchIterator=io.crate.data.InMemoryBatchIterator@1c163e01, finished=false}], closed=true, participating=[]}}
```


