### PR TITLE
Fix COPY FROM S3 URI parsing for default endpoint

### DIFF
--- a/plugins/cr8-copy-s3/src/main/java/io/crate/copy/s3/common/S3Env.java
+++ b/plugins/cr8-copy-s3/src/main/java/io/crate/copy/s3/common/S3Env.java
@@ -36,7 +36,8 @@ public final class S3Env {
         String endpoint = protocol + "://" + s3uri.endpoint();
         String region = S3.getRegion(endpoint, s3uri.bucket());
         if (S3URI.DEFAULT_ENDPOINT.equals(s3uri.endpoint()) && region != null) {
-            endpoint = protocol + "://s3." + region + ".amazonaws.com";
+            String regionalEndpoint = "s3." + region + ".amazonaws.com";
+            endpoint = protocol + "://" + regionalEndpoint;
         }
         return ServiceConfig.S3.builder()
             .bucket(s3uri.bucket())

--- a/plugins/cr8-copy-s3/src/main/java/io/crate/copy/s3/common/S3Env.java
+++ b/plugins/cr8-copy-s3/src/main/java/io/crate/copy/s3/common/S3Env.java
@@ -35,6 +35,9 @@ public final class S3Env {
         String protocol = S3Protocol.get(withClause);
         String endpoint = protocol + "://" + s3uri.endpoint();
         String region = S3.getRegion(endpoint, s3uri.bucket());
+        if (S3URI.DEFAULT_ENDPOINT.equals(s3uri.endpoint()) && region != null) {
+            endpoint = protocol + "://s3." + region + ".amazonaws.com";
+        }
         return ServiceConfig.S3.builder()
             .bucket(s3uri.bucket())
             .endpoint(endpoint)

--- a/plugins/cr8-copy-s3/src/main/java/io/crate/copy/s3/common/S3URI.java
+++ b/plugins/cr8-copy-s3/src/main/java/io/crate/copy/s3/common/S3URI.java
@@ -31,10 +31,11 @@ import io.crate.common.annotations.VisibleForTesting;
 public record S3URI(String bucket,
                     String path,
                     /* endpoint is without http[s]:// prefix */
-                    @Nullable String endpoint,
+                    String endpoint,
                     @Nullable String accessKey,
                     @Nullable String secretKey) {
 
+    static final String DEFAULT_ENDPOINT = "s3.amazonaws.com";
     private static final String INVALID_URI_MSG = "Invalid URI. Please make sure that given URI is encoded properly.";
 
     /// Parse a S3 URI as described in https://crate.io/docs/crate/reference/en/latest/sql/statements/copy-from.html#sql-copy-from-s3
@@ -51,6 +52,9 @@ public record S3URI(String bucket,
             ? -1
             : authority.indexOf("@");
         if (userInfo == null && atIdx >= 0) {
+            if (atIdx == authority.length() - 1) {
+                throw new IllegalArgumentException(INVALID_URI_MSG);
+            }
             userInfo = authority.substring(0, atIdx);
         }
         if (userInfo != null) {
@@ -60,7 +64,7 @@ public record S3URI(String bucket,
                 secretKey = parts[1];
             }
         }
-        boolean bucketInPath = host != null && port > -1 || atIdx > -1 || authority == null;
+        boolean bucketInPath = host != null && port > -1 || authority == null;
         String bucket;
         String path;
         String endpoint;
@@ -77,11 +81,11 @@ public record S3URI(String bucket,
                 bucket = uriPath.substring(0, bucketEnd);
                 path = uriPath.substring(bucketEnd + 1);
             }
-            endpoint = port == -1 ? host : host + ":" + Integer.toString(port);
+            endpoint = port == -1 ? DEFAULT_ENDPOINT : host + ":" + Integer.toString(port);
         } else {
-            bucket = authority;
+            bucket = atIdx == -1 ? authority : authority.substring(atIdx + 1);
             path = uriPath;
-            endpoint = null;
+            endpoint = DEFAULT_ENDPOINT;
         }
         return new S3URI(
             bucket,

--- a/plugins/cr8-copy-s3/src/test/java/io/crate/copy/s3/common/S3URITest.java
+++ b/plugins/cr8-copy-s3/src/test/java/io/crate/copy/s3/common/S3URITest.java
@@ -21,7 +21,9 @@
 
 package io.crate.copy.s3.common;
 
+import static io.crate.copy.s3.common.S3URI.DEFAULT_ENDPOINT;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.net.URI;
 
@@ -36,17 +38,17 @@ class S3URITest {
     @Test
     public void test_bucket_as_host() {
         assertThat(parse("s3://bucketname_not_host:9000/*/*/a"))
-            .isEqualTo(new S3URI("bucketname_not_host:9000", "*/*/a", null, null, null));
+            .isEqualTo(new S3URI("bucketname_not_host:9000", "*/*/a", DEFAULT_ENDPOINT, null, null));
         assertThat(parse("s3://b/prefix/"))
-            .isEqualTo(new S3URI("b", "prefix", null, null, null));
+            .isEqualTo(new S3URI("b", "prefix", DEFAULT_ENDPOINT, null, null));
     }
 
     @Test
     public void test_bucket_as_host_no_path() throws Exception {
         assertThat(parse("s3://bucket"))
-            .isEqualTo(new S3URI("bucket", "", null, null, null));
+            .isEqualTo(new S3URI("bucket", "", DEFAULT_ENDPOINT, null, null));
         assertThat(parse("s3:/bucket"))
-            .isEqualTo(new S3URI("bucket", "", null, null, null));
+            .isEqualTo(new S3URI("bucket", "", DEFAULT_ENDPOINT, null, null));
     }
 
     @Test
@@ -66,20 +68,26 @@ class S3URITest {
     }
 
     @Test
-    public void test_user_without_host_and_bucket_in_path() throws Exception {
-        assertThat(parse("s3://arthur:pw@/mj.myb/foo/bar/"))
-            .isEqualTo(new S3URI("mj.myb", "foo/bar", null, "arthur", "pw"));
+    public void test_user_with_bucket_as_host_uses_default_endpoint() throws Exception {
+        assertThat(parse("s3://arthur:pw@mj.myb/foo/bar/"))
+            .isEqualTo(new S3URI("mj.myb", "foo/bar", DEFAULT_ENDPOINT, "arthur", "pw"));
+    }
+
+    @Test
+    public void test_user_without_host_or_bucket_is_invalid() throws Exception {
+        assertThatThrownBy(() -> parse("s3://arthur:pw@/mj.myb/foo/bar/"))
+            .isExactlyInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     public void test_keys_are_decoded() throws Exception {
         assertThat(parse("s3://access%2F:secret%2F@a/b"))
-            .isEqualTo(new S3URI("b", "", "a", "access/", "secret/"));
+            .isEqualTo(new S3URI("a", "b", DEFAULT_ENDPOINT, "access/", "secret/"));
     }
 
     @Test
     public void test_empty() throws Exception {
         assertThat(parse("s3:///"))
-            .isEqualTo(new S3URI("", "", null, null, null));
+            .isEqualTo(new S3URI("", "", DEFAULT_ENDPOINT, null, null));
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes in S3 URI parsing:
- Making `s3://arthur:pw@/mj.myb/foo/bar/` an invalid URI. FYI`s3://arthur:pw@mj.myb/foo/bar/` is valid.
- Uses the bucket's regional Amazon S3 endpoint (`s3.<region>.amazonaws.com`) when host/port is not provided.



## Checklist

 - [ ] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
