### PR TITLE
IdCollectorExpression should rely on binary data presence instead of version_created metadata

### DIFF
--- a/docs/appendices/release-notes/6.0.8.rst
+++ b/docs/appendices/release-notes/6.0.8.rst
@@ -1,29 +1,26 @@
-.. _version_6.2.11:
+.. _version_6.0.8:
 
-===========================
-Version 6.2.11 - Unreleased
-===========================
+==========================
+Version 6.0.8 - Unreleased
+==========================
 
 .. comment 1. Remove the " - Unreleased" from the header above and adjust the ==
 .. comment 2. Remove the NOTE below and replace with: "Released on 20XX-XX-XX."
 .. comment    (without a NOTE entry, simply starting from col 1 of the line)
 .. NOTE::
 
-    In development. 6.2.11 isn't released yet. These are the release notes for
+    In development. 6.0.8 isn't released yet. These are the release notes for
     the upcoming release.
 
 .. NOTE::
 
     If you are upgrading a cluster, you must be running CrateDB 5.0.0 or higher
-    before you upgrade to 6.2.11.
+    before you upgrade to 6.0.8.
 
-    We recommend that you upgrade to the latest 6.1 release before moving to
-    6.2.11.
+    We recommend that you upgrade to the latest 5.10 release before moving to
+    6.0.8.
 
-    A rolling upgrade from >= 6.1.2 to 6.2.11 is supported. Doing a rolling
-    upgrade from an earlier version than 6.1.2 can cause runtime errors when
-    executing statements relying on implicit casts.
-
+    A rolling upgrade from >= 5.10.1 to 6.0.6 is supported.
     Before upgrading, you should `back up your data`_.
 
 .. WARNING::
@@ -43,15 +40,11 @@ Version 6.2.11 - Unreleased
    :local:
 
 
-See the :ref:`version_6.2.0` release notes for a full list of changes in the 6.2
+See the :ref:`version_6.0.0` release notes for a full list of changes in the 6.0
 series.
 
 Fixes
 =====
-
-- Fixed an issue causing ``KILL`` statement or
-  :ref:`statement_timeout <conf-session-statement-timeout>` to not properly
-  kill a query and leading to resources leak.
 
 - Fixed an issue causing ``IllegalStateException`` errors on inserts into a
   table with primary keys.

--- a/docs/appendices/release-notes/6.1.6.rst
+++ b/docs/appendices/release-notes/6.1.6.rst
@@ -1,29 +1,26 @@
-.. _version_6.2.11:
+.. _version_6.1.6:
 
-===========================
-Version 6.2.11 - Unreleased
-===========================
+==========================
+Version 6.1.6 - Unreleased
+==========================
 
 .. comment 1. Remove the " - Unreleased" from the header above and adjust the ==
 .. comment 2. Remove the NOTE below and replace with: "Released on 20XX-XX-XX."
 .. comment    (without a NOTE entry, simply starting from col 1 of the line)
 .. NOTE::
 
-    In development. 6.2.11 isn't released yet. These are the release notes for
+    In development. 6.1.6 isn't released yet. These are the release notes for
     the upcoming release.
 
 .. NOTE::
 
     If you are upgrading a cluster, you must be running CrateDB 5.0.0 or higher
-    before you upgrade to 6.2.11.
+    before you upgrade to 6.1.6.
 
-    We recommend that you upgrade to the latest 6.1 release before moving to
-    6.2.11.
+    We recommend that you upgrade to the latest 6.0 release before moving to
+    6.1.6.
 
-    A rolling upgrade from >= 6.1.2 to 6.2.11 is supported. Doing a rolling
-    upgrade from an earlier version than 6.1.2 can cause runtime errors when
-    executing statements relying on implicit casts.
-
+    A rolling upgrade from >= 6.0.2 to 6.1.6 is supported.
     Before upgrading, you should `back up your data`_.
 
 .. WARNING::
@@ -43,15 +40,11 @@ Version 6.2.11 - Unreleased
    :local:
 
 
-See the :ref:`version_6.2.0` release notes for a full list of changes in the 6.2
+See the :ref:`version_6.1.0` release notes for a full list of changes in the 6.1
 series.
 
 Fixes
 =====
-
-- Fixed an issue causing ``KILL`` statement or
-  :ref:`statement_timeout <conf-session-statement-timeout>` to not properly
-  kill a query and leading to resources leak.
 
 - Fixed an issue causing ``IllegalStateException`` errors on inserts into a
   table with primary keys.

--- a/docs/appendices/release-notes/6.3.5.rst
+++ b/docs/appendices/release-notes/6.3.5.rst
@@ -46,6 +46,9 @@ series.
 Fixes
 =====
 
+- Fixed an issue causing ``IllegalStateException`` errors on inserts into a
+  table with primary keys.
+
 - Fixed an issue with the JWT authentication method that caused authentication
   failures if the key resources endpoint included the optional ``alg`` field.
 

