### PR TITLE
Remove stale error logging for index mapping update again

### DIFF
--- a/server/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
+++ b/server/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
@@ -512,7 +512,6 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
                     }
 
                     reason = "mapping update failed";
-                    LOGGER.error("Updating mapping for {} {}", index, relation);
                     indexService.updateMapping();
                 } catch (Exception e) {
                     indicesService.removeIndex(indexService.index(), FAILURE, "removing index (" + reason + ")");


### PR DESCRIPTION
Forgot to remove it in https://github.com/crate/crate/pull/19520
Was only used for debugging with no intention to keep it.
