### PR TITLE
Do not treat OpenDAL stat failures as missing blobs

### DIFF
--- a/docs/appendices/release-notes/6.3.5.rst
+++ b/docs/appendices/release-notes/6.3.5.rst
@@ -46,4 +46,6 @@ series.
 Fixes
 =====
 
-None
+- Fixed an issue that would throw a misleading ``NullPointerException`` when
+  ``CREATE REPOSITORY`` failed during repository verification, by returning a
+  user friendly error message.

--- a/libs/opendal/pom.xml
+++ b/libs/opendal/pom.xml
@@ -48,6 +48,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${versions.mockito}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>

--- a/libs/opendal/src/main/java/io/crate/opendal/OpenDALBlobContainer.java
+++ b/libs/opendal/src/main/java/io/crate/opendal/OpenDALBlobContainer.java
@@ -29,8 +29,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.apache.opendal.OpenDALException;
 import org.apache.opendal.OpenDALException.Code;
 import org.apache.opendal.Operator;
@@ -38,8 +36,6 @@ import org.elasticsearch.common.blobstore.BlobContainer;
 import org.elasticsearch.common.blobstore.BlobPath;
 
 public class OpenDALBlobContainer implements BlobContainer {
-
-    private static final Logger LOGGER = LogManager.getLogger(OpenDALBlobContainer.class);
 
     private final BlobPath path;
     private final String pathAsString;
@@ -65,10 +61,10 @@ public class OpenDALBlobContainer implements BlobContainer {
             operator.stat(path);
             return true;
         } catch (OpenDALException ex) {
-            if (ex.getCode() != Code.NotFound) {
-                LOGGER.error("blobExists stat error on {}", path, ex);
+            if (ex.getCode() == Code.NotFound) {
+                return false;
             }
-            return false;
+            throw ex;
         }
     }
 

--- a/libs/opendal/src/test/java/io/crate/opendal/OpenDALBlobContainerTest.java
+++ b/libs/opendal/src/test/java/io/crate/opendal/OpenDALBlobContainerTest.java
@@ -22,6 +22,9 @@
 package io.crate.opendal;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.nio.file.Path;
 import java.util.List;
@@ -29,6 +32,8 @@ import java.util.Map;
 
 import org.apache.opendal.AsyncExecutor;
 import org.apache.opendal.AsyncOperator;
+import org.apache.opendal.OpenDALException;
+import org.apache.opendal.OpenDALException.Code;
 import org.apache.opendal.Operator;
 import org.apache.opendal.ServiceConfig;
 import org.elasticsearch.common.blobstore.BlobPath;
@@ -49,6 +54,26 @@ public class OpenDALBlobContainerTest extends ESTestCase {
     @After
     public void teardown() {
         executor.close();
+    }
+
+    @Test
+    public void test_blobExists_returns_false_on_not_found() throws Exception {
+        Operator operator = mock(Operator.class);
+        when(operator.stat("file1.txt")).thenThrow(new OpenDALException(Code.NotFound, "not found"));
+        OpenDALBlobContainer container = new OpenDALBlobContainer(BlobPath.cleanPath(), operator, 1024);
+
+        assertThat(container.blobExists("file1.txt")).isFalse();
+    }
+
+    @Test
+    public void test_blobExists_propagates_non_not_found_stat_failures() {
+        var failure = new OpenDALException(Code.Unexpected, "network failure");
+        Operator operator = mock(Operator.class);
+        when(operator.stat("file1.txt")).thenThrow(failure);
+        OpenDALBlobContainer container = new OpenDALBlobContainer(BlobPath.cleanPath(), operator, 1024);
+
+        assertThatThrownBy(() -> container.blobExists("file1.txt"))
+            .isSameAs(failure);
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes https://github.com/crate/crate/issues/19586.

https://github.com/crate/crate/blob/34aebc836ae3f73d0465c9e2554bc0e3b455e5c7/libs/opendal/src/main/java/io/crate/opendal/OpenDALBlobContainer.java#L62-L73

As part of `writeBlob()`, `blobExists()` is checked. However, `blobExists()` suppresses stat errors as `false`, which leads to an NPE from the remaining `writeBlob()` logic.

The reported scenario shows that the top level exception is a `RepositoryException` not an NPE. Hence, this PR is not a bug fix but a feature.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
