### PR TITLE
Ensure that kill loop in TaskFinishedListener doesn't trip on errors

### DIFF
--- a/server/src/main/java/io/crate/execution/jobs/RootTask.java
+++ b/server/src/main/java/io/crate/execution/jobs/RootTask.java
@@ -396,7 +396,12 @@ public class RootTask implements CompletionListenable<Void> {
                     if (traceEnabled) {
                         logger.trace("Task id={} failed, killing other task={}", this.task.id(), otherTask);
                     }
-                    otherTask.kill(t);
+                    try {
+                        otherTask.kill(t);
+                    } catch (Exception e) {
+                        assert false : "kill isn't allowed/supposed to fail";
+                        logger.error("Failed to kill task {}", otherTask, e);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Relates to https://github.com/crate/support/issues/874#issuecomment-4775961841

We are seeing stuck tasks with entry point being `TaskFinishedListener.onFailure` and state of `CumulativePageBucketReceiver` showing that kill didn't go through (`lastThrowable = null` for stuck tasks),
despite on `RootTask.killTasksOngoing` being set to `true`.

And this is for a task that started hours after capturing a heap dump, so can't say that kill hasn't been called yet.

`RootTask` will retain all it's children tasks if at least one kill fails: 
`numActiveTasks` will never reach 0 ->
 -> `finishedFuture` won't be completed
  -> `TaskService.TaskCallback` won't clean up `RootTask` entry (with all its dependencies).

It's still not clear if problem is in `DistResultRXTask.kill` throwing an error or some deadlock in `CumulativePageBucketReceiver.kill`.

Even if it's the latter, some safety net + some insights in case of errors would be useful.

