### PR TITLE
Cache currentTable in IndexService and reuse getTableInfo supplier

### DIFF
--- a/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
+++ b/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
@@ -152,8 +152,6 @@ public final class NodeEnvironment implements Closeable {
     }
 
     private final Logger logger = LogManager.getLogger(NodeEnvironment.class);
-    private final Environment environment;
-    private final Settings settings;
     private final NodePath[] nodePaths;
     private final Path sharedDataPath;
     private final Lock[] locks;
@@ -241,8 +239,6 @@ public final class NodeEnvironment implements Closeable {
      * @param settings settings from elasticsearch.yml
      */
     public NodeEnvironment(Settings settings, Environment environment) throws IOException {
-        this.settings = settings;
-        this.environment = environment;
         if (!DiscoveryNode.nodeRequiresLocalStorage(settings)) {
             nodePaths = null;
             sharedDataPath = null;
@@ -303,10 +299,6 @@ public final class NodeEnvironment implements Closeable {
                 close();
             }
         }
-    }
-
-    public Environment environment() {
-        return environment;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/IndexService.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexService.java
@@ -52,8 +52,6 @@ import org.elasticsearch.Assertions;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
-import org.elasticsearch.cluster.metadata.Metadata;
-import org.elasticsearch.cluster.metadata.RelationMetadata;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
@@ -89,13 +87,11 @@ import io.crate.common.io.IOUtils;
 import io.crate.common.unit.TimeValue;
 import io.crate.exceptions.UnsupportedFeatureException;
 import io.crate.execution.dml.TranslogIndexer;
-import io.crate.metadata.IndexName;
 import io.crate.metadata.IndexReference;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
-import io.crate.metadata.blob.BlobTableInfoFactory;
+import io.crate.metadata.blob.BlobTableInfo;
 import io.crate.metadata.doc.DocTableInfo;
-import io.crate.metadata.doc.DocTableInfoFactory;
 import io.crate.metadata.table.TableInfo;
 
 public class IndexService extends AbstractIndexComponent implements Iterable<IndexShard> {
@@ -105,9 +101,6 @@ public class IndexService extends AbstractIndexComponent implements Iterable<Ind
     private final ShardStoreDeleter shardStoreDeleter;
     private final QueryCache queryCache;
     private final IndexStorePlugin.DirectoryFactory directoryFactory;
-    private Supplier<TranslogIndexer> getTranslogIndexer = () -> {
-        throw new IllegalStateException("Translog called before schema validation");
-    };
     private final Collection<Function<IndexSettings, Optional<EngineFactory>>> engineFactoryProviders;
     private volatile Map<Integer, IndexShard> shards = emptyMap();
     private final AtomicBoolean closed = new AtomicBoolean(false);
@@ -130,6 +123,10 @@ public class IndexService extends AbstractIndexComponent implements Iterable<Ind
     private IndexAnalyzers indexAnalyzers;
     private final Analyzer indexAnalyzer;
     private final NodeContext nodeContext;
+    private final Supplier<TableInfo> getTableInfo;
+
+    private volatile TableInfo currentTable;
+    private volatile Supplier<TranslogIndexer> getTranslogIndexer = null;
 
     public IndexService(
             NodeContext nodeContext,
@@ -152,6 +149,7 @@ public class IndexService extends AbstractIndexComponent implements Iterable<Ind
         this.indexSettings = indexSettings;
         this.circuitBreakerService = circuitBreakerService;
         this.analysisRegistry = analysisRegistry;
+        this.getTableInfo = getTableInfo;
         if (indexSettings.getIndexMetadata().getState() == IndexMetadata.State.CLOSE &&
                 indexCreationContext == IndexCreationContext.CREATE_INDEX) { // metadata verification needs a mapper service
             this.indexAnalyzers = null;
@@ -164,7 +162,7 @@ public class IndexService extends AbstractIndexComponent implements Iterable<Ind
 
                 @Override
                 protected Analyzer getWrappedAnalyzer(String storageIdent) {
-                    TableInfo tableInfo = getTableInfo.get();
+                    TableInfo tableInfo = getTable();
                     if (tableInfo instanceof DocTableInfo docTable) {
                         Reference reference = docTable.getReference(storageIdent);
                         if (reference instanceof IndexReference indexRef) {
@@ -192,6 +190,15 @@ public class IndexService extends AbstractIndexComponent implements Iterable<Ind
         this.globalCheckpointTask = new AsyncGlobalCheckpointTask(this);
         this.retentionLeaseSyncTask = new AsyncRetentionLeaseSyncTask(this);
         updateFsyncTaskIfNecessary();
+    }
+
+    private TableInfo getTable() {
+        TableInfo currentTable = this.currentTable;
+        if (currentTable == null) {
+            currentTable = getTableInfo.get();
+            this.currentTable = currentTable;
+        }
+        return currentTable;
     }
 
     public enum IndexCreationContext {
@@ -495,31 +502,27 @@ public class IndexService extends AbstractIndexComponent implements Iterable<Ind
         return indexSettings;
     }
 
-    public void updateMapping(Metadata metadata, final IndexMetadata newIndexMetadata) {
-        Index index = newIndexMetadata.getIndex();
-        String indexName = index.getName();
-        if (IndexName.isDangling(indexName)) {
-            return;
-        }
-        RelationMetadata relation = metadata.getRelation(index.getUUID());
-        if (relation == null) {
-            throw new IndexNotFoundException(index);
-        }
-        Version indexVersionCreated = indexSettings.getIndexVersionCreated();
-        TranslogIndexer indexer = switch (relation) {
-            case RelationMetadata.Table table ->
-                new TranslogIndexer(new DocTableInfoFactory(nodeContext).create(table.name(), metadata), indexVersionCreated);
-            case RelationMetadata.BlobTable blobTable ->
-                new TranslogIndexer(new BlobTableInfoFactory(nodeEnv.environment()).create(blobTable.name(), metadata), indexVersionCreated);
-            default -> throw new UnsupportedFeatureException(
-                "Unsupported table type: " + relation.getClass().getSimpleName());
-        };
-        this.getTranslogIndexer = () -> indexer;
+    public void updateMapping() {
+        this.currentTable = null;
+        this.getTranslogIndexer = null;
     }
 
     @VisibleForTesting
     TranslogIndexer getTranslogIndexer() {
-        return this.getTranslogIndexer.get();
+        Supplier<TranslogIndexer> getTranslogIndexer = this.getTranslogIndexer;
+        if (getTranslogIndexer == null) {
+            Version indexVersionCreated = indexSettings.getIndexVersionCreated();
+            TableInfo table = getTable();
+            TranslogIndexer translogIndexer = switch (table) {
+                case DocTableInfo docTable -> new TranslogIndexer(docTable, indexVersionCreated);
+                case BlobTableInfo blobTable -> new TranslogIndexer(blobTable, indexVersionCreated);
+                default -> throw new UnsupportedFeatureException(
+                    "Unsupported table type: " + table.getClass().getSimpleName());
+            };
+            this.getTranslogIndexer = () -> translogIndexer;
+            return translogIndexer;
+        }
+        return getTranslogIndexer.get();
     }
 
     private class StoreCloseListener implements Store.OnClose {

--- a/server/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
+++ b/server/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
@@ -463,7 +463,7 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
             IndexService indexService = null;
             try {
                 indexService = indicesService.createIndex(indexMetadata, buildInIndexListener, true);
-                indexService.updateMapping(state.metadata(), indexMetadata);
+                indexService.updateMapping();
             } catch (Exception e) {
                 final String failShardReason;
                 if (indexService == null) {
@@ -513,7 +513,7 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
 
                     reason = "mapping update failed";
                     LOGGER.error("Updating mapping for {} {}", index, relation);
-                    indexService.updateMapping(metadata, newIndexMetadata);
+                    indexService.updateMapping();
                 } catch (Exception e) {
                     indicesService.removeIndex(indexService.index(), FAILURE, "removing index (" + reason + ")");
 


### PR DESCRIPTION
Avoids having to create additional tableInfoFactory instances and moves
some of the work out of the cluster-state applier thread.


See https://github.com/crate/crate/pull/19520#discussion_r3419335767 

(I'm not entirely sure if it's worth it)