### PR TITLE
Handle pre-6.3 tables with OID_UNASSIGNED in table lookups

### DIFF
--- a/docs/appendices/release-notes/6.3.7.rst
+++ b/docs/appendices/release-notes/6.3.7.rst
@@ -62,3 +62,8 @@ Fixes
 
 - Fixed an issue that caused casts of tables created before ``6.3`` to
   ``REGCLASS`` to incorrectly return ``0``.
+
+- Fixed an issue that caused
+  :ref:`pg_table_is_visible <scalar-pg_table_is_visible>` and
+  :ref:`has_table_privilege <scalar-has-table-priv>` to return incorrect
+  results for the table OID `0`.

--- a/docs/appendices/release-notes/6.4.2.rst
+++ b/docs/appendices/release-notes/6.4.2.rst
@@ -62,3 +62,8 @@ Fixes
 
 - Fixed an issue that caused casts of tables created before ``6.3`` to
   ``REGCLASS`` to incorrectly return ``0``.
+
+- Fixed an issue that caused
+  :ref:`pg_table_is_visible <scalar-pg_table_is_visible>` and
+  :ref:`has_table_privilege <scalar-has-table-priv>` to return incorrect
+  results for the table OID `0`.

--- a/server/src/main/java/io/crate/expression/scalar/HasTablePrivilegeFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/HasTablePrivilegeFunction.java
@@ -29,6 +29,8 @@ import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.Locale;
 
+import org.elasticsearch.cluster.metadata.Metadata;
+
 import io.crate.metadata.FunctionName;
 import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
