### PR TITLE
kill-on-disconnect must account for disconnects of a coordinator node

### DIFF
--- a/docs/appendices/release-notes/6.4.3.rst
+++ b/docs/appendices/release-notes/6.4.3.rst
@@ -78,3 +78,5 @@ Fixes
       select null
     ) tbl (x);
 
+- Fixed an issue that could lead to a memory leak if nodes within the
+  cluster were temporarily not reachable.

--- a/server/src/main/java/io/crate/execution/jobs/TasksService.java
+++ b/server/src/main/java/io/crate/execution/jobs/TasksService.java
@@ -135,6 +135,8 @@ public class TasksService extends AbstractLifecycleComponent implements Transpor
         for (var task : activeTasks.values()) {
             if (task.participatingNodes().contains(node.getId())) {
                 task.kill(JobKilledException.of("Participating node " + node.getId() + " disconnected"));
+            } else if (task.coordinatorNodeId().equals(node.getId())) {
+                task.kill(JobKilledException.of("Coordinator node " + node.getId() + " disconnected"));
             }
         }
     }

--- a/server/src/test/java/io/crate/execution/jobs/TasksServiceTest.java
+++ b/server/src/test/java/io/crate/execution/jobs/TasksServiceTest.java
@@ -292,6 +292,27 @@ public class TasksServiceTest extends CrateDummyClusterServiceUnitTest {
     }
 
     @Test
+    public void test_kills_tasks_if_coordinator_node_disconnects() throws Exception {
+        UUID jobId = UUID.randomUUID();
+        RootTask.Builder builder = tasksService.newBuilder(jobId);
+        String nodeId = CrateDummyClusterServiceUnitTest.NODE_ID;
+        DiscoveryNode node = clusterService.state().nodes().resolveNode(nodeId);
+        builder.addTask(new DummyTask());
+
+        RootTask task = tasksService.createTask(builder);
+        assertThat(task.coordinatorNodeId()).isEqualTo(nodeId);
+        assertThat(task.participatingNodes()).doesNotContain(nodeId);
+        assertThat(task.completionFuture()).isNotDone();
+
+        tasksService.onNodeDisconnected(node, Mockito.mock(Connection.class));
+        assertThat(task.completionFuture()).failsWithin(1, TimeUnit.SECONDS)
+            .withThrowableThat()
+            .havingRootCause()
+            .isExactlyInstanceOf(JobKilledException.class)
+            .withMessage("Job killed. Coordinator node n1 disconnected");
+    }
+
+    @Test
     public void test_kill_missing_job_adds_job_id_to_recently_failed() throws Exception {
         /// Adding jobs that are missing when killed to recentlyFailed helps
         /// speed up the failure in the following scenario:


### PR DESCRIPTION
Relates to https://wacklig.pipifein.dev/github/crate/crate/c83cfe25-b737-4a76-b028-c474a80f919f/8fcaa067-402f-41f7-8fae-aefef551cdee


<details><summary>Failure</summary>

```
Suppressed: java.lang.AssertionError: Open jobs:
JobContext{id=6d8898ea-c1ff-5f93-f462-9e57678bf1b6, username='crate', stmt='select
    (select count(*) from sys.nodes) as num_nodes,
    (select
        {
            health = health,
            pending_tasks = pending_tasks
        } as cluster_health
        FROM sys.cluster_health
    ),
    (select
        {
            all_states = array_unique(array_agg(current_state)),
            primary_states = array_unique(array_agg(current_state) FILTER (WHERE primary = true)),
            relocating = count(*) FILTER (WHERE current_state = 'RELOCATING')
        } as shards_state
        FROM sys.allocations
    )
', started=1781474734200, classification=Classification{type=SELECT, labels=[Collect, Eval, HashAggregate, Limit, MultiPhase, TableFunction]}}
Active tasks:
## node: node_s0
{3f535d03-a2a7-804e-98e5-e460cf3f47f8=Task{id=3f535d03-a2a7-804e-98e5-e460cf3f47f8, tasks=[DistResultRXTask{id=1, numBuckets=1, isDone=false, pageBucketReceiver=io.crate.execution.IncrementalPageBucketReceiver@143881ab}], closed=false, participating=[ncWOpNlYTNSMGjocpQBHwg]}}

		at org.elasticsearch.test.IntegTestCase.assertNoTasksAreLeftOpen(IntegTestCase.java:1448)
		at java.base/java.lang.reflect.Method.invoke(Method.java:565)
		at com.carrotsearch.randomizedtesting.RandomizedRunner.invoke(RandomizedRunner.java:1763)
		at com.carrotsearch.randomizedtesting.RandomizedRunner$10.evaluate(RandomizedRunner.java:1004)
		at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:330)
		... 1 more
	Caused by: java.lang.AssertionError: 
Expecting empty but was: {3f535d03-a2a7-804e-98e5-e460cf3f47f8=Task{id=3f535d03-a2a7-804e-98e5-e460cf3f47f8, tasks=[DistResultRXTask{id=1, numBuckets=1, isDone=false, pageBucketReceiver=io.crate.execution.IncrementalPageBucketReceiver@143881ab}], closed=false, participating=[ncWOpNlYTNSMGjocpQBHwg]}}
		at org.elasticsearch.test.IntegTestCase.lambda$assertNoTasksAreLeftOpen$0(IntegTestCase.java:1393)
		at org.elasticsearch.test.ESTestCase.assertBusy(ESTestCase.java:711)
		at org.elasticsearch.test.IntegTestCase.assertNoTasksAreLeftOpen(IntegTestCase.java:1388)
		... 5 more
	Suppressed: org.opentest4j.AssertionFailedError: [Query breaker not reset to 0 on node: node_s0] 
expected: 0L
 but was: 2097152L
```

</details>

In https://github.com/crate/crate/pull/17772 we removed NodeDisconnectJobMonitorService
and let TaskService to react on node disonnect itself.

We reflected the case when disconnected node happens to be upstream for some tasks, 
ie `NodeDisconnectJobMonitorService.broadcastKillToParticipatingNodes`

but didn't reflect the case when disconnected node happens to be a coordinator for some specific task, ie didn't relect `NodeDisconnectJobMonitorService.killJobsCoordinatedBy`