### PR TITLE
Remove IndicesOptions from RestoreSnapshotRequest; deprecate it

### DIFF
--- a/server/src/main/java/io/crate/planner/node/ddl/RestoreSnapshotPlan.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/RestoreSnapshotPlan.java
@@ -21,8 +21,6 @@
 
 package io.crate.planner.node.ddl;
 
-import static io.crate.analyze.SnapshotSettings.IGNORE_UNAVAILABLE;
-
 import java.util.HashSet;
 import java.util.List;
 import java.util.function.Function;
@@ -30,16 +28,14 @@ import java.util.function.Function;
 import org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreSnapshotRequest;
 import org.elasticsearch.action.admin.cluster.snapshots.restore.TableOrPartition;
 import org.elasticsearch.action.admin.cluster.snapshots.restore.TransportRestoreSnapshot;
-import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.snapshots.SnapshotRestoreException;
-
-import io.crate.common.annotations.VisibleForTesting;
 
 import io.crate.analyze.AnalyzedRestoreSnapshot;
 import io.crate.analyze.BoundRestoreSnapshot;
 import io.crate.analyze.SnapshotSettings;
 import io.crate.analyze.SymbolEvaluator;
+import io.crate.common.annotations.VisibleForTesting;
 import io.crate.common.collections.Lists;
 import io.crate.data.Row;
 import io.crate.data.Row1;
@@ -91,17 +87,6 @@ public class RestoreSnapshotPlan implements Plan {
             dependencies.schemas()
         );
         var settings = stmt.settings();
-        boolean ignoreUnavailable = IGNORE_UNAVAILABLE.get(settings);
-
-        // ignore_unavailable as set by statement
-        IndicesOptions indicesOptions = IndicesOptions.fromOptions(
-            ignoreUnavailable,
-            true,
-            true,
-            false,
-            IndicesOptions.LENIENT_EXPAND_OPEN
-        );
-
         boolean includeTables = stmt.includeTables();
         boolean includeViews = stmt.includeViews();
 
@@ -119,7 +104,6 @@ public class RestoreSnapshotPlan implements Plan {
             restoreSnapshot.repository(),
             restoreSnapshot.snapshot(),
             tablesToRestore,
-            indicesOptions,
             settings,
             includeTables,
             includeViews,

--- a/server/src/main/java/io/crate/replication/logical/LogicalReplicationService.java
+++ b/server/src/main/java/io/crate/replication/logical/LogicalReplicationService.java
@@ -45,7 +45,6 @@ import org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreClusterSt
 import org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreSnapshotRequest;
 import org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreSnapshotResponse;
 import org.elasticsearch.action.admin.cluster.snapshots.restore.TableOrPartition;
-import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterChangedEvent;
@@ -275,7 +274,6 @@ public class LogicalReplicationService implements ClusterStateListener, Closeabl
             publisherClusterRepoName,
             LogicalReplicationRepository.LATEST,
             tablesToRestore,
-            IndicesOptions.LENIENT_EXPAND_OPEN,
             restoreSettings,
             true,
             false,

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthRequest.java
@@ -162,6 +162,7 @@ public class ClusterHealthRequest extends MasterNodeReadRequest<ClusterHealthReq
         return this.waitForEvents;
     }
 
