### PR TITLE
Optimize casts also for select symbols

### DIFF
--- a/server/src/main/java/io/crate/planner/operators/Collect.java
+++ b/server/src/main/java/io/crate/planner/operators/Collect.java
@@ -293,7 +293,10 @@ public class Collect implements LogicalPlan {
         }
 
         var sessionSettings = plannerContext.transactionContext().sessionSettings();
-        List<Symbol> boundOutputs = Lists.map(outputs, binder);
+        List<Symbol> boundOutputs = Lists.map(
+            outputs,
+            binder.andThen(x -> Optimizer.optimizeCasts(x, plannerContext))
+        );
         return new RoutedCollectPhase(
             plannerContext.jobId(),
             plannerContext.nextExecutionPhaseId(),

--- a/server/src/test/java/io/crate/planner/SelectPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/SelectPlannerTest.java
@@ -92,6 +92,7 @@ import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 import io.crate.testing.T3;
 import io.crate.types.DataTypes;
+import io.crate.types.StringType;
 
 public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
 
@@ -1784,6 +1785,18 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
                 );
             },
             x -> assertThat(x).isExactlyInstanceOf(EvalProjection.class)
+        );
+    }
+
+    @Test
+    public void test_removes_redundant_casts_on_collect_symbols() throws Exception {
+        var e = SQLExecutor.of(clusterService)
+            .addTable("create table tbl (x varchar(3))");
+        Collect collect = e.plan("select max(x) from tbl");
+        assertThat(collect.collectPhase().toCollect()).satisfiesExactly(
+            x -> assertThat(x).isReference()
+                    .hasName("x")
+                    .hasType(StringType.of(3))
         );
     }
 }


### PR DESCRIPTION
We saw a regression in hyperloglog benchmarks after https://github.com/crate/crate-benchmarks/pull/365
This was due to `cCode` changing from `text` to `varchar(3)` which
caused the `hyperloglog_distinct("cCode")` expression to involve an
implicit cast from `varchar(3)` to `text`.

The implicit cast function meant that the `DocValueAggregator` code path
couldn't be used.

Solution is to apply the cast optimizer also for the `toCollect` symbols
of the `RoutedCollectPhase`

    Q: select hyperloglog_distinct("cCode") from uservisits
    C: 1
    | Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
    |   V1    |      251.832 ±   27.172 |    239.072 |    246.272 |    251.487 |    428.932 |
    |   V2    |      173.792 ±   24.890 |    162.651 |    169.501 |    174.631 |    341.372 |
    ├---------┴-------------------------┴------------┴------------┴------------┴------------┘
    |               -  36.67%                           -  36.93%
    There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 36.
    67%
    The test has statistical significance

