### PR TITLE
Don't reraise ParsingException; Set pgError code to SYNTAX_ERROR

### DIFF
--- a/server/src/main/java/io/crate/exceptions/SQLExceptions.java
+++ b/server/src/main/java/io/crate/exceptions/SQLExceptions.java
@@ -58,7 +58,6 @@ import org.jspecify.annotations.Nullable;
 
 import io.crate.auth.AccessControl;
 import io.crate.common.exceptions.Exceptions;
-import io.crate.sql.parser.ParsingException;
 
 public class SQLExceptions {
 
@@ -193,7 +192,7 @@ public class SQLExceptions {
     }
 
     private static Throwable esToCrateException(Throwable unwrappedError) {
-        if (unwrappedError instanceof IllegalArgumentException || unwrappedError instanceof ParsingException) {
+        if (unwrappedError instanceof IllegalArgumentException) {
             return new SQLParseException(unwrappedError.getMessage(), (Exception) unwrappedError);
         } else if (unwrappedError instanceof UnsupportedOperationException) {
             return new UnsupportedFeatureException(unwrappedError.getMessage(), (Exception) unwrappedError);

--- a/server/src/main/java/io/crate/protocols/postgres/PGError.java
+++ b/server/src/main/java/io/crate/protocols/postgres/PGError.java
@@ -36,6 +36,7 @@ import io.crate.exceptions.RelationUnknown;
 import io.crate.exceptions.SQLExceptions;
 import io.crate.exceptions.UnsupportedFunctionException;
 import io.crate.exceptions.UserDefinedFunctionUnknownException;
+import io.crate.sql.parser.ParsingException;
 
 
 public class PGError {
@@ -112,6 +113,8 @@ public class PGError {
             status = PGErrorStatus.AMBIGUOUS_ALIAS;
         } else if (throwable instanceof UserDefinedFunctionUnknownException) {
             status = PGErrorStatus.UNDEFINED_FUNCTION;
+        } else if (throwable instanceof ParsingException) {
+            status = PGErrorStatus.SYNTAX_ERROR;
         } else if (throwable instanceof ElasticsearchException ex) {
             status = ex.pgErrorStatus();
         }

--- a/server/src/main/java/io/crate/rest/action/HttpError.java
+++ b/server/src/main/java/io/crate/rest/action/HttpError.java
@@ -49,6 +49,7 @@ import io.crate.exceptions.RepositoryAlreadyExistsException;
 import io.crate.exceptions.SQLExceptions;
 import io.crate.exceptions.SQLParseException;
 import io.crate.exceptions.UnsupportedFunctionException;
+import io.crate.sql.parser.ParsingException;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufOutputStream;
 import io.netty.handler.codec.http.HttpResponseStatus;
@@ -127,7 +128,7 @@ public class HttpError {
             httpErrorStatus = HttpErrorStatus.RELATION_INVALID_NAME;
         } else if (throwable instanceof RelationValidationException) {
             httpErrorStatus = HttpErrorStatus.FIELD_VALIDATION_FAILED;
-        } else if (throwable instanceof SQLParseException) {
+        } else if (throwable instanceof SQLParseException || throwable instanceof ParsingException) {
             httpErrorStatus = HttpErrorStatus.STATEMENT_INVALID_OR_UNSUPPORTED_SYNTAX;
         } else if (throwable instanceof UnsupportedFunctionException) {
             httpErrorStatus = HttpErrorStatus.POSSIBLE_FEATURE_NOT_SUPPORTED_YET;

--- a/server/src/test/java/io/crate/integrationtests/PostgresITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PostgresITest.java
@@ -803,7 +803,7 @@ public class PostgresITest extends IntegTestCase {
             PreparedStatement stmt = conn.prepareStatement("select name fro sys.cluster");
             Asserts.assertSQLError(() -> stmt.executeQuery())
                 .isExactlyInstanceOf(PSQLException.class)
-                .hasPGError(INTERNAL_ERROR)
+                .hasPGError(PGErrorStatus.SYNTAX_ERROR)
                 .hasMessageContaining("mismatched input 'sys'");
         }
     }

--- a/server/src/test/java/io/crate/integrationtests/RestSQLActionIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/RestSQLActionIntegrationTest.java
@@ -23,6 +23,7 @@ package io.crate.integrationtests;
 
 import static io.crate.execution.engine.indexing.ShardingUpsertExecutor.BULK_RESPONSE_MAX_ERRORS_PER_SHARD;
 import static io.crate.testing.Asserts.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.OutputStream;
 import java.net.Socket;
@@ -391,7 +392,7 @@ public class RestSQLActionIntegrationTest extends SQLHttpIntegrationTest {
         assertThat(response.statusCode()).isEqualTo(400);
         assertThat(response.body()).contains(
             """
-            "error":{"message":"SQLParseException[line 1:11: mismatched input 'select' expecting <EOF>]","code":4000}
+            "error":{"message":"ParsingException[line 1:11: mismatched input 'select' expecting <EOF>]","code":4000}
             """.stripIndent().stripTrailing()
         );
     }


### PR DESCRIPTION
The sql-parser's ParsingException was converted to SQLParseException
before sending it to clients. That caused unnecessary additional work -
due to the stack trace generation.
