### PR TITLE
Update Lucene to 10.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -340,7 +340,7 @@
         <versions.quickcheck>1.0</versions.quickcheck>
         <versions.hppc>0.8.2</versions.hppc>
         <versions.netty>4.2.16.Final</versions.netty>
-        <versions.lucene>10.4.0</versions.lucene>
+        <versions.lucene>10.5.0</versions.lucene>
         <versions.spatial4j>0.8</versions.spatial4j>
         <versions.jts>1.20.0</versions.jts>
         <versions.tdigest>3.3</versions.tdigest>

--- a/server/src/main/java/io/crate/lucene/codec/CustomLucene90DocValuesConsumer.java
+++ b/server/src/main/java/io/crate/lucene/codec/CustomLucene90DocValuesConsumer.java
@@ -286,14 +286,17 @@ final class CustomLucene90DocValuesConsumer extends DocValuesConsumer {
         long globalMaxValue = Long.MIN_VALUE;
         long globalMinValue = Long.MAX_VALUE;
         int globalDocCount = 0;
+        int globalMaxValueCount = 0;
         int maxDocId = -1;
         final List<SkipAccumulator> accumulators = new ArrayList<>();
         SkipAccumulator accumulator = null;
         final int maxAccumulators = 1 << (SKIP_INDEX_LEVEL_SHIFT * (SKIP_INDEX_MAX_LEVEL - 1));
         for (int doc = values.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = values.nextDoc()) {
+            final int valueCount = values.docValueCount();
             final long firstValue = values.nextValue();
+            globalMaxValueCount = Math.max(globalMaxValueCount, valueCount);
             if (accumulator != null
-                && accumulator.isDone(skipIndexIntervalSize, values.docValueCount(), firstValue, doc)) {
+                && accumulator.isDone(skipIndexIntervalSize, valueCount, firstValue, doc)) {
                 globalMaxValue = Math.max(globalMaxValue, accumulator.maxValue);
                 globalMinValue = Math.min(globalMinValue, accumulator.minValue);
                 globalDocCount += accumulator.docCount;
@@ -310,7 +313,7 @@ final class CustomLucene90DocValuesConsumer extends DocValuesConsumer {
             }
             accumulator.nextDoc(doc);
             accumulator.accumulate(firstValue);
-            for (int i = 1, end = values.docValueCount(); i < end; ++i) {
+            for (int i = 1; i < valueCount; ++i) {
                 accumulator.accumulate(values.nextValue());
             }
         }
@@ -330,6 +333,7 @@ final class CustomLucene90DocValuesConsumer extends DocValuesConsumer {
         assert globalDocCount <= maxDocId + 1;
         meta.writeInt(globalDocCount);
         meta.writeInt(maxDocId);
+        meta.writeInt(globalMaxValueCount);
     }
 
     private void writeLevels(List<SkipAccumulator> accumulators) throws IOException {

--- a/server/src/main/java/io/crate/lucene/codec/CustomLucene90DocValuesConsumer.java
+++ b/server/src/main/java/io/crate/lucene/codec/CustomLucene90DocValuesConsumer.java
@@ -55,6 +55,7 @@ import org.apache.lucene.store.IndexOutput;
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefBuilder;
+import org.apache.lucene.util.FixedBitSet;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.LongsRef;
 import org.apache.lucene.util.MathUtil;
@@ -727,6 +728,17 @@ final class CustomLucene90DocValuesConsumer extends DocValuesConsumer {
                             public long cost() {
                                 return sorted.cost();
                             }
+
+                            @Override
+                            public void intoBitSet(int upTo, FixedBitSet bitSet, int offset)
+                                throws IOException {
+                                sorted.intoBitSet(upTo, bitSet, offset);
+                            }
+
+                            @Override
+                            public int docIDRunEnd() throws IOException {
+                                return sorted.docIDRunEnd();
+                            }
                         };
                         return DocValues.singleton(sortedOrds);
                     }
@@ -1042,6 +1054,16 @@ final class CustomLucene90DocValuesConsumer extends DocValuesConsumer {
                             @Override
                             public long cost() {
                                 return values.cost();
+                            }
+
+                            @Override
+                            public void intoBitSet(int upTo, FixedBitSet bitSet, int offset) throws IOException {
+                                values.intoBitSet(upTo, bitSet, offset);
+                            }
+
+                            @Override
+                            public int docIDRunEnd() throws IOException {
+                                return values.docIDRunEnd();
                             }
                         };
                     }

--- a/server/src/main/java/io/crate/lucene/codec/CustomLucene90DocValuesConsumer.java
+++ b/server/src/main/java/io/crate/lucene/codec/CustomLucene90DocValuesConsumer.java
@@ -71,7 +71,7 @@ import io.crate.lucene.codec.CustomLucene90DocValuesFormat.Mode;
 /** writer for {@link Lucene90DocValuesFormat} */
 final class CustomLucene90DocValuesConsumer extends DocValuesConsumer {
 
-    IndexOutput data, meta;
+    IndexOutput data, meta, skipIndex;
     final int maxDoc;
     private byte[] termsDictBuffer;
     private final Mode mode;
@@ -86,6 +86,8 @@ final class CustomLucene90DocValuesConsumer extends DocValuesConsumer {
             String dataExtension,
             String metaCodec,
             String metaExtension,
+            String skipIndexCodec,
+            String skipIndexExtension,
             Mode mode)
             throws IOException {
         this.mode = mode;
@@ -113,6 +115,16 @@ final class CustomLucene90DocValuesConsumer extends DocValuesConsumer {
                     CustomLucene90DocValuesFormat.VERSION_CURRENT,
                     state.segmentInfo.getId(),
                     state.segmentSuffix);
+            String skipIndexName =
+                IndexFileNames.segmentFileName(
+                    state.segmentInfo.name, state.segmentSuffix, skipIndexExtension);
+            skipIndex = state.directory.createOutput(skipIndexName, state.context);
+            CodecUtil.writeIndexHeader(
+                skipIndex,
+                skipIndexCodec,
+                CustomLucene90DocValuesFormat.VERSION_CURRENT,
+                state.segmentInfo.getId(),
+                state.segmentSuffix);
             maxDoc = state.segmentInfo.maxDoc();
             success = true;
         } finally {
@@ -133,14 +145,17 @@ final class CustomLucene90DocValuesConsumer extends DocValuesConsumer {
             if (data != null) {
                 CodecUtil.writeFooter(data); // write checksum
             }
+            if (skipIndex != null) {
+                CodecUtil.writeFooter(skipIndex);
+            }
             success = true;
         } finally {
             if (success) {
-                IOUtils.close(data, meta);
+                IOUtils.close(data, meta, skipIndex);
             } else {
-                IOUtils.closeWhileHandlingException(data, meta);
+                IOUtils.closeWhileHandlingException(data, meta, skipIndex);
             }
-            meta = data = null;
+            meta = data = skipIndex = null;
         }
     }
 
@@ -266,7 +281,7 @@ final class CustomLucene90DocValuesConsumer extends DocValuesConsumer {
         throws IOException {
         assert field.docValuesSkipIndexType() != DocValuesSkipIndexType.NONE;
         // TODO: This disk compression once we introduce levels
-        final long start = data.getFilePointer();
+        final long start = skipIndex.getFilePointer();
         final SortedNumericDocValues values = valuesProducer.getSortedNumeric(field);
         long globalMaxValue = Long.MIN_VALUE;
         long globalMinValue = Long.MAX_VALUE;
@@ -308,7 +323,7 @@ final class CustomLucene90DocValuesConsumer extends DocValuesConsumer {
             writeLevels(accumulators);
         }
         meta.writeLong(start); // record the start in meta
-        meta.writeLong(data.getFilePointer() - start); // record the length
+        meta.writeLong(skipIndex.getFilePointer() - start); // record the length
         assert globalDocCount == 0 || globalMaxValue >= globalMinValue;
         meta.writeLong(globalMaxValue);
         meta.writeLong(globalMinValue);
@@ -328,17 +343,17 @@ final class CustomLucene90DocValuesConsumer extends DocValuesConsumer {
             // compute how many levels we need to write for the current accumulator
             final int levels = getLevels(index, totalAccumulators);
             // write the number of levels
-            data.writeByte((byte) levels);
+            skipIndex.writeByte((byte) levels);
             // write intervals in reverse order. This is done so we don't
             // need to read all of them in case of slipping
             for (int level = levels - 1; level >= 0; level--) {
                 final SkipAccumulator accumulator =
                     accumulatorsLevels.get(level).get(index >> (SKIP_INDEX_LEVEL_SHIFT * level));
-                data.writeInt(accumulator.maxDocID);
-                data.writeInt(accumulator.minDocID);
-                data.writeLong(accumulator.maxValue);
-                data.writeLong(accumulator.minValue);
-                data.writeInt(accumulator.docCount);
+                skipIndex.writeInt(accumulator.maxDocID);
+                skipIndex.writeInt(accumulator.minDocID);
+                skipIndex.writeLong(accumulator.maxValue);
+                skipIndex.writeLong(accumulator.minValue);
+                skipIndex.writeInt(accumulator.docCount);
             }
         }
     }

--- a/server/src/main/java/io/crate/lucene/codec/CustomLucene90DocValuesFormat.java
+++ b/server/src/main/java/io/crate/lucene/codec/CustomLucene90DocValuesFormat.java
@@ -61,21 +61,38 @@ public final class CustomLucene90DocValuesFormat extends DocValuesFormat {
     @Override
     public DocValuesConsumer fieldsConsumer(SegmentWriteState state) throws IOException {
         return new CustomLucene90DocValuesConsumer(
-                state, skipIndexIntervalSize, DATA_CODEC, DATA_EXTENSION, META_CODEC, META_EXTENSION, mode);
+            state,
+            skipIndexIntervalSize,
+            DATA_CODEC,
+            DATA_EXTENSION,
+            META_CODEC,
+            META_EXTENSION,
+            SKIP_INDEX_CODEC,
+            SKIP_INDEX_EXTENSION,
+            mode);
     }
 
     @Override
     public DocValuesProducer fieldsProducer(SegmentReadState state) throws IOException {
         return new CustomLucene90DocValuesProducer(
-                state, DATA_CODEC, DATA_EXTENSION, META_CODEC, META_EXTENSION);
+            state,
+            DATA_CODEC,
+            DATA_EXTENSION,
+            META_CODEC,
+            META_EXTENSION,
+            SKIP_INDEX_CODEC,
+            SKIP_INDEX_EXTENSION);
     }
 
     static final String DATA_CODEC = "Lucene90DocValuesData";
     static final String DATA_EXTENSION = "dvd";
     static final String META_CODEC = "Lucene90DocValuesMetadata";
     static final String META_EXTENSION = "dvm";
+    static final String SKIP_INDEX_CODEC = "Lucene90DocValuesSkipIndex";
+    static final String SKIP_INDEX_EXTENSION = "dvs";
     static final int VERSION_START = 0;
-    static final int VERSION_CURRENT = VERSION_START;
+    static final int VERSION_SKIPPER_SEPARATE_FILE = 1;
+    static final int VERSION_CURRENT = VERSION_SKIPPER_SEPARATE_FILE;
 
     // indicates docvalues type
     static final byte NUMERIC = 0;

--- a/server/src/main/java/io/crate/lucene/codec/CustomLucene90DocValuesFormat.java
+++ b/server/src/main/java/io/crate/lucene/codec/CustomLucene90DocValuesFormat.java
@@ -92,7 +92,8 @@ public final class CustomLucene90DocValuesFormat extends DocValuesFormat {
     static final String SKIP_INDEX_EXTENSION = "dvs";
     static final int VERSION_START = 0;
     static final int VERSION_SKIPPER_SEPARATE_FILE = 1;
-    static final int VERSION_CURRENT = VERSION_SKIPPER_SEPARATE_FILE;
+    static final int VERSION_SKIPPER_MAX_VALUE_COUNT = 2;
+    static final int VERSION_CURRENT = VERSION_SKIPPER_MAX_VALUE_COUNT;
 
     // indicates docvalues type
     static final byte NUMERIC = 0;

--- a/server/src/main/java/io/crate/lucene/codec/CustomLucene90DocValuesProducer.java
+++ b/server/src/main/java/io/crate/lucene/codec/CustomLucene90DocValuesProducer.java
@@ -595,6 +595,16 @@ final class CustomLucene90DocValuesProducer extends DocValuesProducer {
         public int docIDRunEnd() throws IOException {
             return maxDoc;
         }
+
+        @Override
+        public void intoBitSet(int upTo, FixedBitSet bitSet, int offset) throws IOException {
+            assert offset <= doc;
+            upTo = Math.min(upTo, maxDoc);
+            if (upTo > doc) {
+                bitSet.set(doc - offset, upTo - offset);
+                advance(upTo);
+            }
+        }
     }
 
     private abstract static class SparseNumericDocValues extends NumericDocValues {
@@ -877,6 +887,16 @@ final class CustomLucene90DocValuesProducer extends DocValuesProducer {
         public int docIDRunEnd() throws IOException {
             return maxDoc;
         }
+
+        @Override
+        public void intoBitSet(int upTo, FixedBitSet bitSet, int offset) throws IOException {
+            assert offset <= doc;
+            upTo = Math.min(upTo, maxDoc);
+            if (upTo > doc) {
+                bitSet.set(doc - offset, upTo - offset);
+                advance(upTo);
+            }
+        }
     }
 
     private abstract static class SparseBinaryDocValues extends BinaryDocValues {
@@ -1086,6 +1106,16 @@ final class CustomLucene90DocValuesProducer extends DocValuesProducer {
                     public int docIDRunEnd() throws IOException {
                         return maxDoc;
                     }
+
+                    @Override
+                    public void intoBitSet(int upTo, FixedBitSet bitSet, int offset) throws IOException {
+                        assert offset <= doc;
+                        upTo = Math.min(upTo, maxDoc);
+                        if (upTo > doc) {
+                            bitSet.set(doc - offset, upTo - offset);
+                            advance(upTo);
+                        }
+                    }
                 };
             } else if (ordsEntry.docsWithFieldOffset >= 0) { // sparse but non-empty
                 final IndexedDISI disi = new IndexedDISI(
@@ -1177,6 +1207,11 @@ final class CustomLucene90DocValuesProducer extends DocValuesProducer {
             @Override
             public int docIDRunEnd() throws IOException {
                 return ords.docIDRunEnd();
+            }
+
+            @Override
+            public void intoBitSet(int upTo, FixedBitSet bitSet, int offset) throws IOException {
+                ords.intoBitSet(upTo, bitSet, offset);
             }
         };
     }
@@ -1602,6 +1637,16 @@ final class CustomLucene90DocValuesProducer extends DocValuesProducer {
                 public int docIDRunEnd() throws IOException {
                     return maxDoc;
                 }
+
+                @Override
+                public void intoBitSet(int upTo, FixedBitSet bitSet, int offset) throws IOException {
+                    assert offset <= doc;
+                    upTo = Math.min(upTo, maxDoc);
+                    if (upTo > doc) {
+                        bitSet.set(doc - offset, upTo - offset);
+                        advance(upTo);
+                    }
+                }
             };
         } else {
             // sparse
@@ -1768,6 +1813,16 @@ final class CustomLucene90DocValuesProducer extends DocValuesProducer {
                     public int docIDRunEnd() throws IOException {
                         return maxDoc;
                     }
+
+                    @Override
+                    public void intoBitSet(int upTo, FixedBitSet bitSet, int offset) throws IOException {
+                        assert offset <= doc;
+                        upTo = Math.min(upTo, maxDoc);
+                        if (upTo > doc) {
+                            bitSet.set(doc - offset, upTo - offset);
+                            advance(upTo);
+                        }
+                    }
                 };
             } else if (ordsEntry.docsWithFieldOffset >= 0) { // sparse but non-empty
                 final IndexedDISI disi = new IndexedDISI(
@@ -1889,6 +1944,11 @@ final class CustomLucene90DocValuesProducer extends DocValuesProducer {
             @Override
             public int docIDRunEnd() throws IOException {
                 return ords.docIDRunEnd();
+            }
+
+            @Override
+            public void intoBitSet(int upTo, FixedBitSet bitSet, int offset) throws IOException {
+                ords.intoBitSet(upTo, bitSet, offset);
             }
         };
     }

--- a/server/src/main/java/io/crate/lucene/codec/CustomLucene90DocValuesProducer.java
+++ b/server/src/main/java/io/crate/lucene/codec/CustomLucene90DocValuesProducer.java
@@ -1787,11 +1787,6 @@ final class CustomLucene90DocValuesProducer extends DocValuesProducer {
         final DocValuesSkipperEntry entry = skippers.get(field.number);
 
         final IndexInput input = data.slice("doc value skipper", entry.offset, entry.length);
-        // Prefetch the first page of data. Following pages are expected to get prefetched through
-        // read-ahead.
-        if (input.length() > 0) {
-            input.prefetch(0, 1);
-        }
 
         return new DocValuesSkipper() {
             final int[] minDocID = new int[SKIP_INDEX_MAX_LEVEL];

--- a/server/src/main/java/io/crate/lucene/codec/CustomLucene90DocValuesProducer.java
+++ b/server/src/main/java/io/crate/lucene/codec/CustomLucene90DocValuesProducer.java
@@ -114,6 +114,10 @@ final class CustomLucene90DocValuesProducer extends DocValuesProducer {
 
                 readFields(in, state.fieldInfos);
 
+                if (version < CustomLucene90DocValuesFormat.VERSION_SKIPPER_MAX_VALUE_COUNT) {
+                    inferMaxValueCounts(state.fieldInfos);
+                }
+
             } catch (Throwable exception) {
                 priorE = exception;
             } finally {
@@ -228,6 +232,55 @@ final class CustomLucene90DocValuesProducer extends DocValuesProducer {
             true);
     }
 
+    private void inferMaxValueCounts(FieldInfos fieldInfos) {
+        for (var cursor : skippers) {
+            DocValuesSkipperEntry entry = cursor.value;
+            if (entry.maxValueCount == -1 && entry.docCount != 0) {
+                int fieldNumber = cursor.key;
+                FieldInfo info = fieldInfos.fieldInfo(fieldNumber);
+                int inferredMaxValueCount = -1;
+                if (info != null) {
+                    switch (info.getDocValuesType()) {
+                        case NUMERIC, SORTED -> inferredMaxValueCount = 1;
+                        case SORTED_NUMERIC -> {
+                            SortedNumericEntry sne = sortedNumerics.get(fieldNumber);
+                            if (sne != null && sne.numValues == sne.numDocsWithField) {
+                                inferredMaxValueCount = 1;
+                            }
+                        }
+                        case SORTED_SET -> {
+                            SortedSetEntry sse = sortedSets.get(fieldNumber);
+                            if (sse != null) {
+                                if (sse.singleValueEntry != null) {
+                                    inferredMaxValueCount = 1;
+                                } else if (sse.ordsEntry != null
+                                    && sse.ordsEntry.numValues == sse.ordsEntry.numDocsWithField) {
+                                    inferredMaxValueCount = 1;
+                                }
+                            }
+                        }
+                        // $CASES-OMITTED$
+                        default -> {
+                            // leave as -1
+                        }
+                    }
+                }
+                if (inferredMaxValueCount != -1) {
+                    skippers.put(
+                        fieldNumber,
+                        new DocValuesSkipperEntry(
+                            entry.offset,
+                            entry.length,
+                            entry.minValue,
+                            entry.maxValue,
+                            entry.docCount,
+                            entry.maxDocId,
+                            inferredMaxValueCount));
+                }
+            }
+        }
+    }
+
     private void readFields(IndexInput meta, FieldInfos infos) throws IOException {
         for (int fieldNumber = meta.readInt(); fieldNumber != -1; fieldNumber = meta.readInt()) {
             FieldInfo info = infos.fieldInfo(fieldNumber);
@@ -255,8 +308,13 @@ final class CustomLucene90DocValuesProducer extends DocValuesProducer {
     }
 
     private record DocValuesSkipperEntry(
-        long offset, long length, long minValue, long maxValue, int docCount, int maxDocId) {
-    }
+        long offset,
+        long length,
+        long minValue,
+        long maxValue,
+        int docCount,
+        int maxDocId,
+        int maxValueCount) {}
 
     private DocValuesSkipperEntry readDocValueSkipperMeta(IndexInput meta) throws IOException {
         long offset = meta.readLong();
@@ -265,8 +323,15 @@ final class CustomLucene90DocValuesProducer extends DocValuesProducer {
         long minValue = meta.readLong();
         int docCount = meta.readInt();
         int maxDocID = meta.readInt();
+        final int maxValueCount;
+        if (version >= CustomLucene90DocValuesFormat.VERSION_SKIPPER_MAX_VALUE_COUNT) {
+            maxValueCount = meta.readInt();
+        } else {
+            maxValueCount = docCount == 0 ? 0 : -1;
+        }
 
-        return new DocValuesSkipperEntry(offset, length, minValue, maxValue, docCount, maxDocID);
+        return new DocValuesSkipperEntry(
+            offset, length, minValue, maxValue, docCount, maxDocID, maxValueCount);
     }
 
     private NumericEntry readNumeric(IndexInput meta) throws IOException {
@@ -1929,6 +1994,11 @@ final class CustomLucene90DocValuesProducer extends DocValuesProducer {
             @Override
             public int docCount() {
                 return entry.docCount;
+            }
+
+            @Override
+            public int maxValueCount() {
+                return entry.maxValueCount;
             }
         };
     }

--- a/server/src/main/java/io/crate/lucene/codec/CustomLucene90DocValuesProducer.java
+++ b/server/src/main/java/io/crate/lucene/codec/CustomLucene90DocValuesProducer.java
@@ -72,6 +72,7 @@ final class CustomLucene90DocValuesProducer extends DocValuesProducer {
     private final IntObjectHashMap<SortedNumericEntry> sortedNumerics;
     private final IntObjectHashMap<DocValuesSkipperEntry> skippers;
     private final IndexInput data;
+    private final IndexInput skipIndexData;
     private final int maxDoc;
     private int version = -1;
     private final boolean merging;
@@ -84,7 +85,9 @@ final class CustomLucene90DocValuesProducer extends DocValuesProducer {
         String dataCodec,
         String dataExtension,
         String metaCodec,
-        String metaExtension)
+        String metaExtension,
+        String skipIndexCodec,
+        String skipIndexExtension)
         throws IOException {
         final String metaName = IndexFileNames.segmentFileName(state.segmentInfo.name, state.segmentSuffix, metaExtension);
         this.maxDoc = state.segmentInfo.maxDoc();
@@ -150,6 +153,35 @@ final class CustomLucene90DocValuesProducer extends DocValuesProducer {
                 IOUtils.closeWhileHandlingException(this.data);
             }
         }
+
+        if (version >= CustomLucene90DocValuesFormat.VERSION_SKIPPER_SEPARATE_FILE) {
+            String skipIndexName =
+                IndexFileNames.segmentFileName(
+                    state.segmentInfo.name, state.segmentSuffix, skipIndexExtension);
+            this.skipIndexData =
+                state.directory.openInput(skipIndexName, state.context.withHints(FileTypeHint.INDEX));
+            try {
+                final int skipVersion =
+                    CodecUtil.checkIndexHeader(
+                        skipIndexData,
+                        skipIndexCodec,
+                        CustomLucene90DocValuesFormat.VERSION_SKIPPER_SEPARATE_FILE,
+                        CustomLucene90DocValuesFormat.VERSION_CURRENT,
+                        state.segmentInfo.getId(),
+                        state.segmentSuffix);
+                if (version != skipVersion) {
+                    throw new CorruptIndexException(
+                        "Format versions mismatch: meta=" + version + ", skipIndex=" + skipVersion,
+                        skipIndexData);
+                }
+                CodecUtil.retrieveChecksum(skipIndexData);
+            } catch (Throwable t) {
+                IOUtils.closeWhileSuppressingExceptions(t, data, skipIndexData);
+                throw t;
+            }
+        } else {
+            this.skipIndexData = null;
+        }
     }
 
     // Used for cloning
@@ -161,6 +193,7 @@ final class CustomLucene90DocValuesProducer extends DocValuesProducer {
         IntObjectHashMap<SortedNumericEntry> sortedNumerics,
         IntObjectHashMap<DocValuesSkipperEntry> skippers,
         IndexInput data,
+        IndexInput skipIndexData,
         int maxDoc,
         int version,
         boolean merging) {
@@ -171,6 +204,7 @@ final class CustomLucene90DocValuesProducer extends DocValuesProducer {
         this.sortedNumerics = sortedNumerics;
         this.skippers = skippers;
         this.data = data.clone();
+        this.skipIndexData = skipIndexData != null ? skipIndexData.clone() : null;
         this.maxDoc = maxDoc;
         this.version = version;
         this.merging = merging;
@@ -179,7 +213,17 @@ final class CustomLucene90DocValuesProducer extends DocValuesProducer {
     @Override
     public DocValuesProducer getMergeInstance() {
         return new CustomLucene90DocValuesProducer(
-            numerics, binaries, sorted, sortedSets, sortedNumerics, skippers, data, maxDoc, version, true);
+            numerics,
+            binaries,
+            sorted,
+            sortedSets,
+            sortedNumerics,
+            skippers,
+            data,
+            skipIndexData,
+            maxDoc,
+            version,
+            true);
     }
 
     private void readFields(IndexInput meta, FieldInfos infos) throws IOException {
@@ -364,7 +408,7 @@ final class CustomLucene90DocValuesProducer extends DocValuesProducer {
 
     @Override
     public void close() throws IOException {
-        data.close();
+        IOUtils.close(data, skipIndexData);
     }
 
     private static class NumericEntry {
@@ -1786,7 +1830,8 @@ final class CustomLucene90DocValuesProducer extends DocValuesProducer {
     public DocValuesSkipper getSkipper(FieldInfo field) throws IOException {
         final DocValuesSkipperEntry entry = skippers.get(field.number);
 
-        final IndexInput input = data.slice("doc value skipper", entry.offset, entry.length);
+        final IndexInput skipperSource = skipIndexData != null ? skipIndexData : data;
+        final IndexInput input = skipperSource.slice("doc value skipper", entry.offset, entry.length);
 
         return new DocValuesSkipper() {
             final int[] minDocID = new int[SKIP_INDEX_MAX_LEVEL];
@@ -1889,6 +1934,9 @@ final class CustomLucene90DocValuesProducer extends DocValuesProducer {
     @Override
     public void checkIntegrity() throws IOException {
         CodecUtil.checksumEntireFile(data);
+        if (skipIndexData != null) {
+            CodecUtil.checksumEntireFile(skipIndexData);
+        }
     }
 
     /**

--- a/server/src/main/java/io/crate/lucene/codec/CustomLucene90DocValuesProducer.java
+++ b/server/src/main/java/io/crate/lucene/codec/CustomLucene90DocValuesProducer.java
@@ -1560,13 +1560,63 @@ final class CustomLucene90DocValuesProducer extends DocValuesProducer {
         }
     }
 
+    private static int fixedCardinality(
+        SortedNumericEntry entry, DocValuesSkipperEntry skipperEntry) {
+        if (skipperEntry == null
+            || skipperEntry.maxValueCount <= 1
+            || entry.numDocsWithField == 0
+            || entry.numValues % entry.numDocsWithField != 0) {
+            return -1;
+        }
+        long cardinality = entry.numValues / entry.numDocsWithField;
+        if (cardinality > Integer.MAX_VALUE || cardinality != skipperEntry.maxValueCount) {
+            return -1;
+        }
+        return (int) cardinality;
+    }
+
+    private static void sortedNumericScalarRangeIntoBitSet(
+        LongValues values,
+        int fromDoc,
+        int toDoc,
+        int cardinality,
+        long minValue,
+        long maxValue,
+        FixedBitSet bitSet,
+        int offset) {
+        for (int doc = fromDoc; doc < toDoc; doc++) {
+            long valueOffset = (long) doc * cardinality;
+            for (int i = 0; i < cardinality; i++) {
+                long value = values.get(valueOffset + i);
+                if (value >= minValue) {
+                    if (value <= maxValue) {
+                        bitSet.set(doc - offset);
+                    }
+                    break;
+                }
+            }
+        }
+    }
+
+    private static boolean sortedNumericMatchesRange(
+        LongValues values, long start, long end, long minValue, long maxValue) {
+        for (long valueOffset = start; valueOffset < end; valueOffset++) {
+            long value = values.get(valueOffset);
+            if (value >= minValue) {
+                return value <= maxValue;
+            }
+        }
+        return false;
+    }
+
     @Override
     public SortedNumericDocValues getSortedNumeric(FieldInfo field) throws IOException {
         SortedNumericEntry entry = sortedNumerics.get(field.number);
-        return getSortedNumeric(entry);
+        return getSortedNumeric(entry, skippers.get(field.number));
     }
 
-    private SortedNumericDocValues getSortedNumeric(SortedNumericEntry entry) throws IOException {
+    private SortedNumericDocValues getSortedNumeric(
+        SortedNumericEntry entry, DocValuesSkipperEntry skipperEntry) throws IOException {
         if (entry.numValues == entry.numDocsWithField) {
             return DocValues.singleton(getNumeric(entry));
         }
@@ -1579,6 +1629,7 @@ final class CustomLucene90DocValuesProducer extends DocValuesProducer {
         final LongValues addresses = DirectMonotonicReader.getInstance(entry.addressesMeta, addressesInput, merging);
 
         final LongValues values = getNumericValues(entry);
+        final int denseFixedCardinality = fixedCardinality(entry, skipperEntry);
 
         if (entry.docsWithFieldOffset == -1) {
             // dense
@@ -1631,6 +1682,34 @@ final class CustomLucene90DocValuesProducer extends DocValuesProducer {
                 @Override
                 public int docValueCount() {
                     return count;
+                }
+
+                @Override
+                public void rangeIntoBitSet(
+                    int fromDoc, int toDoc, long minValue, long maxValue, FixedBitSet bitSet, int offset) {
+                    int endDoc = Math.min(toDoc, maxDoc);
+                    if (fromDoc >= endDoc) {
+                        return;
+                    }
+                    if (entry.bitsPerValue == 0) {
+                        if (entry.minValue >= minValue && entry.minValue <= maxValue) {
+                            bitSet.set(fromDoc - offset, endDoc - offset);
+                        }
+                        return;
+                    }
+                    int cardinality = denseFixedCardinality;
+                    if (cardinality > 1) {
+                        sortedNumericScalarRangeIntoBitSet(
+                            values, fromDoc, endDoc, cardinality, minValue, maxValue, bitSet, offset);
+                        return;
+                    }
+                    for (int currentDoc = fromDoc; currentDoc < endDoc; currentDoc++) {
+                        long startOffset = addresses.get(currentDoc);
+                        long endOffset = addresses.get(currentDoc + 1L);
+                        if (sortedNumericMatchesRange(values, startOffset, endOffset, minValue, maxValue)) {
+                            bitSet.set(currentDoc - offset);
+                        }
+                    }
                 }
 
                 @Override
@@ -1701,6 +1780,40 @@ final class CustomLucene90DocValuesProducer extends DocValuesProducer {
                 public int docValueCount() {
                     set();
                     return count;
+                }
+
+                @Override
+                public void rangeIntoBitSet(
+                    int fromDoc, int toDoc, long minValue, long maxValue, FixedBitSet bitSet, int offset)
+                    throws IOException {
+                    set = false;
+                    int endDoc = Math.min(toDoc, maxDoc);
+                    if (fromDoc >= endDoc) {
+                        return;
+                    }
+                    int currentDoc = disi.docID();
+                    if (currentDoc < fromDoc) {
+                        currentDoc = disi.advance(fromDoc);
+                    }
+                    if (currentDoc >= endDoc) {
+                        return;
+                    }
+                    if (entry.bitsPerValue == 0) {
+                        if (entry.minValue >= minValue && entry.minValue <= maxValue) {
+                            disi.intoBitSet(endDoc, bitSet, offset);
+                        }
+                        set = false;
+                        return;
+                    }
+                    for (; currentDoc < endDoc; currentDoc = disi.nextDoc()) {
+                        int index = disi.index();
+                        long startOffset = addresses.get(index);
+                        long endOffset = addresses.get(index + 1L);
+                        if (sortedNumericMatchesRange(values, startOffset, endOffset, minValue, maxValue)) {
+                            bitSet.set(currentDoc - offset);
+                        }
+                    }
+                    set = false;
                 }
 
                 @Override
@@ -1903,7 +2016,7 @@ final class CustomLucene90DocValuesProducer extends DocValuesProducer {
             }
         }
 
-        final SortedNumericDocValues ords = getSortedNumeric(entry.ordsEntry);
+        final SortedNumericDocValues ords = getSortedNumeric(entry.ordsEntry, null);
         return new BaseSortedSetDocValues(entry, data) {
 
             @Override

--- a/server/src/main/java/io/crate/lucene/codec/CustomLucene90DocValuesProducer.java
+++ b/server/src/main/java/io/crate/lucene/codec/CustomLucene90DocValuesProducer.java
@@ -155,15 +155,16 @@ final class CustomLucene90DocValuesProducer extends DocValuesProducer {
         }
 
         if (version >= CustomLucene90DocValuesFormat.VERSION_SKIPPER_SEPARATE_FILE) {
-            String skipIndexName =
-                IndexFileNames.segmentFileName(
-                    state.segmentInfo.name, state.segmentSuffix, skipIndexExtension);
-            this.skipIndexData =
-                state.directory.openInput(skipIndexName, state.context.withHints(FileTypeHint.INDEX));
+            IndexInput skipIn = null;
             try {
+                String skipIndexName =
+                    IndexFileNames.segmentFileName(
+                        state.segmentInfo.name, state.segmentSuffix, skipIndexExtension);
+                skipIn =
+                    state.directory.openInput(skipIndexName, state.context.withHints(FileTypeHint.INDEX));
                 final int skipVersion =
                     CodecUtil.checkIndexHeader(
-                        skipIndexData,
+                        skipIn,
                         skipIndexCodec,
                         CustomLucene90DocValuesFormat.VERSION_SKIPPER_SEPARATE_FILE,
                         CustomLucene90DocValuesFormat.VERSION_CURRENT,
@@ -171,14 +172,15 @@ final class CustomLucene90DocValuesProducer extends DocValuesProducer {
                         state.segmentSuffix);
                 if (version != skipVersion) {
                     throw new CorruptIndexException(
-                        "Format versions mismatch: meta=" + version + ", skipIndex=" + skipVersion,
-                        skipIndexData);
+                        "Format versions mismatch: meta=" + version + ", skipIndex=" + skipVersion, skipIn);
+
                 }
-                CodecUtil.retrieveChecksum(skipIndexData);
+                CodecUtil.retrieveChecksum(skipIn);
             } catch (Throwable t) {
-                IOUtils.closeWhileSuppressingExceptions(t, data, skipIndexData);
+                IOUtils.closeWhileSuppressingExceptions(t, data, skipIn);
                 throw t;
             }
+            this.skipIndexData = skipIn;
         } else {
             this.skipIndexData = null;
         }

--- a/server/src/main/java/org/elasticsearch/Version.java
+++ b/server/src/main/java/org/elasticsearch/Version.java
@@ -247,7 +247,7 @@ public class Version implements Comparable<Version> {
     public static final Version V_6_4_0 = new Version(9_04_00_99, false, org.apache.lucene.util.Version.LUCENE_10_4_0);
     public static final Version V_6_4_1 = new Version(9_04_01_99, true, org.apache.lucene.util.Version.LUCENE_10_4_0);
 
-    public static final Version V_6_5_0 = new Version(9_05_00_99, true, org.apache.lucene.util.Version.LUCENE_10_4_0);
+    public static final Version V_6_5_0 = new Version(9_05_00_99, true, org.apache.lucene.util.Version.LUCENE_10_5_0);
 
     public static final Version CURRENT = V_6_5_0;
 

--- a/server/src/test/java/io/crate/lucene/codec/TestCustomLucene90DocValuesFormat.java
+++ b/server/src/test/java/io/crate/lucene/codec/TestCustomLucene90DocValuesFormat.java
@@ -52,6 +52,7 @@ import org.apache.lucene.document.StringField;
 import org.apache.lucene.index.BinaryDocValues;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.DocValuesSkipper;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
@@ -70,6 +71,10 @@ import org.apache.lucene.index.TermsEnum;
 import org.apache.lucene.store.ByteBuffersDataInput;
 import org.apache.lucene.store.ByteBuffersDataOutput;
 import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.FilterDirectory;
+import org.apache.lucene.store.FilterIndexInput;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
 import org.apache.lucene.tests.codecs.asserting.AssertingCodec;
 import org.apache.lucene.tests.index.BaseDocValuesFormatTestCase;
@@ -78,6 +83,7 @@ import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefBuilder;
 import org.elasticsearch.index.codec.CrateCodec;
+import org.junit.Test;
 
 public class TestCustomLucene90DocValuesFormat extends BaseDocValuesFormatTestCase {
 
@@ -1021,5 +1027,54 @@ public class TestCustomLucene90DocValuesFormat extends BaseDocValuesFormatTestCa
         assertNull(termsEnum.next());
         reader.close();
         directory.close();
+    }
+
+    @Test
+    public void testSkipIndexStoredSeparately() throws IOException {
+        try (Directory dir = newDirectory()) {
+            IndexWriterConfig conf = newIndexWriterConfig();
+            conf.setCodec(getCodec());
+            conf.setUseCompoundFile(false);
+            try (IndexWriter writer = new IndexWriter(dir, conf)) {
+                for (int i = 0; i < 100; i++) {
+                    Document doc = new Document();
+                    doc.add(NumericDocValuesField.indexedField("dv", i));
+                    writer.addDocument(doc);
+                }
+                writer.forceMerge(1);
+            }
+
+            // Wrap the directory so that any attempt to slice() the .dvd file throws.
+            // The producer constructor opens .dvd for header/checksum validation (sequential reads),
+            // but getSkipper() should only slice the .dvs file, never the .dvd file.
+            Directory noDataSliceDir =
+                new FilterDirectory(dir) {
+                    @Override
+                    public IndexInput openInput(String name, IOContext context) throws IOException {
+                        IndexInput in = super.openInput(name, context);
+                        if (name.endsWith("." + CustomLucene90DocValuesFormat.DATA_EXTENSION)) {
+                            return new FilterIndexInput("no-slice-" + name, in) {
+                                @Override
+                                public IndexInput slice(String sliceDescription, long offset, long length) {
+                                    throw new AssertionError(
+                                        "should not slice .dvd file for skip index access: " + sliceDescription);
+                                }
+                            };
+                        }
+                        return in;
+                    }
+                };
+
+            try (DirectoryReader reader = DirectoryReader.open(noDataSliceDir)) {
+                LeafReader leaf = getOnlyLeafReader(reader);
+                DocValuesSkipper skipper = leaf.getDocValuesSkipper("dv");
+                assertNotNull(skipper);
+                assertEquals(100, skipper.docCount());
+                skipper.advance(0);
+                assertEquals(0, skipper.minDocID(0));
+                assertTrue(skipper.maxDocID(0) >= 0);
+                assertTrue(skipper.minValue() <= skipper.maxValue());
+            }
+        }
     }
 }


### PR DESCRIPTION
https://lucene.apache.org/core/10_5_0/changes/Changes.html

No new codec, still `Lucene104Codec` is used

From the following changes:
```
g log --oneline releases/lucene/10.4.0..releases/lucene/10.5.0 lucene/core/src/java/org/apache/lucene/codecs/lucene90/{Lucene90DocValuesProducer.java,Lucene90DocValuesConsumer.java,Lucene90DocValuesFormat.java}

ad06ebcc713 Add batch evaluation for sorted numeric ranges (#16166)
4f27413dc99 Add bulk decode for dense NumericDocValues via longValues() (#16129)
ef8dd5fb8bc Implement #intoBitSet and #docIDRunEnd in DocValuesWriter implementations (#16126)
67b3d5422ef Implement DocIdSetIterator#intoBitSet in many of the Lucene90DocValuesProducer implementations (#16097)
84c424ac132 Add SIMD-accelerated bulk range evaluation for dense numeric doc values (#16093)
bd09d6fbad8 Add maxValueCount to DocValuesSkipper metadata (#15993)
7908df2b7c4 Correctly handle errors when opening DocValuesSkipper file
71a214ce53c Store DocValuesSkippers in a separate file (#15976)
ab2df3a92ff Disable prefetching when loading DocValuesSkippers (#15729)
```
[84c424ac132](https://github.com/apache/lucene/commit/84c424ac13) and [4f27413dc99](https://github.com/apache/lucene/commit/4f27413dc99) are not applied because the:
https://github.com/apache/lucene/blob/main/lucene/core/src/java/org/apache/lucene/internal/vectorization/VectorizationProvider.java#L236 only permits hardcoded classes to use it.
