### PR TITLE
Add rule to deduplicate identical join conditions joined by "AND"

### DIFF
--- a/docs/appendices/release-notes/6.5.0.rst
+++ b/docs/appendices/release-notes/6.5.0.rst
@@ -81,7 +81,8 @@ None
 Performance and Resilience Improvements
 ---------------------------------------
 
-None
+- Improved query planning by deduplicating identical join conditions joined by
+  the ``AND`` operator
 
 Administration and Operations
 -----------------------------

--- a/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -95,6 +95,7 @@ import io.crate.planner.consumer.InsertFromSubQueryPlanner;
 import io.crate.planner.optimizer.Optimizer;
 import io.crate.planner.optimizer.Rule;
 import io.crate.planner.optimizer.iterative.IterativeOptimizer;
+import io.crate.planner.optimizer.rule.DeduplicateJoinConditions;
 import io.crate.planner.optimizer.rule.DeduplicateOrder;
 import io.crate.planner.optimizer.rule.EliminateCrossJoin;
 import io.crate.planner.optimizer.rule.EquiJoinToLookupJoin;
@@ -185,6 +186,7 @@ public class LogicalPlanner {
         new EquiJoinToLookupJoin(),
         new RewriteLeftOuterJoinToHashJoin(),
         new RewriteRightOuterJoinToHashJoin(),
+        new DeduplicateJoinConditions(),
         new RewriteJoinPlan()
     );
 

--- a/server/src/main/java/io/crate/planner/optimizer/rule/DeduplicateJoinConditions.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/DeduplicateJoinConditions.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.rule;
+
+import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
+
+import java.util.List;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import io.crate.expression.operator.AndOperator;
+import io.crate.planner.operators.JoinPlan;
+import io.crate.expression.symbol.Function;
+import io.crate.expression.symbol.FunctionCopyVisitor;
+import io.crate.expression.symbol.Symbol;
+import io.crate.planner.optimizer.Rule;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.optimizer.matcher.Captures;
+import io.crate.planner.optimizer.matcher.Pattern;
+
+public class DeduplicateJoinConditions implements Rule<JoinPlan> {
+
+    private final Pattern<JoinPlan> pattern = typeOf(JoinPlan.class)
+            .with(j -> j.joinCondition() != null);
+    private final Visitor VISITOR = new Visitor();
+
+    @Override
+    public Pattern<JoinPlan> pattern() {
+        return pattern;
+    }
+
+    @Override
+    public LogicalPlan apply(JoinPlan join,
+            Captures captures,
+            Rule.Context context) {
+        Symbol conditions = join.joinCondition();
+        Symbol deduplicatedConditions = conditions.accept(VISITOR, null);
+        if (!conditions.equals(deduplicatedConditions)) {
+            return new JoinPlan(
+                    join.lhs(),
+                    join.rhs(),
+                    join.joinType(),
+                    deduplicatedConditions,
+                    join.isFiltered(),
+                    join.isRewriteFilterOnOuterJoinToInnerJoinDone(),
+                    join.isLookUpJoinRuleApplied(),
+                    join.moveConstantJoinConditionRuleApplied(),
+                    join.eliminateCrossJoinRuleIsApplied(),
+                    join.lookUpJoin()
+
+            );
+        }
+        return null;
+    }
+
+    static class Visitor extends FunctionCopyVisitor<Void> {
+
+        @Override
+        public Symbol visitFunction(Function func, Void context) {
+            if (func.name().equals(AndOperator.NAME)) {
+                Symbol deduplicatedSubtrees = super.visitFunction(func, context);
+                List<Symbol> conjunctions = AndOperator.split(deduplicatedSubtrees);
+                Set<Symbol> uniqueConjunctions = new LinkedHashSet<>(conjunctions);
+                return AndOperator.join(uniqueConjunctions);
+            }
+            return super.visitFunction(func, context);
+        }
+
+    }
+
+}

--- a/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
@@ -34,10 +34,10 @@ import org.junit.Before;
 import org.junit.Test;
 
 import io.crate.auth.Protocol;
