### PR TITLE
Use opaque index name for table partitions

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/create/TransportCreatePartitions.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/create/TransportCreatePartitions.java
@@ -89,6 +89,7 @@ import io.crate.metadata.doc.DocTableInfoFactory;
  */
 public class TransportCreatePartitions extends TransportMasterNodeAction<CreatePartitionsRequest, AcknowledgedResponse> {
 
+    private static final String INDEX_NAME_PREFIX = "in_";
     public static final Action ACTION = new Action();
 
     public static class Action extends ActionType<AcknowledgedResponse> {
@@ -238,7 +239,7 @@ public class TransportCreatePartitions extends TransportMasterNodeAction<CreateP
             RoutingTable.Builder routingTableBuilder = RoutingTable.builder(currentState.routingTable());
             ArrayList<String> indexUUIDs = new ArrayList<>(partitions.size());
             for (PartitionName partition : partitions) {
-                String indexName = partition.asIndexName();
+                String indexName = INDEX_NAME_PREFIX + UUIDs.randomBase64UUID();
                 String indexUUID = UUIDs.randomBase64UUID();
                 final IndexMetadata.Builder indexMetadataBuilder = IndexMetadata.builder(indexUUID)
                     .indexName(indexName)

--- a/server/src/test/java/io/crate/integrationtests/PartitionedTableConcurrentIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/PartitionedTableConcurrentIntegrationTest.java
@@ -57,7 +57,6 @@ import io.crate.common.unit.TimeValue;
 import io.crate.data.Bucket;
 import io.crate.data.CollectionBucket;
 import io.crate.data.Row;
-import io.crate.metadata.IndexName;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.RelationName;
 import io.crate.testing.SQLResponse;
@@ -154,7 +153,6 @@ public class PartitionedTableConcurrentIntegrationTest extends IntegTestCase {
                     }
                     String toNode = nodeSwap.get(shardRouting.currentNodeId());
 
-                    assert IndexName.decode(shardRouting.index().name()).table().equals("t") : "Must use index of `t` table";
                     execute(
                         "alter table t PARTITION (p = 'a') REROUTE MOVE SHARD ? FROM ? TO ?",
                         new Object[] { shardRouting.shardId().id(), shardRouting.currentNodeId(), toNode }

--- a/server/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
@@ -118,6 +118,24 @@ public class PartitionedTableIntegrationTest extends IntegTestCase {
         assertThat(response.rows()[1][0]).isEqualTo("04732e1g60qj0dpl6csjicpo");
     }
 
+    /// See https://github.com/crate/crate/pull/19734
+    @Test
+    public void test_rename_partitioned_table_and_insert_doesnt_result_in_duplicate_index_names() throws Exception {
+        execute("create table tbl1 (x int, p int) partitioned by (p)");
+        execute("create table tbl2 (x int, p int) partitioned by (p)");
+
+        execute("insert into tbl1 (x, p) values (1, 1)");
+        execute("alter cluster swap table tbl1 to tbl2");
+        execute("insert into tbl1 (x, p) values (1, 1)");
+
+        ClusterState state = clusterService().state();
+        long numUniqueIndexNames = state.metadata().indices().values().stream()
+            .map(imd -> imd.getIndex().name())
+            .distinct()
+            .count();
+        assertThat(numUniqueIndexNames).isEqualTo(2);
+    }
+
     @Test
     public void testCopyFromIntoPartitionedTable() throws Exception {
         execute("create table quotes (" +

--- a/server/src/test/java/io/crate/integrationtests/SchemaAndRelationNamesIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SchemaAndRelationNamesIntegrationTest.java
@@ -60,9 +60,7 @@ public class SchemaAndRelationNamesIntegrationTest extends IntegTestCase {
         execute("CREATE FUNCTION \"_Abc\".func(string) RETURNS STRING LANGUAGE dummy_lang AS 'DUMMY EATS text'");
         execute("refresh table \"_Abc\".\"_T\"");
 
-        // check index/template names
         var meta = clusterService().state().metadata();
-        assertThat(meta.indices().values().iterator().next().getIndex().name()).isEqualTo("_Abc..partitioned._T.04132");
 
         // check viewMetadata names as well as its target query
         SchemaMetadata schemaMetadata = meta.schemas().get("_Abc");

--- a/server/src/test/java/io/crate/integrationtests/SnapshotRestoreIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SnapshotRestoreIntegrationTest.java
@@ -294,20 +294,17 @@ public class SnapshotRestoreIntegrationTest extends IntegTestCase {
         }
         assertThat(response.rowCount()).isEqualTo(1L);
 
-        execute("select unnest(concrete_indices) as idx, state from sys.snapshots order by 1, 2");
+        execute("select array_length(concrete_indices, 1) as idx, state from sys.snapshots order by 1, 2");
 
-        // Indices show up twice because the repos have the same fs path.
         if (singlePartition) {
             assertThat(response).hasRows(
-                "custom..partitioned.backmeup.04130| SUCCESS",
-                "custom..partitioned.backmeup.04130| SUCCESS"
+                "1| SUCCESS",
+                "1| SUCCESS"
             );
         } else {
             assertThat(response).hasRows(
-                "custom..partitioned.backmeup.04130| SUCCESS",
-                "custom..partitioned.backmeup.04130| SUCCESS",
-                "custom..partitioned.backmeup.046jcchm6krj4e1g60o30c0| SUCCESS",
-                "custom..partitioned.backmeup.046jcchm6krj4e1g60o30c0| SUCCESS"
+                "2| SUCCESS",
+                "2| SUCCESS"
             );
         }
     }
@@ -320,14 +317,7 @@ public class SnapshotRestoreIntegrationTest extends IntegTestCase {
         assertThat(response.rowCount()).isEqualTo(1L);
         execute("select unnest(concrete_indices) as idx, state from sys.snapshots order by 1");
         // All indices show up twice because the repos have the same fs path.
-        assertThat(response).hasRows(
-            "custom..partitioned.backmeup.04130| SUCCESS",
-            "custom..partitioned.backmeup.04130| SUCCESS",
-            "custom..partitioned.backmeup.046jcchm6krj4e1g60o30c0| SUCCESS",
-            "custom..partitioned.backmeup.046jcchm6krj4e1g60o30c0| SUCCESS",
-            "custom..partitioned.backmeup.04732d1k6ksj8c9n6go30c1g| SUCCESS",
-            "custom..partitioned.backmeup.04732d1k6ksj8c9n6go30c1g| SUCCESS"
-        );
+        assertThat(response).hasRowCount(6);
     }
 
     @Test

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/create/TransportCreatePartitionsTest.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/create/TransportCreatePartitionsTest.java
@@ -78,13 +78,8 @@ public class TransportCreatePartitionsTest extends IntegTestCase {
 
         assertThat(updatedMetadata.index(indexUUID).getRoutingNumShards()).isEqualTo(1024);
 
-        // CREATE TABLE statement assigns specific names to partitioned tables indices, all having template name as a prefix.
-        // See BoundCreateTable.templateName
-        String tableTemplateName = PartitionName.templateName("doc", "test");
-
         for (IndexMetadata imd : updatedMetadata.indices().values()) {
-            String indexName = imd.getIndex().name(); // Something like "partitioned.{table_name}.{part}
-            assertThat(PartitionName.templateName(indexName)).isEqualTo(tableTemplateName);
+            assertThat(imd.partitionValues()).isNotEmpty();
         }
     }
 


### PR DESCRIPTION
This will allow us to revert https://github.com/crate/crate/pull/19734
If we derive the index name for partitions from the relation name it can
happen that we end up with duplicate index names in the cluster state
which can break snapshots.

Long term goal would be to get rid of the index name altogether and only
have a UUID, but that requires more work.