### PR TITLE
tests: remove space to actually enable TRACE level

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/CopyFromFailFastITest.java
+++ b/server/src/test/java/io/crate/integrationtests/CopyFromFailFastITest.java
@@ -89,7 +89,7 @@ public class CopyFromFailFastITest extends IntegTestCase {
     }
 
     @UseRandomizedOptimizerRules(0)
-    @TestLogging("io.crate.execution.dml.upsert:DEBUG, io.crate.execution.engine.distribution:TRACE")
+    @TestLogging("io.crate.execution.dml.upsert:DEBUG,io.crate.execution.engine.distribution:TRACE")
     @Test
     public void test_copy_from_with_fail_fast_with_write_error_on_non_handler_node() throws Exception {
         cluster().startNode();
@@ -168,7 +168,7 @@ public class CopyFromFailFastITest extends IntegTestCase {
         assertThat((long) response.rows()[0][0]).isLessThanOrEqualTo(numDocs - failedNumDocs);
     }
 
-    @TestLogging("io.crate.execution.dml.upsert:DEBUG, io.crate.execution.engine.distribution:TRACE")
+    @TestLogging("io.crate.execution.dml.upsert:DEBUG,io.crate.execution.engine.distribution:TRACE")
     @Test
     public void test_copy_from_with_fail_fast_with_write_error_on_handler_node() throws Exception {
         cluster().startNode();


### PR DESCRIPTION
Follow up to https://github.com/crate/crate/commit/d44e88cb19eec0f8ac3d7834b69ececd4d140d89

`LoggingListener` does `testLogging.value().split(",")` and second package mistakenly includes whitespace

Relates to https://crate.slack.com/archives/CDFFXU7CG/p1782285313710409?thread_ts=1782240106.458199&cid=CDFFXU7CG

