### PR TITLE
Test: fix wipeAllTables() to verify dropped tables against master metadata

### DIFF
--- a/server/src/testFixtures/java/org/elasticsearch/test/TestCluster.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/TestCluster.java
@@ -80,6 +80,7 @@ import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.coordination.ClusterBootstrapService;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
@@ -399,8 +400,9 @@ public final class TestCluster implements Closeable {
                 responses.forEach(r -> assertAcked(r));
             } catch (Exception ignore) {
             }
+            Metadata metadata = getCurrentMasterNodeInstance(ClusterService.class).state().metadata();
             for (RelationName name : relationNames) {
-                assertThat(clusterService().state().metadata().contains(name))
+                assertThat(metadata.contains(name))
                     .as("wipeAllTables must remove " + name)
                     .isFalse();
             }


### PR DESCRIPTION
Observed locally, that very rarely tests failed during cleanup because `wipeAllTables()` noticed dropped tables in the metadata.

The fix takes the same approach as:
https://github.com/crate/crate/blob/8deec7511a56d705c415be883af706d70ce88732/server/src/test/java/io/crate/integrationtests/BlobIntegrationTestBase.java#L94-L95

