### PR TITLE
Test: add assertBusy to wait for replication state changes

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/LogicalReplicationITest.java
+++ b/server/src/test/java/io/crate/integrationtests/LogicalReplicationITest.java
@@ -335,14 +335,18 @@ public class LogicalReplicationITest extends LogicalReplicationITestCase {
         response = executeOnSubscriber("SELECT table_name FROM information_schema.tables WHERE table_name = 't1'");
         assertThat(response.rows().length).isZero();
 
-        // also, doc.t1 must not be listed inside the subscription state/metadata
-        var res = executeOnSubscriber(
-            "SELECT" +
-                " s.subname, r.relname, sr.srsubstate, sr.srsubstate_reason" +
-                " FROM pg_subscription s" +
-                " JOIN pg_subscription_rel sr ON s.oid = sr.srsubid" +
-                " JOIN pg_class r ON sr.srrelid = r.oid");
-        assertThat(res).hasRows("sub1| t2| r| NULL");
+        // wait for the subscription state to be updated from d -> r
+        // https://cratedb.com/docs/crate/reference/en/latest/admin/system-information.html#pg-subscription-rel
+        assertBusy(() -> {
+            // also, doc.t1 must not be listed inside the subscription state/metadata
+            var res = executeOnSubscriber(
+                "SELECT" +
+                    " s.subname, r.relname, sr.srsubstate, sr.srsubstate_reason" +
+                    " FROM pg_subscription s" +
+                    " JOIN pg_subscription_rel sr ON s.oid = sr.srsubid" +
+                    " JOIN pg_class r ON sr.srrelid = r.oid");
+            assertThat(res).hasRows("sub1| t2| r| NULL");
+        });
     }
 
     @Test


### PR DESCRIPTION
Failures reported [here](https://wacklig.pipifein.dev/github/crate/crate/case/io.crate.integrationtests.LogicalReplicationITest/test__to_publication_containing_index_with_non_active_shards_wont_be).
```
	at __randomizedtesting.SeedInfo.seed([D1341506ED5E98F7:C77D56B9AFD18F5]:0)
	at io.crate.testing.SQLResponseAssert.hasRows(SQLResponseAssert.java:65)
	at io.crate.integrationtests.LogicalReplicationITest.test__to_publication_containing_index_with_non_active_shards_wont_be(LogicalReplicationITest.java:345)
	Suppressed: org.opentest4j.AssertionFailedError: 
Expecting actual:
  ["sub1| t2| d| NULL"]
to contain exactly (and in same order):
  ["sub1| t2| r| NULL"]
but some elements were not found:
  ["sub1| t2| r| NULL"]
and others were not expected:
  ["sub1| t2| d| NULL"]
```
This failure is actually reproducible if the iterations is increased to 100. As suggested by @BaurzhanSakhariev adding `assertBusy` does resolve the issue.