### PR TITLE
Fix how parted tables are identified in SharedShardContexts

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/fetch/FetchTask.java
+++ b/server/src/main/java/io/crate/execution/engine/fetch/FetchTask.java
@@ -226,8 +226,6 @@ public class FetchTask implements Task {
         }
     }
 
-
-
     @Override
     public CompletableFuture<Void> start() {
         synchronized (jobId) {
@@ -236,12 +234,24 @@ public class FetchTask implements Task {
                 return null;
             }
 
+            var index2TableIdent = new HashMap<String, RelationName>();
+            for (var entry : phase.tableIndices().entrySet()) {
+                for (String indexUUID : entry.getValue()) {
+                    index2TableIdent.put(indexUUID, entry.getKey());
+                }
+            }
+
             ArrayList<CompletableFuture<Void>> refreshActions = new ArrayList<>(routings.size());
             for (Routing routing : routings) {
                 Map<String, Map<String, IntIndexedContainer>> locations = routing.locations();
                 Map<String, IntIndexedContainer> indexShards = locations.get(localNodeId);
                 try {
-                    refreshActions.add(sharedShardContexts.maybeRefreshReaders(metadata, indexShards, phase.bases()));
+                    refreshActions.add(sharedShardContexts.maybeRefreshReaders(
+                        metadata,
+                        indexShards,
+                        phase.bases(),
+                        index2TableIdent
+                    ));
                 } catch (Throwable t) {
                     result.completeExceptionally(t);
                     throw t;
@@ -251,7 +261,7 @@ public class FetchTask implements Task {
             return allRefreshed.thenApply(_ -> {
                 synchronized (jobId) {
                     if (killed == null) {
-                        setupSearchers();
+                        setupSearchers(index2TableIdent);
                     }
                 }
                 return null;
@@ -259,13 +269,7 @@ public class FetchTask implements Task {
         }
     }
 
-    private void setupSearchers() {
-        HashMap<String, RelationName> index2TableIdent = new HashMap<>();
-        for (Map.Entry<RelationName, Collection<String>> entry : phase.tableIndices().entrySet()) {
-            for (String indexUUID : entry.getValue()) {
-                index2TableIdent.put(indexUUID, entry.getKey());
-            }
-        }
+    private void setupSearchers(Map<String, RelationName> index2TableIdent) {
         Set<RelationName> tablesWithFetchRefs = new HashSet<>();
         for (Reference reference : phase.fetchRefs()) {
             tablesWithFetchRefs.add(reference.relation());

--- a/server/src/main/java/io/crate/execution/jobs/SharedShardContexts.java
+++ b/server/src/main/java/io/crate/execution/jobs/SharedShardContexts.java
@@ -29,6 +29,7 @@ import java.util.function.BiFunction;
 
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.metadata.RelationMetadata;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.engine.Engine;
@@ -36,12 +37,13 @@ import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.shard.ShardNotFoundException;
 import org.elasticsearch.indices.IndicesService;
-import io.crate.common.annotations.VisibleForTesting;
 
 import com.carrotsearch.hppc.IntIndexedContainer;
 
+import io.crate.common.annotations.VisibleForTesting;
+import io.crate.exceptions.RelationUnknown;
 import io.crate.execution.engine.fetch.FetchTask;
-import io.crate.metadata.IndexName;
+import io.crate.metadata.RelationName;
 
 public class SharedShardContexts {
 
@@ -60,27 +62,39 @@ public class SharedShardContexts {
 
     public CompletableFuture<Void> maybeRefreshReaders(Metadata metadata,
                                                        Map<String, IntIndexedContainer> shardsByIndex,
-                                                       Map<String, Integer> bases) {
+                                                       Map<String, Integer> bases,
+                                                       Map<String, RelationName> index2Table) {
         ArrayList<CompletableFuture<Boolean>> refreshActions = new ArrayList<>();
         for (var entry : shardsByIndex.entrySet()) {
-            String indexName = entry.getKey();
-            Integer base = bases.get(indexName);
+            String indexUUID = entry.getKey();
+            Integer base = bases.get(indexUUID);
             if (base == null) {
                 continue;
             }
-            IndexMetadata indexMetadata = metadata.index(indexName);
-            boolean isPartitioned = IndexName.isPartitioned(indexName);
+
+            IndexMetadata indexMetadata = metadata.index(indexUUID);
             if (indexMetadata == null) {
-                if (isPartitioned) {
+                RelationName tableName = index2Table.get(indexUUID);
+                // index2Table is built in FetchTask, using FetchPhase.tableIndices()
+                // where it basically inverts the map of tables to index UUIDs.
+                // A missing table for the given index UUID means that it was removed after it was built,
+                //  which shouldn't happen.
+                assert tableName != null : "Table mapping for index UUID unexpectedly removed (was present in FetchTask)";
+                RelationMetadata.Table table = metadata.getRelation(tableName);
+                if (table == null) {
+                    refreshActions.add(CompletableFuture.failedFuture(new RelationUnknown(tableName)));
                     continue;
                 }
-                refreshActions.add(CompletableFuture.failedFuture(new IndexNotFoundException(indexName)));
+                if (table.partitionedBy().isEmpty()) {
+                    refreshActions.add(CompletableFuture.failedFuture(new IndexNotFoundException(indexUUID)));
+                }
                 continue;
             }
+
             IndexService indexService = indicesService.indexService(indexMetadata.getIndex());
             if (indexService == null) {
-                if (isPartitioned == false) {
-                    refreshActions.add(CompletableFuture.failedFuture(new IndexNotFoundException(indexName)));
+                if (indexMetadata.partitionValues().isEmpty()) {
+                    refreshActions.add(CompletableFuture.failedFuture(new IndexNotFoundException(indexUUID)));
                 }
                 continue;
             }
@@ -90,7 +104,7 @@ public class SharedShardContexts {
                 try {
                     shard = indexService.getShard(shardId);
                 } catch (ShardNotFoundException e) {
-                    if (isPartitioned == false) {
+                    if (indexMetadata.partitionValues().isEmpty()) {
                         refreshActions.add(CompletableFuture.failedFuture(e));
                     }
                     continue;

--- a/server/src/test/java/io/crate/execution/engine/fetch/FetchTaskTest.java
+++ b/server/src/test/java/io/crate/execution/engine/fetch/FetchTaskTest.java
@@ -109,7 +109,8 @@ public class FetchTaskTest extends CrateDummyClusterServiceUnitTest {
             @Override
             public CompletableFuture<Void> maybeRefreshReaders(Metadata metadata,
                                                                Map<String, IntIndexedContainer> shardsByIndex,
-                                                               Map<String, Integer> bases) {
+                                                               Map<String, Integer> bases,
+                                                               Map<String, RelationName> index2Table) {
                 calledRefreshReaders.set(true);
                 return CompletableFuture.completedFuture(null);
             }

--- a/server/src/test/java/io/crate/execution/jobs/SharedShardContextsTest.java
+++ b/server/src/test/java/io/crate/execution/jobs/SharedShardContextsTest.java
@@ -21,12 +21,12 @@
 
 package io.crate.execution.jobs;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -47,6 +47,8 @@ import org.junit.Test;
 
 import com.carrotsearch.hppc.IntArrayList;
 import com.carrotsearch.hppc.IntIndexedContainer;
+
+import io.crate.metadata.RelationName;
 
 public class SharedShardContextsTest {
 
@@ -138,20 +140,24 @@ public class SharedShardContextsTest {
             .thenThrow(new ShardNotFoundException(new ShardId("dummy", "uuid", 1)));
         SharedShardContexts contexts = new SharedShardContexts(indicesService, null);
 
-        String partitionedIndex = ".partitioned.t.abc123";
         IndexMetadata indexMetadata = mock(IndexMetadata.class);
-        when(indexMetadata.getIndex()).thenReturn(new Index(partitionedIndex, "uuid"));
+        when(indexMetadata.getIndex()).thenReturn(new Index(".partitioned.t.abc123", "uuid"));
+        when(indexMetadata.partitionValues()).thenReturn(List.of("partition"));
 
         Metadata metadata = mock(Metadata.class);
-        when(metadata.index(partitionedIndex)).thenReturn(indexMetadata);
+        when(metadata.index("uuid")).thenReturn(indexMetadata);
 
         IntIndexedContainer shards = new IntArrayList();
         shards.add(1);
 
-        Map<String, IntIndexedContainer> shardsByIndex = Map.of(partitionedIndex, shards);
-        Map<String, Integer> bases = Map.of(partitionedIndex, 1);
+        Map<String, IntIndexedContainer> shardsByIndex = Map.of("uuid", shards);
+        Map<String, Integer> bases = Map.of("uuid", 1);
 
-        CompletableFuture<Void> future = contexts.maybeRefreshReaders(metadata, shardsByIndex, bases);
+        CompletableFuture<Void> future = contexts.maybeRefreshReaders(metadata,
+            shardsByIndex,
+            bases,
+            Map.of("uuid", new RelationName("doc", "dummy"))
+        );
         assertThat(future).succeedsWithin(5, TimeUnit.SECONDS);
     }
 }

--- a/server/src/test/java/io/crate/execution/jobs/SharedShardContextsTest.java
+++ b/server/src/test/java/io/crate/execution/jobs/SharedShardContextsTest.java
@@ -43,6 +43,7 @@ import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.shard.ShardNotFoundException;
 import org.elasticsearch.indices.IndicesService;
+import org.junit.Before;
 import org.junit.Test;
 
 import com.carrotsearch.hppc.IntArrayList;
@@ -52,17 +53,24 @@ import io.crate.metadata.RelationName;
 
 public class SharedShardContextsTest {
 
+    private IndicesService indicesService;
+    private IndexService indexService;
+    private SharedShardContexts sharedShardContexts;
+
+    @Before
+    public void setUpContexts() {
+        indicesService = mock(IndicesService.class);
+        indexService = mock(IndexService.class);
+        sharedShardContexts = new SharedShardContexts(indicesService, null);
+    }
+
     @Test
     public void test_getOrCreateContext_is_synchronized() {
         ShardId shardId1 = new ShardId("dummy1", "dummyIndex1", 1);
         ShardId shardId2 = new ShardId("dummy2", "dummyIndex2", 2);
         ShardId shardId3 = new ShardId("dummy3", "dummyIndex3", 3);
 
-        IndicesService indicesService = mock(IndicesService.class);
-        IndexService indexService = mock(IndexService.class);
         when(indicesService.indexServiceSafe(any())).thenReturn(indexService);
-
-        SharedShardContexts sharedShardContexts = new SharedShardContexts(indicesService, null);
 
         Stream.of(
             shardId1, shardId1, shardId1,
@@ -78,11 +86,7 @@ public class SharedShardContextsTest {
 
     @Test
     public void test_allocatedShards_accesses_are_synchronized() throws ExecutionException, InterruptedException {
-        IndicesService indicesService = mock(IndicesService.class);
-        IndexService indexService = mock(IndexService.class);
         when(indicesService.indexServiceSafe(any())).thenReturn(indexService);
-
-        SharedShardContexts sharedShardContexts = new SharedShardContexts(indicesService, null);
 
         int[] idx = new int[] {0};
         var shards1 = Stream.generate(() -> {
@@ -112,11 +116,8 @@ public class SharedShardContextsTest {
 
     @Test
     public void test_create_context_returns_existing_instance_for_given_shard_and_reader_id() {
-        IndicesService indicesService = mock(IndicesService.class);
-        IndexService indexService = mock(IndexService.class);
         when(indicesService.indexServiceSafe(any())).thenReturn(indexService);
 
-        SharedShardContexts sharedShardContexts = new SharedShardContexts(indicesService, null);
         ShardId shardId = new ShardId("dummy", "dummyUUID", 1);
         int readerID = 1;
 
@@ -133,12 +134,9 @@ public class SharedShardContextsTest {
 
     @Test
     public void test_maybeRefreshReaders_skips_missing_shard_for_partitioned_table() throws Exception {
-        IndicesService indicesService = mock(IndicesService.class);
-        IndexService indexService = mock(IndexService.class);
         when(indicesService.indexService(any())).thenReturn(indexService);
         when(indexService.getShard(anyInt()))
             .thenThrow(new ShardNotFoundException(new ShardId("dummy", "uuid", 1)));
-        SharedShardContexts contexts = new SharedShardContexts(indicesService, null);
 
         IndexMetadata indexMetadata = mock(IndexMetadata.class);
         when(indexMetadata.getIndex()).thenReturn(new Index(".partitioned.t.abc123", "uuid"));
@@ -153,7 +151,7 @@ public class SharedShardContextsTest {
         Map<String, IntIndexedContainer> shardsByIndex = Map.of("uuid", shards);
         Map<String, Integer> bases = Map.of("uuid", 1);
 
-        CompletableFuture<Void> future = contexts.maybeRefreshReaders(metadata,
+        CompletableFuture<Void> future = sharedShardContexts.maybeRefreshReaders(metadata,
             shardsByIndex,
             bases,
             Map.of("uuid", new RelationName("doc", "dummy"))


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Currently, a partition is identified by using:

```java
boolean isPartitioned = IndexName.isPartitioned(indexName);
```

The `indexName` is actually the UUID. This can be verified by tracking how `shardsByIndex` is built, and also by the line above: `IndexMetadata indexMetadata = metadata.index(indexName);` because `metadata.index()` accepts UUIDs.

However, `IndexName.isPartitioned()` relies on index name patterns, which means that `isPartitioned` is always `false`.

## Checklist

 - [ ] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes
