### PR TITLE
Test: reduce shard pressure in concurrent swap and insert test

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/PartitionedTableConcurrentIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/PartitionedTableConcurrentIntegrationTest.java
@@ -493,8 +493,8 @@ public class PartitionedTableConcurrentIntegrationTest extends IntegTestCase {
 
     @Test
     public void test_concurrent_swaps() throws Exception {
-        execute("create table t1 (p int) partitioned by (p)");
-        execute("create table t2 (p2 int)");
+        execute("create table t1 (p int) partitioned by (p) clustered into 1 shards with (number_of_replicas = 0)");
+        execute("create table t2 (p2 int) clustered into 1 shards with (number_of_replicas = 0)");
 
         final AtomicReference<Throwable> error = new AtomicReference<>();
         final CyclicBarrier barrier = new CyclicBarrier(2);
@@ -544,8 +544,8 @@ public class PartitionedTableConcurrentIntegrationTest extends IntegTestCase {
 
     @Test
     public void test_concurrent_table_swaps_with_insert_from_values() throws Exception {
-        execute("create table t1 (p int) partitioned by (p)");
-        execute("create table t2 (p2 int)");
+        execute("create table t1 (p int) partitioned by (p) clustered into 1 shards with (number_of_replicas = 0)");
+        execute("create table t2 (p2 int) clustered into 1 shards with (number_of_replicas = 0)");
 
         final AtomicReference<Throwable> error = new AtomicReference<>();
         final CyclicBarrier barrier = new CyclicBarrier(2);

--- a/server/src/test/java/io/crate/integrationtests/PartitionedTableConcurrentIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/PartitionedTableConcurrentIntegrationTest.java
@@ -53,6 +53,8 @@ import org.elasticsearch.test.IntegTestCase;
 import org.junit.After;
 import org.junit.Test;
 
+import com.carrotsearch.randomizedtesting.annotations.Repeat;
+
 import io.crate.common.unit.TimeValue;
 import io.crate.data.Bucket;
 import io.crate.data.CollectionBucket;
@@ -491,9 +493,10 @@ public class PartitionedTableConcurrentIntegrationTest extends IntegTestCase {
         ensureGreen();
     }
 
+    @Repeat(iterations = 100)
     @Test
     public void test_concurrent_swaps() throws Exception {
-        execute("create table t1 (p int) partitioned by (p) clustered into 1 shards with (number_of_replicas = 0)");
+        execute("create table t1 (p int) partitioned by (p) clustered into 2 shards with (number_of_replicas = 0)");
         execute("create table t2 (p2 int) clustered into 1 shards with (number_of_replicas = 0)");
 
         final AtomicReference<Throwable> error = new AtomicReference<>();
@@ -542,9 +545,10 @@ public class PartitionedTableConcurrentIntegrationTest extends IntegTestCase {
         assertThat(response.rows()[0][0]).isEqualTo(50L);
     }
 
+    @Repeat(iterations = 100)
     @Test
     public void test_concurrent_table_swaps_with_insert_from_values() throws Exception {
-        execute("create table t1 (p int) partitioned by (p) clustered into 1 shards with (number_of_replicas = 0)");
+        execute("create table t1 (p int) partitioned by (p) clustered into 2 shards with (number_of_replicas = 0)");
         execute("create table t2 (p2 int) clustered into 1 shards with (number_of_replicas = 0)");
 
         final AtomicReference<Throwable> error = new AtomicReference<>();


### PR DESCRIPTION
Follows https://github.com/crate/crate/pull/19554. The tests still failed with increased timeout.

This time reducing the shard creation pressure as it creates 50 partitions * 4 shards * (1 primary + 1 replica) = 400.

FYI, we can reduce the shard pressure because the tests make sure that the concurrent swap and insert are interleaved.