### PR TITLE
Revert #19716

### DIFF
--- a/docs/appendices/release-notes/6.3.6.rst
+++ b/docs/appendices/release-notes/6.3.6.rst
@@ -48,6 +48,3 @@ Fixes
 
 - Fixed an issue that would throw an error when using :ref:`pg_sleep()
   <scalar-pg_sleep>` function in the ``SELECT`` clause.
-
-- Fixed a rare issue where ``INSERT`` statements running concurrently with
-  ``SWAP TABLE`` could insert data into the wrong table.

--- a/server/src/main/java/io/crate/execution/dsl/projection/AbstractIndexWriterProjection.java
+++ b/server/src/main/java/io/crate/execution/dsl/projection/AbstractIndexWriterProjection.java
@@ -25,8 +25,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.elasticsearch.Version;
-import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Setting;
@@ -55,7 +53,6 @@ public abstract class AbstractIndexWriterProjection extends Projection {
 
     private final int bulkActions;
     protected RelationName relationName;
-    protected int tableOid;
     protected String partitionIdent;
     protected List<ColumnIdent> primaryKeys;
 
@@ -72,7 +69,6 @@ public abstract class AbstractIndexWriterProjection extends Projection {
 
 
     protected AbstractIndexWriterProjection(RelationName relationName,
-                                            int tableOid,
                                             @Nullable String partitionIdent,
                                             List<ColumnIdent> primaryKeys,
                                             @Nullable ColumnIdent clusteredByColumn,
@@ -80,7 +76,6 @@ public abstract class AbstractIndexWriterProjection extends Projection {
                                             List<Symbol> idSymbols,
                                             boolean autoCreateIndices) {
         this.relationName = relationName;
-        this.tableOid = tableOid;
         this.partitionIdent = partitionIdent;
         this.primaryKeys = primaryKeys;
         this.clusteredByColumn = clusteredByColumn;
@@ -95,11 +90,6 @@ public abstract class AbstractIndexWriterProjection extends Projection {
 
     protected AbstractIndexWriterProjection(StreamInput in) throws IOException {
         relationName = new RelationName(in);
-        if (in.getVersion().onOrAfter(Version.V_6_3_6)) {
-            tableOid = in.readInt();
-        } else {
-            tableOid = Metadata.OID_UNASSIGNED;
-        }
 
         partitionIdent = in.readOptionalString();
         idSymbols = Symbols.fromStream(in);
@@ -159,10 +149,6 @@ public abstract class AbstractIndexWriterProjection extends Projection {
         return relationName;
     }
 
-    public int tableOid() {
-        return tableOid;
-    }
-
     @Nullable
     public String partitionIdent() {
         return partitionIdent;
@@ -188,7 +174,6 @@ public abstract class AbstractIndexWriterProjection extends Projection {
             return false;
         if (!primaryKeys.equals(that.primaryKeys)) return false;
         if (!relationName.equals(that.relationName)) return false;
-        if (tableOid != that.tableOid) return false;
         if (partitionIdent != null ? !partitionIdent.equals(that.partitionIdent) : that.partitionIdent != null)
             return false;
 
@@ -200,7 +185,6 @@ public abstract class AbstractIndexWriterProjection extends Projection {
         int result = super.hashCode();
         result = 31 * result + Integer.hashCode(bulkActions);
         result = 31 * result + relationName.hashCode();
-        result = 31 * result + tableOid;
         result = 31 * result + (partitionIdent != null ? partitionIdent.hashCode() : 0);
         result = 31 * result + primaryKeys.hashCode();
         result = 31 * result + (clusteredByColumn != null ? clusteredByColumn.hashCode() : 0);
@@ -214,9 +198,6 @@ public abstract class AbstractIndexWriterProjection extends Projection {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         relationName.writeTo(out);
-        if (out.getVersion().onOrAfter(Version.V_6_3_6)) {
-            out.writeInt(tableOid);
-        }
         out.writeOptionalString(partitionIdent);
 
         Symbols.toStream(idSymbols, out);

--- a/server/src/main/java/io/crate/execution/dsl/projection/ColumnIndexWriterProjection.java
+++ b/server/src/main/java/io/crate/execution/dsl/projection/ColumnIndexWriterProjection.java
@@ -67,7 +67,6 @@ public class ColumnIndexWriterProjection extends AbstractIndexWriterProjection {
      * @param onDuplicateKeyAssignments reference to symbol map used for update on duplicate key
      */
     public ColumnIndexWriterProjection(RelationName relationName,
-                                       int tableOid,
                                        @Nullable String partitionIdent,
                                        List<ColumnIdent> primaryKeys,
                                        List<Reference> allTargetColumns,
@@ -83,7 +82,7 @@ public class ColumnIndexWriterProjection extends AbstractIndexWriterProjection {
                                        List<Symbol> returnValues,
                                        long fullDocSizeEstimate) {
 
-        super(relationName, tableOid, partitionIdent, primaryKeys, clusteredByColumn, settings, primaryKeySymbols, autoCreateIndices);
+        super(relationName, partitionIdent, primaryKeys, clusteredByColumn, settings, primaryKeySymbols, autoCreateIndices);
         assert partitionedBySymbols.stream().noneMatch(s -> s.any(Symbol.IS_COLUMN))
             : "All references and fields in partitionedBySymbols must be resolved to inputColumns, got: " + partitionedBySymbols;
         this.allTargetColumns = allTargetColumns;
@@ -275,7 +274,6 @@ public class ColumnIndexWriterProjection extends AbstractIndexWriterProjection {
 
         return new ColumnIndexWriterProjection(
             tableIdent(),
-            tableOid(),
             null,
             primaryKeys,
             allTargetColumns,

--- a/server/src/main/java/io/crate/execution/dsl/projection/SourceIndexWriterProjection.java
+++ b/server/src/main/java/io/crate/execution/dsl/projection/SourceIndexWriterProjection.java
@@ -58,7 +58,6 @@ public class SourceIndexWriterProjection extends AbstractIndexWriterProjection {
     private final String[] excludes;
 
     public SourceIndexWriterProjection(RelationName relationName,
-                                       int tableOid,
                                        @Nullable String partitionIdent,
                                        Reference rawSourceReference,
                                        InputColumn rawSourcePtr,
@@ -71,7 +70,7 @@ public class SourceIndexWriterProjection extends AbstractIndexWriterProjection {
                                        @Nullable Symbol clusteredBySymbol,
                                        List<? extends Symbol> outputs,
                                        boolean autoCreateIndices) {
-        super(relationName, tableOid, partitionIdent, primaryKeys, clusteredByColumn, settings, idSymbols, autoCreateIndices);
+        super(relationName, partitionIdent, primaryKeys, clusteredByColumn, settings, idSymbols, autoCreateIndices);
         this.rawSourceReference = rawSourceReference;
         this.excludes = excludes;
         this.partitionedBySymbols = partitionedBySymbols;

--- a/server/src/main/java/io/crate/execution/dsl/projection/SourceIndexWriterReturnSummaryProjection.java
+++ b/server/src/main/java/io/crate/execution/dsl/projection/SourceIndexWriterReturnSummaryProjection.java
@@ -44,7 +44,6 @@ public class SourceIndexWriterReturnSummaryProjection extends SourceIndexWriterP
     private final InputColumn lineNumber;
 
     public SourceIndexWriterReturnSummaryProjection(RelationName relationName,
-                                                    int tableOid,
                                                     @Nullable String partitionIdent,
                                                     Reference rawSourceReference,
                                                     InputColumn rawSourcePtr,
@@ -61,7 +60,7 @@ public class SourceIndexWriterReturnSummaryProjection extends SourceIndexWriterP
                                                     InputColumn sourceUriFailure,
                                                     InputColumn sourceParsingFailure,
                                                     InputColumn lineNumber) {
-        super(relationName, tableOid, partitionIdent, rawSourceReference, rawSourcePtr, primaryKeys, partitionedBySymbols,
+        super(relationName,partitionIdent, rawSourceReference, rawSourcePtr, primaryKeys, partitionedBySymbols,
             clusteredByColumn, settings, excludes, idSymbols, clusteredBySymbol, outputs, autoCreateIndices);
         this.sourceUri = sourceUri;
         this.sourceUriFailure = sourceUriFailure;

--- a/server/src/main/java/io/crate/metadata/Schemas.java
+++ b/server/src/main/java/io/crate/metadata/Schemas.java
@@ -496,28 +496,6 @@ public class Schemas extends AbstractLifecycleComponent implements Iterable<Sche
         return null;
     }
 
-    @SuppressWarnings("unchecked")
-    public <T extends RelationInfo> T getRelationInfo(int oid) {
-        for (SchemaInfo schema : this) {
-            for (RelationInfo relation : schema.getTables()) {
-                if (oid == relation.oid()) {
-                    return (T) relation;
-                }
-            }
-            for (ViewInfo view : schema.getViews()) {
-                if (oid == view.oid()) {
-                    return (T) view;
-                }
-            }
-            for (RelationMetadata.ForeignTable foreignTable : schema.getForeignTables()) {
-                if (oid == foreignTable.oid()) {
-                    return (T) foreignTable;
-                }
-            }
-        }
-        throw new RelationUnknown(String.format(Locale.ENGLISH, "Relation not found for oid=%s", oid));
-    }
-
     public int getRelationOid(RelationName relationName) {
         RelationMetadata relationMetadata = clusterService.state().metadata().getRelation(relationName);
         return relationMetadata == null ? OidHash.relationOid(OidHash.Type.TABLE, relationName) : relationMetadata.oid();

--- a/server/src/main/java/io/crate/planner/consumer/InsertFromSubQueryPlanner.java
+++ b/server/src/main/java/io/crate/planner/consumer/InsertFromSubQueryPlanner.java
@@ -52,7 +52,6 @@ public final class InsertFromSubQueryPlanner {
 
         ColumnIndexWriterProjection indexWriterProjection = new ColumnIndexWriterProjection(
             statement.tableInfo().ident(),
-            statement.tableInfo().oid(),
             null,
             statement.tableInfo().primaryKey(),
             statement.columns(),

--- a/server/src/main/java/io/crate/planner/operators/InsertFromValues.java
+++ b/server/src/main/java/io/crate/planner/operators/InsertFromValues.java
@@ -139,7 +139,9 @@ public class InsertFromValues implements LogicalPlan {
                               RowConsumer consumer,
                               Row params,
                               SubQueryResults subQueryResults) {
-        DocTableInfo tableInfo = dependencies.schemas().getRelationInfo(writerProjection.tableOid());
+        DocTableInfo tableInfo = dependencies
+            .schemas()
+            .getTableInfo(writerProjection.tableIdent());
 
         // For instance, the target table of the insert from values
         // statement is the table with the following schema:
@@ -275,7 +277,6 @@ public class InsertFromValues implements LogicalPlan {
 
         createPartitions(
             tableInfo,
-            writerProjection.tableOid(),
             dependencies.client(),
             shardedRequests.itemsByMissingPartition().keySet(),
             dependencies.clusterService()
@@ -283,7 +284,7 @@ public class InsertFromValues implements LogicalPlan {
             var shardUpsertRequests = resolveAndGroupShardRequests(
                 shardedRequests,
                 dependencies.clusterService(),
-                writerProjection.tableOid()
+                tableInfo.oid()
             ).values();
             return execute(
                 dependencies.nodeLimits(),
@@ -311,7 +312,9 @@ public class InsertFromValues implements LogicalPlan {
                                                        PlannerContext plannerContext,
                                                        List<Row> bulkParams,
                                                        SubQueryResults subQueryResults) {
-        final DocTableInfo tableInfo = dependencies.schemas().getRelationInfo(writerProjection.tableOid());
+        final DocTableInfo tableInfo = dependencies
+            .schemas()
+            .getTableInfo(writerProjection.tableIdent());
 
         String[] updateColumnNames;
         Assignments assignments;
@@ -423,7 +426,6 @@ public class InsertFromValues implements LogicalPlan {
 
         createPartitions(
             tableInfo,
-            writerProjection.tableOid(),
             dependencies.client(),
             shardedRequests.itemsByMissingPartition().keySet(),
             dependencies.clusterService()
@@ -748,15 +750,13 @@ public class InsertFromValues implements LogicalPlan {
     }
 
     private static CompletableFuture<AcknowledgedResponse> createPartitions(DocTableInfo tableInfo,
-                                                                            int tableOid,
                                                                             Client client,
                                                                             Set<PartitionName> partitions,
                                                                             ClusterService clusterService) {
         List<PartitionName> partitionsToCreate = new ArrayList<>();
-        Metadata metadata = clusterService.state().metadata();
         for (var partition : partitions) {
-            String indexUUID =
-                metadata.getIndex(tableInfo.ident(), partition.values(), true, IndexMetadata::getIndexUUID);
+            String indexUUID = clusterService.state().metadata()
+                .getIndex(tableInfo.ident(), partition.values(), true, IndexMetadata::getIndexUUID);
             if (indexUUID == null) {
                 partitionsToCreate.add(partition);
             }

--- a/server/src/main/java/io/crate/planner/statement/CopyFromPlan.java
+++ b/server/src/main/java/io/crate/planner/statement/CopyFromPlan.java
@@ -262,7 +262,6 @@ public final class CopyFromPlan implements Plan {
 
             sourceIndexWriterProjection = new SourceIndexWriterReturnSummaryProjection(
                 table.ident(),
-                table.oid(),
                 partitionIdent,
                 table.getReference(SysColumns.RAW),
                 new InputColumn(rawOrDocIdx, rawOrDoc.valueType()),
@@ -283,7 +282,6 @@ public final class CopyFromPlan implements Plan {
         } else {
             sourceIndexWriterProjection = new SourceIndexWriterProjection(
                 table.ident(),
-                table.oid(),
                 partitionIdent,
                 table.getReference(SysColumns.RAW),
                 new InputColumn(rawOrDocIdx, rawOrDoc.valueType()),

--- a/server/src/main/java/org/elasticsearch/Version.java
+++ b/server/src/main/java/org/elasticsearch/Version.java
@@ -243,7 +243,6 @@ public class Version implements Comparable<Version> {
     public static final Version V_6_3_3 = new Version(9_03_03_99, false, org.apache.lucene.util.Version.LUCENE_10_4_0);
     public static final Version V_6_3_4 = new Version(9_03_04_99, false, org.apache.lucene.util.Version.LUCENE_10_4_0);
     public static final Version V_6_3_5 = new Version(9_03_05_99, false, org.apache.lucene.util.Version.LUCENE_10_4_0);
-    public static final Version V_6_3_6 = new Version(9_03_06_99, true, org.apache.lucene.util.Version.LUCENE_10_4_0);
 
     public static final Version V_6_4_0 = new Version(9_04_00_99, false, org.apache.lucene.util.Version.LUCENE_10_4_0);
     public static final Version V_6_4_1 = new Version(9_04_01_99, true, org.apache.lucene.util.Version.LUCENE_10_4_0);

--- a/server/src/test/java/io/crate/execution/dsl/projection/ColumnIndexWriterProjectionTest.java
+++ b/server/src/test/java/io/crate/execution/dsl/projection/ColumnIndexWriterProjectionTest.java
@@ -22,7 +22,6 @@
 package io.crate.execution.dsl.projection;
 
 import static io.crate.testing.Asserts.assertThat;
-import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -60,7 +59,6 @@ public class ColumnIndexWriterProjectionTest {
         }
         var projection = new ColumnIndexWriterProjection(
             relationName,
-            OID_UNASSIGNED,
             null,
             List.of(),
             targetColumns,

--- a/server/src/test/java/io/crate/execution/dsl/projection/SourceIndexWriterProjectionSerializationTest.java
+++ b/server/src/test/java/io/crate/execution/dsl/projection/SourceIndexWriterProjectionSerializationTest.java
@@ -75,7 +75,6 @@ public class SourceIndexWriterProjectionSerializationTest {
         // fail_fast property set to true
         SourceIndexWriterProjection expected = new SourceIndexWriterProjection(
             relationName,
-            OID_UNASSIGNED,
             partitionIdent,
             reference,
             inputColumn,

--- a/server/src/test/java/io/crate/integrationtests/PartitionedTableConcurrentIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/PartitionedTableConcurrentIntegrationTest.java
@@ -570,7 +570,8 @@ public class PartitionedTableConcurrentIntegrationTest extends IntegTestCase {
         Thread t2 = new Thread(() -> {
             try {
                 barrier.await();
-                for (int i = 0; i < 7; i++) {
+                for (int i = 0; i < 3; i++) {
+                    Thread.sleep(300); // to prevent swap queries to go through at once
                     execute("ALTER CLUSTER SWAP TABLE t1 TO t2");
                     if (t1.isAlive()) {
                         swapInterleaved[0] = true;


### PR DESCRIPTION
#19716 caused a crate-qa failure - https://github.com/crate/crate/pull/19716#issuecomment-4950797707 as reported by Marios.

#19716 was completed without considering that tables can have oids unassigned - https://github.com/crate/crate/pull/19271#discussion_r3117570032.

I will first revert it and rework on it.