### PR TITLE
Fix analyzer lookup of swapped tables

### DIFF
--- a/docs/appendices/release-notes/6.3.4.rst
+++ b/docs/appendices/release-notes/6.3.4.rst
@@ -46,6 +46,10 @@ series.
 Fixes
 =====
 
+- Fixed an issue where queries on fulltext columns with a non-default analyzer
+  were incorrectly using the default analyzer after using running a ``ALTER
+  CLUSTER SWAP TABLE`` statement.
+
 - Fixed binary encoding and decoding of :ref:`DATE <type-date>` values when
   using PostgreSQL clients.
 

--- a/plugins/es-analysis-common/src/test/java/io/crate/analysis/common/FulltextITest.java
+++ b/plugins/es-analysis-common/src/test/java/io/crate/analysis/common/FulltextITest.java
@@ -144,8 +144,13 @@ public class FulltextITest extends IntegTestCase {
     public void testMatchTypes() throws Exception {
         this.setup.setUpLocationsWithFTIndex();
         execute("refresh table locations");
+        execute("create table areas (name text)");
 
-        execute("select name, _score from locations where match((kind 0.8, name_description_ft 0.6), 'planet earth') " +
+        // Swap breaks indexName decoding (indexName -> RelationName no longer works because names aren't changed with swap)
+        // This is here to ensure analyzer lookup doesn't rely on it.
+        execute("alter cluster swap table locations to areas");
+
+        execute("select name, _score from areas where match((kind 0.8, name_description_ft 0.6), 'planet earth') " +
                 "using best_fields order by _score desc");
         assertThat(response).hasRows(
             "Alpha Centauri| 0.6880375",
@@ -154,7 +159,7 @@ public class FulltextITest extends IntegTestCase {
             "| 0.2462059",
             "Allosimanius Syneca| 0.16214824");
 
-        execute("select name, _score from locations where match((kind 0.6, name_description_ft 0.8), 'planet earth') using most_fields order by _score desc");
+        execute("select name, _score from areas where match((kind 0.6, name_description_ft 0.8), 'planet earth') using most_fields order by _score desc");
         assertThat(response).hasRows(
             "Alpha Centauri| 0.91738325",
             "Bartledan| 0.5132938",
@@ -162,7 +167,7 @@ public class FulltextITest extends IntegTestCase {
             "| 0.3282745",
             "Allosimanius Syneca| 0.21619764");
 
-        execute("select name, _score from locations where match((kind 0.4, name_description_ft 1.0), 'planet earth') using cross_fields order by _score desc");
+        execute("select name, _score from areas where match((kind 0.4, name_description_ft 1.0), 'planet earth') using cross_fields order by _score desc");
         assertThat(response).hasRows(
             "Alpha Centauri| 1.1467291",
             "Bartledan| 0.6416173",
@@ -170,10 +175,10 @@ public class FulltextITest extends IntegTestCase {
             "| 0.41034314",
             "Allosimanius Syneca| 0.27024707");
 
-        execute("select name, _score from locations where match((kind 1.0, name_description_ft 0.4), 'Alpha Centauri') using phrase");
+        execute("select name, _score from areas where match((kind 1.0, name_description_ft 0.4), 'Alpha Centauri') using phrase");
         assertThat(response).hasRows("Alpha Centauri| 0.91738325");
 
-        execute("select name, _score from locations where match(name_description_ft, 'Alpha Centauri') using phrase_prefix");
+        execute("select name, _score from areas where match(name_description_ft, 'Alpha Centauri') using phrase_prefix");
         assertThat(response).hasRows("Alpha Centauri| 2.2934582");
     }
 

--- a/server/src/main/java/org/elasticsearch/index/IndexService.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexService.java
@@ -82,8 +82,8 @@ import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.plugins.IndexStorePlugin;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.jspecify.annotations.Nullable;
-import io.crate.common.annotations.VisibleForTesting;
 
+import io.crate.common.annotations.VisibleForTesting;
 import io.crate.common.io.IOUtils;
 import io.crate.common.unit.TimeValue;
 import io.crate.exceptions.UnsupportedFeatureException;
@@ -164,7 +164,8 @@ public class IndexService extends AbstractIndexComponent implements Iterable<Ind
 
                 @Override
                 protected Analyzer getWrappedAnalyzer(String storageIdent) {
-                    if (getTableInfo.get() instanceof DocTableInfo docTable) {
+                    TableInfo tableInfo = getTableInfo.get();
+                    if (tableInfo instanceof DocTableInfo docTable) {
                         Reference reference = docTable.getReference(storageIdent);
                         if (reference instanceof IndexReference indexRef) {
                             NamedAnalyzer namedAnalyzer = indexAnalyzers.get(indexRef.analyzer());

--- a/server/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -117,7 +117,6 @@ import io.crate.common.collections.Sets;
 import io.crate.common.io.IOUtils;
 import io.crate.common.unit.TimeValue;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.RelationName;
 import io.crate.metadata.Schemas;
 
 public class IndicesService extends AbstractLifecycleComponent
@@ -451,8 +450,9 @@ public class IndicesService extends AbstractLifecycleComponent
         }
 
         final IndexSettings idxSettings = new IndexSettings(safeMetadata, this.settings, indexScopedSettings);
+        Index index = safeMetadata.getIndex();
         LOGGER.debug("creating Index [{}], shards [{}]/[{}] - reason [{}]",
-            safeMetadata.getIndex(),
+            index,
             idxSettings.getNumberOfShards(),
             idxSettings.getNumberOfReplicas(),
             indexCreationContext);
@@ -465,7 +465,6 @@ public class IndicesService extends AbstractLifecycleComponent
         for (IndexEventListener listener : builtInListeners) {
             indexModule.addIndexEventListener(listener);
         }
-        String indexName = safeMetadata.getIndex().getName();
         Schemas schemas = nodeContext.schemas();
         return indexModule.newIndexService(
             nodeContext,
@@ -476,7 +475,7 @@ public class IndicesService extends AbstractLifecycleComponent
             bigArrays,
             threadPool,
             indicesQueryCache,
-            () -> schemas.getTableInfo(RelationName.fromIndexName(indexName))
+            () -> schemas.getTableInfo(index)
         );
     }
 


### PR DESCRIPTION
The analyzer lookup relied on index name decoding which doesn't work
after a table is swapped.