--- a/docs/appendices/release-notes/index.rst
+++ b/docs/appendices/release-notes/index.rst
@@ -68,6 +68,7 @@ Versions
 .. toctree::
     :maxdepth: 1
 
+    6.1.6
     6.1.5
     6.1.4
     6.1.3
@@ -81,6 +82,7 @@ Versions
 .. toctree::
     :maxdepth: 1
 
+    6.0.8
     6.0.7
     6.0.6
     6.0.5

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/IdCollectorExpression.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/IdCollectorExpression.java
@@ -26,76 +26,69 @@ import java.io.UncheckedIOException;
 
 import org.apache.lucene.index.BinaryDocValues;
 import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.DocValuesType;
+import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.Version;
 import org.elasticsearch.index.fieldvisitor.IDVisitor;
 import org.elasticsearch.index.mapper.Uid;
 
+import io.crate.common.annotations.VisibleForTesting;
 import io.crate.execution.engine.fetch.ReaderContext;
 import io.crate.metadata.doc.SysColumns;
 
-public abstract class IdCollectorExpression extends LuceneCollectorExpression<String> {
+/**
+ * CrateDB 6.0+ stores id in BinaryDocValues.
+ * This class is not relying on version_created and instead adapts based on actual state.
+ */
+public class IdCollectorExpression extends LuceneCollectorExpression<String> {
 
     public static final Version STORED_AS_BINARY_VERSION = Version.V_6_0_0;
 
-    public static IdCollectorExpression forVersion(Version version) {
-        if (version.before(STORED_AS_BINARY_VERSION)) {
-            return new StoredIdCollectorExpression();
-        } else {
-            return new BinaryIdCollectorExpression();
-        }
-    }
-
     protected int docId;
+
+    private final IDVisitor visitor = new IDVisitor(SysColumns.ID.COLUMN.name());
+    private ReaderContext context;
+    private BinaryDocValues binaryValues;
+
+
+    @VisibleForTesting
+    BinaryDocValues binaryValues() {
+        return binaryValues;
+    }
 
     @Override
     public void setNextDocId(int docId) {
         this.docId = docId;
     }
 
-    private static class StoredIdCollectorExpression extends IdCollectorExpression {
-
-        private final IDVisitor visitor = new IDVisitor(SysColumns.ID.COLUMN.name());
-        private ReaderContext context;
-
-        @Override
-        public String value() {
-            try {
-                visitor.setCanStop(false);
-                context.visitDocument(docId, visitor);
-                return visitor.getId();
-            } catch (IOException e) {
-                throw new UncheckedIOException(e);
-            }
-        }
-
-        @Override
-        public void setNextReader(ReaderContext context) throws IOException {
-            this.context = context;
-        }
-    }
-
-    private static class BinaryIdCollectorExpression extends IdCollectorExpression {
-
-        private BinaryDocValues values;
-
-        @Override
-        public String value() {
-            try {
-                if (this.values.advanceExact(this.docId)) {
-                    BytesRef bytes = this.values.binaryValue();
+    @Override
+    public String value() {
+        try {
+            if (binaryValues != null) {
+                if (binaryValues.advanceExact(this.docId)) {
+                    BytesRef bytes = this.binaryValues.binaryValue();
                     return Uid.decodeId(bytes.bytes, bytes.offset, bytes.length);
                 } else {
                     throw new IllegalStateException("No binary id for document " + this.docId);
                 }
-            } catch (IOException e) {
-                throw new UncheckedIOException(e);
+            } else {
+                visitor.setCanStop(false);
+                context.visitDocument(docId, visitor);
+                return visitor.getId();
             }
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
         }
+    }
 
-        @Override
-        public void setNextReader(ReaderContext context) throws IOException {
-            this.values = DocValues.getBinary(context.reader(), SysColumns.Names.ID);
+    @Override
+    public void setNextReader(ReaderContext context) throws IOException {
+        this.context = context;
+        var reader = this.context.reader();
+        FieldInfo fieldInfo = reader.getFieldInfos().fieldInfo(SysColumns.Names.ID);
+        if (fieldInfo != null && fieldInfo.getDocValuesType() == DocValuesType.BINARY) {
+            this.binaryValues = DocValues.getBinary(reader, SysColumns.Names.ID);
         }
     }
 }

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/LuceneReferenceResolver.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/LuceneReferenceResolver.java
@@ -82,7 +82,7 @@ public class LuceneReferenceResolver implements ReferenceResolver<LuceneCollecto
     public LuceneCollectorExpression<?> getImplementation(final Reference ref) {
         final ColumnIdent column = ref.column();
         if (ref.valueType() instanceof StringType && isSingletonPrimaryKey.test(column)) {
-            return IdCollectorExpression.forVersion(shardVersion);
+            return new IdCollectorExpression();
         }
         switch (column.name()) {
             case SysColumns.Names.RAW:
@@ -93,7 +93,7 @@ public class LuceneReferenceResolver implements ReferenceResolver<LuceneCollecto
 
             case SysColumns.Names.UID:
             case SysColumns.Names.ID:
-                return IdCollectorExpression.forVersion(shardVersion);
+                return new IdCollectorExpression();
 
             case SysColumns.Names.FETCHID:
                 return new FetchIdCollectorExpression();

--- a/server/src/test/java/io/crate/expression/reference/doc/lucene/LuceneReferenceResolverTest.java
+++ b/server/src/test/java/io/crate/expression/reference/doc/lucene/LuceneReferenceResolverTest.java
@@ -22,12 +22,20 @@
 package io.crate.expression.reference.doc.lucene;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import java.io.IOException;
 import java.util.List;
 
+import org.apache.lucene.index.DocValuesType;
+import org.apache.lucene.index.LeafReader;
 import org.elasticsearch.Version;
 import org.junit.Test;
+import org.mockito.Answers;
 
+import io.crate.execution.engine.fetch.ReaderContext;
 import io.crate.expression.scalar.cast.CastMode;
 import io.crate.expression.symbol.DynamicReference;
 import io.crate.expression.symbol.Function;
@@ -38,6 +46,7 @@ import io.crate.metadata.RelationName;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.SimpleReference;
 import io.crate.metadata.doc.DocTableInfo;
+import io.crate.metadata.doc.SysColumns;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 import io.crate.types.DataTypes;
@@ -81,16 +90,23 @@ public class LuceneReferenceResolverTest extends CrateDummyClusterServiceUnitTes
     }
 
     @Test
-    public void testGetPrimaryKey() {
+    public void testGetPrimaryKey() throws IOException {
         SimpleReference primaryKey = new SimpleReference(
             RELATION_NAME, ColumnIdent.of("key"), RowGranularity.DOC, DataTypes.STRING, 0, null
         );
-        assertThat(LUCENE_REFERENCE_RESOLVER.getImplementation(primaryKey).getClass().toString())
-            .contains("BinaryIdCollectorExpression");
+        IdCollectorExpression expression = (IdCollectorExpression) LUCENE_REFERENCE_RESOLVER.getImplementation(primaryKey);
+        ReaderContext context = mock(ReaderContext.class);
+        LeafReader leafReader = mock(LeafReader.class, Answers.RETURNS_DEEP_STUBS);
+        when(context.reader()).thenReturn(leafReader);
+        when(leafReader.getFieldInfos().fieldInfo(eq(SysColumns.Names.ID)).getDocValuesType())
+            .thenReturn(DocValuesType.BINARY);
+
+        expression.setNextReader(context);
+        assertThat(expression.binaryValues()).isNotNull();
     }
 
     @Test
-    public void testGetPrimaryKeyIn5x() {
+    public void testGetPrimaryKeyIn5x() throws IOException {
         SimpleReference primaryKey = new SimpleReference(
             RELATION_NAME, ColumnIdent.of("key"), RowGranularity.DOC, DataTypes.STRING, 0, null
         );
@@ -101,8 +117,15 @@ public class LuceneReferenceResolverTest extends CrateDummyClusterServiceUnitTes
             Version.V_5_10_0,
             (_) -> false
         );
-        assertThat(resolver.getImplementation(primaryKey).getClass().toString())
-            .contains("StoredIdCollectorExpression");
+        IdCollectorExpression expression = (IdCollectorExpression) resolver.getImplementation(primaryKey);
+        ReaderContext context = mock(ReaderContext.class);
+        LeafReader leafReader = mock(LeafReader.class, Answers.RETURNS_DEEP_STUBS);
+        when(context.reader()).thenReturn(leafReader);
+        when(leafReader.getFieldInfos().fieldInfo(eq(SysColumns.Names.ID)).getDocValuesType())
+            .thenReturn(DocValuesType.SORTED);
+
+        expression.setNextReader(context);
+        assertThat(expression.binaryValues()).isNull();
     }
 
     @Test


### PR DESCRIPTION
Relates to https://github.com/crate/support/issues/893

It's still unclear why, but `version_created` was updated to a wrong value on some partitions
after 5.10.15 -> 6.0.5 -> 6.1.2 -> 6.1.3 -> 6.2.6 upgrade.

This is only a mitigation for the concrete problem. 

I confirmed that it resolves the issue by restoring a bad partition locally
and running  `SELECT _id` on a table with broken metadata. 
Query fails on master branch build and passes on a build from this branch.

We still need to find the root cause of the broken metadata and fix it (and maybe also come up with a reparation).

Idea of this fix is somewhat similar to https://github.com/crate/crate/pull/17580 - instead of relying on metadata, rely on actual data.

