### PR TITLE
Fix typo from #19716

### DIFF
--- a/server/src/main/java/io/crate/execution/dsl/projection/AbstractIndexWriterProjection.java
+++ b/server/src/main/java/io/crate/execution/dsl/projection/AbstractIndexWriterProjection.java
@@ -214,7 +214,7 @@ public abstract class AbstractIndexWriterProjection extends Projection {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         relationName.writeTo(out);
-        if (out.getVersion().onOrAfter(Version.V_6_4_0)) {
+        if (out.getVersion().onOrAfter(Version.V_6_3_6)) {
             out.writeInt(tableOid);
         }
         out.writeOptionalString(partitionIdent);

--- a/server/src/main/java/org/elasticsearch/action/UnavailableShardsException.java
+++ b/server/src/main/java/org/elasticsearch/action/UnavailableShardsException.java
@@ -66,7 +66,7 @@ public class UnavailableShardsException extends ElasticsearchException implement
 
     public UnavailableShardsException(StreamInput in) throws IOException {
         super(in);
-        if (in.getVersion().onOrAfter(Version.V_6_3_6)) {
+        if (in.getVersion().onOrAfter(Version.V_6_4_0)) {
             this.relationName = in.readOptionalWriteable(RelationName::new);
         } else {
             RelationName name = null;


### PR DESCRIPTION
Does not need to be backported, https://github.com/crate/crate/pull/19721 is handled manually.