### PR TITLE
Avoid duplicate row.get() calls for window functions execution

### DIFF
--- a/server/src/main/java/io/crate/breaker/CellsSizeEstimator.java
+++ b/server/src/main/java/io/crate/breaker/CellsSizeEstimator.java
@@ -43,12 +43,12 @@ public abstract class CellsSizeEstimator {
         return new CellsSizeEstimator() {
             @Override
             protected long estimateSize(int valueCount, IntFunction<Object> values) {
-                assert columnTypes.size() == valueCount
-                    : "Size of incoming cells must match number of estimators. "
+                assert columnTypes.size() <= valueCount
+                    : "Must have a column type for all incoming cells"
                     + "Cells=" + valueCount
                     + " estimators=" + columnTypes.size();
                 long size = 0;
-                for (int i = 0; i < valueCount; i++) {
+                for (int i = 0; i < columnTypes.size(); i++) {
                     DataType dataType = columnTypes.get(i);
                     size += dataType.valueBytes(values.apply(i));
                 }

--- a/server/src/main/java/io/crate/execution/engine/window/WindowFunctionBatchIterator.java
+++ b/server/src/main/java/io/crate/execution/engine/window/WindowFunctionBatchIterator.java
@@ -79,7 +79,7 @@ public final class WindowFunctionBatchIterator {
 
     public static BatchIterator<Row> of(BatchIterator<Row> source,
                                         LongConsumer allocateBytes,
-                                        RowAccounting<Row> rowAccounting,
+                                        RowAccounting<Object[]> rowAccounting,
                                         ComputeFrameBoundary<Object[]> computeFrameStart,
                                         ComputeFrameBoundary<Object[]> computeFrameEnd,
                                         Comparator<Object[]> cmpPartitionBy,
@@ -96,8 +96,9 @@ public final class WindowFunctionBatchIterator {
         // As optimization we use 1 list that acts both as inputs(source) and as outputs.
         // The window function results are injected during the computation into spare cells that are eagerly created
         Function<Row, Object[]> materialize = row -> {
-            rowAccounting.accountForAndMaybeBreak(row);
-            return materializeWithSpare(row, windowFunctions.size());
+            Object[] cells = materializeWithSpare(row, windowFunctions.size());
+            rowAccounting.accountForAndMaybeBreak(cells);
+            return cells;
         };
         return CollectingBatchIterator.newInstance(
             source,

--- a/server/src/main/java/io/crate/execution/engine/window/WindowProjector.java
+++ b/server/src/main/java/io/crate/execution/engine/window/WindowProjector.java
@@ -37,7 +37,7 @@ import org.jspecify.annotations.Nullable;
 
 import io.crate.analyze.OrderBy;
 import io.crate.analyze.WindowDefinition;
-import io.crate.breaker.TypedRowAccounting;
+import io.crate.breaker.TypedCellsAccounting;
 import io.crate.data.Input;
 import io.crate.data.Projector;
 import io.crate.data.Row;
@@ -125,7 +125,7 @@ public class WindowProjector {
             () -> inputFactory.ctxForInputColumns(txnCtx);
         int arrayListElementOverHead = 32;
         List<DataType<?>> rowTypes = Symbols.typeView(projection.standalone());
-        TypedRowAccounting accounting = new TypedRowAccounting(
+        TypedCellsAccounting accounting = new TypedCellsAccounting(
             rowTypes, ramAccounting, arrayListElementOverHead);
         Comparator<Object[]> cmpPartitionBy = partitions.isEmpty()
             ? null

--- a/server/src/test/java/io/crate/execution/engine/window/WindowBatchIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/window/WindowBatchIteratorTest.java
@@ -39,7 +39,7 @@ import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.junit.Test;
 
 import io.crate.breaker.ConcurrentRamAccounting;
-import io.crate.breaker.TypedRowAccounting;
+import io.crate.breaker.TypedCellsAccounting;
 import io.crate.common.collections.Lists;
 import io.crate.common.collections.Tuple;
 import io.crate.data.BatchIterator;
@@ -76,7 +76,7 @@ public class WindowBatchIteratorTest {
                 return WindowFunctionBatchIterator.of(
                     TestingBatchIterators.range(0, 10),
                     ignored -> {},
-                    new IgnoreRowAccounting(),
+                    new IgnoreRowAccounting<Object[]>(),
                     getComputeFrameStart(cmpOrderBy, FrameBound.Type.UNBOUNDED_PRECEDING),
                     getComputeFrameEnd(cmpOrderBy, FrameBound.Type.CURRENT_ROW),
                     null,
@@ -101,7 +101,7 @@ public class WindowBatchIteratorTest {
                 return WindowFunctionBatchIterator.of(
                     new BatchSimulatingIterator<>(TestingBatchIterators.range(0, 10), 4, 2, null),
                     ignored -> {},
-                    new IgnoreRowAccounting(),
+                    new IgnoreRowAccounting<Object[]>(),
                     getComputeFrameStart(cmpOrderBy, FrameBound.Type.UNBOUNDED_PRECEDING),
                     getComputeFrameEnd(cmpOrderBy, FrameBound.Type.CURRENT_ROW),
                     null,
@@ -341,7 +341,7 @@ public class WindowBatchIteratorTest {
         BatchIterator<Row> iterator = WindowFunctionBatchIterator.of(
             TestingBatchIterators.range(0, 10),
             ignored -> {},
-            new TypedRowAccounting(List.of(DataTypes.INTEGER), ramAccounting, 32),
+            new TypedCellsAccounting(List.of(DataTypes.INTEGER), ramAccounting, 32),
             (_, _, _, _) -> 0,
             (_, _, currentIndex, _) -> currentIndex,
             null,

--- a/server/src/testFixtures/java/io/crate/execution/engine/window/AbstractWindowFunctionTest.java
+++ b/server/src/testFixtures/java/io/crate/execution/engine/window/AbstractWindowFunctionTest.java
@@ -172,7 +172,7 @@ public abstract class AbstractWindowFunctionTest extends CrateDummyClusterServic
             InMemoryBatchIterator.of(Arrays.stream(inputRows).map(RowN::new).toList(), SENTINEL,
                 true),
             allocateBytes,
-            new IgnoreRowAccounting(),
+            new IgnoreRowAccounting<Object[]>(),
             WindowProjector.createComputeStartFrameBoundary(numCellsInSourceRows, txnCtx, sqlExpressions.nodeCtx, mappedWindowDef, cmpOrderBy),
             WindowProjector.createComputeEndFrameBoundary(numCellsInSourceRows, txnCtx, sqlExpressions.nodeCtx, mappedWindowDef, cmpOrderBy),
             createComparator(() -> inputFactory.ctxForRefs(txnCtx, referenceResolver), rowTypes, partitionOrderBy),

--- a/server/src/testFixtures/java/io/crate/execution/engine/window/IgnoreRowAccounting.java
+++ b/server/src/testFixtures/java/io/crate/execution/engine/window/IgnoreRowAccounting.java
@@ -21,13 +21,12 @@
 
 package io.crate.execution.engine.window;
 
-import io.crate.data.Row;
 import io.crate.data.breaker.RowAccounting;
 
-public class IgnoreRowAccounting implements RowAccounting<Row> {
+public class IgnoreRowAccounting<T> implements RowAccounting<T> {
 
     @Override
-    public long accountForAndMaybeBreak(Row row) {
+    public long accountForAndMaybeBreak(T row) {
         return 42;
     }
 


### PR DESCRIPTION
`Row` can be an `InputRow` based on `LuceneCollectorExpression` inputs,
which were evaluated twice: Once to do the row accounting via
`RowTypedAccounting` and a second time when materializing the row.

This changes the order to first materialize and then account the already
materialized row. We should always have enough spare memory to allocate
a single intermediate row.

    Q: select avg("adRevenue") over (partition by "cCode" order by "visitDate")
                    from uservisits
    C: 1
    | Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
    |   V1    |     3775.493 ±  112.131 |   3546.335 |   3765.974 |   3825.643 |   4087.451 |
    |   V2    |     3425.990 ±   84.173 |   3221.360 |   3422.267 |   3472.367 |   3672.775 |
    ├---------┴-------------------------┴------------┴------------┴------------┴------------┘
    |               -   9.71%                           -   9.56%
    There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 9.71%
    The test has statistical significance

    Q: select nth_value("adRevenue", 3) over (order by "cCode")
                    from uservisits
    C: 1
    | Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
    |   V1    |     3638.078 ±  156.325 |   3304.832 |   3638.004 |   3733.471 |   3979.705 |
    |   V2    |     3480.331 ±  103.626 |   3250.200 |   3490.231 |   3535.802 |   3693.374 |
    ├---------┴-------------------------┴------------┴------------┴------------┴------------┘
    |               -   4.43%                           -   4.15%
    There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 4.43%
    The test has statistical significance

    Q: select nth_value("adRevenue", 3) over (order by "cCode")
                    from uservisits where _fetchid % 10 = 0
    C: 15
    | Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
    |   V1    |      432.026 ±   87.028 |    263.037 |    417.999 |    464.634 |    708.624 |
    |   V2    |      390.905 ±   73.462 |    258.814 |    381.962 |    405.175 |    680.982 |
    ├---------┴-------------------------┴------------┴------------┴------------┴------------┘
    |               -   9.99%                           -   9.01%
    There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 9.99%
    The test has statistical significance

    Q: select nth_value("adRevenue", 3) over (order by "cCode"),
                    avg("duration") over(order by "sourceIP")
                    from uservisits
    C: 1
    | Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
    |   V1    |     8621.914 ±  218.548 |   8141.782 |   8588.127 |   8757.521 |   9135.074 |
    |   V2    |     8071.141 ±  111.385 |   7794.933 |   8052.412 |   8116.419 |   8505.911 |
    ├---------┴-------------------------┴------------┴------------┴------------┴------------┘
    |               -   6.60%                           -   6.44%
    There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 6.60%
    The test has statistical significance

    System/JVM Metrics (durations in ms, byte-values in MB)
        |    YOUNG GC            |       OLD GC           |      HEAP         |     ALLOC
        |  cnt      avg      max |  cnt      avg      max |  initial     used |     rate      total
     V1 |  418    53.12   110.88 |  134   130.11   295.90 |      268     1924 |   292.94     283550
     V2 |  326    62.41   120.18 |  104   178.22   266.39 |      268     1346 |   233.13     209857

    Top allocation frames
      V1
        BytesRef.utf8ToString() total=84522947314, count=20982
        StringUTF16.compress(...) total=31017551730, count=8125
        WindowFunctionBatchIterator.materializeWithSpare(Row, int) total=27584724008, count=25362
        FloatToDecimal.toString(float) total=25069515793, count=19716
        DoubleToDecimal.toString(double) total=25043066945, count=19472
        Arrays.copyOfRange(...) total=23848089297, count=18740
        TimSort.sort(...) total=18600061760, count=1587
        Float.valueOf(float) total=18513996193, count=5036
        Arrays.copyOf(...) total=11331175302, count=1534
        Long.valueOf(long) total=6764039934, count=1660
      V2
        BytesRef.utf8ToString() total=41175167345, count=16065
        WindowFunctionBatchIterator.materializeWithSpare(Row, int) total=26613920923, count=35824
        Arrays.copyOfRange(...) total=24673553695, count=15233
        DoubleToDecimal.toString(double) total=24409084804, count=14352
        FloatToDecimal.toString(float) total=24236959439, count=15269
        StringUTF16.compress(...) total=17736170578, count=5626
        TimSort.sort(...) total=16778674314, count=890
        Float.valueOf(float) total=9776494125, count=3592
        Arrays.copyOf(...) total=9602955924, count=1718
        Array.newInstance(Class, int) total=4593427945, count=6852

    Top frames (by count)
      V1
        WindowFunctionBatchIterator.materializeWithSpare(Row, int) total=27584724008, count=25362
        Lists.findFirstNonPeer(...) total=21403, count=21403
        BytesRef.utf8ToString() total=84522947314, count=20982
        FloatToDecimal.toString(float) total=25069515793, count=19716
        DoubleToDecimal.toString(double) total=25043066945, count=19472
        Arrays.copyOfRange(...) total=23848089297, count=18740
        PriorityQueue.offer(Object) total=10385, count=10385
        OrderingByPosition.lambda$arrayOrdering$0(...) total=9500, count=9500
        Array.newInstance(Class, int) total=3879895736, count=8443
        StringUTF16.compress(...) total=31017551730, count=8125
      V2
        WindowFunctionBatchIterator.materializeWithSpare(Row, int) total=26613920923, count=35824
        Lists.findFirstNonPeer(...) total=21100, count=21100
        BytesRef.utf8ToString() total=41175167345, count=16065
        FloatToDecimal.toString(float) total=24236959439, count=15269
        Arrays.copyOfRange(...) total=24673553695, count=15233
        DoubleToDecimal.toString(double) total=24409084804, count=14352
        PriorityQueue.siftUpUsingComparator(...) total=10811, count=10811
        OrderingByPosition.lambda$arrayOrdering$0(...) total=9634, count=9634
        Array.newInstance(Class, int) total=4593427945, count=6852
        StringUTF16.compress(...) total=17736170578, count=5626

    perf stat
      v1
        branches:u        :   2670030644266.00
        cache-misses:u    :     40326666526.00
        instructions:u    :  14613859699017.00
        faults:u          :        38101839.00
        context-switches:u:               0.00
      v2
        branches:u        :   2500410502990.00
        cache-misses:u    :     40594044497.00
        instructions:u    :  13588129227004.00
        faults:u          :        33933656.00
        context-switches:u:               0.00
