### PR TITLE
Remove IndexNotFoundException to RelationUnknown mapping

### DIFF
--- a/server/src/main/java/io/crate/exceptions/SQLExceptions.java
+++ b/server/src/main/java/io/crate/exceptions/SQLExceptions.java
@@ -201,8 +201,6 @@ public class SQLExceptions {
             return new DuplicateKeyException(
                 ((EngineException) unwrappedError).getIndex().getName(),
                 "A document with the same primary key exists already", unwrappedError);
-        } else if (unwrappedError instanceof IndexNotFoundException) {
-            return new RelationUnknown(((IndexNotFoundException) unwrappedError).getIndex().getName(), unwrappedError);
         } else if (unwrappedError instanceof InterruptedException) {
             return JobKilledException.of(unwrappedError.getMessage());
         }


### PR DESCRIPTION
IndexNotFoundException is sometimes created with `indexUUID` instead of
name, and sometimes with a name that's wrong due to table swap.

The conversion to `RelationUnknown` used index decoding which could
result in a incorrect relation name.

This removes the mapping. `IndexNotFoundException` is mostly retried and
typically shouldn't surface to users. Cases where the table is deleted
raise `RelationUnkown` directly.

If it still goes through to the user (e.g. due to retry attempts all
failing), surfacing the IndexNotFoundException isn't worse than raising
RelationUnknown with an incorrect relation name (or worse - have the
translation failing due to IndexName decoding errors on UUIDs)
