### PR TITLE
Ensure cluster state is recovered in RemoveCorruptedShardDataCommandIT

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/shard/RemoveCorruptedShardDataCommandIT.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/RemoveCorruptedShardDataCommandIT.java
@@ -186,6 +186,8 @@ public class RemoveCorruptedShardDataCommandIT extends IntegTestCase {
 
         // Ensure node has started
         ensureStableCluster(1, node);
+        // Executing ALTER TABLE before the cluster state is recovered results in a RelationUnknown exception.
+        ensureClusterStateRecovered();
 
         execute("ALTER TABLE " + tableIdent + " REROUTE ALLOCATE STALE PRIMARY SHARD 0 ON '" + node + "' WITH (accept_data_loss = ?)", new Object[]{true});
 

--- a/server/src/testFixtures/java/org/elasticsearch/test/IntegTestCase.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/IntegTestCase.java
@@ -105,6 +105,7 @@ import org.elasticsearch.common.util.concurrent.FutureUtils;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.TestEnvironment;
+import org.elasticsearch.gateway.GatewayService;
 import org.elasticsearch.http.HttpTransportSettings;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexService;
@@ -758,6 +759,13 @@ public abstract class IntegTestCase extends ESTestCase {
                 client().health(new ClusterHealthRequest().waitForNodes(Integer.toString(cluster().size())))
             ));
         }
+    }
+
+    protected void ensureClusterStateRecovered() throws Exception {
+        assertBusy(() ->
+            assertThat(clusterService().state().blocks().hasGlobalBlock(GatewayService.STATE_NOT_RECOVERED_BLOCK))
+                .isFalse()
+        );
     }
 
     /**


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Closes #19581.

For the reason, see https://github.com/crate/crate/issues/19581#issuecomment-4740612827 and the comment below.

I ran the test with the fix multiple times [here](https://github.com/crate/crate/pull/19584/changes/16b6625f0204b3f13f8cdfa141a0916626f55581).

## Checklist

 - [ ] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [ ] This does not contain breaking changes
