### PR TITLE
Fix INSERT to use the table OID captured during analysis for consistent table lookups

### DIFF
--- a/docs/appendices/release-notes/6.3.6.rst
+++ b/docs/appendices/release-notes/6.3.6.rst
@@ -48,3 +48,6 @@ Fixes
 
 - Fixed an issue that would throw an error when using :ref:`pg_sleep()
   <scalar-pg_sleep>` function in the ``SELECT`` clause.
+
+- Fixed a rare issue where ``INSERT`` statements running concurrently with
+  ``SWAP TABLE`` could insert data into the wrong table.

--- a/server/src/main/java/io/crate/execution/dsl/projection/AbstractIndexWriterProjection.java
+++ b/server/src/main/java/io/crate/execution/dsl/projection/AbstractIndexWriterProjection.java
@@ -25,6 +25,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Setting;
@@ -53,6 +55,7 @@ public abstract class AbstractIndexWriterProjection extends Projection {
 
     private final int bulkActions;
     protected RelationName relationName;
+    protected int tableOid;
     protected String partitionIdent;
     protected List<ColumnIdent> primaryKeys;
 
@@ -69,6 +72,7 @@ public abstract class AbstractIndexWriterProjection extends Projection {
 
 
     protected AbstractIndexWriterProjection(RelationName relationName,
+                                            int tableOid,
                                             @Nullable String partitionIdent,
                                             List<ColumnIdent> primaryKeys,
                                             @Nullable ColumnIdent clusteredByColumn,
@@ -76,6 +80,7 @@ public abstract class AbstractIndexWriterProjection extends Projection {
                                             List<Symbol> idSymbols,
                                             boolean autoCreateIndices) {
         this.relationName = relationName;
+        this.tableOid = tableOid;
         this.partitionIdent = partitionIdent;
         this.primaryKeys = primaryKeys;
         this.clusteredByColumn = clusteredByColumn;
@@ -90,6 +95,11 @@ public abstract class AbstractIndexWriterProjection extends Projection {
 
     protected AbstractIndexWriterProjection(StreamInput in) throws IOException {
         relationName = new RelationName(in);
+        if (in.getVersion().onOrAfter(Version.V_6_3_6)) {
+            tableOid = in.readInt();
+        } else {
+            tableOid = Metadata.OID_UNASSIGNED;
+        }
 
         partitionIdent = in.readOptionalString();
         idSymbols = Symbols.fromStream(in);
@@ -149,6 +159,10 @@ public abstract class AbstractIndexWriterProjection extends Projection {
         return relationName;
     }
 
+    public int tableOid() {
+        return tableOid;
+    }
+
     @Nullable
     public String partitionIdent() {
         return partitionIdent;
@@ -174,6 +188,7 @@ public abstract class AbstractIndexWriterProjection extends Projection {
             return false;
         if (!primaryKeys.equals(that.primaryKeys)) return false;
         if (!relationName.equals(that.relationName)) return false;
+        if (tableOid != that.tableOid) return false;
         if (partitionIdent != null ? !partitionIdent.equals(that.partitionIdent) : that.partitionIdent != null)
             return false;
 
@@ -185,6 +200,7 @@ public abstract class AbstractIndexWriterProjection extends Projection {
         int result = super.hashCode();
         result = 31 * result + Integer.hashCode(bulkActions);
         result = 31 * result + relationName.hashCode();
+        result = 31 * result + tableOid;
         result = 31 * result + (partitionIdent != null ? partitionIdent.hashCode() : 0);
         result = 31 * result + primaryKeys.hashCode();
         result = 31 * result + (clusteredByColumn != null ? clusteredByColumn.hashCode() : 0);
@@ -198,6 +214,9 @@ public abstract class AbstractIndexWriterProjection extends Projection {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         relationName.writeTo(out);
+        if (out.getVersion().onOrAfter(Version.V_6_4_0)) {
+            out.writeInt(tableOid);
+        }
         out.writeOptionalString(partitionIdent);
 
         Symbols.toStream(idSymbols, out);

--- a/server/src/main/java/io/crate/execution/dsl/projection/ColumnIndexWriterProjection.java
+++ b/server/src/main/java/io/crate/execution/dsl/projection/ColumnIndexWriterProjection.java
@@ -67,6 +67,7 @@ public class ColumnIndexWriterProjection extends AbstractIndexWriterProjection {
      * @param onDuplicateKeyAssignments reference to symbol map used for update on duplicate key
      */
     public ColumnIndexWriterProjection(RelationName relationName,
+                                       int tableOid,
                                        @Nullable String partitionIdent,
                                        List<ColumnIdent> primaryKeys,
                                        List<Reference> allTargetColumns,
@@ -82,7 +83,7 @@ public class ColumnIndexWriterProjection extends AbstractIndexWriterProjection {
                                        List<Symbol> returnValues,
                                        long fullDocSizeEstimate) {
 
-        super(relationName, partitionIdent, primaryKeys, clusteredByColumn, settings, primaryKeySymbols, autoCreateIndices);
+        super(relationName, tableOid, partitionIdent, primaryKeys, clusteredByColumn, settings, primaryKeySymbols, autoCreateIndices);
         assert partitionedBySymbols.stream().noneMatch(s -> s.any(Symbol.IS_COLUMN))
             : "All references and fields in partitionedBySymbols must be resolved to inputColumns, got: " + partitionedBySymbols;
         this.allTargetColumns = allTargetColumns;
@@ -274,6 +275,7 @@ public class ColumnIndexWriterProjection extends AbstractIndexWriterProjection {
 
         return new ColumnIndexWriterProjection(
             tableIdent(),
+            tableOid(),
             null,
             primaryKeys,
             allTargetColumns,

--- a/server/src/main/java/io/crate/execution/dsl/projection/SourceIndexWriterProjection.java
+++ b/server/src/main/java/io/crate/execution/dsl/projection/SourceIndexWriterProjection.java
@@ -58,6 +58,7 @@ public class SourceIndexWriterProjection extends AbstractIndexWriterProjection {
     private final String[] excludes;
 
     public SourceIndexWriterProjection(RelationName relationName,
+                                       int tableOid,
                                        @Nullable String partitionIdent,
                                        Reference rawSourceReference,
                                        InputColumn rawSourcePtr,
@@ -70,7 +71,7 @@ public class SourceIndexWriterProjection extends AbstractIndexWriterProjection {
                                        @Nullable Symbol clusteredBySymbol,
                                        List<? extends Symbol> outputs,
                                        boolean autoCreateIndices) {
-        super(relationName, partitionIdent, primaryKeys, clusteredByColumn, settings, idSymbols, autoCreateIndices);
+        super(relationName, tableOid, partitionIdent, primaryKeys, clusteredByColumn, settings, idSymbols, autoCreateIndices);
         this.rawSourceReference = rawSourceReference;
         this.excludes = excludes;
         this.partitionedBySymbols = partitionedBySymbols;

--- a/server/src/main/java/io/crate/execution/dsl/projection/SourceIndexWriterReturnSummaryProjection.java
+++ b/server/src/main/java/io/crate/execution/dsl/projection/SourceIndexWriterReturnSummaryProjection.java
@@ -44,6 +44,7 @@ public class SourceIndexWriterReturnSummaryProjection extends SourceIndexWriterP
     private final InputColumn lineNumber;
 
     public SourceIndexWriterReturnSummaryProjection(RelationName relationName,
+                                                    int tableOid,
                                                     @Nullable String partitionIdent,
                                                     Reference rawSourceReference,
                                                     InputColumn rawSourcePtr,
@@ -60,7 +61,7 @@ public class SourceIndexWriterReturnSummaryProjection extends SourceIndexWriterP
                                                     InputColumn sourceUriFailure,
                                                     InputColumn sourceParsingFailure,
                                                     InputColumn lineNumber) {
-        super(relationName,partitionIdent, rawSourceReference, rawSourcePtr, primaryKeys, partitionedBySymbols,
+        super(relationName, tableOid, partitionIdent, rawSourceReference, rawSourcePtr, primaryKeys, partitionedBySymbols,
             clusteredByColumn, settings, excludes, idSymbols, clusteredBySymbol, outputs, autoCreateIndices);
         this.sourceUri = sourceUri;
         this.sourceUriFailure = sourceUriFailure;

--- a/server/src/main/java/io/crate/metadata/Schemas.java
+++ b/server/src/main/java/io/crate/metadata/Schemas.java
@@ -496,6 +496,28 @@ public class Schemas extends AbstractLifecycleComponent implements Iterable<Sche
         return null;
     }
 
+    @SuppressWarnings("unchecked")
+    public <T extends RelationInfo> T getRelationInfo(int oid) {
+        for (SchemaInfo schema : this) {
+            for (RelationInfo relation : schema.getTables()) {
+                if (oid == relation.oid()) {
+                    return (T) relation;
+                }
+            }
+            for (ViewInfo view : schema.getViews()) {
+                if (oid == view.oid()) {
+                    return (T) view;
+                }
+            }
+            for (RelationMetadata.ForeignTable foreignTable : schema.getForeignTables()) {
+                if (oid == foreignTable.oid()) {
+                    return (T) foreignTable;
+                }
+            }
+        }
+        throw new RelationUnknown(String.format(Locale.ENGLISH, "Relation not found for oid=%s", oid));
+    }
+
     public int getRelationOid(RelationName relationName) {
         RelationMetadata relationMetadata = clusterService.state().metadata().getRelation(relationName);
         return relationMetadata == null ? OidHash.relationOid(OidHash.Type.TABLE, relationName) : relationMetadata.oid();

--- a/server/src/main/java/io/crate/planner/consumer/InsertFromSubQueryPlanner.java
+++ b/server/src/main/java/io/crate/planner/consumer/InsertFromSubQueryPlanner.java
@@ -52,6 +52,7 @@ public final class InsertFromSubQueryPlanner {
 
         ColumnIndexWriterProjection indexWriterProjection = new ColumnIndexWriterProjection(
             statement.tableInfo().ident(),
+            statement.tableInfo().oid(),
             null,
             statement.tableInfo().primaryKey(),
             statement.columns(),

--- a/server/src/main/java/io/crate/planner/operators/InsertFromValues.java
+++ b/server/src/main/java/io/crate/planner/operators/InsertFromValues.java
@@ -139,9 +139,7 @@ public class InsertFromValues implements LogicalPlan {
                               RowConsumer consumer,
                               Row params,
                               SubQueryResults subQueryResults) {
-        DocTableInfo tableInfo = dependencies
-            .schemas()
-            .getTableInfo(writerProjection.tableIdent());
+        DocTableInfo tableInfo = dependencies.schemas().getRelationInfo(writerProjection.tableOid());
 
         // For instance, the target table of the insert from values
         // statement is the table with the following schema:
@@ -277,6 +275,7 @@ public class InsertFromValues implements LogicalPlan {
 
         createPartitions(
             tableInfo,
+            writerProjection.tableOid(),
             dependencies.client(),
             shardedRequests.itemsByMissingPartition().keySet(),
             dependencies.clusterService()
@@ -284,7 +283,7 @@ public class InsertFromValues implements LogicalPlan {
             var shardUpsertRequests = resolveAndGroupShardRequests(
                 shardedRequests,
                 dependencies.clusterService(),
-                tableInfo.oid()
+                writerProjection.tableOid()
             ).values();
             return execute(
                 dependencies.nodeLimits(),
@@ -312,9 +311,7 @@ public class InsertFromValues implements LogicalPlan {
                                                        PlannerContext plannerContext,
                                                        List<Row> bulkParams,
                                                        SubQueryResults subQueryResults) {
-        final DocTableInfo tableInfo = dependencies
-            .schemas()
-            .getTableInfo(writerProjection.tableIdent());
+        final DocTableInfo tableInfo = dependencies.schemas().getRelationInfo(writerProjection.tableOid());
 
         String[] updateColumnNames;
         Assignments assignments;
@@ -426,6 +423,7 @@ public class InsertFromValues implements LogicalPlan {
 
         createPartitions(
             tableInfo,
+            writerProjection.tableOid(),
             dependencies.client(),
             shardedRequests.itemsByMissingPartition().keySet(),
             dependencies.clusterService()
@@ -750,13 +748,15 @@ public class InsertFromValues implements LogicalPlan {
     }
 
     private static CompletableFuture<AcknowledgedResponse> createPartitions(DocTableInfo tableInfo,
+                                                                            int tableOid,
                                                                             Client client,
                                                                             Set<PartitionName> partitions,
                                                                             ClusterService clusterService) {
         List<PartitionName> partitionsToCreate = new ArrayList<>();
+        Metadata metadata = clusterService.state().metadata();
         for (var partition : partitions) {
-            String indexUUID = clusterService.state().metadata()
-                .getIndex(tableInfo.ident(), partition.values(), true, IndexMetadata::getIndexUUID);
+            String indexUUID =
+                metadata.getIndex(tableInfo.ident(), partition.values(), true, IndexMetadata::getIndexUUID);
             if (indexUUID == null) {
                 partitionsToCreate.add(partition);
             }

--- a/server/src/main/java/io/crate/planner/statement/CopyFromPlan.java
+++ b/server/src/main/java/io/crate/planner/statement/CopyFromPlan.java
@@ -262,6 +262,7 @@ public final class CopyFromPlan implements Plan {
 
             sourceIndexWriterProjection = new SourceIndexWriterReturnSummaryProjection(
                 table.ident(),
+                table.oid(),
                 partitionIdent,
                 table.getReference(SysColumns.RAW),
                 new InputColumn(rawOrDocIdx, rawOrDoc.valueType()),
@@ -282,6 +283,7 @@ public final class CopyFromPlan implements Plan {
         } else {
             sourceIndexWriterProjection = new SourceIndexWriterProjection(
                 table.ident(),
+                table.oid(),
                 partitionIdent,
                 table.getReference(SysColumns.RAW),
                 new InputColumn(rawOrDocIdx, rawOrDoc.valueType()),

--- a/server/src/main/java/org/elasticsearch/Version.java
+++ b/server/src/main/java/org/elasticsearch/Version.java
@@ -243,6 +243,7 @@ public class Version implements Comparable<Version> {
     public static final Version V_6_3_3 = new Version(9_03_03_99, false, org.apache.lucene.util.Version.LUCENE_10_4_0);
     public static final Version V_6_3_4 = new Version(9_03_04_99, false, org.apache.lucene.util.Version.LUCENE_10_4_0);
     public static final Version V_6_3_5 = new Version(9_03_05_99, false, org.apache.lucene.util.Version.LUCENE_10_4_0);
+    public static final Version V_6_3_6 = new Version(9_03_06_99, true, org.apache.lucene.util.Version.LUCENE_10_4_0);
 
     public static final Version V_6_4_0 = new Version(9_04_00_99, false, org.apache.lucene.util.Version.LUCENE_10_4_0);
     public static final Version V_6_4_1 = new Version(9_04_01_99, true, org.apache.lucene.util.Version.LUCENE_10_4_0);

--- a/server/src/main/java/org/elasticsearch/action/UnavailableShardsException.java
+++ b/server/src/main/java/org/elasticsearch/action/UnavailableShardsException.java
@@ -66,7 +66,7 @@ public class UnavailableShardsException extends ElasticsearchException implement
 
     public UnavailableShardsException(StreamInput in) throws IOException {
         super(in);
-        if (in.getVersion().onOrAfter(Version.V_6_4_0)) {
+        if (in.getVersion().onOrAfter(Version.V_6_3_6)) {
             this.relationName = in.readOptionalWriteable(RelationName::new);
         } else {
             RelationName name = null;

--- a/server/src/test/java/io/crate/execution/dsl/projection/ColumnIndexWriterProjectionTest.java
+++ b/server/src/test/java/io/crate/execution/dsl/projection/ColumnIndexWriterProjectionTest.java
@@ -22,6 +22,7 @@
 package io.crate.execution.dsl.projection;
 
 import static io.crate.testing.Asserts.assertThat;
+import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -59,6 +60,7 @@ public class ColumnIndexWriterProjectionTest {
         }
         var projection = new ColumnIndexWriterProjection(
             relationName,
+            OID_UNASSIGNED,
             null,
             List.of(),
             targetColumns,

--- a/server/src/test/java/io/crate/execution/dsl/projection/SourceIndexWriterProjectionSerializationTest.java
+++ b/server/src/test/java/io/crate/execution/dsl/projection/SourceIndexWriterProjectionSerializationTest.java
@@ -75,6 +75,7 @@ public class SourceIndexWriterProjectionSerializationTest {
         // fail_fast property set to true
         SourceIndexWriterProjection expected = new SourceIndexWriterProjection(
             relationName,
+            OID_UNASSIGNED,
             partitionIdent,
             reference,
             inputColumn,

--- a/server/src/test/java/io/crate/integrationtests/PartitionedTableConcurrentIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/PartitionedTableConcurrentIntegrationTest.java
@@ -570,8 +570,7 @@ public class PartitionedTableConcurrentIntegrationTest extends IntegTestCase {
         Thread t2 = new Thread(() -> {
             try {
                 barrier.await();
-                for (int i = 0; i < 3; i++) {
-                    Thread.sleep(300); // to prevent swap queries to go through at once
+                for (int i = 0; i < 7; i++) {
                     execute("ALTER CLUSTER SWAP TABLE t1 TO t2");
                     if (t1.isAlive()) {
                         swapInterleaved[0] = true;


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Below test is flaky:
```
@Test
public void test_concurrent_table_swaps_with_insert_from_values() throws Exception {
    execute("create table t1 (p int) partitioned by (p)");
    execute("create table t2 (p2 int)");

    final AtomicReference<Throwable> error = new AtomicReference<>();
    final CyclicBarrier barrier = new CyclicBarrier(2);
    boolean[] swapInterleaved = {false};

    Thread t1 = new Thread(() -> {
        try {
            barrier.await();
            execute("""
                INSERT INTO t1 VALUES
                (1), (2), (3), (4), (5), (6), (7), (8), (9), (10),
                (11), (12), (13), (14), (15), (16), (17), (18), (19), (20),
                (21), (22), (23), (24), (25), (26), (27), (28), (29), (30),
                (31), (32), (33), (34), (35), (36), (37), (38), (39), (40),
                (41), (42), (43), (44), (45), (46), (47), (48), (49), (50);
                """, null, TimeValue.timeValueSeconds(30));
        } catch (Throwable e) {
            error.set(e);
        }
    });

    Thread t2 = new Thread(() -> {
        try {
            barrier.await();
            for (int i = 0; i < 3; i++) {
                
                execute("ALTER CLUSTER SWAP TABLE t1 TO t2");
                if (t1.isAlive()) {
                    swapInterleaved[0] = true;
                }
            }
        } catch (Throwable e) {
            error.set(e);
        }
    });

    t1.start();
    t2.start();

    t1.join();
    t2.join();

    assertThat(error.get()).isNull();
    assertThat(swapInterleaved[0])
        .as("The test failed to interleave a swap with the insert")
        .isTrue();

    execute("refresh table t1, t2");
    execute("select count(*) from t2");
    assertThat(response.rows()[0][0]).isEqualTo(50L);
    execute("select count(*) from information_schema.table_partitions where table_name = 't2'");
    assertThat(response.rows()[0][0]).isEqualTo(50L);
}
```
with this assertion error:
```
java.lang.AssertionError: Non-Partitioned table doc.t1 must have exactly one indexUUID: [vYjg3wXTSjuoF81biBZ8wg, KvD0UnkATb-6HcQBG0LSuA, S7_gC38ORm66XeQZ1Bq2Jg, ukGMwjC7QqCQ-xt8LH5iMA, nUIIQPNuQT-nRg10PviK_A, kXd9TGwoQB-YfJtLesxZBg, QzEjn2FdSLSjrkuDh0h0sQ, DMpDHsTJSCqaXqJUIcuAhg, EMK7aPEcQFWJ1e2BajNtQQ, qeO9PB_LT-eHgOkpgbQNBg, c7Db0w6DR_6ijUwr_dgvvw, Hv4Ey8oaQ7eHtIxj70Pc2g, lMxPrbYjS0eih3iT3bYreQ, jl0T1ugKSO6oguvPSNNSBg, R33fpP8vTRyJ16aZEJjsGQ, D_rNGgOdRW-Q_EraYZrcqw, t8N7bkv2Td6u1Z4IKGkgtQ, chcvTEGASBuTJhvYWpKuKA, 5XYxCzSKQuqmkmRISTEvfw, 1RpJV9HuRVGvsdfVVKZEJQ, ZQN1Qjy5T3ua5M8f5aIE1Q, MdykjHywSI2ee_4YSSQCkA, 9VweGns-Q021jTdz8cZ5UA, a47W_bK5TbS6slB3uoqdlw, zsSrwSJQRwGtBtylIUb-Xw, X8H75ZZKQhqX8m7WGNGVRw, tXiikw54RSuLfuK3kIVs4Q, 0XnplKJ-SNKYQLqKdSXa2A, k8L6cMEuQHuRihU_mzAGDw, Z01zUF8RQjeeC4xHlY9Jxw, ms_hdwCzQoybYltkbIuRbw, WunNsbBwRNuZnc9MNPqNuQ, xtcOCYWjSrmnTuzN4TfqYg, loldQhqaQgm5qJA0ELK_Sg, qFngzmqjSBSCPmBRIF8mtA, LJzymYIuQra4G7dY9YAryA, 2K8Ny0B-Rnqoyvw6ov3t9Q, g8JR-1OdSQKk2FVsBSTK0g, NRbjrEouQLWmLSSZoUZ7rg, kSQELpzbSqiw76tmAi075g, 55XJTXTAReuimpVGyT7NYg, KREMyYy8Q7-MEqNzDtMICw, rrHLjD9pRjOHyxZi0ZyzyQ, KOn0n_TMQlqGoO1qEqqDSg, J4QaKxnpTgyl0A3Qa6Vr8w, xWETQ_isSoCs3ItAEm40QA, 6AkZ006zTWmm7nADlyQH8w, B3AS-R4tQ3OkvM0rtP3fnQ, Tg_JSlTHQxuUcx1jLcZhCg, oTPxFfuzQY-THyNntb8LCA, xYWjnEKtRJegvLBQcEvLUg]
	at __randomizedtesting.SeedInfo.seed([32FB258EA0DDE222]:0)
	at org.elasticsearch.cluster.metadata.RelationMetadata$Table.<init>(RelationMetadata.java:261)
	at org.elasticsearch.cluster.metadata.Metadata$Builder.addIndexUUIDs(Metadata.java:1511)
	at org.elasticsearch.action.admin.indices.create.TransportCreatePartitions.executeCreateIndices(TransportCreatePartitions.java:271)
	at org.elasticsearch.action.admin.indices.create.TransportCreatePartitions.lambda$createIndices$0(TransportCreatePartitions.java:306)
	at org.elasticsearch.cluster.service.MasterService.executeTasks(MasterService.java:664)
	at org.elasticsearch.cluster.service.MasterService.calculateTaskOutputs(MasterService.java:281)
	at org.elasticsearch.cluster.service.MasterService.runTasks(MasterService.java:176)
```

Above assertion error can occur when INSERT is interleaved with SWAP. For example, during INSERT analysis, `t1` is referencing table(`oid=1`). If SWAP ocurred in between, then `t1` references table(`oid=2`). Then during the remaining execution of INSERT, any re-resolution of tables by table names like

https://github.com/crate/crate/blob/db60f5afc49d40735d411ca61977fa128559caac/server/src/main/java/io/crate/planner/operators/InsertFromValues.java#L142-L144

will return table(`oid=2`) causing the assertion - creating 50 new partitions to a non-partitioned table.

Approach to fix - preserve the table oid obtained during the analysis of the INSERT for the remaining execution paths.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes.
       If you're an external contributor you can give yourself attribution and include your name and Github handle.
       e.g.:
       ```
       `John Doe <https://github.com/John_Doe>`_ added support for ...
       ```
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
