### PR TITLE
Move storage support validation for NumericType from toMapping() to NumericStorage

### DIFF
--- a/server/src/main/java/io/crate/types/ArrayType.java
+++ b/server/src/main/java/io/crate/types/ArrayType.java
@@ -59,8 +59,8 @@ import io.crate.expression.reference.doc.lucene.SourceParser;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.Reference;
-import io.crate.metadata.RelationName;
 import io.crate.metadata.RelationLookup;
+import io.crate.metadata.RelationName;
 import io.crate.metadata.settings.SessionSettings;
 import io.crate.protocols.postgres.parser.PgArrayParser;
 import io.crate.protocols.postgres.parser.PgArrayParsingException;
@@ -86,20 +86,34 @@ public class ArrayType<T> extends DataType<List<T>> {
     private final DataType<T> innerType;
     private Streamer<List<T>> streamer;
 
-    private final StorageSupport<List<T>> storageSupport;
+    private boolean storageInitialized = false;
+    /// Initialized lazy to allow cases like `new ArrayType<>(NUMERIC)` for
+    /// type signatures where [#storageSupport()] is never called.
+    private StorageSupport<List<T>> storageSupport = null;
 
     /**
      * Construct a new Collection type
      * @param innerType The type of the elements inside the collection
      */
-    @SuppressWarnings({"unchecked", "rawtypes"})
     public ArrayType(DataType<T> innerType) {
         this.innerType = Objects.requireNonNull(innerType, "Inner type must not be null.");
+    }
+
+    public static DataType<?> makeArray(DataType<?> valueType, int numArrayDimensions) {
+        DataType<?> arrayType = valueType;
+        for (int i = 0; i < numArrayDimensions; i++) {
+            arrayType = new ArrayType<>(arrayType);
+        }
+        return arrayType;
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private StorageSupport<List<T>> newStorageSupport() {
         StorageSupport innerStorage = innerType.storageSupport();
         if (innerStorage == null) {
-            this.storageSupport = null;
+            return null;
         } else if (ArrayType.unnest(this) instanceof ObjectType objectType) {
-            this.storageSupport = new StorageSupport<List<T>>(innerStorage) {
+            return new StorageSupport<List<T>>(innerStorage) {
                 @Override
                 public ValueIndexer<List<? super T>> valueIndexer(RelationName table,
                                                             Reference ref,
@@ -136,7 +150,7 @@ public class ArrayType<T> extends DataType<List<T>> {
                 }
             };
         } else {
-            this.storageSupport = new StorageSupport<List<T>>(innerStorage) {
+            return new StorageSupport<List<T>>(innerStorage) {
                 @Override
                 public ValueIndexer<List<T>> valueIndexer(RelationName table,
                                                     Reference ref,
@@ -172,14 +186,6 @@ public class ArrayType<T> extends DataType<List<T>> {
         }
     }
 
-    public static DataType<?> makeArray(DataType<?> valueType, int numArrayDimensions) {
-        DataType<?> arrayType = valueType;
-        for (int i = 0; i < numArrayDimensions; i++) {
-            arrayType = new ArrayType<>(arrayType);
-        }
-        return arrayType;
-    }
-
     @Override
     public TypeSignature getTypeSignature() {
         return new TypeSignature(NAME, List.of(innerType.getTypeSignature()));
@@ -196,7 +202,9 @@ public class ArrayType<T> extends DataType<List<T>> {
     @Override
     public Streamer<List<T>> streamer() {
         if (streamer == null) {
-            streamer = new ArrayStreamer<>(innerType);
+            ArrayStreamer<T> arrayStreamer = new ArrayStreamer<>(innerType);
+            streamer = arrayStreamer;
+            return arrayStreamer;
         }
         return streamer;
     }
@@ -492,6 +500,12 @@ public class ArrayType<T> extends DataType<List<T>> {
     @Override
     @SuppressWarnings({"rawtypes", "unchecked"})
     public StorageSupport storageSupport() {
+        if (!storageInitialized) {
+            StorageSupport<List<T>> arrayStorage = newStorageSupport();
+            storageSupport = arrayStorage;
+            storageInitialized = true;
+            return arrayStorage;
+        }
         return storageSupport;
     }
 

--- a/server/src/main/java/io/crate/types/NumericStorage.java
+++ b/server/src/main/java/io/crate/types/NumericStorage.java
@@ -33,6 +33,7 @@ import org.apache.lucene.document.LongPoint;
 import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.document.SortedSetDocValuesField;
 import org.apache.lucene.document.StoredField;
+import org.apache.lucene.index.PointValues;
 import org.apache.lucene.search.PointRangeQuery;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.NumericUtils;
@@ -73,6 +74,18 @@ public final class NumericStorage extends StorageSupport<BigDecimal> {
     public NumericStorage(NumericType numericType) {
         super(true, true, NumericEqQuery.of(numericType));
         this.type = numericType;
+        Integer precision = numericType.numericPrecision();
+        if (precision == null || numericType.scale() == null) {
+            // Scale would be lost with the current encoding schemes used in NumericStorage
+            // The error is raised here to trigger this early on CREATE TABLE instead of
+            // INSERT INTO
+            throw new UnsupportedOperationException(
+                "NUMERIC storage is only supported if precision and scale are specified");
+        }
+        if (numericType.maxBytes() > PointValues.MAX_NUM_BYTES) {
+            throw new UnsupportedOperationException(
+                "Precision for NUMERIC(" + precision + ") is too large. Only up to 38 can be stored");
+        }
     }
 
     @Override

--- a/server/src/main/java/io/crate/types/NumericType.java
+++ b/server/src/main/java/io/crate/types/NumericType.java
@@ -32,7 +32,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.Supplier;
 
-import org.apache.lucene.index.PointValues;
 import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -353,17 +352,6 @@ public class NumericType extends DataType<BigDecimal> implements Streamer<BigDec
 
     @Override
     public void addMappingOptions(Map<String, Object> mapping) {
-        if (precision == null || scale == null) {
-            // Scale would be lost with the current encoding schemes used in NumericStorage
-            // The error is raised here to trigger this early on CREATE TABLE instead of
-            // INSERT INTO
-            throw new UnsupportedOperationException(
-                "NUMERIC storage is only supported if precision and scale are specified");
-        }
-        if (maxBytes() > PointValues.MAX_NUM_BYTES) {
-            throw new UnsupportedOperationException(
-                "Precision for NUMERIC(" + precision + ") is too large. Only up to 38 can be stored");
-        }
         mapping.put("precision", precision);
         mapping.put("scale", scale);
     }

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/MaximumAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/MaximumAggregationTest.java
@@ -21,6 +21,15 @@
 
 package io.crate.execution.engine.aggregation.impl;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import org.joda.time.Period;
+import org.junit.Test;
+
 import io.crate.exceptions.UnsupportedFunctionException;
 import io.crate.metadata.FunctionType;
 import io.crate.metadata.Scalar;
@@ -29,14 +38,6 @@ import io.crate.operation.aggregation.AggregationTestCase;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import io.crate.types.NumericType;
-import org.joda.time.Period;
-import org.junit.Test;
-
-import java.math.BigDecimal;
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class MaximumAggregationTest extends AggregationTestCase {
 
@@ -134,10 +135,10 @@ public class MaximumAggregationTest extends AggregationTestCase {
 
     @Test
     public void test_numeric_aggregation_not_supported_without_scale_or_precision() {
-        assertThat(getDocValueAggregator(MaximumAggregation.NAME, List.of(new NumericType(6, null))))
-            .isNull();
-        assertThat(getDocValueAggregator(MaximumAggregation.NAME, List.of(new NumericType(null, null))))
-            .isNull();
+        assertThatThrownBy(() -> getDocValueAggregator(MaximumAggregation.NAME, List.of(new NumericType(6, null))))
+            .isExactlyInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> getDocValueAggregator(MaximumAggregation.NAME, List.of(new NumericType(null, null))))
+            .isExactlyInstanceOf(UnsupportedOperationException.class);
     }
 
     @Test

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/MinimumAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/MinimumAggregationTest.java
@@ -135,11 +135,11 @@ public class MinimumAggregationTest extends AggregationTestCase {
 
     @Test
     public void test_numeric_aggregation_not_supported_without_scale_or_precision() {
-        assertThat(getDocValueAggregator(MinimumAggregation.NAME, List.of(new NumericType(6, null))))
-            .isNull();
+        assertThatThrownBy(() -> getDocValueAggregator(MinimumAggregation.NAME, List.of(new NumericType(6, null))))
+            .isExactlyInstanceOf(UnsupportedOperationException.class);
 
-        assertThat(getDocValueAggregator(MinimumAggregation.NAME, List.of(new NumericType(null, null))))
-            .isNull();
+        assertThatThrownBy(() -> getDocValueAggregator(MinimumAggregation.NAME, List.of(new NumericType(null, null))))
+            .isExactlyInstanceOf(UnsupportedOperationException.class);
     }
 
     @Test

--- a/server/src/testFixtures/java/io/crate/expression/scalar/ScalarTestCase.java
+++ b/server/src/testFixtures/java/io/crate/expression/scalar/ScalarTestCase.java
@@ -23,6 +23,7 @@ package io.crate.expression.scalar;
 
 import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.Asserts.isNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
 import java.util.LinkedList;
@@ -96,7 +97,7 @@ public abstract class ScalarTestCase extends CrateDummyClusterServiceUnitTest {
             "  int_array array(int)," +
             "  short_array array(short)," +
             "  double_array array(double precision)," +
-            "  numeric_array array(numeric)," +
+            "  numeric_array array(numeric(38, 8))," +
             "  regex_pattern text," +
             "  geoshape geo_shape," +
             "  geopoint geo_point," +


### PR DESCRIPTION
Relates to https://github.com/crate/crate/pull/19520
If we remove the mapping generation the validation for scale/precision
would be missing.
