### PR TITLE
Avoid list copies in DocTableRelation ctor

### DIFF
--- a/server/src/main/java/io/crate/analyze/relations/AbstractTableRelation.java
+++ b/server/src/main/java/io/crate/analyze/relations/AbstractTableRelation.java
@@ -36,12 +36,10 @@ public abstract class AbstractTableRelation<T extends TableInfo> implements Anal
 
     protected final T tableInfo;
     private final List<Symbol> outputs;
-    private final List<Symbol> hiddenOutputs;
 
-    protected AbstractTableRelation(T tableInfo, List<Symbol> outputs, List<Symbol> hiddenOutputs) {
+    protected AbstractTableRelation(T tableInfo, List<Symbol> outputs) {
         this.tableInfo = tableInfo;
         this.outputs = outputs;
-        this.hiddenOutputs = hiddenOutputs;
     }
 
     public T tableInfo() {
@@ -51,11 +49,6 @@ public abstract class AbstractTableRelation<T extends TableInfo> implements Anal
     @Override
     public List<Symbol> outputs() {
         return outputs;
-    }
-
-    @Override
-    public List<Symbol> hiddenOutputs() {
-        return hiddenOutputs;
     }
 
     @Nullable

--- a/server/src/main/java/io/crate/analyze/relations/DocTableRelation.java
+++ b/server/src/main/java/io/crate/analyze/relations/DocTableRelation.java
@@ -28,11 +28,12 @@ import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.common.logging.DeprecationLogger;
 import org.jspecify.annotations.Nullable;
-import io.crate.common.annotations.VisibleForTesting;
 
+import io.crate.common.annotations.VisibleForTesting;
 import io.crate.exceptions.AmbiguousColumnException;
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.exceptions.ColumnValidationException;
+import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.GeneratedReference;
 import io.crate.metadata.Reference;
@@ -45,15 +46,23 @@ public class DocTableRelation extends AbstractTableRelation<DocTableInfo> {
     public static final DeprecationLogger DEPRECATION_LOGGER =
         new DeprecationLogger(LogManager.getLogger(DocTableRelation.class));
 
+    private List<Symbol> hiddenOutputs = null;
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
     public DocTableRelation(DocTableInfo tableInfo) {
         // System columns are excluded from `tableInfo.columns()` by default,
         // but parent relations need to be able to see them so that they're selectable.
         // E.g. in `select a._id from tbl as a`
-        super(
-            tableInfo,
-            List.copyOf(tableInfo.rootColumns()),
-            concat(SysColumns.forTable(tableInfo.ident()), tableInfo.indexColumns())
-        );
+        super(tableInfo, (List<Symbol>) (List) tableInfo.rootColumns());
+    }
+
+    @Override
+    public List<Symbol> hiddenOutputs() {
+        // Lazy because hidden outputs aren't used without table alias in the query
+        if (hiddenOutputs == null) {
+            hiddenOutputs = concat(SysColumns.forTable(tableInfo.ident()), tableInfo.indexColumns());
+        }
+        return hiddenOutputs;
     }
 
     @Override

--- a/server/src/main/java/io/crate/analyze/relations/TableRelation.java
+++ b/server/src/main/java/io/crate/analyze/relations/TableRelation.java
@@ -25,6 +25,7 @@ import java.util.List;
 
 import io.crate.exceptions.AmbiguousColumnException;
 import io.crate.exceptions.ColumnUnknownException;
+import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Reference;
 import io.crate.metadata.table.Operation;
@@ -33,7 +34,12 @@ import io.crate.metadata.table.TableInfo;
 public class TableRelation extends AbstractTableRelation<TableInfo> {
 
     public TableRelation(TableInfo tableInfo) {
-        super(tableInfo, List.copyOf(tableInfo.rootColumns()), List.of());
+        super(tableInfo, List.copyOf(tableInfo.rootColumns()));
+    }
+
+    @Override
+    public List<Symbol> hiddenOutputs() {
+        return List.of();
     }
 
     @Override

--- a/server/src/main/java/io/crate/fdw/ForeignTableRelation.java
+++ b/server/src/main/java/io/crate/fdw/ForeignTableRelation.java
@@ -38,7 +38,12 @@ import io.crate.metadata.table.Operation;
 public class ForeignTableRelation extends AbstractTableRelation<RelationMetadata.ForeignTable> {
 
     public ForeignTableRelation(RelationMetadata.ForeignTable table) {
-        super(table, List.copyOf(table.rootColumns()), List.of());
+        super(table, List.copyOf(table.rootColumns()));
+    }
+
+    @Override
+    public List<Symbol> hiddenOutputs() {
+        return List.of();
     }
 
     @Override


### PR DESCRIPTION
Minor micro optimization. Noticed looking at an insert from values profile:

<img width="3752" height="954" alt="image" src="https://github.com/user-attachments/assets/0aaeef16-336d-4d72-97f0-443861d39568" />
