### PR TITLE
Fix HBA protocol resolving for "pg" (postgres)

### DIFF
--- a/blackbox/test_ssl.py
+++ b/blackbox/test_ssl.py
@@ -47,6 +47,7 @@ crate = CrateNode(
         'auth.host_based.config.0.method': 'trust',
         'auth.host_based.config.1.user': 'client1',
         'auth.host_based.config.1.method': 'cert',
+        'auth.host_based.config.1.protocol': 'pg',
         'auth.host_based.config.1.ssl': 'on',
     },
     env=env,

--- a/docs/appendices/release-notes/6.3.5.rst
+++ b/docs/appendices/release-notes/6.3.5.rst
@@ -46,6 +46,10 @@ series.
 Fixes
 =====
 
+- Fixed an issue that caused authentication to fail when requiring the `pg`
+  protocol in the :ref:`HBA <admin_hba>` configuration section while connecting
+  via the postgres protocol.
+
 - Fixed an issue that would throw a misleading ``NullPointerException`` when
   ``CREATE REPOSITORY`` failed during repository verification, by returning a
   user friendly error message.

--- a/server/src/main/java/io/crate/auth/AuthSettings.java
+++ b/server/src/main/java/io/crate/auth/AuthSettings.java
@@ -74,7 +74,7 @@ public final class AuthSettings {
         for (var entry : hbaSettings.getAsGroups().entrySet()) {
             Settings entrySettings = entry.getValue();
             String protocolEntry = entrySettings.get("protocol");
-            if (protocolEntry != null && !protocol.name().equalsIgnoreCase(protocolEntry)) {
+            if (protocolEntry != null && !protocol.toString().equalsIgnoreCase(protocolEntry)) {
                 // We need null check for protocolEntry since we want entry without protocol be matched with any protocol
                 // Without it !equalsIgnoreCase returns true and HBA with only 'cert' entries but all without protocol
                 // might end up with NONE while correct value is 'REQUIRED'.

--- a/server/src/test/java/io/crate/auth/AuthSettingsTest.java
+++ b/server/src/test/java/io/crate/auth/AuthSettingsTest.java
@@ -99,4 +99,17 @@ public class AuthSettingsTest {
         assertThat(AuthSettings.resolveClientAuth(settings, Protocol.HTTP)).isEqualTo(ClientAuth.NONE);
         assertThat(AuthSettings.resolveClientAuth(settings, Protocol.POSTGRES)).isEqualTo(ClientAuth.NONE);
     }
+
+    /// See [Issue #19669](https://github.com/crate/crate/issues/19669)
+    @Test
+    public void test_cert_required_only_on_postgres_protocol() {
+        Settings settings = Settings.builder()
+            .put("auth.host_based.config.1.method", "cert")
+            .put("auth.host_based.config.1.protocol", "pg")
+            .build();
+
+        assertThat(AuthSettings.resolveClientAuth(settings, Protocol.POSTGRES)).isEqualTo(ClientAuth.REQUIRE);
+        assertThat(AuthSettings.resolveClientAuth(settings, Protocol.HTTP)).isEqualTo(ClientAuth.NONE);
+        assertThat(AuthSettings.resolveClientAuth(settings, Protocol.TRANSPORT)).isEqualTo(ClientAuth.NONE);
+    }
 }


### PR DESCRIPTION
We document `pg` to be used for requiring the postgres protocol at HBA entries.
But the code compared it to the `POSTGRES` Enum name instead.

Fixes #19669.
