### PR TITLE
Remove index name decoding from table-upgrade sys check

### DIFF
--- a/server/src/main/java/io/crate/expression/reference/sys/check/cluster/TablesNeedUpgradeSysCheck.java
+++ b/server/src/main/java/io/crate/expression/reference/sys/check/cluster/TablesNeedUpgradeSysCheck.java
@@ -21,11 +21,14 @@
 
 package io.crate.expression.reference.sys.check.cluster;
 
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.concurrent.CompletableFuture;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.metadata.RelationMetadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
@@ -41,7 +44,7 @@ public class TablesNeedUpgradeSysCheck extends AbstractSysCheck {
         "The following tables need to be recreated for compatibility with future major versions of CrateDB: ";
 
     private final ClusterService clusterService;
-    private volatile Collection<String> tablesNeedUpgrade;
+    private volatile Collection<RelationName> tablesNeedUpgrade;
 
     @Inject
     public TablesNeedUpgradeSysCheck(ClusterService clusterService) {
@@ -56,18 +59,24 @@ public class TablesNeedUpgradeSysCheck extends AbstractSysCheck {
 
     @Override
     public CompletableFuture<?> computeResult() {
-        HashSet<String> fqTables = new HashSet<>();
-        for (IndexMetadata cursor : clusterService.state()
-            .metadata()
-            .indices()
-            .values()) {
+        ArrayList<RelationName> tables = new ArrayList<>();
+        Metadata metadata = clusterService.state().metadata();
 
-            if (cursor.getCreationVersion().major < org.elasticsearch.Version.CURRENT.major) {
-                fqTables.add(RelationName.fqnFromIndexName(cursor.getIndex().getName()));
+        table_loop:
+        for (var table : metadata.relations(RelationMetadata.Table.class)) {
+            for (String indexUUID : table.indexUUIDs()) {
+                IndexMetadata index = metadata.index(indexUUID);
+                if (index == null) {
+                    continue;
+                }
+                if (index.getCreationVersion().major < Version.CURRENT.major) {
+                    tables.add(table.name());
+                    continue table_loop;
+                }
             }
         }
-        tablesNeedUpgrade = fqTables;
-        return CompletableFuture.completedFuture(fqTables);
+        tablesNeedUpgrade = tables;
+        return CompletableFuture.completedFuture(tables);
     }
 
     @Override

--- a/server/src/test/java/io/crate/integrationtests/TablesNeedUpgradeSysCheckTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TablesNeedUpgradeSysCheckTest.java
@@ -21,6 +21,7 @@
 
 package io.crate.integrationtests;
 
+import static io.crate.testing.Asserts.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.elasticsearch.test.IntegTestCase;
@@ -33,5 +34,14 @@ public class TablesNeedUpgradeSysCheckTest extends IntegTestCase {
     public void test_4x_indices_not_supported() throws Exception {
         assertThatThrownBy(() -> startUpNodeWithDataDir("/indices/data_home/cratedata-4.3.0.zip"))
             .hasMessageContaining("was created with version [4.3.0] but the minimum compatible version is [5.0.0]");
+    }
+
+    @Test
+    public void test_shows_5x_needs_upgrade() throws Exception {
+        startUpNodeWithDataDir("/indices/data_home/cratedata-5.0-bebe506.zip");
+        execute("select * from sys.checks where id = 3");
+        assertThat(response).hasRows(
+            "The following tables need to be recreated for compatibility with future major versions of CrateDB: [doc.partitioned, doc.testing] https://cr8.is/d-cluster-check-3| 3| false| 1"
+        );
     }
 }


### PR DESCRIPTION
For 5.x indices the index name decoding is safe. This is merely future proofing.