### PR TITLE
Deduplicate IndexMetadata lookup in DocTableInfo.writeTo

### DIFF
--- a/server/src/main/java/io/crate/metadata/doc/DocTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocTableInfo.java
@@ -1196,13 +1196,9 @@ public class DocTableInfo implements TableInfo, ShardedTable, StoredTable {
         for (var check : checkConstraints) {
             checkConstraintMap.put(check.name(), check.expressionStr());
         }
-        String[] concreteIndices = concreteIndices(metadata);
-        ArrayList<String> indexUUIDs = new ArrayList<>(concreteIndices.length);
-        for (String indexUUID : concreteIndices) {
-            IndexMetadata indexMetadata = metadata.index(indexUUID);
-            if (indexMetadata == null) {
-                throw new UnsupportedOperationException("Cannot create index via DocTableInfo.writeTo");
-            }
+        List<IndexMetadata> indices = metadata.getIndices(ident, List.of(), !isPartitioned, imd -> imd);
+        ArrayList<String> indexUUIDs = new ArrayList<>(indices.size());
+        for (IndexMetadata indexMetadata : indices) {
             indexUUIDs.add(indexMetadata.getIndexUUID());
 
             final Settings indexSettings = indexMetadata.getSettings();

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -211,7 +211,6 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata> {
         this.totalNumberOfShards = totalNumberOfShards;
         this.totalOpenIndexShards = totalOpenIndexShards;
         this.numberOfShards = numberOfShards;
-        this.aliasAndIndexLookup = aliasAndIndexLookup;
         HashMap<String, RelationMetadata> indexUUIDsRelationsBuilder = HashMap.newHashMap(indices.size());
         ImmutableOpenIntMap.Builder<RelationMetadata> oidsRelationsBuilder = ImmutableOpenIntMap.builder();
         for (var schema : schemas.values()) {


### PR DESCRIPTION
Instead of:

    concreteIndices -> metadata.getIndices -> getIndexUUID -> metadata.index(indexUUID)

To get `IndexMetadata` entries, we can use `metadata.getIndices`
directly.
