### PR TITLE
Use term dictionary for keys-only GROUP BY on a single string column

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -117,34 +118,34 @@ final class GroupByOptimizedIterator {
 
     /**
      * This was chosen after benchmarking different ratios with this optimization always enabled:
-     *
+     * <p>
      * Q: select count(*) from (select distinct x from t) t
-     *
+     * <p>
      * cardinality-ratio | mean difference
      * ------------------+-----------------
      *              0.90 |      -5.65%
      *              0.75 |      -5.06%
      *              0.50 |      +1.51%
      *              0.25 |     +38.79%
-     *
+     * <p>
      * (+ being faster, - being slower)
      */
     private static final double CARDINALITY_RATIO_THRESHOLD = 0.5;
     private static final long HASH_MAP_ENTRY_OVERHEAD = 32; // see private RamUsageEstimator.shallowSizeOfInstance(HashMap.Node.class)
 
-
-
-    /// Returns a batchIterator that uses termFrequences for queries like:
+    /// Returns a BatchIterator that reads the term dictionary of a single string key column instead
+    /// of scanning documents, for group-by queries without a WHERE clause:
     ///
-    ///     SELECT strKey, count(*) GROUP BY strKey`
+    ///     `SELECT strKey GROUP BY strKey`            (keys only)
+    ///     `SELECT strKey, count(*) GROUP BY strKey`  (with an unfiltered count(*))
     ///
-    /// Only works if the key is not nullable and if there is no WHERE clause
-    /// and no aggregate filter.
-    /// Returns null for other queries.
+    /// Terms of deleted documents linger in the dictionary until segments merge, so each term is
+    /// checked against live docs. A NULL group is added for nullable columns that have null docs.
+    /// Returns null for queries that don't match this shape.
     @Nullable
-    static BatchIterator<Row> tryUseTermFrequencies(IndexShard indexShard,
-                                                    RoutedCollectPhase collectPhase,
-                                                    CollectTask collectTask) {
+    static BatchIterator<Row> tryUseTermDictionary(IndexShard indexShard,
+                                                   RoutedCollectPhase collectPhase,
+                                                   CollectTask collectTask) {
         GroupProjection groupProjection = getSingleStringKeyGroupProjection(collectPhase.projections());
         if (groupProjection == null) {
             return null;
@@ -158,13 +159,16 @@ final class GroupByOptimizedIterator {
         }
 
         List<Aggregation> values = groupProjection.values();
-        if (values.size() != 1 || !values.getFirst().signature().equals(CountAggregation.COUNT_STAR_SIGNATURE)) {
-            return null;
-        }
-
-        Symbol aggregateFilter = values.getFirst().filter();
-        if (!aggregateFilter.equals(Literal.BOOLEAN_TRUE)) {
-            return null;
+        boolean keysOnly = values.isEmpty();
+        if (!keysOnly) {
+            // The only aggregate we can serve straight from the term dictionary is an unfiltered count(*).
+            if (values.size() != 1 || !values.getFirst().signature().equals(CountAggregation.COUNT_STAR_SIGNATURE)) {
+                return null;
+            }
+            Symbol aggregateFilter = values.getFirst().filter();
+            if (!aggregateFilter.equals(Literal.BOOLEAN_TRUE)) {
+                return null;
+            }
         }
 
         Symbol where = collectPhase.where();
@@ -185,12 +189,84 @@ final class GroupByOptimizedIterator {
         IndexSearcher searcher = searcherRef.item();
 
         Token killToken = new Killable.Token();
+        RamAccounting ramAccounting = collectTask.getRamAccounting();
+        if (keysOnly) {
+            return CollectingBatchIterator.newInstance(
+                killToken,
+                () -> keysToRows(getDistinctKeys(ramAccounting, keyRef, searcher, killToken)),
+                true
+            );
+        }
         AggregateMode mode = groupProjection.mode();
         return CollectingBatchIterator.newInstance(
             killToken,
-            () -> countsToRows(getCountsByKey(collectTask.getRamAccounting(), keyRef, searcher, killToken), mode),
+            () -> countsToRows(getCountsByKey(ramAccounting, keyRef, searcher, killToken), mode),
             true
         );
+    }
+
+    private static Iterable<Row> keysToRows(Collection<BytesRef> keys) {
+        final Object[] cells = new Object[1];
+        final Row row = new RowN(cells);
+        return () -> keys.stream()
+            .map(key -> {
+                cells[0] = key == null ? null : key.utf8ToString();
+                return row;
+            })
+            .iterator();
+    }
+
+    /// Collects the distinct live values of `keyRef` by iterating the term dictionary of each segment
+    /// instead of scanning documents. A NULL group is added when the (nullable) column has null docs,
+    /// matching the semantics of a keys-only GROUP BY.
+    static Collection<BytesRef> getDistinctKeys(RamAccounting ramAccounting,
+                                                Reference keyRef,
+                                                IndexSearcher searcher,
+                                                Token killToken) throws IOException {
+        HashSet<BytesRef> keys = new HashSet<>();
+        String keyStorageIdent = keyRef.storageIdent();
+        PostingsEnum postings = null;
+        for (var leaf : searcher.getLeafContexts()) {
+            LeafReader reader = leaf.reader();
+            Terms terms = reader.terms(keyStorageIdent);
+            if (terms == null) {
+                continue;
+            }
+            TermsEnum termsEnum = terms.iterator();
+            Bits liveDocs = reader.getLiveDocs();
+            BytesRef sharedKey;
+            while ((sharedKey = termsEnum.next()) != null) {
+                killToken.raiseIfKilled();
+                if (keys.contains(sharedKey)) {
+                    continue;
+                }
+                if (liveDocs != null) {
+                    // Terms of deleted documents stay in the dictionary until segments merge,
+                    // hence we need to check for terms without live docs.
+                    postings = termsEnum.postings(postings, PostingsEnum.NONE);
+                    if (!hasLiveDoc(postings, liveDocs)) {
+                        continue;
+                    }
+                }
+                ramAccounting.addBytes(BYTES_REF_SHALLOW_SIZE + sharedKey.length + HASH_MAP_ENTRY_OVERHEAD);
+                keys.add(BytesRef.deepCopyOf(sharedKey));
+            }
+        }
+        if (keyRef.isNullable() && countNullValues(keyRef, searcher) > 0) {
+            ramAccounting.addBytes(HASH_MAP_ENTRY_OVERHEAD);
+            keys.add(null);
+        }
+        return keys;
+    }
+
+    private static boolean hasLiveDoc(PostingsEnum postings, Bits liveDocs) throws IOException {
+        int doc;
+        while ((doc = postings.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
+            if (liveDocs.get(doc)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static Iterable<Row> countsToRows(ObjectLongHashMap<BytesRef> countsByKey, AggregateMode mode) {
@@ -252,19 +328,24 @@ final class GroupByOptimizedIterator {
             }
         }
         if (keyRef.isNullable()) {
-            Query existsQuery = keyRef.hasDocValues() || keyRef.indexType() == IndexType.FULLTEXT
-                ? new FieldExistsQuery(keyStorageIdent)
-                : new ConstantScoreQuery(new TermQuery(new Term(SysColumns.FieldNames.NAME, keyStorageIdent)));
-            Query notNull = Queries.not(existsQuery);
-
-            TotalHitCountCollectorManager topHitCounts = new TotalHitCountCollectorManager(searcher.getSlices());
-            Integer count = searcher.search(notNull, topHitCounts);
+            int count = countNullValues(keyRef, searcher);
             if (count > 0) {
                 ramAccounting.addBytes(HASH_MAP_ENTRY_OVERHEAD);
                 countsByKey.put(null, count);
             }
         }
         return countsByKey;
+    }
+
+    private static int countNullValues(Reference keyRef, IndexSearcher searcher) throws IOException {
+        String keyStorageIdent = keyRef.storageIdent();
+        Query existsQuery = keyRef.hasDocValues() || keyRef.indexType() == IndexType.FULLTEXT
+            ? new FieldExistsQuery(keyStorageIdent)
+            : new ConstantScoreQuery(new TermQuery(new Term(SysColumns.FieldNames.NAME, keyStorageIdent)));
+        Query notNull = Queries.not(existsQuery);
+
+        TotalHitCountCollectorManager topHitCounts = new TotalHitCountCollectorManager(searcher.getSlices());
+        return searcher.search(notNull, topHitCounts);
     }
 
     private static int countFromPostings(PostingsEnum postings, Bits liveDocs) throws IOException {

--- a/server/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
@@ -116,34 +116,34 @@ final class GroupByOptimizedIterator {
 
     /**
      * This was chosen after benchmarking different ratios with this optimization always enabled:
-     *
+     * <p>
      * Q: select count(*) from (select distinct x from t) t
-     *
+     * <p>
      * cardinality-ratio | mean difference
      * ------------------+-----------------
      *              0.90 |      -5.65%
      *              0.75 |      -5.06%
      *              0.50 |      +1.51%
      *              0.25 |     +38.79%
-     *
+     * <p>
      * (+ being faster, - being slower)
      */
     private static final double CARDINALITY_RATIO_THRESHOLD = 0.5;
     private static final long HASH_MAP_ENTRY_OVERHEAD = 32; // see private RamUsageEstimator.shallowSizeOfInstance(HashMap.Node.class)
 
-
-
-    /// Returns a batchIterator that uses termFrequences for queries like:
+    /// Returns a BatchIterator that reads the term dictionary of a single string key column instead
+    /// of scanning documents, for group-by queries without a WHERE clause:
     ///
-    ///     SELECT strKey, count(*) GROUP BY strKey`
+    ///     `SELECT strKey GROUP BY strKey`            (keys only)
+    ///     `SELECT strKey, count(*) GROUP BY strKey`  (with an unfiltered count(*))
     ///
-    /// Only works if the key is not nullable and if there is no WHERE clause
-    /// and no aggregate filter.
-    /// Returns null for other queries.
+    /// Terms of deleted documents linger in the dictionary until segments merge, so each term is
+    /// checked against live docs. A NULL group is added for nullable columns that have null docs.
+    /// Returns null for queries that don't match this shape.
     @Nullable
-    static BatchIterator<Row> tryUseTermFrequencies(IndexShard indexShard,
-                                                    RoutedCollectPhase collectPhase,
-                                                    CollectTask collectTask) {
+    static BatchIterator<Row> tryUseTermDictionary(IndexShard indexShard,
+                                                   RoutedCollectPhase collectPhase,
+                                                   CollectTask collectTask) {
         GroupProjection groupProjection = getSingleStringKeyGroupProjection(collectPhase.projections());
         if (groupProjection == null) {
             return null;
@@ -157,13 +157,16 @@ final class GroupByOptimizedIterator {
         }
 
         List<Aggregation> values = groupProjection.values();
-        if (values.size() != 1 || !values.getFirst().signature().equals(CountAggregation.COUNT_STAR_SIGNATURE)) {
-            return null;
-        }
-
-        Symbol aggregateFilter = values.getFirst().filter();
-        if (!aggregateFilter.equals(Literal.BOOLEAN_TRUE)) {
-            return null;
+        boolean keysOnly = values.isEmpty();
+        if (!keysOnly) {
+            // The only aggregate we can serve straight from the term dictionary is an unfiltered count(*).
+            if (values.size() != 1 || !values.getFirst().signature().equals(CountAggregation.COUNT_STAR_SIGNATURE)) {
+                return null;
+            }
+            Symbol aggregateFilter = values.getFirst().filter();
+            if (!aggregateFilter.equals(Literal.BOOLEAN_TRUE)) {
+                return null;
+            }
         }
 
         Symbol where = collectPhase.where();
@@ -184,12 +187,31 @@ final class GroupByOptimizedIterator {
         IndexSearcher searcher = searcherRef.item();
 
         Token killToken = new Killable.Token();
+        RamAccounting ramAccounting = collectTask.getRamAccounting();
+        if (keysOnly) {
+            return CollectingBatchIterator.newInstance(
+                killToken,
+                () -> keysToRows(getCountsByKey(ramAccounting, keyRef, searcher, killToken)),
+                true
+            );
+        }
         AggregateMode mode = groupProjection.mode();
         return CollectingBatchIterator.newInstance(
             killToken,
-            () -> countsToRows(getCountsByKey(collectTask.getRamAccounting(), keyRef, searcher, killToken), mode),
+            () -> countsToRows(getCountsByKey(ramAccounting, keyRef, searcher, killToken), mode),
             true
         );
+    }
+
+    private static Iterable<Row> keysToRows(Map<String, Long> countsByKey) {
+        final Object[] cells = new Object[1];
+        final Row row = new RowN(cells);
+        return () -> countsByKey.keySet().stream()
+            .map(key -> {
+                cells[0] = key;
+                return row;
+            })
+            .iterator();
     }
 
     private static Iterable<Row> countsToRows(Map<String, Long> countsByKey, AggregateMode mode) {
@@ -266,13 +288,7 @@ final class GroupByOptimizedIterator {
         }
 
         if (keyRef.isNullable()) {
-            Query existsQuery = keyRef.hasDocValues() || keyRef.indexType() == IndexType.FULLTEXT
-                ? new FieldExistsQuery(keyStorageIdent)
-                : new ConstantScoreQuery(new TermQuery(new Term(SysColumns.FieldNames.NAME, keyStorageIdent)));
-            Query notNull = Queries.not(existsQuery);
-
-            TotalHitCountCollectorManager topHitCounts = new TotalHitCountCollectorManager(searcher.getSlices());
-            Integer count = searcher.search(notNull, topHitCounts);
+            int count = countNullValues(keyRef, searcher);
             if (count > 0) {
                 ramAccounting.addBytes(HASH_MAP_ENTRY_OVERHEAD);
                 countsByKey.put(null, Long.valueOf(count));
@@ -280,6 +296,17 @@ final class GroupByOptimizedIterator {
         }
 
         return countsByKey;
+    }
+
+    private static int countNullValues(Reference keyRef, IndexSearcher searcher) throws IOException {
+        String keyStorageIdent = keyRef.storageIdent();
+        Query existsQuery = keyRef.hasDocValues() || keyRef.indexType() == IndexType.FULLTEXT
+            ? new FieldExistsQuery(keyStorageIdent)
+            : new ConstantScoreQuery(new TermQuery(new Term(SysColumns.FieldNames.NAME, keyStorageIdent)));
+        Query notNull = Queries.not(existsQuery);
+
+        TotalHitCountCollectorManager topHitCounts = new TotalHitCountCollectorManager(searcher.getSlices());
+        return searcher.search(notNull, topHitCounts);
     }
 
     private static int countFromPostings(PostingsEnum postings, Bits liveDocs) throws IOException {

--- a/server/src/main/java/io/crate/execution/engine/collect/LuceneShardCollectorProvider.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/LuceneShardCollectorProvider.java
@@ -165,7 +165,7 @@ public class LuceneShardCollectorProvider extends ShardCollectorProvider {
     protected BatchIterator<Row> getProjectionFusedIterator(RoutedCollectPhase normalizedPhase, CollectTask collectTask) {
         PartitionName partitionName = clusterService.state().metadata().getPartitionName(indexShard.shardId().getIndexUUID());
         DocTableInfo table = nodeCtx.schemas().getTableInfo(indexShard.shardId().getIndex());
-        var it = GroupByOptimizedIterator.tryUseTermFrequencies(
+        var it = GroupByOptimizedIterator.tryUseTermDictionary(
             indexShard,
             normalizedPhase,
             collectTask

--- a/server/src/main/java/io/crate/planner/operators/HashAggregate.java
+++ b/server/src/main/java/io/crate/planner/operators/HashAggregate.java
@@ -57,6 +57,8 @@ import io.crate.planner.PlannerContext;
 import io.crate.planner.ResultDescription;
 import io.crate.planner.distribution.DistributionInfo;
 
+/// Represents an aggregate that is run on all rows resulting from a query,
+/// and  **not** on groups of rows.
 public class HashAggregate extends ForwardingLogicalPlan {
 
     private static final String MERGE_PHASE_NAME = "mergeOnHandler";

--- a/server/src/test/java/io/crate/execution/engine/collect/GroupByOptimizedIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/GroupByOptimizedIteratorTest.java
@@ -260,6 +260,42 @@ public class GroupByOptimizedIteratorTest extends CrateDummyClusterServiceUnitTe
     }
 
     @Test
+    public void test_create_optimized_iterator_for_keys_only_group_by() throws Exception {
+        GroupProjection groupProjection = new GroupProjection(
+            List.of(new InputColumn(0, DataTypes.STRING)),
+            List.of(),
+            AggregateMode.ITER_PARTIAL,
+            RowGranularity.SHARD
+        );
+        var reference = new SimpleReference(
+            new RelationName("doc", "test"),
+            ColumnIdent.of("x"),
+            RowGranularity.DOC,
+            DataTypes.STRING,
+            IndexType.PLAIN,
+            true,
+            true,
+            0,
+            111,
+            false,
+            null
+        );
+        IndexShard shard = newStartedPrimaryShard(
+            TestingHelpers.createNodeContext(),
+            List.of(reference),
+            THREAD_POOL
+        );
+        var collectPhase = createCollectPhase(List.of(reference), List.of(groupProjection));
+        var collectTask = createCollectTask(shard, collectPhase, Version.CURRENT);
+
+        var it = GroupByOptimizedIterator.tryUseTermDictionary(shard, collectPhase, collectTask);
+        assertThat(it).isNotNull();
+
+        collectTask.kill(JobKilledException.of(null));
+        closeShard(shard);
+    }
+
+    @Test
     public void test_create_optimized_iterator_for_single_string_key_using_doc_value_agg_iter_partial() throws Exception {
         assertOptimizedIteratorForSingleStringKeyUsingDocValueAgg(AggregateMode.ITER_PARTIAL);
     }

--- a/server/src/test/java/io/crate/execution/engine/collect/GroupByOptimizedIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/GroupByOptimizedIteratorTest.java
@@ -43,9 +43,11 @@ import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.SortedSetDocValuesField;
+import org.apache.lucene.document.StringField;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.Term;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.store.ByteBuffersDirectory;
@@ -61,6 +63,7 @@ import io.crate.data.BatchIterator;
 import io.crate.data.Row;
 import io.crate.data.breaker.RamAccounting;
 import io.crate.data.testing.BatchIteratorTester;
+import io.crate.common.concurrent.Killable;
 import io.crate.data.testing.BatchIteratorTester.ResultOrder;
 import io.crate.exceptions.JobKilledException;
 import io.crate.execution.dml.StringIndexer;
@@ -339,6 +342,85 @@ public class GroupByOptimizedIteratorTest extends CrateDummyClusterServiceUnitTe
 
         collectTask.kill(JobKilledException.of(null));
         closeShard(shard);
+    }
+
+    @Test
+    public void test_create_terms_distinct_keys_iterator_for_keys_only_group_by() throws Exception {
+        GroupProjection groupProjection = new GroupProjection(
+            List.of(new InputColumn(0, DataTypes.STRING)),
+            List.of(),
+            AggregateMode.ITER_PARTIAL,
+            RowGranularity.SHARD
+        );
+        var reference = new SimpleReference(
+            new RelationName("doc", "test"),
+            ColumnIdent.of("x"),
+            RowGranularity.DOC,
+            DataTypes.STRING,
+            IndexType.PLAIN,
+            true,
+            true,
+            0,
+            111,
+            false,
+            null
+        );
+        IndexShard shard = newStartedPrimaryShard(
+            TestingHelpers.createNodeContext(),
+            List.of(reference),
+            THREAD_POOL
+        );
+        var collectPhase = createCollectPhase(List.of(reference), List.of(groupProjection));
+        var collectTask = createCollectTask(shard, collectPhase, Version.CURRENT);
+
+        // keys-only group-by is served from the term dictionary
+        assertThat(GroupByOptimizedIterator.tryUseTermDictionary(shard, collectPhase, collectTask)).isNotNull();
+
+        collectTask.kill(JobKilledException.of(null));
+        closeShard(shard);
+    }
+
+    @Test
+    public void test_getDistinctKeys_skips_terms_without_live_documents() throws Exception {
+        SimpleReference keyRef = new SimpleReference(
+            new RelationName("doc", "test"),
+            ColumnIdent.of("x"),
+            RowGranularity.DOC,
+            DataTypes.STRING,
+            IndexType.PLAIN,
+            false,   // not nullable -> skip the null-group handling
+            true,
+            0,
+            111,
+            false,
+            null
+        );
+        String field = keyRef.storageIdent();
+
+        IndexWriter iw = new IndexWriter(new ByteBuffersDirectory(), new IndexWriterConfig(new StandardAnalyzer()));
+        // (id, x): (0,a) (1,a) (2,b) (3,c) (4,c)
+        String[] values = { "a", "a", "b", "c", "c" };
+        for (int i = 0; i < values.length; i++) {
+            Document doc = new Document();
+            doc.add(new StringField("id", Integer.toString(i), Field.Store.NO));
+            doc.add(new Field(field, new BytesRef(values[i]), StringIndexer.FIELD_TYPE));
+            iw.addDocument(doc);
+        }
+        iw.commit();
+        // delete both "c" docs -> the term "c" lingers in the dictionary with no live document
+        iw.deleteDocuments(new Term(field, "c"));
+        // delete one of the two "a" docs -> the term "a" still has a live document
+        iw.deleteDocuments(new Term("id", "1"));
+        iw.commit();
+
+        IndexSearcher searcher = new IndexSearcher(DirectoryReader.open(iw));
+
+        var keys = GroupByOptimizedIterator.getDistinctKeys(
+            RamAccounting.NO_ACCOUNTING, keyRef, searcher, new Killable.Token());
+
+        // "c" is excluded (all its documents are deleted); "a" survives via its remaining live document.
+        assertThat(keys).containsExactlyInAnyOrder(new BytesRef("a"), new BytesRef("b"));
+        iw.close();
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/CircuitBreakerIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/CircuitBreakerIntegrationTest.java
@@ -70,7 +70,7 @@ public class CircuitBreakerIntegrationTest extends IntegTestCase {
         execute("set global \"indices.breaker.query.limit\"='100b'");
 
         Asserts.assertSQLError(() -> execute("select text from t1 group by text"))
-            .hasMessageContaining("Allocating 120b for 'collect: 0' failed, breaker would use 120b in total. Limit is 100b. Either increase memory and limit, change the query or reduce concurrent query load")
+            .hasMessageContaining("Allocating 73b for 'collect: 0' failed, breaker would use 139b in total. Limit is 100b. Either increase memory and limit, change the query or reduce concurrent query load")
             .hasPGError(INTERNAL_ERROR)
             .hasHTTPError(INTERNAL_SERVER_ERROR, 5000);
     }

--- a/server/src/test/java/io/crate/integrationtests/CircuitBreakerIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/CircuitBreakerIntegrationTest.java
@@ -70,7 +70,7 @@ public class CircuitBreakerIntegrationTest extends IntegTestCase {
         execute("set global \"indices.breaker.query.limit\"='100b'");
 
         Asserts.assertSQLError(() -> execute("select text from t1 group by text"))
-            .hasMessageContaining("Allocating 136b for 'collect: 0' failed, breaker would use 136b in total. Limit is 100b. Either increase memory and limit, change the query or reduce concurrent query load")
+            .hasMessageContaining("Allocating 112b for 'collect: 0' failed, breaker would use 208b in total. Limit is 100b. Either increase memory and limit, change the query or reduce concurrent query load")
             .hasPGError(INTERNAL_ERROR)
             .hasHTTPError(INTERNAL_SERVER_ERROR, 5000);
     }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This optimization is valuable on its own, but it's also useful in the context of #13818.

```

# Results (server side duration in ms)
V1: 6.5.0-d4e66f1f368913d11c1c234a045d3c3870497df6
V2: 6.5.0-76eebdfd6d7ad2f7d7a7a7ba5bfec663b4b6aef0

Q:     select "destinationURL" from uservisits group by "destinationURL";

C: 5
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |     8262.436 ± 1550.209 |   4255.721 |   8334.416 |   9111.583 |  12786.340 |
|   V2    |     5480.290 ± 1010.923 |   3328.871 |   5522.361 |   6145.425 |   8272.195 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -  40.49%                           -  40.59%   
There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 40.49%
The test has statistical significance


System/JVM Metrics (durations in ms, byte-values in MB)
    |    YOUNG GC            |       OLD GC           |      HEAP         |     ALLOC     
    |  cnt      avg      max |  cnt      avg      max |  initial     used |     rate      total
 V1 |  259   221.12   203.30 |   21  5330.63  6056.26 |    17180     7076 |   727.45     197501
 V2 |  232   199.92   164.78 |   19  4210.25  6167.25 |    17180     7956 |   959.84     178608
```

## Checklist

 - [ ] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes.
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
