### PR TITLE
Add 6.3.6 release notes

### DIFF
--- a/docs/appendices/release-notes/6.3.6.rst
+++ b/docs/appendices/release-notes/6.3.6.rst
@@ -1,0 +1,49 @@
+.. _version_6.3.6:
+
+==========================
+Version 6.3.6 - Unreleased
+==========================
+
+.. comment 1. Remove the " - Unreleased" from the header above and adjust the ==
+.. comment 2. Remove the NOTE below and replace with: "Released on 20XX-XX-XX."
+.. comment    (without a NOTE entry, simply starting from col 1 of the line)
+.. NOTE::
+
+    In development. 6.3.6 isn't released yet. These are the release notes for
+    the upcoming release.
+
+.. NOTE::
+
+    If you are upgrading a cluster, you must be running CrateDB 5.0.0 or higher
+    before you upgrade to 6.3.6.
+
+    We recommend that you upgrade to the latest 6.2 release before moving to
+    6.3.6.
+
+    A rolling upgrade from >= 6.2.0 to 6.3.6 is supported.
+    Before upgrading, you should `back up your data`_.
+
+.. WARNING::
+
+    Tables that were created before CrateDB 5.x will not function with 6.x
+    and must be recreated before moving to 6.x.x.
+
+    You can recreate tables using ``COPY TO`` and ``COPY FROM`` or by
+    `inserting the data into a new table`_.
+
+.. _back up your data: https://cratedb.com/docs/crate/reference/en/latest/admin/snapshots.html
+.. _inserting the data into a new table: https://cratedb.com/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
+
+.. rubric:: Table of contents
+
+.. contents::
+   :local:
+
+
+See the :ref:`version_6.3.0` release notes for a full list of changes in the 6.3
+series.
+
+Fixes
+=====
+
+None

--- a/docs/appendices/release-notes/index.rst
+++ b/docs/appendices/release-notes/index.rst
@@ -44,6 +44,7 @@ Versions
 .. toctree::
     :maxdepth: 1
 
+    6.3.6
     6.3.5
     6.3.4
     6.3.3


### PR DESCRIPTION
We have them on 6.3 - I reflected 6.3.5 on master too early (before the bump). 

Was in rush with 4 releases and forgot to reflect unreleased notes.

Not touching Version - we will reflect it on master when releasing 6.3.6