### PR TITLE
Fix: `mean` alias for `avg` not working with `distinct`

### DIFF
--- a/docs/appendices/release-notes/6.3.5.rst
+++ b/docs/appendices/release-notes/6.3.5.rst
@@ -53,3 +53,8 @@ Fixes
 - Fixed an issue causing ``KILL`` statement or
   :ref:`statement_timeout <conf-session-statement-timeout>` to not properly
   kill a query and leading to resources leak.
+
+- Fixed an issue that led to an error being thrown when using ``distinct`` with
+  the ``mean`` alias of the :ref:`avg() function <aggregation-avg>`. e.g.::
+
+      SELECT mean(DISTINCT <columnName>) FROM tbl

--- a/server/src/main/java/io/crate/expression/scalar/CollectionAverageFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/CollectionAverageFunction.java
@@ -37,18 +37,20 @@ import io.crate.types.TypeSignature;
 
 public class CollectionAverageFunction extends Scalar<Double, List<Object>> {
 
-    public static final String NAME = "collection_avg";
+    public static final String[] NAMES = new String[]{"collection_avg", "collection_mean"};
 
     public static void register(Functions.Builder builder) {
-        builder.add(
-                Signature.builder(NAME, FunctionType.SCALAR)
-                        .argumentTypes(TypeSignature.ARRAY_E)
-                        .returnType(DataTypes.DOUBLE.getTypeSignature())
-                        .typeVariableConstraints(TypeVariableConstraint.E)
-                        .features(Feature.DETERMINISTIC, Feature.STRICTNULL)
-                        .build(),
+        for (var functionName : NAMES) {
+            builder.add(
+                Signature.builder(functionName, FunctionType.SCALAR)
+                    .argumentTypes(TypeSignature.ARRAY_E)
+                    .returnType(DataTypes.DOUBLE.getTypeSignature())
+                    .typeVariableConstraints(TypeVariableConstraint.E)
+                    .features(Feature.DETERMINISTIC, Feature.STRICTNULL)
+                    .build(),
                 CollectionAverageFunction::new
-        );
+            );
+        }
     }
 
     private CollectionAverageFunction(Signature signature, BoundSignature boundSignature) {

--- a/server/src/main/java/io/crate/expression/scalar/NumericCollectionAverageFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/NumericCollectionAverageFunction.java
@@ -38,17 +38,19 @@ import io.crate.types.DataTypes;
 
 public class NumericCollectionAverageFunction extends Scalar<BigDecimal, List<BigDecimal>> {
 
-    public static final String NAME = "collection_avg";
+    public static final String[] NAMES = new String[]{"collection_avg", "collection_mean"};
 
     public static void register(Functions.Builder builder) {
-        builder.add(
-            Signature.builder(NAME, FunctionType.SCALAR)
-                .argumentTypes(new ArrayType<>(DataTypes.NUMERIC).getTypeSignature())
-                .returnType(DataTypes.NUMERIC.getTypeSignature())
-                .features(Feature.DETERMINISTIC, Feature.STRICTNULL)
-                .build(),
-            NumericCollectionAverageFunction::new
-        );
+        for (String functionName : NAMES) {
+            builder.add(
+                Signature.builder(functionName, FunctionType.SCALAR)
+                    .argumentTypes(new ArrayType<>(DataTypes.NUMERIC).getTypeSignature())
+                    .returnType(DataTypes.NUMERIC.getTypeSignature())
+                    .features(Feature.DETERMINISTIC, Feature.STRICTNULL)
+                    .build(),
+                NumericCollectionAverageFunction::new
+            );
+        }
     }
 
     private NumericCollectionAverageFunction(Signature signature, BoundSignature boundSignature) {

--- a/server/src/test/java/io/crate/analyze/expressions/AggregateExpressionAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/expressions/AggregateExpressionAnalyzerTest.java
@@ -25,7 +25,6 @@ import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.Asserts.exactlyInstanceOf;
 import static io.crate.testing.Asserts.isLiteral;
 import static io.crate.testing.Asserts.isReference;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.Before;
@@ -57,7 +56,8 @@ public class AggregateExpressionAnalyzerTest extends CrateDummyClusterServiceUni
 
     @Test
     public void test_distinct_aggregate_function_with_filter_expression() {
-        var symbol = e.asSymbol("avg(distinct t.x) filter (where t.x < 1)");
+        String functionName = randomBoolean() ? "avg" : "mean";
+        var symbol = e.asSymbol(functionName + "(distinct t.x) filter (where t.x < 1)");
         assertThat(symbol).isExactlyInstanceOf(Function.class);
 
         var outerFunc = (Function) symbol;


### PR DESCRIPTION
The issue was that `mean(distinct xxx)` is rewritten to a collect set function, and only the `collection_avg` was registered.

