### PR TITLE
Add collection_sum scalar function for SUM(DISTINCT) support.

### DIFF
--- a/server/src/main/java/io/crate/expression/scalar/CollectionSumFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/CollectionSumFunction.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.expression.scalar;
+
+import java.util.List;
+
+import io.crate.data.Input;
+import io.crate.execution.engine.aggregation.impl.util.KahanSummationForDouble;
+import io.crate.execution.engine.aggregation.impl.util.KahanSummationForFloat;
+import io.crate.metadata.FunctionType;
+import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.Scalar;
+import io.crate.metadata.TransactionContext;
+import io.crate.metadata.functions.BoundSignature;
+import io.crate.metadata.functions.Signature;
+import io.crate.types.ArrayType;
+import io.crate.types.DataType;
+import io.crate.types.DataTypes;
+
+public class CollectionSumFunction extends Scalar<Number, List<Object>> {
+
+    public static final String NAME = "collection_sum";
+
+    public static void register(Functions.Builder builder) {
+        for (DataType<?> supportedType : List.of(DataTypes.BYTE, DataTypes.SHORT, DataTypes.INTEGER, DataTypes.LONG)) {
+            builder.add(
+                Signature.builder(NAME, FunctionType.SCALAR)
+                    .argumentTypes(new ArrayType<>(supportedType).getTypeSignature())
+                    .returnType(DataTypes.LONG.getTypeSignature())
+                    .features(Feature.DETERMINISTIC, Feature.STRICTNULL)
+                    .build(),
+                CollectionSumFunction::new
+            );
+        }
+        builder.add(
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(new ArrayType<>(DataTypes.FLOAT).getTypeSignature())
+                .returnType(DataTypes.FLOAT.getTypeSignature())
+                .features(Feature.DETERMINISTIC, Feature.STRICTNULL)
+                .build(),
+            CollectionSumFunction::new
+        );
+        builder.add(
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(new ArrayType<>(DataTypes.DOUBLE).getTypeSignature())
+                .returnType(DataTypes.DOUBLE.getTypeSignature())
+                .features(Feature.DETERMINISTIC, Feature.STRICTNULL)
+                .build(),
+            CollectionSumFunction::new
+        );
+    }
+
+    private CollectionSumFunction(Signature signature, BoundSignature boundSignature) {
+        super(signature, boundSignature);
+    }
+
+    @Override
+    @SafeVarargs
+    public final Number evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<List<Object>>... args) {
+        List<Object> argArray = args[0].value();
+        if (argArray == null) {
+            return null;
+        }
+
+        DataType<?> returnType = boundSignature().returnType();
+
+        if (returnType == DataTypes.LONG) {
+            long sum = 0L;
+            boolean hasValues = false;
+            for (Object value : argArray) {
+                if (value != null) {
+                    sum = Math.addExact(sum, ((Number) value).longValue());
+                    hasValues = true;
+                }
+            }
+            return hasValues ? sum : null;
+        } else if (returnType == DataTypes.FLOAT) {
+            float sum = 0f;
+            KahanSummationForFloat kahanSummation = new KahanSummationForFloat();
+            boolean hasValues = false;
+            for (Object value : argArray) {
+                if (value != null) {
+                    sum = kahanSummation.sum(sum, ((Number) value).floatValue());
+                    hasValues = true;
+                }
+            }
+            return hasValues ? sum : null;
+        } else if (returnType == DataTypes.DOUBLE) {
+            double sum = 0d;
+            KahanSummationForDouble kahanSummation = new KahanSummationForDouble();
+            boolean hasValues = false;
+            for (Object value : argArray) {
+                if (value != null) {
+                    sum = kahanSummation.sum(sum, ((Number) value).doubleValue());
+                    hasValues = true;
+                }
+            }
+            return hasValues ? sum : null;
+        }
+        return null;
+    }
+}