+    @SuppressWarnings("deprecation")
     public ClusterHealthRequest(StreamInput in) throws IOException {
         super(in);
         if (in.getVersion().before(Version.V_6_0_0)) {
@@ -185,6 +186,7 @@ public class ClusterHealthRequest extends MasterNodeReadRequest<ClusterHealthReq
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         if (out.getVersion().before(Version.V_6_0_0)) {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequest.java
@@ -46,7 +46,6 @@ public class RestoreSnapshotRequest extends MasterNodeRequest<RestoreSnapshotReq
     private final String snapshot;
     private final String repository;
 
-    private final IndicesOptions indicesOptions;
     private final Settings settings;
 
     private final boolean includeTables;
@@ -68,7 +67,6 @@ public class RestoreSnapshotRequest extends MasterNodeRequest<RestoreSnapshotReq
     public RestoreSnapshotRequest(String repository,
                                   String snapshot,
                                   List<TableOrPartition> tablesToRestore,
-                                  IndicesOptions indicesOptions,
                                   Settings settings,
                                   boolean includeTables,
                                   boolean includeViews,
@@ -79,7 +77,6 @@ public class RestoreSnapshotRequest extends MasterNodeRequest<RestoreSnapshotReq
         this.repository = repository;
         this.snapshot = snapshot;
         this.tablesToRestore = tablesToRestore;
-        this.indicesOptions = indicesOptions;
         this.settings = settings;
         this.includeTables = includeTables;
         this.includeViews = includeViews;
@@ -109,16 +106,6 @@ public class RestoreSnapshotRequest extends MasterNodeRequest<RestoreSnapshotReq
 
     public List<TableOrPartition> tablesToRestore() {
         return tablesToRestore;
-    }
-
-    /**
-     * Specifies what type of requested indices to ignore and how to deal with wildcard expressions.
-     * For example indices that don't exist.
-     *
-     * @return the desired behaviour regarding indices to ignore and wildcard indices expression
-     */
-    public IndicesOptions indicesOptions() {
-        return indicesOptions;
     }
 
     /**
@@ -206,7 +193,9 @@ public class RestoreSnapshotRequest extends MasterNodeRequest<RestoreSnapshotReq
         if (version.before(Version.V_6_0_0)) {
             in.readStringArray(); // indices
         }
-        indicesOptions = IndicesOptions.readIndicesOptions(in);
+        if (version.before(Version.V_6_4_0)) {
+            IndicesOptions.readIndicesOptions(in);
+        }
         if (version.before(Version.V_6_0_0)) {
             // Since 5.6 there are default values which behave similarly as pre-5.6 with NULL values.
             // tableRenamePattern
@@ -257,7 +246,17 @@ public class RestoreSnapshotRequest extends MasterNodeRequest<RestoreSnapshotReq
             // indices
             out.writeStringArray(Strings.EMPTY_ARRAY);
         }
-        indicesOptions.writeIndicesOptions(out);
+        if (version.before(Version.V_6_4_0)) {
+            Boolean ignoreUnavailable = SnapshotSettings.IGNORE_UNAVAILABLE.get(settings);
+            IndicesOptions indicesOptions = IndicesOptions.fromOptions(
+                ignoreUnavailable,
+                true,
+                true,
+                false,
+                IndicesOptions.LENIENT_EXPAND_OPEN
+            );
+            indicesOptions.writeIndicesOptions(out);
+        }
         if (version.before(Version.V_6_0_0)) {
             out.writeString(tableRenamePattern());
             out.writeString(tableRenameReplacement());
@@ -301,7 +300,6 @@ public class RestoreSnapshotRequest extends MasterNodeRequest<RestoreSnapshotReq
         RestoreSnapshotRequest that = (RestoreSnapshotRequest) o;
         return Objects.equals(snapshot, that.snapshot) &&
             Objects.equals(repository, that.repository) &&
-            Objects.equals(indicesOptions, that.indicesOptions) &&
             Objects.equals(settings, that.settings) &&
             includeTables == that.includeTables &&
             includeViews == that.includeViews &&
@@ -316,7 +314,6 @@ public class RestoreSnapshotRequest extends MasterNodeRequest<RestoreSnapshotReq
         int result = Objects.hash(
             snapshot,
             repository,
-            indicesOptions,
             settings,
             includeTables,
             includeViews,

--- a/server/src/main/java/org/elasticsearch/action/support/IndicesOptions.java
+++ b/server/src/main/java/org/elasticsearch/action/support/IndicesOptions.java
@@ -33,8 +33,10 @@ import org.elasticsearch.common.io.stream.StreamOutput;
  * Controls how to deal with unavailable concrete indices (closed or missing), how wildcard expressions are expanded
  * to actual indices (all, closed or open indices) and how to deal with wildcard expressions that resolve to no indices.
  */
+@Deprecated
 public class IndicesOptions {
 
+    @Deprecated
     public enum WildcardStates {
         OPEN,
         CLOSED;
@@ -42,6 +44,7 @@ public class IndicesOptions {
         public static final EnumSet<WildcardStates> NONE = EnumSet.noneOf(WildcardStates.class);
     }
 
+    @Deprecated
     public enum Option {
         IGNORE_UNAVAILABLE,
         ALLOW_NO_INDICES,
@@ -55,6 +58,7 @@ public class IndicesOptions {
      * wildcards only to open indices and allows that no indices are resolved from
      * wildcard expressions (not returning an error).
      */
+    @Deprecated
     public static final IndicesOptions STRICT_EXPAND_OPEN = new IndicesOptions(
         EnumSet.of(Option.ALLOW_NO_INDICES),
         EnumSet.of(WildcardStates.OPEN)
@@ -65,6 +69,7 @@ public class IndicesOptions {
      * open indices and allows that no indices are resolved from wildcard
      * expressions (not returning an error).
      */
+    @Deprecated
     public static final IndicesOptions LENIENT_EXPAND_OPEN = new IndicesOptions(
         EnumSet.of(Option.ALLOW_NO_INDICES, Option.IGNORE_UNAVAILABLE),
         EnumSet.of(WildcardStates.OPEN)
@@ -75,6 +80,7 @@ public class IndicesOptions {
      * open and closed indices and allows that no indices are resolved from wildcard
      * expressions (not returning an error).
      */
+    @Deprecated
     public static final IndicesOptions LENIENT_EXPAND_OPEN_CLOSED = new IndicesOptions(
         EnumSet.of(Option.ALLOW_NO_INDICES, Option.IGNORE_UNAVAILABLE),
         EnumSet.of(WildcardStates.OPEN, WildcardStates.CLOSED)
@@ -140,25 +146,12 @@ public class IndicesOptions {
         return new IndicesOptions(in.readEnumSet(Option.class), in.readEnumSet(WildcardStates.class));
     }
 
+    @Deprecated
     public static IndicesOptions fromOptions(boolean ignoreUnavailable,
                                              boolean allowNoIndices,
                                              boolean expandToOpenIndices,
                                              boolean expandToClosedIndices,
                                              IndicesOptions defaultOptions) {
-        return fromOptions(
-            ignoreUnavailable,
-            allowNoIndices,
-            expandToOpenIndices,
-            expandToClosedIndices,
-            defaultOptions.forbidClosedIndices()
-        );
-    }
-
-    public static IndicesOptions fromOptions(boolean ignoreUnavailable,
-                                             boolean allowNoIndices,
-                                             boolean expandToOpenIndices,
-                                             boolean expandToClosedIndices,
-                                             boolean forbidClosedIndices) {
         final Set<Option> opts = new HashSet<>();
         final Set<WildcardStates> wildcards = new HashSet<>();
 
@@ -174,10 +167,9 @@ public class IndicesOptions {
         if (expandToClosedIndices) {
             wildcards.add(WildcardStates.CLOSED);
         }
-        if (forbidClosedIndices) {
+        if (defaultOptions.forbidClosedIndices()) {
             opts.add(Option.FORBID_CLOSED_INDICES);
         }
-
         return new IndicesOptions(opts, wildcards);
     }
 

--- a/server/src/main/java/org/elasticsearch/action/support/broadcast/BroadcastRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/support/broadcast/BroadcastRequest.java
@@ -72,6 +72,7 @@ public class BroadcastRequest extends TransportRequest {
         }
     }
 
+    @SuppressWarnings("deprecation")
     public static List<PartitionName> readPartitionNamesFromPre60(StreamInput in) throws IOException {
         String[] indexes = in.readStringArray();
         List<PartitionName> partitions = new ArrayList<>(indexes.length);
@@ -83,6 +84,7 @@ public class BroadcastRequest extends TransportRequest {
         return partitions;
     }
 
+    @SuppressWarnings("deprecation")
     public static void writePartitionNamesToPre60(StreamOutput out, List<PartitionName> partitions) throws IOException {
         List<String> indexes = new ArrayList<>();
         for (var partition : partitions) {

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/snapshots/create/CreateSnapshotRequestTest.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/snapshots/create/CreateSnapshotRequestTest.java
@@ -42,6 +42,7 @@ import io.crate.metadata.RelationName;
 public class CreateSnapshotRequestTest {
 
     @Test
+    @SuppressWarnings("deprecation")
     public void test_streaming_bwc_can_be_read_on_5() throws Exception {
         RelationName table = new RelationName("foo", "bar");
         PartitionName partition = new PartitionName(new RelationName("my_schema", "my_table"), "my_partition");
@@ -79,6 +80,7 @@ public class CreateSnapshotRequestTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void test_streaming_bwc_can_be_read_from_5() throws Exception {
         RelationName table = new RelationName("foo", "bar");
         PartitionName partition = new PartitionName(new RelationName("my_schema", "my_table"), "my_partition");

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequestTest.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequestTest.java
@@ -28,7 +28,6 @@ import java.util.List;
 import java.util.Set;
 
 import org.elasticsearch.Version;
-import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.settings.Settings;
 import org.junit.Test;
@@ -45,7 +44,6 @@ public class RestoreSnapshotRequestTest {
             List.of(
                 new TableOrPartition(new RelationName("s", "t1"), null)
             ),
-            IndicesOptions.LENIENT_EXPAND_OPEN_CLOSED,
             Settings.EMPTY,
             true,
             true,
@@ -65,7 +63,6 @@ public class RestoreSnapshotRequestTest {
             List.of(
                 new TableOrPartition(new RelationName("s", "t1"), null)
             ),
-            IndicesOptions.LENIENT_EXPAND_OPEN_CLOSED,
             Settings.EMPTY,
             true,
             true,

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/state/ClusterStateRequestTest.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/state/ClusterStateRequestTest.java
@@ -39,6 +39,7 @@ import io.crate.metadata.RelationName;
 public class ClusterStateRequestTest {
 
     @Test
+    @SuppressWarnings("deprecation")
     public void test_streaming_bwc_can_be_read_on_5() throws Exception {
         RelationName table = new RelationName("foo", "bar");
 
@@ -71,6 +72,7 @@ public class ClusterStateRequestTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void test_streaming_bwc_can_be_read_from_5() throws Exception {
         RelationName table = new RelationName("foo", "bar");
         String[] indices = new String[] { table.indexNameOrAlias() };

--- a/server/src/test/java/org/elasticsearch/action/support/broadcast/BroadcastRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/broadcast/BroadcastRequestTests.java
@@ -66,6 +66,7 @@ public class BroadcastRequestTests extends ESTestCase {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void testPreV6ReadStreaming() throws Exception {
         // Check that reading from pre v6 indices-request-style streams provides PartitionNames
 
@@ -94,6 +95,7 @@ public class BroadcastRequestTests extends ESTestCase {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void testPre60WriteStreaming() throws Exception {
 
         List<PartitionName> partitions = partitions();

--- a/server/src/test/java/org/elasticsearch/snapshots/RestoreServiceTest.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/RestoreServiceTest.java
@@ -32,7 +32,6 @@ import java.util.Set;
 
 import org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreSnapshotRequest;
 import org.elasticsearch.action.admin.cluster.snapshots.restore.TableOrPartition;
-import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.settings.Settings;
@@ -73,7 +72,6 @@ public class RestoreServiceTest extends CrateDummyClusterServiceUnitTest {
             "repo1",
             snapshotInfo.snapshotId().getUUID(),
             tablesToRestore,
-            IndicesOptions.LENIENT_EXPAND_OPEN,
             Settings.EMPTY,
             true,
             false,
@@ -116,7 +114,6 @@ public class RestoreServiceTest extends CrateDummyClusterServiceUnitTest {
             "repo1",
             snapshotInfo.snapshotId().getName(),
             tablesToRestore,
-            IndicesOptions.LENIENT_EXPAND_OPEN,
             Settings.builder().put(IGNORE_UNAVAILABLE.getKey(), true).build(),
             true,
             false,
@@ -162,7 +159,6 @@ public class RestoreServiceTest extends CrateDummyClusterServiceUnitTest {
             "repo1",
             snapshotInfo.snapshotId().getName(),
             tablesToRestore,
-            IndicesOptions.LENIENT_EXPAND_OPEN,
             Settings.EMPTY,
             true,
             false,
@@ -205,7 +201,6 @@ public class RestoreServiceTest extends CrateDummyClusterServiceUnitTest {
             "repo1",
             snapshotInfo.snapshotId().getName(),
             tablesToRestore,
-            IndicesOptions.LENIENT_EXPAND_OPEN,
             Settings.EMPTY,
             true,
             false,
@@ -256,7 +251,6 @@ public class RestoreServiceTest extends CrateDummyClusterServiceUnitTest {
             "repo1",
             snapshotInfo.snapshotId().getUUID(),
             tablesToRestore,
-            IndicesOptions.LENIENT_EXPAND_OPEN,
             Settings.EMPTY,
             true,
             false,


### PR DESCRIPTION
IndicesOptions is only used in BWC cases. It's no longer used for actual
indices resolving. It got replaced with `Metadata.getRelations`
