### PR TITLE
Test: enable more debug logging for flaky copy-from-fail-fast

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/CopyFromFailFastITest.java
+++ b/server/src/test/java/io/crate/integrationtests/CopyFromFailFastITest.java
@@ -89,7 +89,7 @@ public class CopyFromFailFastITest extends IntegTestCase {
     }
 
     @UseRandomizedOptimizerRules(0)
-    @TestLogging("io.crate.execution.dml.upsert:DEBUG,io.crate.execution.engine.distribution:TRACE")
+    @TestLogging("io.crate.execution.dml.upsert:DEBUG,io.crate.execution.engine.distribution:TRACE,io.crate.execution.engine.indexing:DEBUG")
     @Test
     public void test_copy_from_with_fail_fast_with_write_error_on_non_handler_node() throws Exception {
         cluster().startNode();
@@ -168,7 +168,7 @@ public class CopyFromFailFastITest extends IntegTestCase {
         assertThat((long) response.rows()[0][0]).isLessThanOrEqualTo(numDocs - failedNumDocs);
     }
 
-    @TestLogging("io.crate.execution.dml.upsert:DEBUG,io.crate.execution.engine.distribution:TRACE")
+    @TestLogging("io.crate.execution.dml.upsert:DEBUG,io.crate.execution.engine.distribution:TRACE,io.crate.execution.engine.indexing:DEBUG")
     @Test
     public void test_copy_from_with_fail_fast_with_write_error_on_handler_node() throws Exception {
         cluster().startNode();


### PR DESCRIPTION
Please see https://github.com/crate/crate/pull/19632 - the flaky failures could be due to backpressure delays. Enabling debug logging for `BatchIteratorBackpressureExecutor` would also help with investigating the root cause.

Relates: https://github.com/crate/crate/pull/19624.