### PR TITLE
Debug: Increase backpressure delay for COPY FROM fail-fast timeout

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/indexing/BatchIteratorBackpressureExecutor.java
+++ b/server/src/main/java/io/crate/execution/engine/indexing/BatchIteratorBackpressureExecutor.java
@@ -170,7 +170,7 @@ public class BatchIteratorBackpressureExecutor<T, R> {
             while (batchIterator.moveNext()) {
                 T item = batchIterator.currentElement();
                 if (pauseConsumption.test(item)) {
-                    long delayInMs = getDelayInMs.apply(item);
+                    long delayInMs = getDelayInMs.apply(item) * 1000;
                     if (delayInMs > 0) {
                         if (LOGGER.isDebugEnabled()) {
                             LOGGER.debug("Pausing consumption jobId={} delayInMs={}", jobId, delayInMs);

--- a/server/src/test/java/io/crate/integrationtests/CopyFromFailFastITest.java
+++ b/server/src/test/java/io/crate/integrationtests/CopyFromFailFastITest.java
@@ -45,6 +45,7 @@ import org.junit.After;
 import org.junit.Test;
 
 import com.carrotsearch.randomizedtesting.LifecycleScope;
+import com.carrotsearch.randomizedtesting.annotations.Repeat;
 
 import io.crate.exceptions.JobKilledException;
 import io.crate.metadata.RelationName;
@@ -88,6 +89,7 @@ public class CopyFromFailFastITest extends IntegTestCase {
             .hasMessageContaining("Job killed. Cannot cast value `fail here` to type `integer`");
     }
 
+    @Repeat(iterations = 10)
     @UseRandomizedOptimizerRules(0)
     @TestLogging("io.crate.execution.dml.upsert:DEBUG, io.crate.execution.engine.distribution:TRACE")
     @Test


### PR DESCRIPTION
This PR is an attempt to reproduce extremely rarely failing test - https://wacklig.pipifein.dev/github/crate/crate/case/io.crate.integrationtests.CopyFromFailFastITest/test_copy_from_with_fail_fast_with_write_error_on_non_handler_node

Below is the stack trace from above link:
```
org.opentest4j.MultipleFailuresError: 
Multiple Failures (3 failures)
	java.lang.AssertionError: 
Expecting throwable message:
  "Job killed. statement_timeout (10s/exec)"
to contain:
  "Cannot cast value `fail here` to type `integer`"
but did not.

Throwable that failed the check:

io.crate.exceptions.JobKilledException: Job killed. statement_timeout (10s/exec)
	at io.crate.exceptions.JobKilledException.of(JobKilledException.java:42)
	at io.crate.session.Session.lambda$addStatementTimeout$0(Session.java:661)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:545)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:328)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:309)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
	at java.base/java.lang.Thread.run(Thread.java:1474)

	org.opentest4j.AssertionFailedError: [Query breaker not reset to 0 on node: node_s0] 
expected: 0L
 but was: 2097152L
	java.lang.AssertionError: Open jobs:
Active tasks:
## node: node_s0
{8055dd39-04ae-fc14-db9c-676a3d2205ef=Task{id=8055dd39-04ae-fc14-db9c-676a3d2205ef, tasks=[CollectTask{id=0, sharedContexts=SharedShardContexts{allocatedShards=[]}, consumer=DistributingConsumer{jobId=8055dd39-04ae-fc14-db9c-676a3d2205ef, targetPhaseId=1, inputId=0, bucketIdx=1, downstreams=[Downstream{04NSOQjNQQ277W3TFppXOQ', needsMoreData=true}], failure=io.crate.exceptions.JobKilledException: Job killed. statement_timeout (10s/exec)}, searchContexts=[], batchIterator=io.crate.data.CollectingBatchIterator@4482ec4b, finished=false}], closed=true, participating=[04NSOQjNQQ277W3TFppXOQ]}}

	at com.carrotsearch.randomizedtesting.ThreadLeakControl$SubNotifier.fireTestFinished(ThreadLeakControl.java:213)
	at com.carrotsearch.randomizedtesting.RandomizedRunner.runSingleTest(RandomizedRunner.java:964)
	at com.carrotsearch.randomizedtesting.RandomizedRunner$5.evaluate(RandomizedRunner.java:840)
	at com.carrotsearch.randomizedtesting.RandomizedRunner$6.evaluate(RandomizedRunner.java:891)
	at com.carrotsearch.randomizedtesting.RandomizedRunner$7.evaluate(RandomizedRunner.java:902)
	at org.apache.lucene.tests.util.AbstractBeforeAfterRule$1.evaluate(AbstractBeforeAfterRule.java:43)
	at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
	at org.apache.lucene.tests.util.TestRuleStoreClassName$1.evaluate(TestRuleStoreClassName.java:38)
	at com.carrotsearch.randomizedtesting.rules.NoShadowingOrOverridesOnMethodsRule$1.evaluate(NoShadowingOrOverridesOnMethodsRule.java:40)
	at com.carrotsearch.randomizedtesting.rules.NoShadowingOrOverridesOnMethodsRule$1.evaluate(NoShadowingOrOverridesOnMethodsRule.java:40)
	at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
	at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
	at org.apache.lucene.tests.util.TestRuleAssertionsRequired$1.evaluate(TestRuleAssertionsRequired.java:53)
	at org.apache.lucene.tests.util.AbstractBeforeAfterRule$1.evaluate(AbstractBeforeAfterRule.java:43)
	at org.apache.lucene.tests.util.TestRuleMarkFailure$1.evaluate(TestRuleMarkFailure.java:44)
	at org.apache.lucene.tests.util.TestRuleIgnoreAfterMaxFailures$1.evaluate(TestRuleIgnoreAfterMaxFailures.java:60)
	at org.apache.lucene.tests.util.TestRuleIgnoreTestSuites$1.evaluate(TestRuleIgnoreTestSuites.java:47)
	at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
	at com.carrotsearch.randomizedtesting.ThreadLeakControl$StatementRunner.run(ThreadLeakControl.java:390)
	at com.carrotsearch.randomizedtesting.ThreadLeakControl.lambda$forkTimeoutingTask$0(ThreadLeakControl.java:850)
	at java.base/java.lang.Thread.run(Thread.java:1474)
	Suppressed: java.lang.AssertionError: 
Expecting throwable message:
  "Job killed. statement_timeout (10s/exec)"
to contain:
  "Cannot cast value `fail here` to type `integer`"
but did not.

Throwable that failed the check:

io.crate.exceptions.JobKilledException: Job killed. statement_timeout (10s/exec)
	at io.crate.exceptions.JobKilledException.of(JobKilledException.java:42)
	at io.crate.session.Session.lambda$addStatementTimeout$0(Session.java:661)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:545)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:328)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:309)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
	at java.base/java.lang.Thread.run(Thread.java:1474)

		at io.crate.integrationtests.CopyFromFailFastITest.lambda$test_copy_from_with_fail_fast_with_write_error_on_non_handler_node$1(CopyFromFailFastITest.java:156)
		at io.crate.testing.Asserts.assertExpectedLogMessages(Asserts.java:341)
		at io.crate.integrationtests.CopyFromFailFastITest.test_copy_from_with_fail_fast_with_write_error_on_non_handler_node(CopyFromFailFastITest.java:150)
	Suppressed: org.opentest4j.AssertionFailedError: [Query breaker not reset to 0 on node: node_s0] 
expected: 0L
 but was: 2097152L
		at org.elasticsearch.test.TestCluster.lambda$ensureEstimatedStats$1(TestCluster.java:469)
		at org.elasticsearch.test.ESTestCase.assertBusy(ESTestCase.java:711)
		at org.elasticsearch.test.ESTestCase.assertBusy(ESTestCase.java:685)
		at org.elasticsearch.test.TestCluster.ensureEstimatedStats(TestCluster.java:464)
		at org.elasticsearch.test.TestCluster.assertAfterTest(TestCluster.java:2289)
		at org.elasticsearch.test.IntegTestCase.afterInternal(IntegTestCase.java:481)
		at org.elasticsearch.test.IntegTestCase.cleanUpCluster(IntegTestCase.java:1195)
		at java.base/java.lang.reflect.Method.invoke(Method.java:565)
		at com.carrotsearch.randomizedtesting.RandomizedRunner.invoke(RandomizedRunner.java:1763)
		at com.carrotsearch.randomizedtesting.RandomizedRunner$10.evaluate(RandomizedRunner.java:1004)
		at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:328)
		... 1 more
	Suppressed: java.lang.AssertionError: Open jobs:
Active tasks:
## node: node_s0
{8055dd39-04ae-fc14-db9c-676a3d2205ef=Task{id=8055dd39-04ae-fc14-db9c-676a3d2205ef, tasks=[CollectTask{id=0, sharedContexts=SharedShardContexts{allocatedShards=[]}, consumer=DistributingConsumer{jobId=8055dd39-04ae-fc14-db9c-676a3d2205ef, targetPhaseId=1, inputId=0, bucketIdx=1, downstreams=[Downstream{04NSOQjNQQ277W3TFppXOQ', needsMoreData=true}], failure=io.crate.exceptions.JobKilledException: Job killed. statement_timeout (10s/exec)}, searchContexts=[], batchIterator=io.crate.data.CollectingBatchIterator@4482ec4b, finished=false}], closed=true, participating=[04NSOQjNQQ277W3TFppXOQ]}}

		at org.elasticsearch.test.IntegTestCase.assertNoTasksAreLeftOpen(IntegTestCase.java:1456)
		at java.base/java.lang.reflect.Method.invoke(Method.java:565)
		at com.carrotsearch.randomizedtesting.RandomizedRunner.invoke(RandomizedRunner.java:1763)
		at com.carrotsearch.randomizedtesting.RandomizedRunner$10.evaluate(RandomizedRunner.java:1004)
		at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:328)
		... 1 more
	Caused by: java.lang.AssertionError: 
Expecting empty but was: {8055dd39-04ae-fc14-db9c-676a3d2205ef=Task{id=8055dd39-04ae-fc14-db9c-676a3d2205ef, tasks=[CollectTask{id=0, sharedContexts=SharedShardContexts{allocatedShards=[]}, consumer=DistributingConsumer{jobId=8055dd39-04ae-fc14-db9c-676a3d2205ef, targetPhaseId=1, inputId=0, bucketIdx=1, downstreams=[Downstream{04NSOQjNQQ277W3TFppXOQ', needsMoreData=true}], failure=io.crate.exceptions.JobKilledException: Job killed. statement_timeout (10s/exec)}, searchContexts=[], batchIterator=io.crate.data.CollectingBatchIterator@4482ec4b, finished=false}], closed=true, participating=[04NSOQjNQQ277W3TFppXOQ]}}
		at org.elasticsearch.test.IntegTestCase.lambda$assertNoTasksAreLeftOpen$0(IntegTestCase.java:1401)
		at org.elasticsearch.test.ESTestCase.assertBusy(ESTestCase.java:711)
		at org.elasticsearch.test.IntegTestCase.assertNoTasksAreLeftOpen(IntegTestCase.java:1396)
		... 5 more
```

And this is what I observed when executed current commit locally:
```
java.lang.AssertionError: 
Expecting throwable message:
  "Job killed. statement_timeout (10s/exec)"
to contain:
  "Cannot cast value `fail here` to type `integer`"
but did not.

Throwable that failed the check:

io.crate.exceptions.JobKilledException: Job killed. statement_timeout (10s/exec)
	at io.crate.exceptions.JobKilledException.of(JobKilledException.java:42)
	at io.crate.session.Session.lambda$addStatementTimeout$0(Session.java:661)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:545)
	at java.base/java.util.concurrent.FutureTask.run$$$capture(FutureTask.java:330)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java)
	at --- Async.Stack.Trace --- (captured by IntelliJ IDEA debugger)
	at java.base/java.util.concurrent.FutureTask.<init>(FutureTask.java:153)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.<init>(ScheduledThreadPoolExecutor.java:220)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor.schedule(ScheduledThreadPoolExecutor.java:548)
	at io.crate.session.Session.addStatementTimeout(Session.java:669)
	at io.crate.session.Session.singleExec(Session.java:926)
	at io.crate.session.Session.exec(Session.java:711)
	at io.crate.session.Session.triggerDeferredExecutions(Session.java:683)
	at io.crate.session.Session.sync(Session.java:620)
	at io.crate.testing.SQLTransportExecutor.execute(SQLTransportExecutor.java:320)
	at io.crate.testing.SQLTransportExecutor.execute(SQLTransportExecutor.java:289)
	at io.crate.testing.SQLTransportExecutor.executeTransportOrJdbc(SQLTransportExecutor.java:223)
	at io.crate.testing.SQLTransportExecutor.exec(SQLTransportExecutor.java:134)
	at io.crate.integrationtests.CopyFromFailFastITest.lambda$test_copy_from_with_fail_fast_with_write_error_on_non_handler_node$2(CopyFromFailFastITest.java:154)
	at org.assertj.core.api.ThrowableAssert.catchThrowable(ThrowableAssert.java:66)
	at org.assertj.core.api.AssertionsForClassTypes.catchThrowable(AssertionsForClassTypes.java:908)
	at org.assertj.core.api.Assertions.catchThrowable(Assertions.java:1476)
	at org.assertj.core.api.Assertions.assertThatThrownBy(Assertions.java:1319)
	at io.crate.integrationtests.CopyFromFailFastITest.lambda$test_copy_from_with_fail_fast_with_write_error_on_non_handler_node$1(CopyFromFailFastITest.java:154)
	at io.crate.testing.Asserts.assertExpectedLogMessages(Asserts.java:341)
	at io.crate.integrationtests.CopyFromFailFastITest.test_copy_from_with_fail_fast_with_write_error_on_non_handler_node(CopyFromFailFastITest.java:152)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
	at java.base/java.lang.reflect.Method.invoke(Method.java:565)
	at com.carrotsearch.randomizedtesting.RandomizedRunner.invoke(RandomizedRunner.java:1780)
	at com.carrotsearch.randomizedtesting.RandomizedRunner$8.evaluate(RandomizedRunner.java:959)
	at com.carrotsearch.randomizedtesting.RandomizedRunner$9.evaluate(RandomizedRunner.java:995)
	at com.carrotsearch.randomizedtesting.RandomizedRunner$10.evaluate(RandomizedRunner.java:1009)
	at org.junit.rules.TestWatcher$1.evaluate(TestWatcher.java:61)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:299)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:293)
	at java.base/java.util.concurrent.FutureTask.run$$$capture(FutureTask.java:330)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java)
	at --- Async.Stack.Trace --- (captured by IntelliJ IDEA debugger)
	at java.base/java.util.concurrent.FutureTask.<init>(FutureTask.java:134)
	at org.junit.internal.runners.statements.FailOnTimeout.evaluate(FailOnTimeout.java:122)
	at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
	at org.apache.lucene.tests.util.TestRuleSetupTeardownChained$1.evaluate(TestRuleSetupTeardownChained.java:48)
	at org.apache.lucene.tests.util.AbstractBeforeAfterRule$1.evaluate(AbstractBeforeAfterRule.java:43)
	at org.apache.lucene.tests.util.TestRuleThreadAndTestName$1.evaluate(TestRuleThreadAndTestName.java:45)
	at org.apache.lucene.tests.util.TestRuleIgnoreAfterMaxFailures$1.evaluate(TestRuleIgnoreAfterMaxFailures.java:60)
	at org.apache.lucene.tests.util.TestRuleMarkFailure$1.evaluate(TestRuleMarkFailure.java:44)
	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
	at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
	at com.carrotsearch.randomizedtesting.ThreadLeakControl$StatementRunner.run(ThreadLeakControl.java:390)
	at com.carrotsearch.randomizedtesting.ThreadLeakControl.forkTimeoutingTask(ThreadLeakControl.java:843)
	at com.carrotsearch.randomizedtesting.ThreadLeakControl$3.evaluate(ThreadLeakControl.java:490)
	at com.carrotsearch.randomizedtesting.RandomizedRunner.runSingleTest(RandomizedRunner.java:968)
	at com.carrotsearch.randomizedtesting.RandomizedRunner$5.evaluate(RandomizedRunner.java:853)
	at com.carrotsearch.randomizedtesting.RandomizedRunner$6.evaluate(RandomizedRunner.java:904)
	at com.carrotsearch.randomizedtesting.RandomizedRunner$7.evaluate(RandomizedRunner.java:915)
	at org.apache.lucene.tests.util.AbstractBeforeAfterRule$1.evaluate(AbstractBeforeAfterRule.java:43)
	at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
	at org.apache.lucene.tests.util.TestRuleStoreClassName$1.evaluate(TestRuleStoreClassName.java:38)
	at com.carrotsearch.randomizedtesting.rules.NoShadowingOrOverridesOnMethodsRule$1.evaluate(NoShadowingOrOverridesOnMethodsRule.java:40)
	at com.carrotsearch.randomizedtesting.rules.NoShadowingOrOverridesOnMethodsRule$1.evaluate(NoShadowingOrOverridesOnMethodsRule.java:40)
	at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
	at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
	at org.apache.lucene.tests.util.TestRuleAssertionsRequired$1.evaluate(TestRuleAssertionsRequired.java:53)
	at org.apache.lucene.tests.util.AbstractBeforeAfterRule$1.evaluate(AbstractBeforeAfterRule.java:43)
	at org.apache.lucene.tests.util.TestRuleMarkFailure$1.evaluate(TestRuleMarkFailure.java:44)
	at org.apache.lucene.tests.util.TestRuleIgnoreAfterMaxFailures$1.evaluate(TestRuleIgnoreAfterMaxFailures.java:60)
	at org.apache.lucene.tests.util.TestRuleIgnoreTestSuites$1.evaluate(TestRuleIgnoreTestSuites.java:47)
	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
	at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
	at com.carrotsearch.randomizedtesting.ThreadLeakControl$StatementRunner.run(ThreadLeakControl.java:390)
	at com.carrotsearch.randomizedtesting.ThreadLeakControl.lambda$forkTimeoutingTask$0(ThreadLeakControl.java:850)
	at java.base/java.lang.Thread.run(Thread.java:1516)


	at io.crate.integrationtests.CopyFromFailFastITest.lambda$test_copy_from_with_fail_fast_with_write_error_on_non_handler_node$1(CopyFromFailFastITest.java:158)
	at io.crate.testing.Asserts.assertExpectedLogMessages(Asserts.java:341)
	at io.crate.integrationtests.CopyFromFailFastITest.test_copy_from_with_fail_fast_with_write_error_on_non_handler_node(CopyFromFailFastITest.java:152)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
	at java.base/java.lang.reflect.Method.invoke(Method.java:565)
	at com.carrotsearch.randomizedtesting.RandomizedRunner.invoke(RandomizedRunner.java:1780)
	at com.carrotsearch.randomizedtesting.RandomizedRunner$8.evaluate(RandomizedRunner.java:959)
	at com.carrotsearch.randomizedtesting.RandomizedRunner$9.evaluate(RandomizedRunner.java:995)
	at com.carrotsearch.randomizedtesting.RandomizedRunner$10.evaluate(RandomizedRunner.java:1009)
	at org.junit.rules.TestWatcher$1.evaluate(TestWatcher.java:61)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:299)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:293)
	at java.base/java.util.concurrent.FutureTask.run$$$capture(FutureTask.java:330)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java)
	at --- Async.Stack.Trace --- (captured by IntelliJ IDEA debugger)
	at java.base/java.util.concurrent.FutureTask.<init>(FutureTask.java:134)
	at org.junit.internal.runners.statements.FailOnTimeout.evaluate(FailOnTimeout.java:122)
	at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
	at org.apache.lucene.tests.util.TestRuleSetupTeardownChained$1.evaluate(TestRuleSetupTeardownChained.java:48)
	at org.apache.lucene.tests.util.AbstractBeforeAfterRule$1.evaluate(AbstractBeforeAfterRule.java:43)
	at org.apache.lucene.tests.util.TestRuleThreadAndTestName$1.evaluate(TestRuleThreadAndTestName.java:45)
	at org.apache.lucene.tests.util.TestRuleIgnoreAfterMaxFailures$1.evaluate(TestRuleIgnoreAfterMaxFailures.java:60)
	at org.apache.lucene.tests.util.TestRuleMarkFailure$1.evaluate(TestRuleMarkFailure.java:44)
	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
	at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
	at com.carrotsearch.randomizedtesting.ThreadLeakControl$StatementRunner.run(ThreadLeakControl.java:390)
	at com.carrotsearch.randomizedtesting.ThreadLeakControl.forkTimeoutingTask(ThreadLeakControl.java:843)
	at com.carrotsearch.randomizedtesting.ThreadLeakControl$3.evaluate(ThreadLeakControl.java:490)
	at com.carrotsearch.randomizedtesting.RandomizedRunner.runSingleTest(RandomizedRunner.java:968)
	at com.carrotsearch.randomizedtesting.RandomizedRunner$5.evaluate(RandomizedRunner.java:853)
	at com.carrotsearch.randomizedtesting.RandomizedRunner$6.evaluate(RandomizedRunner.java:904)
	at com.carrotsearch.randomizedtesting.RandomizedRunner$7.evaluate(RandomizedRunner.java:915)
	at org.apache.lucene.tests.util.AbstractBeforeAfterRule$1.evaluate(AbstractBeforeAfterRule.java:43)
	at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
	at org.apache.lucene.tests.util.TestRuleStoreClassName$1.evaluate(TestRuleStoreClassName.java:38)
	at com.carrotsearch.randomizedtesting.rules.NoShadowingOrOverridesOnMethodsRule$1.evaluate(NoShadowingOrOverridesOnMethodsRule.java:40)
	at com.carrotsearch.randomizedtesting.rules.NoShadowingOrOverridesOnMethodsRule$1.evaluate(NoShadowingOrOverridesOnMethodsRule.java:40)
	at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
	at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
	at org.apache.lucene.tests.util.TestRuleAssertionsRequired$1.evaluate(TestRuleAssertionsRequired.java:53)
	at org.apache.lucene.tests.util.AbstractBeforeAfterRule$1.evaluate(AbstractBeforeAfterRule.java:43)
	at org.apache.lucene.tests.util.TestRuleMarkFailure$1.evaluate(TestRuleMarkFailure.java:44)
	at org.apache.lucene.tests.util.TestRuleIgnoreAfterMaxFailures$1.evaluate(TestRuleIgnoreAfterMaxFailures.java:60)
	at org.apache.lucene.tests.util.TestRuleIgnoreTestSuites$1.evaluate(TestRuleIgnoreTestSuites.java:47)
	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
	at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
	at com.carrotsearch.randomizedtesting.ThreadLeakControl$StatementRunner.run(ThreadLeakControl.java:390)
	at com.carrotsearch.randomizedtesting.ThreadLeakControl.lambda$forkTimeoutingTask$0(ThreadLeakControl.java:850)
	at java.base/java.lang.Thread.run(Thread.java:1516)


java.lang.AssertionError: Open jobs:
Active tasks:
## node: node_s1
{079750e3-5993-658d-5eae-ad76259bffae=Task{id=079750e3-5993-658d-5eae-ad76259bffae, tasks=[CollectTask{id=0, sharedContexts=SharedShardContexts{allocatedShards=[]}, consumer=DistributingConsumer{jobId=079750e3-5993-658d-5eae-ad76259bffae, targetPhaseId=1, inputId=0, bucketIdx=1, downstreams=[Downstream{OenzfnPXSQizg5z46KIQ6Q', needsMoreData=true}], failure=io.crate.exceptions.JobKilledException: Job killed. statement_timeout (10s/exec)}, searchContexts=[], batchIterator=io.crate.data.CollectingBatchIterator@658a64a3, finished=false}], closed=true, participating=[OenzfnPXSQizg5z46KIQ6Q]}}


	at org.elasticsearch.test.IntegTestCase.assertNoTasksAreLeftOpen(IntegTestCase.java:1456)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
	at java.base/java.lang.reflect.Method.invoke(Method.java:565)
	at com.carrotsearch.randomizedtesting.RandomizedRunner.invoke(RandomizedRunner.java:1780)
	at com.carrotsearch.randomizedtesting.RandomizedRunner$10.evaluate(RandomizedRunner.java:1017)
	at org.junit.rules.TestWatcher$1.evaluate(TestWatcher.java:61)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:299)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:293)
	at java.base/java.util.concurrent.FutureTask.run$$$capture(FutureTask.java:330)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java)
	at --- Async.Stack.Trace --- (captured by IntelliJ IDEA debugger)
	at java.base/java.util.concurrent.FutureTask.<init>(FutureTask.java:134)
	at org.junit.internal.runners.statements.FailOnTimeout.evaluate(FailOnTimeout.java:122)
	at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
	at org.apache.lucene.tests.util.TestRuleSetupTeardownChained$1.evaluate(TestRuleSetupTeardownChained.java:48)
	at org.apache.lucene.tests.util.AbstractBeforeAfterRule$1.evaluate(AbstractBeforeAfterRule.java:43)
	at org.apache.lucene.tests.util.TestRuleThreadAndTestName$1.evaluate(TestRuleThreadAndTestName.java:45)
	at org.apache.lucene.tests.util.TestRuleIgnoreAfterMaxFailures$1.evaluate(TestRuleIgnoreAfterMaxFailures.java:60)
	at org.apache.lucene.tests.util.TestRuleMarkFailure$1.evaluate(TestRuleMarkFailure.java:44)
	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
	at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
	at com.carrotsearch.randomizedtesting.ThreadLeakControl$StatementRunner.run(ThreadLeakControl.java:390)
	at com.carrotsearch.randomizedtesting.ThreadLeakControl.forkTimeoutingTask(ThreadLeakControl.java:843)
	at com.carrotsearch.randomizedtesting.ThreadLeakControl$3.evaluate(ThreadLeakControl.java:490)
	at com.carrotsearch.randomizedtesting.RandomizedRunner.runSingleTest(RandomizedRunner.java:968)
	at com.carrotsearch.randomizedtesting.RandomizedRunner$5.evaluate(RandomizedRunner.java:853)
	at com.carrotsearch.randomizedtesting.RandomizedRunner$6.evaluate(RandomizedRunner.java:904)
	at com.carrotsearch.randomizedtesting.RandomizedRunner$7.evaluate(RandomizedRunner.java:915)
	at org.apache.lucene.tests.util.AbstractBeforeAfterRule$1.evaluate(AbstractBeforeAfterRule.java:43)
	at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
	at org.apache.lucene.tests.util.TestRuleStoreClassName$1.evaluate(TestRuleStoreClassName.java:38)
	at com.carrotsearch.randomizedtesting.rules.NoShadowingOrOverridesOnMethodsRule$1.evaluate(NoShadowingOrOverridesOnMethodsRule.java:40)
	at com.carrotsearch.randomizedtesting.rules.NoShadowingOrOverridesOnMethodsRule$1.evaluate(NoShadowingOrOverridesOnMethodsRule.java:40)
	at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
	at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
	at org.apache.lucene.tests.util.TestRuleAssertionsRequired$1.evaluate(TestRuleAssertionsRequired.java:53)
	at org.apache.lucene.tests.util.AbstractBeforeAfterRule$1.evaluate(AbstractBeforeAfterRule.java:43)
	at org.apache.lucene.tests.util.TestRuleMarkFailure$1.evaluate(TestRuleMarkFailure.java:44)
	at org.apache.lucene.tests.util.TestRuleIgnoreAfterMaxFailures$1.evaluate(TestRuleIgnoreAfterMaxFailures.java:60)
	at org.apache.lucene.tests.util.TestRuleIgnoreTestSuites$1.evaluate(TestRuleIgnoreTestSuites.java:47)
	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
	at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
	at com.carrotsearch.randomizedtesting.ThreadLeakControl$StatementRunner.run(ThreadLeakControl.java:390)
	at com.carrotsearch.randomizedtesting.ThreadLeakControl.lambda$forkTimeoutingTask$0(ThreadLeakControl.java:850)
	at java.base/java.lang.Thread.run(Thread.java:1516)
Caused by: java.lang.AssertionError: 
Expecting empty but was: {079750e3-5993-658d-5eae-ad76259bffae=Task{id=079750e3-5993-658d-5eae-ad76259bffae, tasks=[CollectTask{id=0, sharedContexts=SharedShardContexts{allocatedShards=[]}, consumer=DistributingConsumer{jobId=079750e3-5993-658d-5eae-ad76259bffae, targetPhaseId=1, inputId=0, bucketIdx=1, downstreams=[Downstream{OenzfnPXSQizg5z46KIQ6Q', needsMoreData=true}], failure=io.crate.exceptions.JobKilledException: Job killed. statement_timeout (10s/exec)}, searchContexts=[], batchIterator=io.crate.data.CollectingBatchIterator@658a64a3, finished=false}], closed=true, participating=[OenzfnPXSQizg5z46KIQ6Q]}}
	at org.elasticsearch.test.IntegTestCase.lambda$assertNoTasksAreLeftOpen$0(IntegTestCase.java:1401)
	at org.elasticsearch.test.ESTestCase.assertBusy(ESTestCase.java:711)
	at org.elasticsearch.test.IntegTestCase.assertNoTasksAreLeftOpen(IntegTestCase.java:1396)
	... 45 more


org.opentest4j.AssertionFailedError: [Query breaker not reset to 0 on node: node_s1] 
expected: 0L
 but was: 2097152L
Expected :0L
Actual   :2097152L
```

Both had:
- JobKilledExceptions due to timeout
- no ConversionExceptions thrown at all
- CollectTasks remain open after test cleanup
- `Query breaker not reset to 0`

Because of these similarities, I think the commit does reproduce the failure.