### PR TITLE
Avoid queueSize setting lookup per ConcurrencyLimit update

### DIFF
--- a/libs/shared/src/main/java/io/crate/common/concurrent/ConcurrencyLimit.java
+++ b/libs/shared/src/main/java/io/crate/common/concurrent/ConcurrencyLimit.java
@@ -18,7 +18,6 @@ package io.crate.common.concurrent;
 
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.IntUnaryOperator;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -94,7 +93,7 @@ public final class ConcurrencyLimit {
 
     private final int minLimit;
 
-    private final IntUnaryOperator queueSize;
+    private final int queueSize;
 
     private final double smoothing;
 
@@ -107,7 +106,7 @@ public final class ConcurrencyLimit {
     public ConcurrencyLimit(int initialLimit,
                             int minConcurrency,
                             int maxConcurrency,
-                            IntUnaryOperator queueSize,
+                            int queueSize,
                             double smoothing,
                             int longWindow,
                             double rttTolerance) {
@@ -148,7 +147,6 @@ public final class ConcurrencyLimit {
 
     private int update(final long rtt, final int inflight) {
         double estimatedLimit = this.estimatedLimit; // single volatile read
-        final double queueSize = this.queueSize.applyAsInt((int) estimatedLimit);
 
         this.lastRtt = rtt;
         final double shortRtt = (double)rtt;

--- a/server/src/main/java/io/crate/execution/jobs/NodeLimits.java
+++ b/server/src/main/java/io/crate/execution/jobs/NodeLimits.java
@@ -41,7 +41,6 @@ public class NodeLimits {
 
     private volatile ConcurrencyLimit unknownNodelimit;
     private final Map<String, ConcurrencyLimit> limitsPerNode = new ConcurrentHashMap<>();
-    private final ClusterSettings clusterSettings;
 
     public static final Setting<Integer> INITIAL_CONCURRENCY =
         Setting.intSetting("overload_protection.dml.initial_concurrency", 5, Property.NodeScope, Property.Dynamic, Property.Exposed);
@@ -56,15 +55,36 @@ public class NodeLimits {
     private static final int LONG_WINDOW = 600;
     private static final double RTT_TOLERANCE = 1.5;
 
+    private volatile int initialConcurrency;
+    private volatile int minConcurrency;
+    private volatile int maxConcurrency;
+    private volatile int queueSize;
+
     @Inject
     public NodeLimits(ClusterSettings clusterSettings) {
-        this.clusterSettings = clusterSettings;
+        this.initialConcurrency = clusterSettings.get(INITIAL_CONCURRENCY);
+        this.minConcurrency = clusterSettings.get(MIN_CONCURRENCY);
+        this.maxConcurrency = clusterSettings.get(MAX_CONCURRENCY);
+        this.queueSize = clusterSettings.get(QUEUE_SIZE);
+
         // New settings are applied lazy on next access via #get(nodeId)
         // (And all earlier dynamic adjustments of the limit is reset)
-        clusterSettings.addSettingsUpdateConsumer(INITIAL_CONCURRENCY, ignored -> wipeLimits());
-        clusterSettings.addSettingsUpdateConsumer(MIN_CONCURRENCY, ignored -> wipeLimits());
-        clusterSettings.addSettingsUpdateConsumer(MAX_CONCURRENCY, ignored -> wipeLimits());
-        clusterSettings.addSettingsUpdateConsumer(QUEUE_SIZE, ignored -> wipeLimits());
+        clusterSettings.addSettingsUpdateConsumer(INITIAL_CONCURRENCY, value -> {
+            initialConcurrency = value;
+            wipeLimits();
+        });
+        clusterSettings.addSettingsUpdateConsumer(MIN_CONCURRENCY, value -> {
+            minConcurrency = value;
+            wipeLimits();
+        });
+        clusterSettings.addSettingsUpdateConsumer(MAX_CONCURRENCY, value -> {
+            maxConcurrency = value;
+            wipeLimits();
+        });
+        clusterSettings.addSettingsUpdateConsumer(QUEUE_SIZE, value -> {
+            queueSize = value;
+            wipeLimits();
+        });
     }
 
     private void wipeLimits() {
@@ -74,10 +94,10 @@ public class NodeLimits {
 
     private ConcurrencyLimit newLimit() {
         return new ConcurrencyLimit(
-            clusterSettings.get(INITIAL_CONCURRENCY),
-            clusterSettings.get(MIN_CONCURRENCY),
-            clusterSettings.get(MAX_CONCURRENCY),
-            ignored -> clusterSettings.get(QUEUE_SIZE),
+            initialConcurrency,
+            minConcurrency,
+            maxConcurrency,
+            queueSize,
             SMOOTHING,
             LONG_WINDOW,
             RTT_TOLERANCE


### PR DESCRIPTION
There was already a setting update listener that wipes all current node
limits. We can extend that to also set the current values and use those
for the next ConcurrencyLimit instances.

<img width="3586" height="514" alt="image" src="https://github.com/user-attachments/assets/6b49f3cd-b066-4d77-917e-beb6636a5b2e" />