@@ -66,7 +68,7 @@ public class HasTablePrivilegeFunction {
                                           Functions functions,
                                           SearchPath searchPath) {
         int tableOid = (int) table;
-        RelationName relationName = schemas.getRelationName(tableOid);
+        RelationName relationName = tableOid == Metadata.OID_UNASSIGNED ? null : schemas.getRelationName(tableOid);
         String tableFqn;
         if (relationName == null) {
             // Proceed to checkPrivileges with tableFqn as 'null' which will return 'true' for a superuser or a

--- a/server/src/main/java/io/crate/expression/scalar/postgres/PgTableIsVisibleFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/postgres/PgTableIsVisibleFunction.java
@@ -23,6 +23,8 @@ package io.crate.expression.scalar.postgres;
 
 import static io.crate.role.Permission.READ_WRITE_DEFINE;
 
+import org.elasticsearch.cluster.metadata.Metadata;
+
 import io.crate.data.Input;
 import io.crate.exceptions.RelationUnknown;
 import io.crate.expression.scalar.HasTablePrivilegeFunction;
@@ -73,7 +75,7 @@ public class PgTableIsVisibleFunction extends Scalar<Boolean, Integer> {
         }
 
         Schemas schemas = nodeContext.schemas();
-        RelationName relationName = schemas.getRelationName(tableOid);
+        RelationName relationName = tableOid == Metadata.OID_UNASSIGNED ? null : schemas.getRelationName(tableOid);
         if (relationName == null) {
             return false;
         }

--- a/server/src/main/java/io/crate/metadata/Schemas.java
+++ b/server/src/main/java/io/crate/metadata/Schemas.java
@@ -475,6 +475,11 @@ public class Schemas extends AbstractLifecycleComponent implements Iterable<Sche
         return viewInfo;
     }
 
+    /**
+     * Resolves a relation name by table OID.
+     *
+     * WARNING: All tables created before 6.3 are assigned OID_UNASSIGNED, and cannot be resolved by OID.
+     */
     @Nullable
     public RelationName getRelationName(int oid) {
         for (SchemaInfo schema : this) {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -1624,6 +1624,11 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata> {
         return getRelation(tableName) != null;
     }
 
+    /**
+     * Resolves a relation name by table OID.
+     *
+     * WARNING: All tables created before 6.3 are assigned OID_UNASSIGNED, and cannot be resolved by OID.
+     */
     public RelationName getRelationName(int tableOID) {
         RelationMetadata relationMetadata = getRelation(tableOID);
         if (relationMetadata == null) {
@@ -1643,10 +1648,14 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata> {
         return indexUUIDsRelations.get(indexUUID);
     }
 
+    /**
+     * Resolves relation metadata by table OID.
+     *
+     * WARNING: All tables created before 6.3 are assigned OID_UNASSIGNED, and cannot be resolved by OID.
+     */
     @Nullable
     @SuppressWarnings("unchecked")
     public <T extends RelationMetadata> T getRelation(int tableOID) {
-        assert tableOID > Metadata.OID_UNASSIGNED : "Invalid tableOID: " + tableOID;
         return (T) oidsRelations.get(tableOID);
     }
 


### PR DESCRIPTION
Please see this failure https://jenkins.crate.io/job/CrateDB/job/crate_on_pr/5598/testReport/ (this test only exists on `6.3` so only observed this while backporting https://github.com/crate/crate/pull/19721 - the issue was `Schemas.getRelationInfo(oid)` being added did not account for OID_UNASSIGNED):

```
io.crate.integrationtests.FixCorruptedMetadataCommandITest.test_swap_tables_does_not_affect_tables_with_identical_names_in_different_schemas(FixCorruptedMetadataCommandITest.java:359)
Caused by: java.lang.IllegalArgumentException: Can't convert "q" to boolean
	at io.crate.types.BooleanType.booleanFromString(BooleanType.java:234)
	at io.crate.types.BooleanType.implicitCast(BooleanType.java:211)
	at io.crate.types.BooleanType.implicitCast(BooleanType.java:50)
	at io.crate.execution.dml.Indexer$RefResolver.getImplementation(Indexer.java:210)
	at io.crate.execution.dml.Indexer$RefResolver.getImplementation(Indexer.java:141)
	at io.crate.expression.reference.GatheringRefResolver.getImplementation(GatheringRefResolver.java:41)
	at io.crate.expression.InputFactory$RefVisitor.visitReference(InputFactory.java:240)
	at io.crate.expression.InputFactory$RefVisitor.visitReference(InputFactory.java:223)
	at io.crate.metadata.SimpleReference.accept(SimpleReference.java:300)
	at io.crate.expression.InputFactory$Context.add(InputFactory.java:160)
	at io.crate.execution.dml.Indexer.addNotNullConstraints(Indexer.java:825)
	at io.crate.execution.dml.Indexer.createConstraintCheck(Indexer.java:1072)
	at io.crate.planner.operators.InsertFromValues.lambda$checkConstraints$0(InsertFromValues.java:506)
	at java.base/java.util.HashMap.computeIfAbsent(HashMap.java:1229)
	at io.crate.planner.operators.InsertFromValues.checkConstraints(InsertFromValues.java:504)
	at io.crate.planner.operators.InsertFromValues.lambda$executeOrFail$0(InsertFromValues.java:218)
	at io.crate.execution.engine.indexing.GroupRowsByShard.apply(GroupRowsByShard.java:170)
	at io.crate.planner.operators.InsertFromValues.executeOrFail(InsertFromValues.java:268)
	at io.crate.planner.Plan.execute(Plan.java:75)
	at io.crate.session.Session.singleExec(Session.java:930)
	at io.crate.session.Session.exec(Session.java:719)
	at io.crate.session.Session.triggerDeferredExecutions(Session.java:691)
	at io.crate.session.Session.sync(Session.java:628)
	at io.crate.testing.SQLTransportExecutor.execute(SQLTransportExecutor.java:313)
	at io.crate.testing.SQLTransportExecutor.execute(SQLTransportExecutor.java:289)
	... 5 more
```

It occurred because the table lookup was affected by multiple pre-6.3 tables assigned to OID_UNASSIGNED. 

As mentioned,

https://github.com/crate/crate/pull/19271#discussion_r3117570032
> all tableOID usage places need to be aware that it can be unassigned for old tables

I am extending all oid based table lookups to handle pre-6.3 tables with OID_UNASSIGNED.