### PR TITLE
Move batchPagingIterator.kill outside synchronized to avoid deadlocks

### DIFF
--- a/docs/appendices/release-notes/6.3.5.rst
+++ b/docs/appendices/release-notes/6.3.5.rst
@@ -49,3 +49,7 @@ Fixes
 - Fixed an issue that would throw a misleading ``NullPointerException`` when
   ``CREATE REPOSITORY`` failed during repository verification, by returning a
   user friendly error message.
+
+- Fixed an issue causing ``KILL`` statement or
+  :ref:`statement_timeout <conf-session-statement-timeout>` to not properly
+  kill a query and leading to resources leak.

--- a/server/src/main/java/io/crate/execution/jobs/CumulativePageBucketReceiver.java
+++ b/server/src/main/java/io/crate/execution/jobs/CumulativePageBucketReceiver.java
@@ -215,9 +215,7 @@ public class CumulativePageBucketReceiver implements PageBucketReceiver {
         try {
             buckets = getBuckets();
         } catch (Throwable t) {
-            kill(t);
-            // the iterator already returned it's loadNextBatch future, we must complete it exceptionally
-            currentPage.completeExceptionally(t);
+            kill(t); // Also takes care of completing currentPage.
             return;
         }
         if (allUpstreamsExhausted()) {
@@ -303,7 +301,6 @@ public class CumulativePageBucketReceiver implements PageBucketReceiver {
         boolean shouldTriggerConsumer = false;
         synchronized (lock) {
             lastThrowable = t;
-            currentPage.completeExceptionally(t);
             if (receivingFirstPage) {
                 // no active consumer - can "activate" it with a failure
                 receivingFirstPage = false;
@@ -311,6 +308,7 @@ public class CumulativePageBucketReceiver implements PageBucketReceiver {
             }
         }
         batchPagingIterator.kill(t); // this causes a already active consumer to fail
+        currentPage.completeExceptionally(t);
         if (shouldTriggerConsumer) {
             consumer.accept(null, t);
         }

--- a/server/src/main/java/io/crate/execution/jobs/CumulativePageBucketReceiver.java
+++ b/server/src/main/java/io/crate/execution/jobs/CumulativePageBucketReceiver.java
@@ -303,7 +303,6 @@ public class CumulativePageBucketReceiver implements PageBucketReceiver {
         boolean shouldTriggerConsumer = false;
         synchronized (lock) {
             lastThrowable = t;
-            batchPagingIterator.kill(t); // this causes a already active consumer to fail
             currentPage.completeExceptionally(t);
             if (receivingFirstPage) {
                 // no active consumer - can "activate" it with a failure
@@ -311,6 +310,7 @@ public class CumulativePageBucketReceiver implements PageBucketReceiver {
                 shouldTriggerConsumer = true;
             }
         }
+        batchPagingIterator.kill(t); // this causes a already active consumer to fail
         if (shouldTriggerConsumer) {
             consumer.accept(null, t);
         }

--- a/server/src/test/java/io/crate/execution/jobs/CumulativePageBucketReceiverTest.java
+++ b/server/src/test/java/io/crate/execution/jobs/CumulativePageBucketReceiverTest.java
@@ -36,6 +36,7 @@ import org.junit.Test;
 import io.crate.Streamer;
 import io.crate.data.ArrayBucket;
 import io.crate.data.testing.TestingRowConsumer;
+import io.crate.exceptions.JobKilledException;
 import io.crate.execution.engine.distribution.merge.PassThroughPagingIterator;
 import io.crate.types.DataTypes;
 
@@ -122,6 +123,62 @@ public class CumulativePageBucketReceiverTest extends ESTestCase {
             );
             bucketReceiver.consumeRows();
             assertThat(rowConsumer.completionFuture()).isDone();
+        }
+    }
+
+    @Test
+    public void two_threads_running_2_kill_chains_dont_deadlock() throws Exception {
+        try (var executor = Executors.newFixedThreadPool(2)) {
+            CumulativePageBucketReceiver receiver1 = new CumulativePageBucketReceiver(
+                "n1",
+                1,
+                executor,
+                new Streamer[]{DataTypes.INTEGER.streamer()},
+                new TestingRowConsumer(),
+                PassThroughPagingIterator.oneShot(),
+                1
+            );
+            CumulativePageBucketReceiver receiver2 = new CumulativePageBucketReceiver(
+                "n1",
+                2,
+                executor,
+                new Streamer[]{DataTypes.INTEGER.streamer()},
+                new TestingRowConsumer(),
+                PassThroughPagingIterator.oneShot(),
+                1
+            );
+
+            // Imitating 2 concurrent kill chains.
+            // RootTask.killTasks and RootTask.taskFinishedListener.onFailure.
+            // Let's say we have the following tasks in orderedTasks:
+            // rx1_rec1, rx_rec2.
+
+            // rx1_rec1 gets killed in TaskService, forwardFailure handler kills rx1_rec1
+            receiver1.completionFuture().whenComplete((r, t) -> {
+                if (t != null) {
+                    // rx_rec2 is picked up in the RootTask.taskFinishedListener.onFailure
+                    // because other kill chain RootTasks.killTasks hasn't picked up rx_rec2 yet.
+                    receiver2.kill(t);
+                }
+            });
+            // RootTasks.killTasks goes to the next task in orderedTasks:rx_rec2
+            // and grabs its lock right after another kill chain passed isDone check
+            receiver2.completionFuture().whenComplete((r, t) -> {
+                if (t != null) {
+                    receiver1.kill(t);
+                }
+            });
+            Thread t1 = new Thread(() -> receiver1.kill(JobKilledException.of("test kill")));
+            Thread t2 = new Thread(() -> receiver2.kill(JobKilledException.of("test kill")));
+
+            t1.start();
+            t2.start();
+
+            t1.join(1000);
+            t2.join(1000);
+
+            assertThat(t1.isAlive()).isFalse();
+            assertThat(t2.isAlive()).isFalse();
         }
     }
 }


### PR DESCRIPTION
Relates to https://github.com/crate/support/issues/874

`TaskService.killTasks -> RootTask.kill `starts a kill chain. 
A task kill can lead to `DistributingConsumer.forwardFailure`, triggering another kill on response handler.

Response handler kill, in turn, can start another kill chain in the `CumulativePageBucketReceiver.kill` via 
`batchPagingIterator.kill -> closeCallback -> task finish -> TaskFinishedListener.onFailure`.

We shouldn't hold a lock while starting another kill chain,
otherwise it can lead to deadlocks.

