### PR TITLE
Reflect backport of https://github.com/crate/crate/commit/53834af77f3840bb97131e19622dc946db62c971 to 6.1

### DIFF
--- a/docs/appendices/release-notes/6.1.6.rst
+++ b/docs/appendices/release-notes/6.1.6.rst
@@ -40,5 +40,8 @@ series.
 Fixes
 =====
 
+- Fixed a regression introduced with :ref:`version_6.0.0`, leading to stuck
+  ``DROP SNAPSHOT`` and ``CREATE SNAPSHOT`` queries.
+
 - Fixed an issue causing ``IllegalStateException`` errors on inserts into a
   table with primary keys.


### PR DESCRIPTION
Need to get it in https://cratedb.com/docs/crate/reference/en/master/appendices/release-notes/6.1.6.html

I use master branch for old versions in https://github.com/crate/crate/releases/ 