### PR TITLE
Fix pg_sleep() return value

### DIFF
--- a/docs/appendices/release-notes/6.3.6.rst
+++ b/docs/appendices/release-notes/6.3.6.rst
@@ -46,4 +46,5 @@ series.
 Fixes
 =====
 
-None
+- Fixed an issue that would throw an error when using :ref:`pg_sleep()
+  <scalar-pg_sleep>` function in the ``SELECT`` clause.

--- a/docs/appendices/release-notes/6.4.1.rst
+++ b/docs/appendices/release-notes/6.4.1.rst
@@ -46,4 +46,5 @@ series.
 Fixes
 =====
 
-None
+- Fixed an issue that would throw an error when using :ref:`pg_sleep()
+  <scalar-pg_sleep>` function in the ``SELECT`` clause.

--- a/server/src/main/java/io/crate/expression/scalar/postgres/PgSleepFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/postgres/PgSleepFunction.java
@@ -22,7 +22,6 @@
 package io.crate.expression.scalar.postgres;
 
 import io.crate.data.Input;
-import io.crate.expression.symbol.Literal;
 import io.crate.metadata.FunctionName;
 import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
@@ -64,9 +63,9 @@ public class PgSleepFunction extends Scalar<Object, Double> {
             try {
                 Thread.sleep((long) (duration * 1000.0));
             } catch (InterruptedException e) {
-                return Literal.NULL;
+                return null;
             }
         }
-        return Literal.NULL;
+        return null;
     }
 }

--- a/server/src/test/java/io/crate/expression/scalar/PGSleepFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/PGSleepFunctionTest.java
@@ -26,21 +26,19 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.Test;
 
-import io.crate.expression.symbol.Literal;
-
 public class PGSleepFunctionTest extends ScalarTestCase {
 
     @Test
     public void test_pg_sleep() {
         long before = System.currentTimeMillis();
-        assertEvaluate("pg_catalog.pg_sleep(0.1)", Literal.NULL);
+        assertEvaluateNull("pg_catalog.pg_sleep(0.1)");
         long after = System.currentTimeMillis();
         assertThat(after - before >= 100).isTrue();
     }
 
     @Test
     public void test_pg_sleep_wrong_arguments() {
-        assertThatThrownBy(() -> assertEvaluate("pg_sleep(1, 1)", Literal.NULL))
+        assertThatThrownBy(() -> assertEvaluateNull("pg_sleep(1, 1)"))
             .hasMessageContaining("Invalid arguments in: pg_sleep(1, 1) with (integer, integer). Valid types: (double precision)");
     }
 }


### PR DESCRIPTION
Previously it was returning Literal.NULL, instead of plain `null`, which cannot be handled by the XContentBuilder.

Fixes: #19701
