### PR TITLE
Improve error message for deserializing unknown type id

### DIFF
--- a/server/src/main/java/io/crate/types/DataTypes.java
+++ b/server/src/main/java/io/crate/types/DataTypes.java
@@ -44,6 +44,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.io.stream.Writeable.Reader;
 import org.jspecify.annotations.Nullable;
 import org.locationtech.spatial4j.shape.impl.PointImpl;
 import org.locationtech.spatial4j.shape.jts.JtsPoint;
@@ -267,13 +268,16 @@ public final class DataTypes {
     }
 
     public static DataType<?> fromStream(StreamInput in) throws IOException {
-        int i = in.readVInt();
-        try {
-            return TYPE_REGISTRY.get(i).read(in);
-        } catch (NullPointerException e) {
-            Lazy.LOGGER.error(String.format(Locale.ENGLISH, "%d is missing in TYPE_REGISTRY", i), e);
-            throw e;
+        int typeId = in.readVInt();
+        Reader<DataType<?>> reader = TYPE_REGISTRY.get(typeId);
+        if (reader == null) {
+            throw new IllegalArgumentException(String.format(
+                Locale.ENGLISH,
+                "DataType with id=%d is missing in type registry. This can happen if using functions or types added in a newer CrateDB version while there is still a node with an older version present",
+                typeId
+            ));
         }
+        return reader.read(in);
     }
 
     public static void toStream(Collection<? extends DataType<?>> types, StreamOutput out) throws IOException {

--- a/server/src/test/java/io/crate/types/DataTypesTest.java
+++ b/server/src/test/java/io/crate/types/DataTypesTest.java
@@ -29,6 +29,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Test;
 
@@ -374,5 +376,17 @@ public class DataTypesTest extends ESTestCase {
         assertThat(DataTypes.innerType(arrayType, List.of("a"))).isEqualTo(new ArrayType<>(DataTypes.STRING));
         assertThat(DataTypes.innerType(arrayType, List.of("obj_array", "i"))).isEqualTo(new ArrayType<>(new ArrayType<>(DataTypes.INTEGER)));
         assertThat(DataTypes.innerType(arrayType, List.of("obj", "b"))).isEqualTo(new ArrayType<>(DataTypes.LONG));
+    }
+
+    @Test
+    public void test_from_stream_fails_with_nice_error_on_missing_id() throws Exception {
+        try (var out = new BytesStreamOutput()) {
+            out.writeVInt(999_999);
+
+            StreamInput in = out.bytes().streamInput();
+            assertThatThrownBy(() -> DataTypes.fromStream(in))
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("DataType with id=999999 is missing in type registry. This can happen if using functions or types added in a newer CrateDB version while there is still a node with an older version present");
+        }
     }
 }


### PR DESCRIPTION
Relates to https://github.com/crate/crate/issues/19704

`lttb` uses the `LttbStateType` which is missing on older nodes, causing
failures when it tries to read the collect phase:

    NullPointerException[Cannot invoke "org.elasticsearch.common.io.stream.Writeable$Reader.read(org.elasticsearch.common.io.stream.StreamInput)" because the return value of "java.util.Map.get(Object)" is null]
    java.lang.NullPointerException: Cannot invoke "org.elasticsearch.common.io.stream.Writeable$Reader.read(org.elasticsearch.common.io.stream.StreamInput)" because the return value of "java.util.Map.get(Object)" is null
    at io.crate.types.DataTypes.fromStream(DataTypes.java:266)
    at io.crate.execution.dsl.phases.AbstractProjectionsPhase.<init>(AbstractProjectionsPhase.java:124)
