### PR TITLE
Log transport-not-ready errors on debug instead of warn

### DIFF
--- a/server/src/main/java/io/crate/exceptions/TransportNotReady.java
+++ b/server/src/main/java/io/crate/exceptions/TransportNotReady.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.exceptions;
+
+public class TransportNotReady extends RuntimeException {
+
+    public TransportNotReady() {
+        super("transport not ready yet to handle incoming requests");
+    }
+
+    @Override
+    public synchronized Throwable fillInStackTrace() {
+        return this;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
+++ b/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
@@ -75,15 +75,16 @@ import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.monitor.jvm.JvmInfo;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.threadpool.ThreadPool;
-import io.crate.common.annotations.VisibleForTesting;
 
 import com.carrotsearch.hppc.IntHashSet;
 import com.carrotsearch.hppc.IntSet;
 
+import io.crate.common.annotations.VisibleForTesting;
 import io.crate.common.collections.Sets;
 import io.crate.common.exceptions.Exceptions;
 import io.crate.common.unit.TimeValue;
 import io.crate.concurrent.CountDown;
+import io.crate.exceptions.TransportNotReady;
 import io.crate.protocols.ConnectionStats;
 import io.crate.rest.action.HttpErrorStatus;
 import io.netty.channel.ChannelFuture;
@@ -617,6 +618,9 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
             }
         } else if (e instanceof StreamCorruptedException) {
             logger.warn(() -> new ParameterizedMessage("{}, [{}], closing connection", e.getMessage(), channel));
+            CloseableChannel.closeChannel(channel, false);
+        } else if (e instanceof TransportNotReady) {
+            logger.debug("{} [{}], closing connection", e.getMessage(), channel);
             CloseableChannel.closeChannel(channel, false);
         } else {
             logger.warn(() -> new ParameterizedMessage("exception caught on transport layer [{}], closing connection", channel), e);

--- a/server/src/main/java/org/elasticsearch/transport/TransportService.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportService.java
@@ -55,10 +55,11 @@ import org.elasticsearch.node.NodeClosedException;
 import org.elasticsearch.threadpool.Scheduler;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.jspecify.annotations.Nullable;
-import io.crate.common.annotations.VisibleForTesting;
 
+import io.crate.common.annotations.VisibleForTesting;
 import io.crate.common.io.IOUtils;
 import io.crate.common.unit.TimeValue;
+import io.crate.exceptions.TransportNotReady;
 import io.crate.protocols.ConnectionStats;
 
 public class TransportService extends AbstractLifecycleComponent implements TransportMessageListener, TransportConnectionListener {
@@ -682,7 +683,7 @@ public class TransportService extends AbstractLifecycleComponent implements Tran
     @Override
     public void onRequestReceived(long requestId, String action) {
         if (handleIncomingRequests.get() == false) {
-            throw new IllegalStateException("transport not ready yet to handle incoming requests");
+            throw new TransportNotReady();
         }
         if (tracerLog.isTraceEnabled()) {
             tracerLog.trace("[{}][{}] received request", requestId, action);


### PR DESCRIPTION
Other nodes can try to connect before the transport service is fully
initialized. That led to a scary looking warning in the logs that is
actually harmless as the other node will retry again.

This changes the log level for those races to debug.
