### PR TITLE
Add rule to deduplicate predicates joined by `AND` in Filter

### DIFF
--- a/docs/appendices/release-notes/6.4.0.rst
+++ b/docs/appendices/release-notes/6.4.0.rst
@@ -166,6 +166,9 @@ Performance and Resilience Improvements
   collection of columns that are not needed during join execution until the
   final fetch phase.
 
+- Improved query planning by deduplicating identical predicates in filter when
+  joined by the ``AND`` operator
+
 
 Administration and Operations
 -----------------------------

--- a/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -95,6 +95,7 @@ import io.crate.planner.consumer.InsertFromSubQueryPlanner;
 import io.crate.planner.optimizer.Optimizer;
 import io.crate.planner.optimizer.Rule;
 import io.crate.planner.optimizer.iterative.IterativeOptimizer;
+import io.crate.planner.optimizer.rule.DeduplicateFilterAndConditions;
 import io.crate.planner.optimizer.rule.DeduplicateOrder;
 import io.crate.planner.optimizer.rule.EliminateCrossJoin;
 import io.crate.planner.optimizer.rule.EquiJoinToLookupJoin;
@@ -157,6 +158,7 @@ public class LogicalPlanner {
         new MergeAggregateAndCollectToCount(),
         new MergeAggregateRenameAndCollectToCount(),
         new MergeFilters(),
+        new DeduplicateFilterAndConditions(),
         new RewriteFilterOnCrossJoinToInnerJoin(),
         new MoveFilterBeneathRename(),
         new MoveFilterBeneathEval(),

--- a/server/src/main/java/io/crate/planner/optimizer/rule/DeduplicateFilterAndConditions.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/DeduplicateFilterAndConditions.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.rule;
+
+import java.util.List;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
+
+import io.crate.expression.operator.AndOperator;
+import io.crate.expression.symbol.Function;
+import io.crate.expression.symbol.FunctionCopyVisitor;
+import io.crate.expression.symbol.Symbol;
+import io.crate.planner.operators.Filter;
+import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.matcher.Captures;
+import io.crate.planner.optimizer.matcher.Pattern;
+
+public class DeduplicateFilterAndConditions implements Rule<Filter> {
+
+    private final Pattern<Filter> pattern = typeOf(Filter.class);
+
+    private static final Visitor VISITOR = new Visitor();
+
+    @Override
+    public Pattern<Filter> pattern() {
+        return pattern;
+    }
+
+    @Override
+    public Filter apply(Filter plan, Captures captures, Rule.Context context) {
+        Symbol query = plan.query();
+        Symbol newQuery = query.accept(VISITOR, null);
+        if (newQuery != query) {
+            return new Filter(plan.source(), newQuery);
+        }
+        return null;
+    }
+
+    static class Visitor extends FunctionCopyVisitor<Void> {
+
+        @Override
+        public Symbol visitFunction(Function func, Void context) {
+            if (func.name().equals(AndOperator.NAME)) {
+                Symbol newFunc = super.visitFunction(func, context);
+                List<Symbol> conjunctions = AndOperator.split(newFunc);
+                Set<Symbol> uniqueConjunctions = new LinkedHashSet<>(conjunctions);
+                if (uniqueConjunctions.size() < conjunctions.size()) {
+                    return AndOperator.join(uniqueConjunctions);
+                }
+                return newFunc;
+            }
+            return super.visitFunction(func, context);
+        }
+
+    }
+
+}

--- a/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
@@ -266,6 +266,7 @@ public class PgCatalogITest extends IntegTestCase {
             "max_identifier_length| 255| Shows the maximum length of identifiers in bytes.| NULL| NULL",
             "max_index_keys| 32| Shows the maximum number of index keys.| NULL| NULL",
             "memory.operation_limit| 0| Memory limit in bytes for an individual operation. 0 by-passes the operation limit, relying entirely on the global circuit breaker limits| NULL| NULL",
+            "optimizer_deduplicate_filter_and_conditions| true| Indicates if the optimizer rule DeduplicateFilterAndConditions is activated.| NULL| NULL",
             "optimizer_deduplicate_order| true| Indicates if the optimizer rule DeduplicateOrder is activated.| NULL| NULL",
             "optimizer_eliminate_cross_join| true| Indicates if the optimizer rule EliminateCrossJoin is activated.| NULL| NULL",
             "optimizer_equi_join_to_lookup_join| false| Indicates if the optimizer rule EquiJoinToLookupJoin is activated.| NULL| NULL",

--- a/server/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
@@ -410,6 +410,7 @@ public class ShowIntegrationTest extends IntegTestCase {
             "max_identifier_length| 255| Shows the maximum length of identifiers in bytes.",
             "max_index_keys| 32| Shows the maximum number of index keys.",
             "memory.operation_limit| 0| Memory limit in bytes for an individual operation. 0 by-passes the operation limit, relying entirely on the global circuit breaker limits",
+            "optimizer_deduplicate_filter_and_conditions| true| Indicates if the optimizer rule DeduplicateFilterAndConditions is activated.",
             "optimizer_deduplicate_order| true| Indicates if the optimizer rule DeduplicateOrder is activated.",
             "optimizer_eliminate_cross_join| true| Indicates if the optimizer rule EliminateCrossJoin is activated.",
             "optimizer_equi_join_to_lookup_join| false| Indicates if the optimizer rule EquiJoinToLookupJoin is activated.",

--- a/server/src/test/java/io/crate/planner/optimizer/rule/DeduplicateFilterAndConditionsTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/rule/DeduplicateFilterAndConditionsTest.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.rule;
+
+import static io.crate.testing.Asserts.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import io.crate.expression.symbol.Symbol;
+import io.crate.planner.operators.Filter;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.optimizer.matcher.Captures;
+import io.crate.planner.optimizer.matcher.Match;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.SQLExecutor;
+
+public class DeduplicateFilterAndConditionsTest extends CrateDummyClusterServiceUnitTest {
+    private LogicalPlan t1;
+    private SQLExecutor e;
+
+    @Before
+    public void prepare() throws Exception {
+        e = SQLExecutor.of(clusterService).addTable("create table t1 (a int, b int)");
+
+        t1 = e.logicalPlan("SELECT a FROM t1");
+    }
+
+    @Test
+    public void test_deduplicates_identical_predicates_joined_by_and() {
+        Symbol predicates = e.asSymbol("a > 2 AND a > 2 AND a < 10");
+        Filter filter = new Filter(t1, predicates);
+
+        assertThat(filter).hasOperators(
+                "Filter[(((a > 2) AND (a > 2)) AND (a < 10))]",
+                "  └ Collect[doc.t1 | [a] | true]");
+
+        DeduplicateFilterAndConditions rule = new DeduplicateFilterAndConditions();
+        Match<Filter> match = rule.pattern().accept(filter, Captures.empty());
+
+        assertThat(match.isPresent()).isTrue();
+        assertThat(match.value()).isSameAs(filter);
+
+        Filter deduplicatedFilter = rule.apply(match.value(), match.captures(), e.ruleContext());
+        assertThat(deduplicatedFilter).hasOperators(
+                "Filter[((a > 2) AND (a < 10))]",
+                "  └ Collect[doc.t1 | [a] | true]");
+    }
+
+    @Test
+    public void test_does_nothing_if_no_duplicates() {
+        Symbol predicates = e.asSymbol("a > 2 AND a < 10");
+        Filter filter = new Filter(t1, predicates);
+
+        assertThat(filter).hasOperators(
+                "Filter[((a > 2) AND (a < 10))]",
+                "  └ Collect[doc.t1 | [a] | true]");
+
+        DeduplicateFilterAndConditions rule = new DeduplicateFilterAndConditions();
+        Match<Filter> match = rule.pattern().accept(filter, Captures.empty());
+
+        assertThat(match.isPresent()).isTrue();
+        assertThat(match.value()).isSameAs(filter);
+
+        Filter deduplicatedFilter = rule.apply(match.value(), match.captures(), e.ruleContext());
+        assertThat(deduplicatedFilter).isNull();
+    }
+
+    @Test
+    public void test_does_nothing_if_no_AND_operator() {
+        Symbol predicates = e.asSymbol("a = 20 OR a = 20");
+        Filter filter = new Filter(t1, predicates);
+
+        assertThat(filter).hasOperators(
+                "Filter[((a = 20) OR (a = 20))]",
+                "  └ Collect[doc.t1 | [a] | true]");
+
+        DeduplicateFilterAndConditions rule = new DeduplicateFilterAndConditions();
+        Match<Filter> match = rule.pattern().accept(filter, Captures.empty());
+
+        assertThat(match.isPresent()).isTrue();
+        assertThat(match.value()).isSameAs(filter);
+
+        Filter deduplicatedFilter = rule.apply(match.value(), match.captures(), e.ruleContext());
+        assertThat(deduplicatedFilter).isNull();
+    }
+
+    @Test
+    public void test_deduplicates_and_preserves_other_conjunctions() {
+        Symbol predicates = e.asSymbol("a = 20 AND a = 20 OR b = 10");
+        Filter filter = new Filter(t1, predicates);
+
+        assertThat(filter).hasOperators(
+                "Filter[(((a = 20) AND (a = 20)) OR (b = 10))]",
+                "  └ Collect[doc.t1 | [a] | true]");
+
+        DeduplicateFilterAndConditions rule = new DeduplicateFilterAndConditions();
+        Match<Filter> match = rule.pattern().accept(filter, Captures.empty());
+
+        assertThat(match.isPresent()).isTrue();
+        assertThat(match.value()).isSameAs(filter);
+
+        Filter deduplicatedFilter = rule.apply(match.value(), match.captures(), e.ruleContext());
+        assertThat(deduplicatedFilter).hasOperators(
+                "Filter[((a = 20) OR (b = 10))]",
+                "  └ Collect[doc.t1 | [a] | true]");
+    }
+
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Related to https://github.com/crate/crate/issues/13810

Currently, duplicate predicates in Filter are kept throughout the logical planning phase (see example in https://github.com/crate/crate/issues/15190). In order to provide the optimizer with simpler plans to operate on, this PR adds a rule for deduplicating identical predicates in the Filter operator if they are joined by the ``AND`` operator.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [ ] (not applicable I think) Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
