### PR TITLE
Add `pg_get_constraintdef` scalar function

### DIFF
--- a/docs/appendices/release-notes/6.4.0.rst
+++ b/docs/appendices/release-notes/6.4.0.rst
@@ -128,6 +128,10 @@ Scalar and Aggregation Functions
   function for downsampling data using the Largest Triangle Three Buckets
   algorithm
 
+- Added the :ref:`pg_get_constraintdef() <scalar-pg_get_constraintdef>` scalar function to
+  improve PostgreSQL compatibility for ORM schema introspection (e.g. Prisma,
+  TypeORM).
+
 Performance and Resilience Improvements
 ---------------------------------------
 

--- a/docs/general/builtins/scalar-functions.rst
+++ b/docs/general/builtins/scalar-functions.rst
@@ -4862,6 +4862,53 @@ Example:
     SELECT 1 row in set (... sec)
 
 
+.. _scalar-pg_get_constraintdef:
+
+``pg_catalog.pg_get_constraintdef()``
+-------------------------------------
+
+The function ``pg_get_constraintdef`` returns the SQL definition of the
+``PRIMARY KEY`` or ``CHECK`` constraint identified by the given
+``pg_constraint`` OID. It returns ``NULL`` if no constraint matches the OID.
+
+The optional ``pretty`` argument exists for compatibility with PostgreSQL but
+is ignored; the definition is always returned in the same format. Like other
+strict functions, it returns ``NULL`` whenever any argument is ``NULL`` — so a
+``NULL`` ``pretty`` value also yields ``NULL``, even with a valid OID.
+
+Returns: ``text``
+
+Synopsis::
+
+   pg_get_constraintdef(constraint_oid integer [, pretty boolean])
+
+.. Hidden: create table pg_get_constraintdef_example
+
+    cr> create table tbl (
+    ...   id int primary key,
+    ...   qty int constraint qty_check check (qty > 0));
+    CREATE OK, 1 row affected (... sec)
+
+Example::
+
+    cr> select conname, pg_get_constraintdef(oid) as def
+    ...   from pg_constraint
+    ...   where conname in ('tbl_pkey', 'qty_check')
+    ...   order by conname;
+    +-----------+-------------------+
+    | conname   | def               |
+    +-----------+-------------------+
+    | qty_check | CHECK ("qty" > 0) |
+    | tbl_pkey  | PRIMARY KEY (id)  |
+    +-----------+-------------------+
+    SELECT 2 rows in set (... sec)
+
+.. Hidden: drop table pg_get_constraintdef_example
+
+    cr> drop table tbl;
+    DROP OK, 1 row affected (... sec)
+
+
 .. _scalar-version:
 
 ``pg_catalog.version()``

--- a/server/src/main/java/io/crate/expression/scalar/ScalarFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/ScalarFunctions.java
@@ -97,6 +97,7 @@ import io.crate.expression.scalar.systeminformation.CurrentSchemasFunction;
 import io.crate.expression.scalar.systeminformation.FormatTypeFunction;
 import io.crate.expression.scalar.systeminformation.ObjDescriptionFunction;
 import io.crate.expression.scalar.systeminformation.PgFunctionIsVisibleFunction;
+import io.crate.expression.scalar.systeminformation.PgGetConstraintDefFunction;
 import io.crate.expression.scalar.systeminformation.PgGetExpr;
 import io.crate.expression.scalar.systeminformation.PgGetFunctionResultFunction;
 import io.crate.expression.scalar.systeminformation.PgGetPartkeydefFunction;
