### PR TITLE
Fix `<foreign-table>::regclass` to return OidHash instead of OID_UNASSIGNED

### DIFF
--- a/docs/appendices/release-notes/6.3.6.rst
+++ b/docs/appendices/release-notes/6.3.6.rst
@@ -55,3 +55,6 @@ Fixes
 
 - Fixed an issue that would throw an error when using :ref:`pg_sleep()
   <scalar-pg_sleep>` function in the ``SELECT`` clause.
+
+- Fixed an issue that caused casts of foreign tables to ``REGCLASS`` to
+  incorrectly return ``0``.

--- a/docs/appendices/release-notes/6.4.1.rst
+++ b/docs/appendices/release-notes/6.4.1.rst
@@ -55,3 +55,6 @@ Fixes
 
 - Fixed an issue that would throw an error when using :ref:`pg_sleep()
   <scalar-pg_sleep>` function in the ``SELECT`` clause.
+
+- Fixed an issue that caused casts of foreign tables to ``REGCLASS`` to
+  incorrectly return ``0``.

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/RelationMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/RelationMetadata.java
@@ -448,7 +448,7 @@ public sealed interface RelationMetadata extends Diffable<RelationMetadata>
 
         @Override
         public int oid() {
-            return Metadata.OID_UNASSIGNED;
+            return OidHash.relationOid(OidHash.Type.TABLE, name);
         }
 
         @Override

--- a/server/src/test/java/io/crate/types/RegclassTypeTest.java
+++ b/server/src/test/java/io/crate/types/RegclassTypeTest.java
@@ -25,6 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.assertj.core.api.Assertions;
 import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.indices.InvalidRelationName;
 import org.jspecify.annotations.Nullable;
 import org.junit.Test;
@@ -34,6 +35,7 @@ import io.crate.metadata.RelationLookup;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.SearchPath;
 import io.crate.metadata.settings.SessionSettings;
+import io.crate.testing.SQLExecutor;
 
 public class RegclassTypeTest extends DataTypeTestCase<Regclass> {
 
@@ -121,5 +123,17 @@ public class RegclassTypeTest extends DataTypeTestCase<Regclass> {
         Assertions.assertThatThrownBy(() -> RegclassType.INSTANCE.explicitCast("\"\"myTable\"\"", SESSION_SETTINGS, null))
             .isExactlyInstanceOf(InvalidRelationName.class)
             .hasMessageContaining("Relation name '\"\"myTable\"\"' is invalid");
+    }
+
+    @Test
+    public void test_cast_foreign_table() throws Exception {
+        Settings options = Settings.builder()
+            .put("url", "jdbc:postgresql://localhost:5432/")
+            .build();
+        var e = SQLExecutor.of(clusterService)
+            .addServer("pg", "jdbc", "crate", options)
+            .addForeignTable("create foreign table doc.tbl (x int) server pg options (schema_name 'doc')");
+        var regclass = RegclassType.INSTANCE.explicitCast("\"tbl\"", SESSION_SETTINGS, e.schemas());
+        assertThat(regclass.oid()).isEqualTo(-579575814);
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Follows https://github.com/crate/crate/pull/19112.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes.
       If you're an external contributor you can give yourself attribution and include your name and Github handle.
       e.g.:
       ```
       `John Doe <https://github.com/John_Doe>`_ added support for ...
       ```
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
