### PR TITLE
Fix issue with cols format in SQLLogicITest

### DIFF
--- a/server/src/test/resources/integtests/arithmetic.test
+++ b/server/src/test/resources/integtests/arithmetic.test
@@ -105,7 +105,7 @@ select d, i from t order by abs(d)
 1.6| NULL
 2.2| NULL
 
-query RI rows select-orderby-ln
+query I rows select-orderby-ln
 select i from t order by ln(i)
 ----
 5
@@ -114,7 +114,7 @@ NULL
 NULL
 NULL
 
-query RI rows select-orderby-log
+query I rows select-orderby-log
 select i from t order by log(i, 100)
 ----
 5
@@ -155,7 +155,7 @@ insert into t (x, base) values (144, 12), (65536, 2), (9, 3)
 statement ok
 refresh table t;
 
-query II rows where-arithmetic-scalar-two-reference-args
+query III rows where-arithmetic-scalar-two-reference-args
 select x, base, round(log(x, base)) from t where round(log(x, base)) = 2 order by x
 ----
   9|  3| 2
@@ -197,7 +197,7 @@ insert into t (d) values (-7), (null), (5), (null)
 statement ok
 refresh table t;
 
-query RR rows order-by-arithmetic-with-nulls
+query R rows order-by-arithmetic-with-nulls
 select (d - 10) from t order by (d - 10) nulls first limit 2
 ----
 NULL

--- a/server/src/testFixtures/java/io/crate/test/integration/SQLLogicParser.java
+++ b/server/src/testFixtures/java/io/crate/test/integration/SQLLogicParser.java
@@ -251,6 +251,18 @@ public final class SQLLogicParser {
                                        int lnum) {
 
             int colCount = response.cols().length;
+            if (colCount != resultFormats.size()) {
+                throw new IncorrectResultException(String.format(
+                    Locale.ENGLISH,
+                    "[%s:%d][%s] Expected noCols: %s. Got: %s running %s",
+                    filename,
+                    lnum,
+                    testname,
+                    resultFormats.size(),
+                    colCount,
+                    query
+                ));
+            }
             List<List<Object>> rows = new ArrayList<>();
             for (Object[] resultRow : response.rows()) {
                 List<Object> row = new ArrayList<>(colCount);
@@ -259,7 +271,7 @@ public final class SQLLogicParser {
                         row.add("NULL");
                     } else {
                         String raw = resultRow[c].toString();
-                        ColumnFormat fmt = resultFormats.get(c % resultFormats.size());
+                        ColumnFormat fmt = resultFormats.get(c);
                         row.add(fmt.format(raw));
                     }
                 }
@@ -311,7 +323,7 @@ public final class SQLLogicParser {
                         row.add("NULL");
                         continue;
                     }
-                    ColumnFormat fmt = resultFormats.get(j % resultFormats.size());
+                    ColumnFormat fmt = resultFormats.get(j);
                     row.add(fmt.format(cols[j]));
                 }
                 out.add(row);


### PR DESCRIPTION
Previously a `%` logic was applied to get the format of the result cols, which was wrongly coppied from the "flat" format outputs. Fix it to get the exact output col format, add a check for equal array sizes (to avoid IndexOutOfBounds exceptions) and fix the `arithmetic.test` to comply with the changes.
