### PR TITLE
[WIP] Handle `distinct` in LogicalPlanner and not in ExpressionAnalyzer

### DIFF
--- a/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
@@ -58,6 +58,7 @@ import io.crate.analyze.validator.SemanticSortValidator;
 import io.crate.common.collections.Lists;
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.exceptions.ConversionException;
+import io.crate.execution.engine.aggregation.impl.CollectSetAggregation;
 import io.crate.expression.eval.EvaluatingNormalizer;
 import io.crate.expression.operator.AndOperator;
 import io.crate.expression.operator.EqOperator;
@@ -262,7 +263,69 @@ public class ExpressionAnalyzer {
         return whereExpression.map(expression -> convert(expression, context)).orElse(Literal.BOOLEAN_TRUE);
     }
 
-    private Symbol convertFunctionCall(FunctionCall node, ExpressionAnalysisContext context) {
+    private Symbol convertFunctionCallOld(FunctionCall node, ExpressionAnalysisContext context) {
+        List<Symbol> arguments = new ArrayList<>(node.getArguments().size());
+        for (Expression expression : node.getArguments()) {
+            Symbol argSymbol = expression.accept(innerAnalyzer, context);
+            arguments.add(argSymbol);
+        }
+
+        List<String> parts = node.getName().getParts();
+        // We don't set a default schema here because no supplied schema
+        // means that we first try to lookup builtin functions, followed
+        // by a lookup in the default schema for UDFs.
+        String schema = null;
+        String name;
+        if (parts.size() == 1) {
+            name = parts.get(0);
+        } else {
+            schema = parts.get(0);
+            name = parts.get(1);
+        }
+
+        Symbol filter = node.filter()
+            .map(expression -> convert(expression, context))
+            .orElse(null);
+
+        WindowDefinition windowDefinition = getWindowDefinition(node.getWindow(), context);
+        if (node.isDistinct()) {
+            if (arguments.size() > 1) {
+                throw new UnsupportedOperationException(String.format(Locale.ENGLISH,
+                    "%s(DISTINCT x) does not accept more than one argument", node.getName()));
+            }
+            Symbol collectSetFunction = allocateFunction(
+                CollectSetAggregation.NAME,
+                arguments,
+                filter,
+                context,
+                coordinatorTxnCtx,
+                nodeCtx);
+
+            // define the outer function which contains the inner function as argument.
+            String nodeName = "collection_" + name;
+            List<Symbol> outerArguments = List.of(collectSetFunction);
+            try {
+                return allocateBuiltinOrUdfFunction(
+                    schema, nodeName, outerArguments, null, node.ignoreNulls(), false, windowDefinition, context);
+            } catch (UnsupportedOperationException ex) {
+                throw new UnsupportedOperationException(String.format(Locale.ENGLISH,
+                    "unknown function %s(DISTINCT %s)", name, arguments.get(0).valueType()), ex);
+            }
+        } else {
+            return allocateBuiltinOrUdfFunction(
+                schema,
+                name,
+                arguments,
+                filter,
+                node.ignoreNulls(),
+                node.isDistinct(),
+                windowDefinition,
+                context
+            );
+        }
+    }
+
+    private Symbol convertFunctionCallNew(FunctionCall node, ExpressionAnalysisContext context) {
         List<Symbol> arguments = new ArrayList<>(node.getArguments().size());
         for (Expression expression : node.getArguments()) {
             Symbol argSymbol = expression.accept(innerAnalyzer, context);
@@ -520,7 +583,7 @@ public class ExpressionAnalyzer {
                 return visitSubscriptExpression(
                     new SubscriptExpression(node.getArguments().get(0), node.getArguments().get(1)), context);
             }
-            return convertFunctionCall(node, context);
+            return convertFunctionCallNew(node, context);
         }
 
         @Override

--- a/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
@@ -1276,6 +1276,7 @@ public class ExpressionAnalyzer {
         return allocateFunction(functionName, arguments, null, context, coordinatorTxnCtx, nodeCtx);
     }
 
+    // needed for CollectSetAggregation
     public static Function allocateFunction(String functionName,
                                             List<Symbol> arguments,
                                             @Nullable Symbol filter,
@@ -1301,7 +1302,7 @@ public class ExpressionAnalyzer {
      * @param nodeCtx The {@link NodeContext} to normalize constant expressions.
      * @return The supplied {@link Function} or a {@link Literal} in case of constant folding.
      */
-    private static Function allocateBuiltinOrUdfFunction(@Nullable String schema,
+    public static Function allocateBuiltinOrUdfFunction(@Nullable String schema,
                                                          String functionName,
                                                          List<Symbol> arguments,
                                                          @Nullable Symbol filter,
@@ -1327,7 +1328,7 @@ public class ExpressionAnalyzer {
         List<Symbol> castArguments = cast(arguments, boundSignature.argTypes());
         Function newFunction;
         if (windowDefinition == null) {
-            if (signature.getType() == FunctionType.AGGREGATE) {
+            if (signature.getType() == FunctionType.AGGREGATE && context != null) {
                 context.indicateAggregates();
             } else if (filter != null) {
                 throw new UnsupportedOperationException(

--- a/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
@@ -58,7 +58,6 @@ import io.crate.analyze.validator.SemanticSortValidator;
 import io.crate.common.collections.Lists;
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.exceptions.ConversionException;
-import io.crate.execution.engine.aggregation.impl.CollectSetAggregation;
 import io.crate.expression.eval.EvaluatingNormalizer;
 import io.crate.expression.operator.AndOperator;
 import io.crate.expression.operator.EqOperator;
@@ -288,32 +287,41 @@ public class ExpressionAnalyzer {
             .orElse(null);
 
         WindowDefinition windowDefinition = getWindowDefinition(node.getWindow(), context);
-        if (node.isDistinct()) {
-            if (arguments.size() > 1) {
-                throw new UnsupportedOperationException(String.format(Locale.ENGLISH,
-                    "%s(DISTINCT x) does not accept more than one argument", node.getName()));
-            }
-            Symbol collectSetFunction = allocateFunction(
-                CollectSetAggregation.NAME,
+//        if (node.isDistinct()) {
+//            if (arguments.size() > 1) {
+//                throw new UnsupportedOperationException(String.format(Locale.ENGLISH,
+//                    "%s(DISTINCT x) does not accept more than one argument", node.getName()));
+//            }
+//            Symbol collectSetFunction = allocateFunction(
+//                CollectSetAggregation.NAME,
+//                arguments,
+//                filter,
+//                context,
+//                coordinatorTxnCtx,
+//                nodeCtx);
+//
+//            // define the outer function which contains the inner function as argument.
+//            String nodeName = "collection_" + name;
+//            List<Symbol> outerArguments = List.of(collectSetFunction);
+//            try {
+//                return allocateBuiltinOrUdfFunction(
+//                    schema, nodeName, outerArguments, null, node.ignoreNulls(), windowDefinition, context);
+//            } catch (UnsupportedOperationException ex) {
+//                throw new UnsupportedOperationException(String.format(Locale.ENGLISH,
+//                    "unknown function %s(DISTINCT %s)", name, arguments.get(0).valueType()), ex);
+//            }
+//        } else {
+            return allocateBuiltinOrUdfFunction(
+                schema,
+                name,
                 arguments,
                 filter,
-                context,
-                coordinatorTxnCtx,
-                nodeCtx);
-
-            // define the outer function which contains the inner function as argument.
-            String nodeName = "collection_" + name;
-            List<Symbol> outerArguments = List.of(collectSetFunction);
-            try {
-                return allocateBuiltinOrUdfFunction(
-                    schema, nodeName, outerArguments, null, node.ignoreNulls(), windowDefinition, context);
-            } catch (UnsupportedOperationException ex) {
-                throw new UnsupportedOperationException(String.format(Locale.ENGLISH,
-                    "unknown function %s(DISTINCT %s)", name, arguments.get(0).valueType()), ex);
-            }
-        } else {
-            return allocateBuiltinOrUdfFunction(schema, name, arguments, filter, node.ignoreNulls(), windowDefinition, context);
-        }
+                node.ignoreNulls(),
+                node.isDistinct(),
+                windowDefinition,
+                context
+            );
+//        }
     }
 
     @Nullable
@@ -1254,10 +1262,12 @@ public class ExpressionAnalyzer {
                                                 List<Symbol> arguments,
                                                 Symbol filter,
                                                 @Nullable Boolean ignoreNulls,
+                                                boolean distinct,
                                                 WindowDefinition windowDefinition,
                                                 ExpressionAnalysisContext context) {
         return allocateBuiltinOrUdfFunction(
-            schema, functionName, arguments, filter, ignoreNulls, context, windowDefinition, coordinatorTxnCtx, nodeCtx);
+            schema, functionName, arguments, filter, ignoreNulls, context, distinct, windowDefinition, coordinatorTxnCtx, nodeCtx
+        );
     }
 
     public Symbol allocateFunction(String functionName,
@@ -1273,7 +1283,8 @@ public class ExpressionAnalyzer {
                                             TransactionContext txnCtx,
                                             NodeContext nodeCtx) {
         return allocateBuiltinOrUdfFunction(
-            null, functionName, arguments, filter, null, context, null, txnCtx, nodeCtx);
+            null, functionName, arguments, filter, null, context, false, null, txnCtx, nodeCtx
+        );
     }
 
     /**
@@ -1296,6 +1307,7 @@ public class ExpressionAnalyzer {
                                                          @Nullable Symbol filter,
                                                          @Nullable Boolean ignoreNulls,
                                                          ExpressionAnalysisContext context,
+                                                         boolean distinct,
                                                          @Nullable WindowDefinition windowDefinition,
                                                          TransactionContext txnCtx,
                                                          NodeContext nodeCtx) {
@@ -1327,7 +1339,13 @@ public class ExpressionAnalyzer {
                     "%s cannot accept RESPECT or IGNORE NULLS flag.",
                     functionName));
             }
-            newFunction = new Function(signature, castArguments, boundSignature.returnType(), filter);
+            newFunction = new Function(
+                signature,
+                castArguments,
+                boundSignature.returnType(),
+                filter,
+                distinct
+            );
         } else {
             if (signature.getType() != FunctionType.WINDOW) {
                 if (signature.getType() != FunctionType.AGGREGATE) {
@@ -1353,7 +1371,8 @@ public class ExpressionAnalyzer {
                 boundSignature.returnType(),
                 filter,
                 windowDefinition,
-                ignoreNulls);
+                ignoreNulls
+            );
         }
         return newFunction;
     }

--- a/server/src/main/java/io/crate/execution/dsl/projection/builder/SplitPointsBuilder.java
+++ b/server/src/main/java/io/crate/execution/dsl/projection/builder/SplitPointsBuilder.java
@@ -48,6 +48,8 @@ public final class SplitPointsBuilder extends DefaultTraversalSymbolVisitor<Spli
     private static final SplitPointsBuilder INSTANCE = new SplitPointsBuilder();
 
     static class Context {
+        public java.util.function.Function<Symbol, Symbol> preprocessSymbol;
+
         private final ArrayList<Function> aggregates = new ArrayList<>();
         private final ArrayList<Function> tableFunctions = new ArrayList<>();
         private final ArrayList<Symbol> standalone = new ArrayList<>();
@@ -102,14 +104,22 @@ public final class SplitPointsBuilder extends DefaultTraversalSymbolVisitor<Spli
 
     private void process(Symbol symbol, Context context) {
         context.foundAggregateOrTableFunction = false;
-        symbol.accept(this, context);
+
+        Symbol s = context.preprocessSymbol.apply(symbol);
+        s.accept(this, context);
         if (context.foundAggregateOrTableFunction == false) {
-            context.standalone.add(symbol);
+            context.standalone.add(s);
         }
     }
 
     public static SplitPoints create(QueriedSelectRelation relation) {
+        return create(relation, java.util.function.Function.identity());
+    }
+
+    public static SplitPoints create(QueriedSelectRelation relation, java.util.function.Function<Symbol, Symbol> preprocessSymbol) {
         Context context = new Context();
+        context.preprocessSymbol = preprocessSymbol;
+
         INSTANCE.process(relation.outputs(), context);
         OrderBy orderBy = relation.orderBy();
         if (orderBy != null) {

--- a/server/src/main/java/io/crate/expression/symbol/Function.java
+++ b/server/src/main/java/io/crate/expression/symbol/Function.java
@@ -91,16 +91,22 @@ public class Function implements Symbol, Cloneable {
     protected final Signature signature;
     @Nullable
     protected final Symbol filter;
+    protected boolean distinct;
 
     public Function(Signature signature, List<Symbol> arguments, DataType<?> returnType) {
-        this(signature, arguments, returnType, null);
+        this(signature, arguments, returnType, null, false);
     }
 
     public Function(Signature signature, List<Symbol> arguments, DataType<?> returnType, @Nullable Symbol filter) {
+        this(signature, arguments, returnType, filter, false);
+    }
+
+    public Function(Signature signature, List<Symbol> arguments, DataType<?> returnType, @Nullable Symbol filter, boolean distinct) {
         this.signature = signature;
         this.arguments = List.copyOf(arguments);
         this.returnType = returnType;
         this.filter = filter;
+        this.distinct = distinct;
     }
 
     public Function(StreamInput in) throws IOException {
@@ -138,6 +144,10 @@ public class Function implements Symbol, Cloneable {
     @Override
     public DataType<?> valueType() {
         return returnType;
+    }
+
+    public boolean distinct() {
+        return distinct;
     }
 
     @Override
@@ -204,7 +214,7 @@ public class Function implements Symbol, Cloneable {
                 throw new ConversionException(returnType, targetType);
             }
         }
-        return new Function(signature, newArgs, targetType, null);
+        return new Function(signature, newArgs, targetType, null, false);
     }
 
     public boolean isCast() {

--- a/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -292,7 +292,18 @@ public class LogicalPlanner {
         var timeoutToken = plannerContext.timeoutToken();
         LogicalPlan optimizedPlan = optimizer.optimize(plan, plannerContext.planStats(), txnCtx, tracer, timeoutToken);
         optimizedPlan = joinImplementationOptimizer.optimize(optimizedPlan, plannerContext.planStats(), txnCtx, tracer, timeoutToken);
-        LogicalPlan prunedPlan = optimizedPlan.pruneOutputsExcept(relation.outputs());
+        // This is interesting when a function is in the output (e.g. select count(distinct x)).
+        // Functions are equal iff their arguments, signature, filter and return types are equal.
+        // (See: io.crate.expression.symbol.Function.equals).
+        // That limits us when optimizing plans. When we have count(distinct x), then we can't
+        // replace `distinct x` with something else.
+        // This currently work because the relation itself is rewritten in ExpressionAnalyzer.InnerExpressionAnalyzer.visitFunctionCall.
+        // IMHO, it would make sense that in this particular case, the equality conditions are relaxed
+        // and limited to checking the output (return types).
+
+        // todo temporary hack
+        // LogicalPlan prunedPlan = optimizedPlan.pruneOutputsExcept(relation.outputs());
+        LogicalPlan prunedPlan = optimizedPlan;
         assert prunedPlan.outputs().equals(optimizedPlan.outputs())
             : "Pruned plan must have the same outputs as original plan";
         LogicalPlan fetchOptimized = fetchOptimizer.optimize(
@@ -528,10 +539,17 @@ public class LogicalPlanner {
 
 
         @Override
-        public LogicalPlan visitQueriedSelectRelation(QueriedSelectRelation relation, List<Symbol> outputs) {
+        public LogicalPlan visitQueriedSelectRelation(QueriedSelectRelation relation, List<Symbol> _outputs) {
+            java.util.function.Function<Symbol, Symbol> preprocessSymbol =
+                s -> wrapIfDistinctFunction(coordinatorTxnCtx, nodeCtx, s);
+
+            List<Symbol> outputs = relation.outputs().stream()
+                .map(preprocessSymbol)
+                .toList();
+
             SplitPoints splitPoints = SplitPointsBuilder.create(
                 relation,
-                s -> wrapIfDistinctFunction(coordinatorTxnCtx, nodeCtx, s)
+                preprocessSymbol
             );
             SubQueries subQueries = subqueryPlanner.planSubQueries(relation);
             LogicalPlan source = buildImplicitJoins(
@@ -579,7 +597,7 @@ public class LogicalPlanner {
                                     splitPoints.tableFunctions()
                                 ),
                                 relation.isDistinct(),
-                                relation.outputs()
+                                outputs
                             ),
                             relation.orderBy()
                         ),

--- a/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -529,7 +529,10 @@ public class LogicalPlanner {
 
         @Override
         public LogicalPlan visitQueriedSelectRelation(QueriedSelectRelation relation, List<Symbol> outputs) {
-            SplitPoints splitPoints = SplitPointsBuilder.create(relation);
+            SplitPoints splitPoints = SplitPointsBuilder.create(
+                relation,
+                s -> wrapIfDistinctFunction(coordinatorTxnCtx, nodeCtx, s)
+            );
             SubQueries subQueries = subqueryPlanner.planSubQueries(relation);
             LogicalPlan source = buildImplicitJoins(
                 relation.from(),
@@ -629,11 +632,11 @@ public class LogicalPlanner {
         return source;
     }
 
-    private static Function wrapIfDistinct(CoordinatorTxnCtx coordinatorTxnCtx, NodeContext nodeCtx, Function fn) {
-        if (fn.distinct()) {
+    private static Symbol wrapIfDistinctFunction(CoordinatorTxnCtx coordinatorTxnCtx, NodeContext nodeCtx, Symbol symbol) {
+        if (symbol instanceof Function fn && fn.distinct()) {
             return wrapWithCollectSet(fn, coordinatorTxnCtx, nodeCtx);
         }
-        return fn;
+        return symbol;
     }
 
     private static Function wrapWithCollectSet(Function original, CoordinatorTxnCtx coordinatorTxnCtx, NodeContext nodeCtx) {

--- a/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -21,6 +21,9 @@
 
 package io.crate.planner.operators;
 
+import static io.crate.analyze.expressions.ExpressionAnalyzer.allocateBuiltinOrUdfFunction;
+import static io.crate.analyze.expressions.ExpressionAnalyzer.allocateFunction;
+
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
@@ -47,7 +50,8 @@ import io.crate.analyze.OrderBy;
 import io.crate.analyze.QueriedSelectRelation;
 import io.crate.analyze.RelationNames;
 import io.crate.analyze.WhereClause;
-import io.crate.analyze.expressions.ExpressionAnalyzer;
+import io.crate.analyze.WindowDefinition;
+import io.crate.analyze.expressions.ExpressionAnalysisContext;
 import io.crate.analyze.relations.AbstractTableRelation;
 import io.crate.analyze.relations.AliasedAnalyzedRelation;
 import io.crate.analyze.relations.AnalyzedRelation;
@@ -76,6 +80,7 @@ import io.crate.expression.symbol.ScopedSymbol;
 import io.crate.expression.symbol.SelectSymbol;
 import io.crate.expression.symbol.SelectSymbol.ResultType;
 import io.crate.expression.symbol.Symbol;
+import io.crate.expression.symbol.WindowFunction;
 import io.crate.fdw.ForeignDataWrapper;
 import io.crate.fdw.ForeignDataWrappers;
 import io.crate.fdw.ForeignTableRelation;
@@ -522,7 +527,6 @@ public class LogicalPlanner {
         }
 
 
-
         @Override
         public LogicalPlan visitQueriedSelectRelation(QueriedSelectRelation relation, List<Symbol> outputs) {
             SplitPoints splitPoints = SplitPointsBuilder.create(relation);
@@ -641,30 +645,32 @@ public class LogicalPlanner {
     }
 
     private static Function wrapWithCollectSet(Function original, CoordinatorTxnCtx coordinatorTxnCtx, NodeContext nodeCtx) {
-//            if (arguments.size() > 1) {
-//                throw new UnsupportedOperationException(String.format(Locale.ENGLISH,
-//                    "%s(DISTINCT x) does not accept more than one argument", node.getName()));
-//            }
-            Symbol collectSetFunction = ExpressionAnalyzer.allocateFunction(
-                CollectSetAggregation.NAME,
-                original.arguments(),
-                original.filter(),
-                //  ExpressionAnalysisContext  needed to indicate expression has aggregates.
-                // analysis done so we can ignore this.
-                null,
-                coordinatorTxnCtx,
-                nodeCtx
-            );
+        var arguments = original.arguments();
+        var filter = original.filter();
+        ExpressionAnalysisContext context = null;
+        String name = original.name();
+        WindowDefinition windowDefinition = (original instanceof WindowFunction wf) ? wf.windowDefinition() : null;
+        Boolean ignoreNulls = (original instanceof WindowFunction wf) ? wf.ignoreNulls() : null;
+        String schema = original.signature().getName().schema();
 
-            // define the outer function which contains the inner function as argument.
-            String nodeName = "collection_" + original.name();
+        Symbol collectSetFunction = allocateFunction(
+            CollectSetAggregation.NAME,
+            arguments,
+            filter,
+            context,
+            coordinatorTxnCtx,
+            nodeCtx);
 
-            return new Function(
-                original.signature(),
-                List.of(collectSetFunction),
-                original.valueType(),
-                null
-            );
+        // define the outer function which contains the inner function as argument.
+        String nodeName = "collection_" + name;
+        List<Symbol> outerArguments = List.of(collectSetFunction);
+        try {
+            return allocateBuiltinOrUdfFunction(
+                schema, nodeName, outerArguments, null, ignoreNulls, context, true, windowDefinition, coordinatorTxnCtx, nodeCtx);
+        } catch (UnsupportedOperationException ex) {
+            throw new UnsupportedOperationException(String.format(Locale.ENGLISH,
+                "unknown function %s(DISTINCT %s)", name, arguments.get(0).valueType()), ex);
+        }
 
     }
 

--- a/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -299,7 +299,7 @@ public class LogicalPlanner {
         // replace `distinct x` with something else.
         // This currently work because the relation itself is rewritten in ExpressionAnalyzer.InnerExpressionAnalyzer.visitFunctionCall.
         // IMHO, it would make sense that in this particular case, the equality conditions are relaxed
-        // and limited to checking the output (return types).
+        // and limited to checking the return types.
 
         // todo temporary hack
         // LogicalPlan prunedPlan = optimizedPlan.pruneOutputsExcept(relation.outputs());

--- a/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -47,6 +47,7 @@ import io.crate.analyze.OrderBy;
 import io.crate.analyze.QueriedSelectRelation;
 import io.crate.analyze.RelationNames;
 import io.crate.analyze.WhereClause;
+import io.crate.analyze.expressions.ExpressionAnalyzer;
 import io.crate.analyze.relations.AbstractTableRelation;
 import io.crate.analyze.relations.AliasedAnalyzedRelation;
 import io.crate.analyze.relations.AnalyzedRelation;
@@ -66,6 +67,7 @@ import io.crate.execution.dsl.phases.NodeOperationTree;
 import io.crate.execution.dsl.projection.builder.SplitPoints;
 import io.crate.execution.dsl.projection.builder.SplitPointsBuilder;
 import io.crate.execution.engine.NodeOperationTreeGenerator;
+import io.crate.execution.engine.aggregation.impl.CollectSetAggregation;
 import io.crate.expression.operator.AndOperator;
 import io.crate.expression.symbol.FieldReplacer;
 import io.crate.expression.symbol.Function;
@@ -268,7 +270,8 @@ public class LogicalPlanner {
             subqueryPlanner,
             foreignDataWrappers,
             plannerContext.clusterState(),
-            plannerContext.transactionContext()
+            plannerContext.transactionContext(),
+            plannerContext.nodeContext()
         );
         LogicalPlan plan = relation.accept(planBuilder, relation.outputs());
         plan = tryOptimizeForInSubquery(selectSymbol, relation, plan);
@@ -358,7 +361,8 @@ public class LogicalPlanner {
             subqueryPlanner,
             foreignDataWrappers,
             plannerContext.clusterState(),
-            plannerContext.transactionContext()
+            plannerContext.transactionContext(),
+            plannerContext.nodeContext()
         );
         LogicalPlan logicalPlan = relation.accept(planBuilder, relation.outputs());
         return optimize(logicalPlan, relation, plannerContext, avoidTopLevelFetch);
@@ -370,15 +374,18 @@ public class LogicalPlanner {
         private final ForeignDataWrappers foreignDataWrappers;
         private final ClusterState clusterState;
         private final CoordinatorTxnCtx coordinatorTxnCtx;
+        private final NodeContext nodeCtx;
 
         private PlanBuilder(SubqueryPlanner subqueryPlanner,
                             ForeignDataWrappers foreignDataWrappers,
                             ClusterState clusterState,
-                            CoordinatorTxnCtx coordinatorTxnCtx) {
+                            CoordinatorTxnCtx coordinatorTxnCtx,
+                            NodeContext nodeCtx) {
             this.subqueryPlanner = subqueryPlanner;
             this.foreignDataWrappers = foreignDataWrappers;
             this.clusterState = clusterState;
             this.coordinatorTxnCtx = coordinatorTxnCtx;
+            this.nodeCtx = nodeCtx;
         }
 
         @Override
@@ -556,7 +563,9 @@ public class LogicalPlanner {
                                                     splitPoints.tableFunctionsBelowGroupBy()
                                                 ),
                                                 relation.groupBy(),
-                                                splitPoints.aggregates()
+                                                splitPoints.aggregates(),
+                                                coordinatorTxnCtx,
+                                                nodeCtx
                                             ),
                                             having
                                         ),
@@ -608,14 +617,55 @@ public class LogicalPlanner {
 
     private static LogicalPlan groupByOrAggregate(LogicalPlan source,
                                                   List<Symbol> groupKeys,
-                                                  List<Function> aggregates) {
+                                                  List<Function> aggregates,
+                                                  CoordinatorTxnCtx coordinatorTxnCtx,
+                                                  NodeContext nodeCtx) {
         if (!groupKeys.isEmpty()) {
             return new GroupHashAggregate(source, groupKeys, aggregates);
         }
         if (!aggregates.isEmpty()) {
-            return new HashAggregate(source, aggregates);
+            return new HashAggregate(source, handleDistinctFunctions(aggregates, coordinatorTxnCtx, nodeCtx));
         }
         return source;
+    }
+
+    private static List<Function> handleDistinctFunctions(List<Function> aggregates, CoordinatorTxnCtx coordinatorTxnCtx, NodeContext nodeCtx) {
+        return aggregates.stream()
+            .map(fn -> {
+                if (fn.distinct()) {
+                    return wrapWithCollectSet(fn, coordinatorTxnCtx, nodeCtx);
+                }
+                return fn;
+            })
+            .toList();
+    }
+
+    private static Function wrapWithCollectSet(Function original, CoordinatorTxnCtx coordinatorTxnCtx, NodeContext nodeCtx) {
+//            if (arguments.size() > 1) {
+//                throw new UnsupportedOperationException(String.format(Locale.ENGLISH,
+//                    "%s(DISTINCT x) does not accept more than one argument", node.getName()));
+//            }
+            Symbol collectSetFunction = ExpressionAnalyzer.allocateFunction(
+                CollectSetAggregation.NAME,
+                original.arguments(),
+                original.filter(),
+                //  ExpressionAnalysisContext  needed to indicate expression has aggregates.
+                // analysis done so we can ignore this.
+                null,
+                coordinatorTxnCtx,
+                nodeCtx
+            );
+
+            // define the outer function which contains the inner function as argument.
+            String nodeName = "collection_" + original.name();
+
+            return new Function(
+                original.signature(),
+                List.of(collectSetFunction),
+                original.valueType(),
+                null
+            );
+
     }
 
     public static Set<Symbol> extractColumns(Symbol symbol) {

--- a/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -629,7 +629,7 @@ public class LogicalPlanner {
         return source;
     }
 
-    private static Function handleDistinctFunction(CoordinatorTxnCtx coordinatorTxnCtx, NodeContext nodeCtx, Function fn) {
+    private static Function wrapIfDistinct(CoordinatorTxnCtx coordinatorTxnCtx, NodeContext nodeCtx, Function fn) {
         if (fn.distinct()) {
             return wrapWithCollectSet(fn, coordinatorTxnCtx, nodeCtx);
         }

--- a/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -567,9 +567,7 @@ public class LogicalPlanner {
                                                     splitPoints.tableFunctionsBelowGroupBy()
                                                 ),
                                                 relation.groupBy(),
-                                                splitPoints.aggregates(),
-                                                coordinatorTxnCtx,
-                                                nodeCtx
+                                                splitPoints.aggregates()
                                             ),
                                             having
                                         ),
@@ -621,27 +619,21 @@ public class LogicalPlanner {
 
     private static LogicalPlan groupByOrAggregate(LogicalPlan source,
                                                   List<Symbol> groupKeys,
-                                                  List<Function> aggregates,
-                                                  CoordinatorTxnCtx coordinatorTxnCtx,
-                                                  NodeContext nodeCtx) {
+                                                  List<Function> aggregates) {
         if (!groupKeys.isEmpty()) {
             return new GroupHashAggregate(source, groupKeys, aggregates);
         }
         if (!aggregates.isEmpty()) {
-            return new HashAggregate(source, handleDistinctFunctions(aggregates, coordinatorTxnCtx, nodeCtx));
+            return new HashAggregate(source, aggregates);
         }
         return source;
     }
 
-    private static List<Function> handleDistinctFunctions(List<Function> aggregates, CoordinatorTxnCtx coordinatorTxnCtx, NodeContext nodeCtx) {
-        return aggregates.stream()
-            .map(fn -> {
-                if (fn.distinct()) {
-                    return wrapWithCollectSet(fn, coordinatorTxnCtx, nodeCtx);
-                }
-                return fn;
-            })
-            .toList();
+    private static Function handleDistinctFunction(CoordinatorTxnCtx coordinatorTxnCtx, NodeContext nodeCtx, Function fn) {
+        if (fn.distinct()) {
+            return wrapWithCollectSet(fn, coordinatorTxnCtx, nodeCtx);
+        }
+        return fn;
     }
 
     private static Function wrapWithCollectSet(Function original, CoordinatorTxnCtx coordinatorTxnCtx, NodeContext nodeCtx) {


### PR DESCRIPTION
Hey team,

I'd like your thoughts on this one. 

Currently, `distinct` in functions is handled by rewriting the analyzed relation in ExpressionAnalyzer ([code](https://github.com/crate/crate/blob/efcdeb4397558b661b82bc183e4c9b33c10ba92e/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java#L291-L314)). For example, `select count(distinct col) from t` becomes `collection_count(collect_set(col))`.

The relation's output become an invariant that's checked in the LogicalPlanner ([code](https://github.com/crate/crate/blob/efcdeb4397558b661b82bc183e4c9b33c10ba92e/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java#L287-L288)). Whatever optimization is done, the outputs need to stay.

This is limits in certain cases when we optimize a plan, like in #19715 (check this [comment](https://github.com/crate/crate/pull/19715#discussion_r3544594476) out).

This PR is PoC that moves the handling of `distinct` to the planner. I've added comments here and there in the PR for what I think might be good discussions.