@@ -236,6 +237,7 @@ public class ScalarFunctions implements FunctionsProvider {
         CurrentSchemaFunction.register(builder);
         CurrentSchemasFunction.register(builder);
         PgGetExpr.register(builder);
+        PgGetConstraintDefFunction.register(builder);
         PgGetPartkeydefFunction.register(builder);
         CurrentSettingFunction.register(builder, sessionSettingRegistry);
 

--- a/server/src/main/java/io/crate/expression/scalar/systeminformation/PgGetConstraintDefFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/systeminformation/PgGetConstraintDefFunction.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.expression.scalar.systeminformation;
+
+import java.util.stream.Collectors;
+
+import io.crate.data.Input;
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.FunctionName;
+import io.crate.metadata.FunctionType;
+import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.Scalar;
+import io.crate.metadata.TransactionContext;
+import io.crate.metadata.functions.BoundSignature;
+import io.crate.metadata.functions.Signature;
+import io.crate.metadata.pgcatalog.OidHash;
+import io.crate.metadata.pgcatalog.PgCatalogSchemaInfo;
+import io.crate.metadata.pgcatalog.PgCatalogTableDefinitions;
+import io.crate.metadata.table.ConstraintInfo;
+import io.crate.metadata.table.SchemaInfo;
+import io.crate.metadata.table.TableInfo;
+import io.crate.role.Role;
+import io.crate.role.Roles;
+import io.crate.role.Securable;
+import io.crate.sql.tree.CheckConstraint;
+import io.crate.types.DataTypes;
+
+/**
+ * Implements {@code pg_get_constraintdef(oid [, pretty])}, returning the SQL definition of the
+ * constraint with the given {@code pg_constraint} OID, e.g. {@code PRIMARY KEY (id)} or
+ * {@code CHECK (...)}. Used by ORM introspection (Prisma, TypeORM; see issue #18795).
+ *
+ * <p>There is no reverse OID index, so the OID is matched by recomputing
+ * {@link OidHash#constraintOid} per constraint, using the constraint type's <em>text</em> form</p>
+ *
+ * <p>Results are limited to constraints whose table the session user can see, mirroring the row
+ * filter applied to {@code pg_constraint}. PostgreSQL itself performs no privilege check here
+ * (its system catalogs are world-readable); restricting to visible tables is a deliberate
+ * CrateDB choice that keeps this function consistent with our filtered {@code pg_constraint}.</p>
+ */
+public class PgGetConstraintDefFunction extends Scalar<String, Object> {
+
+    public static final String NAME = "pg_get_constraintdef";
+    private static final FunctionName FQN = new FunctionName(PgCatalogSchemaInfo.NAME, NAME);
+
+    public static void register(Functions.Builder module) {
+        module.add(
+            Signature.builder(FQN, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.INTEGER.getTypeSignature())
+                .returnType(DataTypes.STRING.getTypeSignature())
+                .features(Feature.DETERMINISTIC, Feature.STRICTNULL)
+                .build(),
+            PgGetConstraintDefFunction::new
+        );
+        module.add(
+            Signature.builder(FQN, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.INTEGER.getTypeSignature(),
+                    DataTypes.BOOLEAN.getTypeSignature())
+                .returnType(DataTypes.STRING.getTypeSignature())
+                .features(Feature.DETERMINISTIC, Feature.STRICTNULL)
+                .build(),
+            PgGetConstraintDefFunction::new
+        );
+    }
+
+    public PgGetConstraintDefFunction(Signature signature, BoundSignature boundSignature) {
+        super(signature, boundSignature);
+    }
+
+    @Override
+    @SafeVarargs
+    public final String evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Object>... args) {
+        for (Input<Object> arg : args) {
+            if (arg.value() == null) {
+                return null;
+            }
+        }
+        int oid = (Integer) args[0].value();
+        Roles roles = nodeCtx.roles();
+        Role user = roles.findUser(txnCtx.sessionSettings().userName());
+        if (user == null) {
+            return null;
+        }
+        for (SchemaInfo schema : nodeCtx.schemas()) {
+            boolean visibleToAll = PgCatalogTableDefinitions.isPgCatalogOrInformationSchema(schema.name());
+            for (TableInfo table : schema.getTables()) {
+                String pkName = table.pkConstraintNameOrDefault();
+                var checkConstraints = table.checkConstraints();
+                if (pkName == null && checkConstraints.isEmpty()) {
+                    continue;
+                }
+                String fqn = table.ident().fqn();
+                if (!visibleToAll && !roles.hasAnyPrivilege(user, Securable.TABLE, fqn)) {
+                    continue;
+                }
+                if (pkName != null
+                        && OidHash.constraintOid(fqn, pkName, ConstraintInfo.Type.PRIMARY_KEY.toString()) == oid) {
+                    return renderPrimaryKey(table);
+                }
+                for (CheckConstraint<?> check : checkConstraints) {
+                    if (OidHash.constraintOid(fqn, check.name(), ConstraintInfo.Type.CHECK.toString()) == oid) {
+                        return "CHECK (" + check.expressionStr() + ")";
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    private static String renderPrimaryKey(TableInfo table) {
+        String columns = table.primaryKey().stream()
+            .map(ColumnIdent::quotedOutputName)
+            .collect(Collectors.joining(", "));
+        return "PRIMARY KEY (" + columns + ")";
+    }
+}

--- a/server/src/test/java/io/crate/expression/scalar/systeminformation/PgGetConstraintDefFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/systeminformation/PgGetConstraintDefFunctionTest.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.expression.scalar.systeminformation;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import io.crate.expression.scalar.ScalarTestCase;
+import io.crate.metadata.RelationName;
+import io.crate.metadata.Schemas;
+import io.crate.metadata.pgcatalog.OidHash;
+import io.crate.metadata.table.ConstraintInfo;
+import io.crate.metadata.table.TableInfo;
+import io.crate.role.Role;
+import io.crate.role.metadata.RolesHelper;
+import io.crate.testing.SQLExecutor;
+import io.crate.testing.SqlExpressions;
+
+public class PgGetConstraintDefFunctionTest extends ScalarTestCase {
+
+    private static final RelationName TABLE = new RelationName("my_schema", "t");
+
+    private Schemas schemas;
+    private int pkOid;
+    private int checkOid;
+
+    @Before
+    public void setUpSchemas() throws IOException {
+        // The default ScalarTestCase wiring has no Schemas; build a real one so the
+        // function can resolve constraint oids (same pattern as PgTableIsVisibleFunctionTest).
+        schemas = SQLExecutor.of(clusterService)
+            .addTable("create table my_schema.t (" +
+                      "  id int," +
+                      "  x int," +
+                      "  constraint x_positive check (x > 0)," +
+                      "  primary key (id)" +
+                      ")")
+            .schemas();
+        sqlExpressions = new SqlExpressions(tableSources, null, Role.CRATE_USER, List.of(), schemas);
+        TableInfo table = schemas.getTableInfo(TABLE);
+        pkOid = OidHash.constraintOid(
+            TABLE.fqn(), table.pkConstraintNameOrDefault(), ConstraintInfo.Type.PRIMARY_KEY.toString());
+        checkOid = OidHash.constraintOid(
+            TABLE.fqn(), "x_positive", ConstraintInfo.Type.CHECK.toString());
+    }
+
+    @Test
+    public void test_returns_null_for_null_oid() {
+        assertEvaluateNull("pg_get_constraintdef(null)");
+    }
+
+    @Test
+    public void test_returns_null_for_unknown_oid() {
+        assertEvaluateNull("pg_get_constraintdef(-1)");
+    }
+
+    @Test
+    public void test_renders_primary_key_definition() {
+        assertEvaluate("pg_get_constraintdef(" + pkOid + ")", "PRIMARY KEY (id)");
+    }
+
+    @Test
+    public void test_renders_check_definition() {
+        assertEvaluate("pg_get_constraintdef(" + checkOid + ")", "CHECK (\"x\" > 0)");
+    }
+
+    @Test
+    public void test_pretty_flag_is_accepted_and_ignored() {
+        assertEvaluate("pg_get_constraintdef(" + pkOid + ", true)", "PRIMARY KEY (id)");
+        assertEvaluate("pg_get_constraintdef(" + pkOid + ", false)", "PRIMARY KEY (id)");
+    }
+
+    @Test
+    public void test_null_pretty_flag_returns_null() {
+        // strict function, like in PostgreSQL
+        assertEvaluateNull("pg_get_constraintdef(" + pkOid + ", null)");
+    }
+
+    @Test
+    public void test_works_with_fully_qualified_name() {
+        assertEvaluate("pg_catalog.pg_get_constraintdef(" + pkOid + ")", "PRIMARY KEY (id)");
+    }
+
+    @Test
+    public void test_returns_null_for_user_without_privileges_on_table() {
+        // mirrors the row filter on pg_constraint: constraints of tables the user
+        // cannot see must not be resolvable
+        sqlExpressions = new SqlExpressions(
+            tableSources, null, RolesHelper.userOf("dummy_user"), List.of(), schemas);
+        assertEvaluateNull("pg_get_constraintdef(" + pkOid + ")");
+        assertEvaluateNull("pg_get_constraintdef(" + checkOid + ")");
+    }
+}

--- a/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
@@ -471,6 +471,30 @@ public class PgCatalogITest extends IntegTestCase {
         );
     }
 
+    @Test
+    public void test_pg_get_constraintdef_renders_primary_key_and_check() throws Exception {
+        execute("CREATE TABLE doc.tbl (" +
+            "int_col int," +
+            "long_col bigint," +
+            "checked int CONSTRAINT positive CHECK(checked > 0)," +
+            "PRIMARY KEY (int_col, long_col))"
+        );
+        // Prisma/TypeORM-style introspection query joining pg_constraint and resolving the def.
+        response = execute("""
+                SELECT
+                    cn.conname,
+                    pg_catalog.pg_get_constraintdef(cn.oid)
+                FROM pg_catalog.pg_constraint cn
+                JOIN pg_catalog.pg_class c ON cn.conrelid = c.oid
+                WHERE c.relname = 'tbl'
+                ORDER BY cn.conname;
+            """);
+        assertThat(response).hasRows(
+            "positive| CHECK (\"checked\" > 0)",
+            "tbl_pkey| PRIMARY KEY (int_col, long_col)"
+        );
+    }
+
     @UseRandomizedSchema(random = false)
     @Test
     public void test_pg_class_oid_equals_cast_of_string_to_regclass() {


### PR DESCRIPTION
Support Prisma and TypeORM introspection by implementing the `pg_get_constraintdef` function. Includes tests for constraint rendering and privilege handling.

Closes #18795 
