### PR TITLE
Watch table version when mappings are updated while replaying shard changes

### DIFF
--- a/server/src/main/java/io/crate/replication/logical/action/ReplayChangesAction.java
+++ b/server/src/main/java/io/crate/replication/logical/action/ReplayChangesAction.java
@@ -38,6 +38,7 @@ import org.elasticsearch.action.support.replication.TransportWriteAction;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateObserver;
 import org.elasticsearch.cluster.action.shard.ShardStateAction;
+import org.elasticsearch.cluster.metadata.RelationMetadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.inject.Inject;
@@ -154,7 +155,10 @@ public class ReplayChangesAction extends ActionType<ReplicationResponse> {
                     break;
                 }
 
-                Engine.Result engineResult = null;
+                Engine.Result engineResult;
+                // Get table version now, because it may change while the translog op is being applied
+                // (i.e., the cluster metadata might change during that time).
+                Long currentTableVersion = getTableVersion(clusterService.state(), request.shardId().getIndexUUID());
                 try {
                     engineResult = primary.applyTranslogOperation(opWithPrimary, Engine.Operation.Origin.PRIMARY);
                 } catch (IOException e) {
@@ -163,7 +167,7 @@ public class ReplayChangesAction extends ActionType<ReplicationResponse> {
                 }
                 if (engineResult.getResultType() == Engine.Result.Type.MAPPING_UPDATE_REQUIRED) {
                     // Retry to process the translog operations, once the mappings are updated
-                    retryWhenMappingsAreUpdated(primary, request, accumulator, i, result, failure);
+                    retryWhenMappingsAreUpdated(primary, request, accumulator, i, result, failure, currentTableVersion);
                     return;
                 }
                 accumulator.add(engineResult);
@@ -171,14 +175,23 @@ public class ReplayChangesAction extends ActionType<ReplicationResponse> {
             result.accept(accumulator);
         }
 
+
+        private static Long getTableVersion(ClusterState cs, String indexUUID) {
+            // Cast safe because a mapping change indicates it is a table.
+            RelationMetadata.Table table = (RelationMetadata.Table) cs.metadata()
+                .getRelation(indexUUID);
+
+            return table == null ? null : table.tableVersion();
+        }
+
         private void retryWhenMappingsAreUpdated(IndexShard primary,
                                                  Request request,
                                                  List<Engine.Result> accumulator,
                                                  int offset,
                                                  Consumer<List<Engine.Result>> result,
-                                                 Consumer<Exception> failure) {
+                                                 Consumer<Exception> failure,
+                                                 Long currentTableVersion) {
             var indexUUID = request.shardId().getIndexUUID();
-            var currentMappingVersion = clusterService.state().metadata().index(indexUUID).getMappingVersion();
             var clusterStateObserver = new ClusterStateObserver(clusterService, new TimeValue(60_000), LOGGER);
             clusterStateObserver.waitForNextChange(
                 new ClusterStateObserver.Listener() {
@@ -197,18 +210,16 @@ public class ReplayChangesAction extends ActionType<ReplicationResponse> {
                         failure.accept(new ElasticsearchTimeoutException("Mappings did not update in time"));
                     }
 
-                }, cs -> isIndexMetadataUpdated(cs, indexUUID, currentMappingVersion)
+                }, cs -> isTableVersionUpdated(cs, indexUUID, currentTableVersion)
             );
         }
 
-        private static boolean isIndexMetadataUpdated(ClusterState cs, String indexUUID, long mappingVersion) {
-            var indexMetadata = cs.metadata().index(indexUUID);
-            if (indexMetadata == null) {
+        private static boolean isTableVersionUpdated(ClusterState cs, String indexUUID, Long prevVersion) {
+            Long currentTableVersion = getTableVersion(cs, indexUUID);
+            if (currentTableVersion == null) {
                 return false;
-            } else {
-                var newMappingVersion = indexMetadata.getMappingVersion();
-                return newMappingVersion > mappingVersion;
             }
+            return currentTableVersion > prevVersion;
         }
 
         @Override

--- a/server/src/test/java/io/crate/integrationtests/MetadataTrackerITest.java
+++ b/server/src/test/java/io/crate/integrationtests/MetadataTrackerITest.java
@@ -81,7 +81,7 @@ public class MetadataTrackerITest extends LogicalReplicationITestCase {
         executeOnPublisher("INSERT INTO t1 (id, name) VALUES (3, 'chewbacca')");
         executeOnPublisher("INSERT INTO t1 (id, name) VALUES (4, 'r2d2')");
         executeOnPublisher("REFRESH TABLE t1");
-        //Lets alter the table again
+        //Let's alter the table again
         executeOnPublisher("ALTER TABLE t1 ADD COLUMN age integer");
         executeOnPublisher("INSERT INTO t1 (id, name, age) VALUES (5, 'luke', 37)");
         executeOnPublisher("INSERT INTO t1 (id, name, age) VALUES (6, 'yoda', 900)");
@@ -98,7 +98,7 @@ public class MetadataTrackerITest extends LogicalReplicationITestCase {
                 "5| luke| 37",
                 "6| yoda| 900"
             );
-        }, 60, TimeUnit.SECONDS);
+        }, 5, TimeUnit.SECONDS);
     }
 
     @Test
@@ -273,7 +273,7 @@ public class MetadataTrackerITest extends LogicalReplicationITestCase {
         executeOnPublisher("DROP PUBLICATION pub2"); // exclude publication with regular table
         executeOnPublisher("DROP PUBLICATION pub3"); // exclude publication with partitioned table
 
-        // Dropping of the one one multiple publications doesn't stop tracking of the whole subscription.
+        // Dropping of the one multiple publications doesn't stop tracking of the whole subscription.
         assertBusy(() -> assertThat(isTrackerActive()).isTrue());
 
         // Subscriber keeps receiving updates from non-dropped publication's regular table.


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Fixes #19587.

An explanation of how it comes to the issue and the solution can be found [here](https://github.com/crate/crate/issues/19587#issuecomment-4752871028).

## Checklist

 - [ ] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