-import io.crate.metadata.pgcatalog.OidHash;
 import io.crate.common.unit.TimeValue;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Schemas;
+import io.crate.metadata.pgcatalog.OidHash;
 import io.crate.metadata.table.SchemaInfo;
 import io.crate.metadata.view.ViewInfo;
 import io.crate.protocols.postgres.ConnectionProperties;
@@ -266,6 +266,7 @@ public class PgCatalogITest extends IntegTestCase {
             "max_identifier_length| 255| Shows the maximum length of identifiers in bytes.| NULL| NULL",
             "max_index_keys| 32| Shows the maximum number of index keys.| NULL| NULL",
             "memory.operation_limit| 0| Memory limit in bytes for an individual operation. 0 by-passes the operation limit, relying entirely on the global circuit breaker limits| NULL| NULL",
+            "optimizer_deduplicate_join_conditions| true| Indicates if the optimizer rule DeduplicateJoinConditions is activated.| NULL| NULL",
             "optimizer_deduplicate_order| true| Indicates if the optimizer rule DeduplicateOrder is activated.| NULL| NULL",
             "optimizer_eliminate_cross_join| true| Indicates if the optimizer rule EliminateCrossJoin is activated.| NULL| NULL",
             "optimizer_equi_join_to_lookup_join| false| Indicates if the optimizer rule EquiJoinToLookupJoin is activated.| NULL| NULL",

--- a/server/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
@@ -410,6 +410,7 @@ public class ShowIntegrationTest extends IntegTestCase {
             "max_identifier_length| 255| Shows the maximum length of identifiers in bytes.",
             "max_index_keys| 32| Shows the maximum number of index keys.",
             "memory.operation_limit| 0| Memory limit in bytes for an individual operation. 0 by-passes the operation limit, relying entirely on the global circuit breaker limits",
+            "optimizer_deduplicate_join_conditions| true| Indicates if the optimizer rule DeduplicateJoinConditions is activated.",
             "optimizer_deduplicate_order| true| Indicates if the optimizer rule DeduplicateOrder is activated.",
             "optimizer_eliminate_cross_join| true| Indicates if the optimizer rule EliminateCrossJoin is activated.",
             "optimizer_equi_join_to_lookup_join| false| Indicates if the optimizer rule EquiJoinToLookupJoin is activated.",

--- a/server/src/test/java/io/crate/planner/optimizer/rule/DeduplicateJoinConditionsTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/rule/DeduplicateJoinConditionsTest.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.rule;
+
+import static io.crate.testing.Asserts.assertThat;
+
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.expression.symbol.Function;
+import io.crate.expression.operator.AndOperator;
+import io.crate.expression.operator.OrOperator;
+import io.crate.expression.operator.Operator;
+import io.crate.expression.symbol.Symbol;
+import io.crate.testing.SQLExecutor;
+import io.crate.planner.operators.JoinPlan;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.matcher.Captures;
+import io.crate.planner.optimizer.matcher.Match;
+import io.crate.sql.tree.JoinType;
+
+public class DeduplicateJoinConditionsTest extends CrateDummyClusterServiceUnitTest {
+
+    private LogicalPlan t1;
+    private LogicalPlan t2;
+    private SQLExecutor e;
+
+    @Before
+    public void prepare() throws Exception {
+        e = SQLExecutor.of(clusterService)
+                .addTable("create table t1 (a int)")
+                .addTable("create table t2 (b int, c int)");
+
+        t1 = e.logicalPlan("SELECT a FROM t1");
+        t2 = e.logicalPlan("SELECT b FROM t2");
+    }
+
+    @Test
+    public void test_does_not_match_if_no_join_conditions() {
+        JoinPlan plan = new JoinPlan(t1, t2, JoinType.CROSS, null);
+
+        assertThat(plan).hasOperators(
+                "Join[CROSS]",
+                "  ├ Collect[doc.t1 | [a] | true]",
+                "  └ Collect[doc.t2 | [b] | true]");
+
+        Rule<JoinPlan> rule = new DeduplicateJoinConditions();
+        Match<JoinPlan> match = rule.pattern().accept(plan, Captures.empty());
+        assertThat(match.isPresent()).isFalse();
+    }
+
+    @Test
+    public void test_deduplicates_identical_join_conditions() {
+        Symbol joinCondition1 = e.asSymbol("doc.t1.a = doc.t2.b");
+        Symbol joinCondition2 = e.asSymbol("doc.t1.a > 20");
+        JoinPlan plan = new JoinPlan(t1, t2, JoinType.INNER,
+                AndOperator.join(List.of(joinCondition1, joinCondition2, joinCondition1)));
+
+        assertThat(plan).hasOperators(
+                "Join[INNER | (((a = b) AND (a > 20)) AND (a = b))]",
+                "  ├ Collect[doc.t1 | [a] | true]",
+                "  └ Collect[doc.t2 | [b] | true]");
+
+        Rule<JoinPlan> rule = new DeduplicateJoinConditions();
+        Match<JoinPlan> match = rule.pattern().accept(plan, Captures.empty());
+        assertThat(match.isPresent()).isTrue();
+        assertThat(match.value()).isEqualTo(plan);
+
+        LogicalPlan result = rule.apply(plan, match.captures(), e.ruleContext());
+        assertThat(result).hasOperators(
+                "Join[INNER | ((a = b) AND (a > 20))]",
+                "  ├ Collect[doc.t1 | [a] | true]",
+                "  └ Collect[doc.t2 | [b] | true]");
+    }
+
+    @Test
+    public void test_does_nothing_if_no_duplicates() {
+        Symbol joinCondition1 = e.asSymbol("doc.t1.a = doc.t2.b");
+        Symbol joinCondition2 = e.asSymbol("doc.t1.a > 20");
+        JoinPlan plan = new JoinPlan(t1, t2, JoinType.INNER, AndOperator.join(List.of(joinCondition1, joinCondition2)));
+
+        assertThat(plan).hasOperators(
+                "Join[INNER | ((a = b) AND (a > 20))]",
+                "  ├ Collect[doc.t1 | [a] | true]",
+                "  └ Collect[doc.t2 | [b] | true]");
+
+        Rule<JoinPlan> rule = new DeduplicateJoinConditions();
+        Match<JoinPlan> match = rule.pattern().accept(plan, Captures.empty());
+        assertThat(match.isPresent()).isTrue();
+        assertThat(match.value()).isEqualTo(plan);
+
+        LogicalPlan result = rule.apply(plan, match.captures(), e.ruleContext());
+        assertThat(result).isNull();
+    }
+
+    @Test
+    public void test_does_nothing_if_no_and_operator() {
+        Symbol joinCondition = e.asSymbol("doc.t1.a = doc.t2.b");
+        Symbol orConjunction = new Function(OrOperator.SIGNATURE, List.of(joinCondition, joinCondition),
+                Operator.RETURN_TYPE);
+        JoinPlan plan = new JoinPlan(t1, t2, JoinType.INNER, orConjunction);
+
+        assertThat(plan).hasOperators(
+                "Join[INNER | ((a = b) OR (a = b))]",
+                "  ├ Collect[doc.t1 | [a] | true]",
+                "  └ Collect[doc.t2 | [b] | true]");
+
+        Rule<JoinPlan> rule = new DeduplicateJoinConditions();
+        Match<JoinPlan> match = rule.pattern().accept(plan, Captures.empty());
+        assertThat(match.isPresent()).isTrue();
+        assertThat(match.value()).isEqualTo(plan);
+
+        LogicalPlan result = rule.apply(plan, match.captures(), e.ruleContext());
+        assertThat(result).isNull();
+    }
+
+    @Test
+    public void test_deduplicates_and_preserves_other_conjunctions() {
+        Symbol joinCondition1 = e.asSymbol("doc.t1.a = doc.t2.b");
+        Symbol joinCondition2 = e.asSymbol("doc.t2.c > doc.t1.a");
+        Symbol andConjunction = AndOperator.join(List.of(joinCondition1, joinCondition1));
+        Symbol orConjunction = new Function(OrOperator.SIGNATURE, List.of(andConjunction, joinCondition2),
+                Operator.RETURN_TYPE);
+        JoinPlan plan = new JoinPlan(t1, t2, JoinType.INNER, orConjunction);
+
+        assertThat(plan).hasOperators(
+                "Join[INNER | (((a = b) AND (a = b)) OR (c > a))]",
+                "  ├ Collect[doc.t1 | [a] | true]",
+                "  └ Collect[doc.t2 | [b] | true]");
+
+        Rule<JoinPlan> rule = new DeduplicateJoinConditions();
+        Match<JoinPlan> match = rule.pattern().accept(plan, Captures.empty());
+        assertThat(match.isPresent()).isTrue();
+        assertThat(match.value()).isEqualTo(plan);
+
+        LogicalPlan result = rule.apply(plan, match.captures(), e.ruleContext());
+        assertThat(result).hasOperators(
+                "Join[INNER | ((a = b) OR (c > a))]",
+                "  ├ Collect[doc.t1 | [a] | true]",
+                "  └ Collect[doc.t2 | [b] | true]");
+    }
+
+}


### PR DESCRIPTION


## Summary of the changes / Why this improves CrateDB

Related to https://github.com/crate/crate/issues/13810 and https://github.com/crate/crate/issues/16230

Previously, identical join conditions were not deduplicated and the same condition was then evaluated multiple times. 
For example: 
```sql
SELECT * FROM j1  JOIN j2 ON j1.x = j2.y AND j1.x = j2.y;
``` 
or
```sql
select * from t1 join t2 on t1.x = t2.x where t1.x = t2.x;
```
In this second example, a duplicate join condition is introduced due to the rule `optimizer_move_equi_join_filter_into_inner_join`.

```
cr> explain verbose select * from t1 join t2 on t1.x = t2.x where t1.x = t2.x;
+-------------------------------------------------+------------------------------------------------------+
| STEP                                            | QUERY PLAN                                           |
+-------------------------------------------------+------------------------------------------------------+
| Initial logical plan                            | Filter[(x = x)] (rows=0)                             |
|                                                 |   └ Join[INNER | (x = x)] (rows=unknown)             |
|                                                 |     ├ Collect[doc.t1 | [a, x] | true] (rows=unknown) |
|                                                 |     └ Collect[doc.t2 | [b, x] | true] (rows=unknown) |
| optimizer_move_equi_join_filter_into_inner_join | Join[INNER | ((x = x) AND (x = x))] (rows=unknown)   |
|                                                 |   ├ Collect[doc.t1 | [a, x] | true] (rows=unknown)   |
|                                                 |   └ Collect[doc.t2 | [b, x] | true] (rows=unknown)   |
| optimizer_deduplicate_and_join_conditions       | Join[INNER | (x = x)] (rows=unknown)                 |
|                                                 |   ├ Collect[doc.t1 | [a, x] | true] (rows=unknown)   |
|                                                 |   └ Collect[doc.t2 | [b, x] | true] (rows=unknown)   |
| optimizer_rewrite_join_plan                     | HashJoin[INNER | (x = x)] (rows=unknown)             |
|                                                 |   ├ Collect[doc.t1 | [a, x] | true] (rows=unknown)   |
|                                                 |   └ Collect[doc.t2 | [b, x] | true] (rows=unknown)   |
| Final logical plan                              | HashJoin[INNER | (x = x)] (rows=unknown)             |
|                                                 |   ├ Collect[doc.t1 | [a, x] | true] (rows=unknown)   |
|                                                 |   └ Collect[doc.t2 | [b, x] | true] (rows=unknown)   |
+-------------------------------------------------+------------------------------------------------------+
```

Deduplication can provide simpler plans for the optimizer to optimize, and reduces per-row evaluation costs when testing the join condition (i.e. evaluate x=y once instead of twice).

This PR introduces a new optimizer rule `DeduplicateAndJoinConditions` that deduplicates identical join conditions joined by the `AND` operator.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
