### PR TITLE
Remove indexName decoding from UnavailableShardsException ctor

### DIFF
--- a/server/src/main/java/io/crate/metadata/RoutingProvider.java
+++ b/server/src/main/java/io/crate/metadata/RoutingProvider.java
@@ -118,6 +118,7 @@ public final class RoutingProvider {
     }
 
     public Routing forIndices(ClusterState state,
+                              RelationName relation,
                               String[] concreteIndicesUUIDs,
                               Set<String> routingValues,
                               boolean ignoreMissingShards,
@@ -151,12 +152,13 @@ public final class RoutingProvider {
                 default:
                     throw new AssertionError("Invalid ShardSelection: " + shardSelection);
             }
-            fillLocationsFromShardIterator(ignoreMissingShards, locations, shardIt);
+            fillLocationsFromShardIterator(relation, ignoreMissingShards, locations, shardIt);
         }
         return new Routing(locations);
     }
 
-    private static void fillLocationsFromShardIterator(boolean ignoreMissingShards,
+    private static void fillLocationsFromShardIterator(RelationName relation,
+                                                       boolean ignoreMissingShards,
                                                        Map<String, Map<String, IntIndexedContainer>> locations,
                                                        ShardIterator shardIterator) {
         ShardRouting shardRouting = shardIterator.nextOrNull();
@@ -164,7 +166,7 @@ public final class RoutingProvider {
             if (ignoreMissingShards) {
                 return;
             }
-            throw new UnavailableShardsException(shardIterator.shardId());
+            throw new UnavailableShardsException(relation, shardIterator.shardId());
         }
         processShardRouting(locations, shardRouting);
     }

--- a/server/src/main/java/io/crate/metadata/blob/BlobTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/blob/BlobTableInfo.java
@@ -126,7 +126,7 @@ public class BlobTableInfo implements TableInfo, ShardedTable, StoredTable {
                               RoutingProvider.ShardSelection shardSelection,
                               CoordinatorSessionSettings sessionSettings) {
         String[] indices = state.metadata().getIndices(ident, List.of(), true, IndexMetadata::getIndexUUID).toArray(new String[0]);
-        return routingProvider.forIndices(state, indices, Set.of(), false, shardSelection);
+        return routingProvider.forIndices(state, ident, indices, Set.of(), false, shardSelection);
     }
 
     @Override

--- a/server/src/main/java/io/crate/metadata/doc/DocTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocTableInfo.java
@@ -468,6 +468,7 @@ public class DocTableInfo implements TableInfo, ShardedTable, StoredTable {
         }
         return routingProvider.forIndices(
             state,
+            ident,
             indices,
             whereClause.routingValues(),
             isPartitioned,

--- a/server/src/main/java/org/elasticsearch/action/UnavailableShardsException.java
+++ b/server/src/main/java/org/elasticsearch/action/UnavailableShardsException.java
@@ -24,10 +24,14 @@ import java.util.List;
 import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.index.shard.ShardId;
 import org.jspecify.annotations.Nullable;
+
 import io.crate.exceptions.TableScopeException;
 import io.crate.metadata.RelationName;
 import io.crate.rest.action.HttpErrorStatus;
@@ -39,37 +43,49 @@ public class UnavailableShardsException extends ElasticsearchException implement
     @Nullable
     private final RelationName relationName;
 
-    public UnavailableShardsException(@Nullable ShardId shardId, String message, Object... args) {
-        super(buildMessage(shardId, message), args);
-        this.relationName = shardId == null ? null : RelationName.fromIndexName(shardId.getIndexName());
+    public UnavailableShardsException(ShardId shardId, @Nullable RelationName relationName, String message, Object... args) {
+        super(buildMessage(relationName, shardId, message), args);
+        this.relationName = relationName;
     }
 
-    public UnavailableShardsException(ShardId shardId) {
-        super(buildMessage(shardId));
-        this.relationName = shardId == null ? null : RelationName.fromIndexName(shardId.getIndexName());
+    public UnavailableShardsException(RelationName relation, ShardId shardId) {
+        super(buildMessage(relation, shardId));
+        this.relationName = relation;
     }
 
-    private static String buildMessage(ShardId shardId) {
-        return String.format(Locale.ENGLISH, "[%s] shard %s is not available", shardId.getIndexName(), shardId.id());
+    private static String buildMessage(RelationName relation, ShardId shardId) {
+        return String.format(Locale.ENGLISH, "[%s] shard %s is not available", relation, shardId.id());
     }
 
-    private static String buildMessage(@Nullable ShardId shardId, String message) {
-        if (shardId == null) {
-            return message;
+    private static String buildMessage(@Nullable RelationName relationName, ShardId shardId, String message) {
+        if (relationName == null) {
+            return "[" + shardId.getIndexUUID() + "][" + shardId.id() + "] " + message;
         }
-        return "[" + shardId.getIndexName() + "][" + shardId.id() + "] " + message;
+        return "[" + relationName + "][" + shardId.id() + "] " + message;
     }
 
     public UnavailableShardsException(StreamInput in) throws IOException {
         super(in);
-        RelationName name = null;
-        try {
-            Matcher matcher = MSG_INDEX_NAME_PATTERN.matcher(getMessage());
-            name = matcher.matches() ? RelationName.fromIndexName(matcher.group(1)) : null;
-        } catch (Exception ex) {
-            name = null;
+        if (in.getVersion().onOrAfter(Version.V_6_4_0)) {
+            this.relationName = in.readOptionalWriteable(RelationName::new);
+        } else {
+            RelationName name = null;
+            try {
+                Matcher matcher = MSG_INDEX_NAME_PATTERN.matcher(getMessage());
+                name = matcher.matches() ? RelationName.fromIndexName(matcher.group(1)) : null;
+            } catch (Exception ex) {
+                name = null;
+            }
+            this.relationName = name;
         }
-        this.relationName = name;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        if (out.getVersion().onOrAfter(Version.V_6_4_0)) {
+            out.writeOptionalWriteable(relationName);
+        }
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/support/replication/ReplicationOperation.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/ReplicationOperation.java
@@ -91,10 +91,15 @@ public class ReplicationOperation<
 
     private final List<ReplicationResponse.ShardInfo.Failure> shardReplicaFailures = Collections.synchronizedList(new ArrayList<>());
 
-    public ReplicationOperation(Request request, Primary<Request, ReplicaRequest, PrimaryResultT> primary,
+    public ReplicationOperation(Request request,
+                                Primary<Request, ReplicaRequest, PrimaryResultT> primary,
                                 ActionListener<PrimaryResultT> listener,
                                 Replicas<ReplicaRequest> replicas,
-                                Logger logger, ThreadPool threadPool, String opType, long primaryTerm, TimeValue initialRetryBackoffBound,
+                                Logger logger,
+                                ThreadPool threadPool,
+                                String opType,
+                                long primaryTerm,
+                                TimeValue initialRetryBackoffBound,
                                 TimeValue retryTimeout) {
         this.replicasProxy = replicas;
         this.primary = primary;
@@ -113,8 +118,14 @@ public class ReplicationOperation<
         final ShardRouting primaryRouting = primary.routingEntry();
         final ShardId primaryId = primaryRouting.shardId();
         if (activeShardCountFailure != null) {
-            finishAsFailed(new UnavailableShardsException(primaryId,
-                "{} Timeout: [{}], request: [{}]", activeShardCountFailure, request.timeout(), request));
+            finishAsFailed(new UnavailableShardsException(
+                primaryId,
+                null,
+                "{} Timeout: [{}], request: [{}]",
+                activeShardCountFailure,
+                request.timeout(),
+                request
+            ));
             return;
         }
 

--- a/server/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
@@ -42,6 +42,7 @@ import org.elasticsearch.cluster.action.shard.ShardStateAction;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.RelationMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.routing.AllocationId;
 import org.elasticsearch.cluster.routing.ShardRouting;
@@ -82,6 +83,7 @@ import org.jspecify.annotations.Nullable;
 import io.crate.common.exceptions.Exceptions;
 import io.crate.common.unit.TimeValue;
 import io.crate.exceptions.SQLExceptions;
+import io.crate.metadata.RelationName;
 
 /**
  * Base class for requests that should be executed on a primary copy followed by replica copies.
@@ -663,13 +665,13 @@ public abstract class TransportReplicationAction<
             if (primary == null || primary.active() == false) {
                 logger.trace("primary shard [{}] is not yet active, scheduling a retry: action [{}], request [{}], "
                     + "cluster state version [{}]", request.shardId(), actionName, request, state.version());
-                retryBecauseUnavailable(request.shardId(), "primary shard is not active");
+                retryBecauseUnavailable(state, request.shardId(), "primary shard is not active");
                 return;
             }
             if (state.nodes().nodeExists(primary.currentNodeId()) == false) {
                 logger.trace("primary shard [{}] is assigned to an unknown node [{}], scheduling a retry: action [{}], request [{}], "
                     + "cluster state version [{}]", request.shardId(), primary.currentNodeId(), actionName, request, state.version());
-                retryBecauseUnavailable(request.shardId(), "primary shard isn't assigned to a known node.");
+                retryBecauseUnavailable(state, request.shardId(), "primary shard isn't assigned to a known node.");
                 return;
             }
             final DiscoveryNode node = state.nodes().get(primary.currentNodeId());
@@ -701,6 +703,7 @@ public abstract class TransportReplicationAction<
                 );
 
                 retryBecauseUnavailable(
+                    state,
                     request.shardId(),
                     "failed to find primary as current cluster state with version [" + state.version() + "] is stale (expected at least [" + request.routedBasedOnClusterVersion() + "]"
                 );
@@ -823,8 +826,11 @@ public abstract class TransportReplicationAction<
             }
         }
 
-        void retryBecauseUnavailable(ShardId shardId, String message) {
-            retry(new UnavailableShardsException(shardId, "{} Timeout: [{}], request: [{}]", message, request.timeout(), request));
+        void retryBecauseUnavailable(ClusterState state, ShardId shardId, String message) {
+            @Nullable
+            RelationMetadata relation = state.metadata().getRelation(shardId.getIndexUUID());
+            RelationName relationName = relation == null ? null : relation.name();
+            retry(new UnavailableShardsException(shardId, relationName, "{} Timeout: [{}], request: [{}]", message, request.timeout(), request));
         }
     }
 

--- a/server/src/test/java/io/crate/exceptions/SQLExceptionsTest.java
+++ b/server/src/test/java/io/crate/exceptions/SQLExceptionsTest.java
@@ -33,13 +33,14 @@ import org.elasticsearch.index.shard.ShardId;
 import org.junit.Test;
 
 import io.crate.common.exceptions.Exceptions;
+import io.crate.metadata.RelationName;
 
 public class SQLExceptionsTest {
 
     @Test
     public void test_unavailable_shard_exception_is_shard_failure() throws Exception {
         ShardId shardId = new ShardId("idx1", UUIDs.randomBase64UUID(), 0);
-        UnavailableShardsException ex = new UnavailableShardsException(shardId);
+        UnavailableShardsException ex = new UnavailableShardsException(new RelationName("doc", "tbl"), shardId);
         assertThat(SQLExceptions.isShardNotAvailable(ex)).isTrue();
         assertThat(SQLExceptions.maybeTemporary(ex)).isTrue();
     }

--- a/server/src/test/java/io/crate/planner/PlannerTest.java
+++ b/server/src/test/java/io/crate/planner/PlannerTest.java
@@ -49,6 +49,7 @@ import io.crate.exceptions.ConversionException;
 import io.crate.execution.dsl.phases.RoutedCollectPhase;
 import io.crate.expression.symbol.Literal;
 import io.crate.metadata.CoordinatorTxnCtx;
+import io.crate.metadata.RelationName;
 import io.crate.metadata.RoutingProvider;
 import io.crate.metadata.settings.CoordinatorSessionSettings;
 import io.crate.planner.node.ddl.UpdateSettingsPlan;
@@ -144,9 +145,10 @@ public class PlannerTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void test_execution_exception_is_not_wrapped_in_logical_planner() {
         LogicalPlan plan = e.logicalPlan("select * from doc.tbl");
+        RelationName relation = new RelationName("doc", "tbl");
         var mockedPlannerCtx = mock(PlannerContext.class);
         when(mockedPlannerCtx.transactionContext()).thenThrow(
-            new UnavailableShardsException(new ShardId("tbl", "uuid", 11)));
+            new UnavailableShardsException(relation, new ShardId("tbl", "uuid", 11)));
 
         assertSQLError(() -> LogicalPlanner.getNodeOperationTree(
                 plan,
@@ -157,7 +159,7 @@ public class PlannerTest extends CrateDummyClusterServiceUnitTest {
             ))
             .hasPGError(INTERNAL_ERROR)
             .hasHTTPError(INTERNAL_SERVER_ERROR, 5002)
-            .hasMessageContaining("[tbl] shard 11 is not available");
+            .hasMessageContaining("[doc.tbl] shard 11 is not available");
     }
 
     @Test

--- a/server/src/test/java/org/elasticsearch/action/UnavailableShardsExceptionTest.java
+++ b/server/src/test/java/org/elasticsearch/action/UnavailableShardsExceptionTest.java
@@ -35,13 +35,14 @@ public class UnavailableShardsExceptionTest {
 
     @Test
     public void test_can_get_relation_name_from_streamed_exception() throws Exception {
-        var ex = new UnavailableShardsException(new ShardId("idx1", UUIDs.randomBase64UUID(), 0));
+        RelationName relationName = new RelationName("doc", "idx1");
+        var ex = new UnavailableShardsException(relationName, new ShardId("idx1", UUIDs.randomBase64UUID(), 0));
         var out = new BytesStreamOutput();
         ex.writeTo(out);
         try (var in = out.bytes().streamInput()) {
             var inEx = new UnavailableShardsException(in);
 
-            assertThat(inEx.getTableIdents()).containsExactly(new RelationName("doc", "idx1"));
+            assertThat(inEx.getTableIdents()).containsExactly(relationName);
         }
     }
 }


### PR DESCRIPTION
indexName of shardId can refer to outdated table due to rename/swap.
