### PR TITLE
Rename and reallocate index names again for table swap/rename

### DIFF
--- a/docs/appendices/release-notes/6.3.6.rst
+++ b/docs/appendices/release-notes/6.3.6.rst
@@ -46,5 +46,12 @@ series.
 Fixes
 =====
 
+- Changed swap table and rename table operations to reallocate shards again -
+  reverting the change from 6.3.0. This will cause swap and rename operations to
+  interrupt in-progress snapshots again but solves an issue where creating
+  partitions on a previously swapped table could lead to duplicate index names
+  in the cluster, breaking snapshot functionality until a duplicate partition
+  was deleted again.
+
 - Fixed an issue that would throw an error when using :ref:`pg_sleep()
   <scalar-pg_sleep>` function in the ``SELECT`` clause.

--- a/docs/appendices/release-notes/6.4.1.rst
+++ b/docs/appendices/release-notes/6.4.1.rst
@@ -46,5 +46,12 @@ series.
 Fixes
 =====
 
+- Changed swap table and rename table operations to reallocate shards again -
+  reverting the change from 6.3.0. This will cause swap and rename operations to
+  interrupt in-progress snapshots again but solves an issue where creating
+  partitions on a previously swapped table could lead to duplicate index names
+  in the cluster, breaking snapshot functionality until a duplicate partition
+  was deleted again.
+
 - Fixed an issue that would throw an error when using :ref:`pg_sleep()
   <scalar-pg_sleep>` function in the ``SELECT`` clause.

--- a/server/src/main/java/io/crate/execution/ddl/SwapRelationsOperation.java
+++ b/server/src/main/java/io/crate/execution/ddl/SwapRelationsOperation.java
@@ -26,7 +26,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlocks;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
@@ -170,22 +169,19 @@ public class SwapRelationsOperation {
                 );
         }
 
