### PR TITLE
Revert "Revert JDK to 25"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Maven Java
         uses: actions/setup-java@v5
         with:
-          java-version: "25.0.3"
+          java-version: "26.0.1"
           distribution: "temurin"
           cache: maven
 
@@ -65,7 +65,7 @@ jobs:
       - name: Setup Maven Java
         uses: actions/setup-java@v5
         with:
-          java-version: "25.0.3"
+          java-version: "26.0.1"
           distribution: "temurin"
           cache: maven
       - name: Run forbiddenapis:check
@@ -82,7 +82,7 @@ jobs:
       - name: Setup Maven Java
         uses: actions/setup-java@v5
         with:
-          java-version: "25.0.3"
+          java-version: "26.0.1"
           distribution: "temurin"
       - name: Run checkstyle
         run: mvn compile checkstyle:checkstyle

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Maven Java
         uses: actions/setup-java@v5
         with:
-          java-version: "25.0.3"
+          java-version: "26.0.1"
           distribution: "temurin"
           cache: maven
 

--- a/pom.xml
+++ b/pom.xml
@@ -313,7 +313,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.release>25</maven.compiler.release>
+        <maven.compiler.release>26</maven.compiler.release>
 
         <!-- see surefire plugin configuration for explanation -->
         <skipRunTests>false</skipRunTests>
@@ -324,8 +324,8 @@
       ./mvnw -P jmods -Dos.arch=aarch64 -Dos.name="Mac OS X" package -DskipTests=true
     To verify the version is available for both platforms
     -->
-        <versions.jdk>25.0.3</versions.jdk>
-        <versions.jdkbuild>25.0.3+9</versions.jdkbuild>
+        <versions.jdk>26.0.1</versions.jdk>
+        <versions.jdkbuild>26.0.1+8</versions.jdkbuild>
 
         <versions.jspecify>1.0.0</versions.jspecify>
         <versions.log4j>2.26.0</versions.log4j>


### PR DESCRIPTION
This reverts commit 5a48cad9402a7f89a662c845fd265bd064990e13.

With 6.4.0 out we can revert back to JDK 26 for dev. Lucene update
follows soon.