--- a/server/src/main/java/io/crate/expression/scalar/NumericCollectionSumFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/NumericCollectionSumFunction.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.expression.scalar;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import io.crate.data.Input;
+import io.crate.metadata.FunctionType;
+import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.Scalar;
+import io.crate.metadata.TransactionContext;
+import io.crate.metadata.functions.BoundSignature;
+import io.crate.metadata.functions.Signature;
+import io.crate.types.ArrayType;
+import io.crate.types.DataTypes;
+
+public class NumericCollectionSumFunction extends Scalar<BigDecimal, List<BigDecimal>> {
+
+    public static final String NAME = "collection_sum";
+
+    public static void register(Functions.Builder builder) {
+        builder.add(
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(new ArrayType<>(DataTypes.NUMERIC).getTypeSignature())
+                .returnType(DataTypes.NUMERIC.getTypeSignature())
+                .features(Feature.DETERMINISTIC, Feature.STRICTNULL)
+                .build(),
+            NumericCollectionSumFunction::new
+        );
+    }
+
+    private NumericCollectionSumFunction(Signature signature, BoundSignature boundSignature) {
+        super(signature, boundSignature);
+    }
+
+    @Override
+    @SafeVarargs
+    public final BigDecimal evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<List<BigDecimal>>... args) {
+        List<BigDecimal> argArray = args[0].value();
+        if (argArray == null) {
+            return null;
+        }
+
+        BigDecimal sum = BigDecimal.ZERO;
+        boolean hasValues = false;
+        for (BigDecimal value : argArray) {
+            if (value != null) {
+                sum = sum.add(value);
+                hasValues = true;
+            }
+        }
+        return hasValues ? sum : null;
+    }
+}

--- a/server/src/main/java/io/crate/expression/scalar/ScalarFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/ScalarFunctions.java
@@ -123,7 +123,9 @@ public class ScalarFunctions implements FunctionsProvider {
         NegateFunctions.register(builder);
         CollectionCountFunction.register(builder);
         CollectionAverageFunction.register(builder);
+        CollectionSumFunction.register(builder);
         NumericCollectionAverageFunction.register(builder);
+        NumericCollectionSumFunction.register(builder);
         FormatFunction.register(builder);
         SubstrFunction.register(builder);
         RegexpCountFunction.register(builder);

--- a/server/src/test/java/io/crate/expression/scalar/CollectionSumFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/CollectionSumFunctionTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.expression.scalar;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import org.junit.Test;
+
+import io.crate.expression.symbol.Literal;
+import io.crate.types.ArrayType;
+import io.crate.types.DoubleType;
+import io.crate.types.LongType;
+import io.crate.types.NumericType;
+
+public class CollectionSumFunctionTest extends ScalarTestCase {
+
+    @Test
+    public void testEvaluate() throws Exception {
+        assertEvaluate("collection_sum(long_array)",
+            10L,
+            Literal.of(List.of(3L, 7L), new ArrayType<>(LongType.INSTANCE)));
+    }
+
+    @Test
+    public void testEvaluateDouble() throws Exception {
+        assertEvaluate("collection_sum(double_array)",
+            10.5,
+            Literal.of(List.of(3.2, 7.3), new ArrayType<>(DoubleType.INSTANCE)));
+    }
+
+    @Test
+    public void testEvaluateNumeric() throws Exception {
+        assertEvaluate("collection_sum(numeric_array)",
+            new BigDecimal("4.0"),
+            Literal.of(List.of(new BigDecimal("1.5"), new BigDecimal("2.5")), new ArrayType<>(NumericType.INSTANCE)));
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Adds DISTINCT support for SUM aggregation similar to the existing collection_count / collection_avg pattern (Scalar, not Aggregation).

Fixes #19665 

##Problem 
Earlier the query collection_sum(collect_set) was not able to process as collection_sum was not in the list of Implemented Functions.

##Solution
Implemented CollectionSumFunction taking reference from CollectionAverageFunction and CollectionCountFunction.The CollectionSumFunction returns a scalar value for the vector passed , in this case the list returned by CollectSetAggregation.

Screenshot of a query executed in local
<img width="581" height="366" alt="Screenshot 2026-07-04 at 9 22 08 PM" src="https://github.com/user-attachments/assets/c1d46cd1-92f8-484b-98b0-4e3cdaed39e7" />