-        boolean needIndexAndRoutingUpdate = state.nodes().getSmallestNonClientNodeVersion().before(Version.V_6_1_0);
-        if (needIndexAndRoutingUpdate) {
-            // Remove all involved indices first so that rename operations are independent of each other
-            for (RelationNameSwap swapAction : swapRelationsRequest.swapActions()) {
-                removeOccurrences(state, blocksBuilder, routingBuilder, updatedMetadata, swapAction.source());
-                removeOccurrences(state, blocksBuilder, routingBuilder, updatedMetadata, swapAction.target());
-            }
+        // Remove all involved indices first so that rename operations are independent of each other
+        for (RelationNameSwap swapAction : swapRelationsRequest.swapActions()) {
+            removeOccurrences(state, blocksBuilder, routingBuilder, updatedMetadata, swapAction.source());
+            removeOccurrences(state, blocksBuilder, routingBuilder, updatedMetadata, swapAction.target());
+        }
 
-            for (RelationNameSwap relationNameSwap : swapRelationsRequest.swapActions()) {
-                RelationName source = relationNameSwap.source();
-                RelationName target = relationNameSwap.target();
-                addSourceIndicesRenamedToTargetName(
-                    metadata, updatedMetadata, blocksBuilder, routingBuilder, source, target, newIndexNames::add);
-                addSourceIndicesRenamedToTargetName(
-                    metadata, updatedMetadata, blocksBuilder, routingBuilder, target, source, newIndexNames::add);
-            }
+        for (RelationNameSwap relationNameSwap : swapRelationsRequest.swapActions()) {
+            RelationName source = relationNameSwap.source();
+            RelationName target = relationNameSwap.target();
+            addSourceIndicesRenamedToTargetName(
+                metadata, updatedMetadata, blocksBuilder, routingBuilder, source, target, newIndexNames::add);
+            addSourceIndicesRenamedToTargetName(
+                metadata, updatedMetadata, blocksBuilder, routingBuilder, target, source, newIndexNames::add);
         }
 
         ClusterState stateAfterSwap = applyClusterStateModifiers(
@@ -196,9 +192,7 @@ public class SwapRelationsOperation {
                 .build(),
             swapRelationsRequest.swapActions()
         );
-        ClusterState reroutedState = needIndexAndRoutingUpdate
-            ? allocationService.reroute(stateAfterSwap, "indices name switch")
-            : stateAfterSwap;
+        ClusterState reroutedState = allocationService.reroute(stateAfterSwap, "indices name switch");
         return new UpdatedState(reroutedState, newIndexNames);
     }
 

--- a/server/src/main/java/io/crate/metadata/cluster/RenameTableClusterStateExecutor.java
+++ b/server/src/main/java/io/crate/metadata/cluster/RenameTableClusterStateExecutor.java
@@ -26,7 +26,6 @@ import java.util.Locale;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlocks;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
@@ -110,37 +109,34 @@ public class RenameTableClusterStateExecutor {
                 table.oid()
             );
 
-        boolean needIndexAndRoutingUpdate = currentState.nodes().getSmallestNonClientNodeVersion().before(Version.V_6_1_0);
         RoutingTable.Builder newRoutingTable = null;
-        if (needIndexAndRoutingUpdate) {
-            newRoutingTable = RoutingTable.builder(currentState.routingTable());
-            List<IndexMetadata> sourceIndices = currentState.metadata().getIndices(source, List.of(), true, x -> x);
-            for (IndexMetadata sourceIndex : sourceIndices) {
-                String sourceIndexUUID = sourceIndex.getIndexUUID();
-                String targetIndexName;
-                if (sourceIndex.partitionValues().isEmpty()) {
-                    targetIndexName = target.indexNameOrAlias();
-                } else {
-                    PartitionName newPartitionName = new PartitionName(target, sourceIndex.partitionValues());
-                    targetIndexName = newPartitionName.asIndexName();
-                }
-
-                newMetadata.remove(sourceIndexUUID);
-                newRoutingTable.remove(sourceIndexUUID);
-                blocksBuilder.removeIndexBlocks(sourceIndexUUID);
-
-                IndexMetadata targetMd = IndexMetadata.builder(sourceIndex)
-                    .indexName(targetIndexName)
-                    .build();
-                newMetadata.put(targetMd, true);
-                newRoutingTable.addAsFromCloseToOpen(targetMd);
-                blocksBuilder.addBlocks(targetMd);
+        newRoutingTable = RoutingTable.builder(currentState.routingTable());
+        List<IndexMetadata> sourceIndices = currentState.metadata().getIndices(source, List.of(), true, x -> x);
+        for (IndexMetadata sourceIndex : sourceIndices) {
+            String sourceIndexUUID = sourceIndex.getIndexUUID();
+            String targetIndexName;
+            if (sourceIndex.partitionValues().isEmpty()) {
+                targetIndexName = target.indexNameOrAlias();
+            } else {
+                PartitionName newPartitionName = new PartitionName(target, sourceIndex.partitionValues());
+                targetIndexName = newPartitionName.asIndexName();
             }
+
+            newMetadata.remove(sourceIndexUUID);
+            newRoutingTable.remove(sourceIndexUUID);
+            blocksBuilder.removeIndexBlocks(sourceIndexUUID);
+
+            IndexMetadata targetMd = IndexMetadata.builder(sourceIndex)
+                .indexName(targetIndexName)
+                .build();
+            newMetadata.put(targetMd, true);
+            newRoutingTable.addAsFromCloseToOpen(targetMd);
+            blocksBuilder.addBlocks(targetMd);
         }
 
         ClusterState clusterStateAfterRename = ClusterState.builder(currentState)
             .metadata(newMetadata)
-            .routingTable(needIndexAndRoutingUpdate ? newRoutingTable.build() : currentState.routingTable())
+            .routingTable(newRoutingTable.build())
             .blocks(blocksBuilder)
             .build();
 

--- a/server/src/test/java/org/elasticsearch/snapshots/ConcurrentSnapshotsIT.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/ConcurrentSnapshotsIT.java
@@ -22,6 +22,7 @@
 package org.elasticsearch.snapshots;
 
 import static io.crate.testing.Asserts.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.assertj.core.api.InstanceOfAssertFactories.THROWABLE;
 import static org.elasticsearch.snapshots.SnapshotsService.MAX_CONCURRENT_SNAPSHOT_OPERATIONS_SETTING;
@@ -66,6 +67,7 @@ import org.elasticsearch.test.disruption.NetworkDisruption;
 import org.elasticsearch.test.transport.MockTransportService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.threadpool.ThreadPoolStats;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import io.crate.common.concurrent.CompletableFutures;
@@ -365,10 +367,18 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
         unblockNode(repoName, dataNode);
         assertThat(snapshot).succeedsWithin(5, TimeUnit.SECONDS);
         SnapshotInfo snapshotInfo = snapshot.join();
-        assertThat(snapshotInfo.state()).isEqualTo(SnapshotState.SUCCESS);
-        execute("drop table tbl1");
-        execute("drop table tbl2");
-        execute("restore snapshot r1.s1 ALL with (wait_for_completion = true)");
+        if (snapshotInfo.state() == SnapshotState.SUCCESS) {
+            execute("drop table tbl1");
+            execute("drop table tbl2");
+            execute("restore snapshot r1.s1 ALL with (wait_for_completion = true)");
+        } else if (snapshotInfo.state() == SnapshotState.FAILED) {
+            assertThat(snapshotInfo.reason()).isEqualTo("aborted");
+        } else {
+            assertThat(snapshotInfo.shardFailures()).isNotEmpty();
+            for (SnapshotShardFailure shardFailures : snapshotInfo.shardFailures()) {
+                assertThat(shardFailures.reason()).isEqualTo("aborted");
+            }
+        }
 
         // can still create new snapshots after
         execute("create snapshot r1.s2 all with (wait_for_completion = true)");
@@ -386,6 +396,7 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
     }
 
     @Test
+    @Ignore
     public void test_swap_table_after_snapshot_blocked_on_index_file() throws Exception {
         String masterNode = cluster().startMasterOnlyNode();
         cluster().startDataOnlyNode();
@@ -409,6 +420,7 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
     }
 
     @Test
+    @Ignore
     public void test_rename_table_after_snapshot_blocked_on_data_node() throws Exception {
         cluster().startMasterOnlyNode();
         String dataNode = cluster().startDataOnlyNode();


### PR DESCRIPTION
It was possible to end up with duplicate index names in the cluster if
creating a partition on a swapped table:

    create table tbl1 (x int, p int) partitioned by (p);
    create table tbl2 (x int, p int) partitioned by (p);
    insert into tbl1 (x, p) values (1, 1);
    alter cluster swap table tbl1 to tbl2;
    insert into tbl1 (x, p) values (1, 1);

This would then break the snapshot functionality, leading to errors
like:

    java.lang.IllegalStateException: Duplicate key foo..partitioned.tbl.ident (attempted merging values [foo..partitioned.tbl.ident/HPt5VVqgRqi31lldo6Kl-Q] and [foo..partitioned.tbl.ident/VQ3-qi4ESoqXnS_j9QrMNA])
    at java.base/java.util.stream.Collectors.duplicateKeyException(Collectors.java:135)
    at org.elasticsearch.snapshots.SnapshotShardsService.lambda$startNewShards$0(SnapshotShardsService.java:250)

To fix this properly we'll probably need to move away from deriving the
index name from the table (https://github.com/crate/crate/pull/19726)

But given the scope of that change, and given that there are/were a few
more index name decoding issues, this opts to rename the names again for
the hotfix
