### PR TITLE
Fix INSERT into wrong table due to concurrent SWAP TABLE

### DIFF
--- a/docs/appendices/release-notes/6.3.7.rst
+++ b/docs/appendices/release-notes/6.3.7.rst
@@ -46,6 +46,9 @@ series.
 Fixes
 =====
 
+- Fixed a rare issue where ``INSERT`` statements running concurrently with
+  ``SWAP TABLE`` could insert data into the wrong table.
+
 - Fixed an issue that could cause a :ref:`CREATE ANALYZER <ref-create-analyzer>`
   statement to not preserve the order of ``TOKEN_FILTERS`` and ``CHAR_FILTERS``.
   As the filters are applied as an ordered chain, this could silently change

--- a/docs/appendices/release-notes/6.4.2.rst
+++ b/docs/appendices/release-notes/6.4.2.rst
@@ -46,6 +46,9 @@ series.
 Fixes
 =====
 
+- Fixed a rare issue where ``INSERT`` statements running concurrently with
+  ``SWAP TABLE`` could insert data into the wrong table.
+
 - Fixed an issue that could cause a :ref:`CREATE ANALYZER <ref-create-analyzer>`
   statement to not preserve the order of ``TOKEN_FILTERS`` and ``CHAR_FILTERS``.
   As the filters are applied as an ordered chain, this could silently change

--- a/server/src/main/java/io/crate/execution/dsl/projection/AbstractIndexWriterProjection.java
+++ b/server/src/main/java/io/crate/execution/dsl/projection/AbstractIndexWriterProjection.java
@@ -25,6 +25,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Setting;
@@ -53,6 +55,7 @@ public abstract class AbstractIndexWriterProjection extends Projection {
 
     private final int bulkActions;
     protected RelationName relationName;
+    protected int tableOid;
     protected String partitionIdent;
     protected List<ColumnIdent> primaryKeys;
 
@@ -69,6 +72,7 @@ public abstract class AbstractIndexWriterProjection extends Projection {
 
 
     protected AbstractIndexWriterProjection(RelationName relationName,
+                                            int tableOid,
                                             @Nullable String partitionIdent,
                                             List<ColumnIdent> primaryKeys,
                                             @Nullable ColumnIdent clusteredByColumn,
@@ -76,6 +80,7 @@ public abstract class AbstractIndexWriterProjection extends Projection {
                                             List<Symbol> idSymbols,
                                             boolean autoCreateIndices) {
         this.relationName = relationName;
+        this.tableOid = tableOid;
         this.partitionIdent = partitionIdent;
         this.primaryKeys = primaryKeys;
         this.clusteredByColumn = clusteredByColumn;
@@ -90,6 +95,12 @@ public abstract class AbstractIndexWriterProjection extends Projection {
 
     protected AbstractIndexWriterProjection(StreamInput in) throws IOException {
         relationName = new RelationName(in);
+        if ((in.getVersion().before(Version.V_6_4_0) && in.getVersion().onOrAfter(Version.V_6_3_7))
+            || in.getVersion().onOrAfter(Version.V_6_4_2)) {
+            tableOid = in.readInt();
+        } else {
+            tableOid = Metadata.OID_UNASSIGNED;
+        }
 
         partitionIdent = in.readOptionalString();
         idSymbols = Symbols.fromStream(in);
@@ -149,6 +160,10 @@ public abstract class AbstractIndexWriterProjection extends Projection {
         return relationName;
     }
 
+    public int tableOid() {
+        return tableOid;
+    }
+
     @Nullable
     public String partitionIdent() {
         return partitionIdent;
@@ -174,6 +189,7 @@ public abstract class AbstractIndexWriterProjection extends Projection {
             return false;
         if (!primaryKeys.equals(that.primaryKeys)) return false;
         if (!relationName.equals(that.relationName)) return false;
+        if (tableOid != that.tableOid) return false;
         if (partitionIdent != null ? !partitionIdent.equals(that.partitionIdent) : that.partitionIdent != null)
             return false;
 
@@ -185,6 +201,7 @@ public abstract class AbstractIndexWriterProjection extends Projection {
         int result = super.hashCode();
         result = 31 * result + Integer.hashCode(bulkActions);
         result = 31 * result + relationName.hashCode();
+        result = 31 * result + tableOid;
         result = 31 * result + (partitionIdent != null ? partitionIdent.hashCode() : 0);
         result = 31 * result + primaryKeys.hashCode();
         result = 31 * result + (clusteredByColumn != null ? clusteredByColumn.hashCode() : 0);
@@ -198,6 +215,10 @@ public abstract class AbstractIndexWriterProjection extends Projection {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         relationName.writeTo(out);
+        if ((out.getVersion().before(Version.V_6_4_0) && out.getVersion().onOrAfter(Version.V_6_3_7))
+            || out.getVersion().onOrAfter(Version.V_6_4_2)) {
+            out.writeInt(tableOid);
+        }
         out.writeOptionalString(partitionIdent);
 
         Symbols.toStream(idSymbols, out);

--- a/server/src/main/java/io/crate/execution/dsl/projection/ColumnIndexWriterProjection.java
+++ b/server/src/main/java/io/crate/execution/dsl/projection/ColumnIndexWriterProjection.java
@@ -67,6 +67,7 @@ public class ColumnIndexWriterProjection extends AbstractIndexWriterProjection {
      * @param onDuplicateKeyAssignments reference to symbol map used for update on duplicate key
      */
     public ColumnIndexWriterProjection(RelationName relationName,
+                                       int tableOid,
                                        @Nullable String partitionIdent,
                                        List<ColumnIdent> primaryKeys,
                                        List<Reference> allTargetColumns,
@@ -82,7 +83,7 @@ public class ColumnIndexWriterProjection extends AbstractIndexWriterProjection {
                                        List<Symbol> returnValues,
                                        long fullDocSizeEstimate) {
 
-        super(relationName, partitionIdent, primaryKeys, clusteredByColumn, settings, primaryKeySymbols, autoCreateIndices);
+        super(relationName, tableOid, partitionIdent, primaryKeys, clusteredByColumn, settings, primaryKeySymbols, autoCreateIndices);
         assert partitionedBySymbols.stream().noneMatch(s -> s.any(Symbol.IS_COLUMN))
             : "All references and fields in partitionedBySymbols must be resolved to inputColumns, got: " + partitionedBySymbols;
         this.allTargetColumns = allTargetColumns;
@@ -274,6 +275,7 @@ public class ColumnIndexWriterProjection extends AbstractIndexWriterProjection {
 
         return new ColumnIndexWriterProjection(
             tableIdent(),
+            tableOid(),
             null,
             primaryKeys,
             allTargetColumns,

--- a/server/src/main/java/io/crate/execution/dsl/projection/SourceIndexWriterProjection.java
+++ b/server/src/main/java/io/crate/execution/dsl/projection/SourceIndexWriterProjection.java
@@ -58,6 +58,7 @@ public class SourceIndexWriterProjection extends AbstractIndexWriterProjection {
     private final String[] excludes;
 
     public SourceIndexWriterProjection(RelationName relationName,
+                                       int tableOid,
                                        @Nullable String partitionIdent,
                                        Reference rawSourceReference,
                                        InputColumn rawSourcePtr,
@@ -70,7 +71,7 @@ public class SourceIndexWriterProjection extends AbstractIndexWriterProjection {
                                        @Nullable Symbol clusteredBySymbol,
                                        List<? extends Symbol> outputs,
                                        boolean autoCreateIndices) {
-        super(relationName, partitionIdent, primaryKeys, clusteredByColumn, settings, idSymbols, autoCreateIndices);
+        super(relationName, tableOid, partitionIdent, primaryKeys, clusteredByColumn, settings, idSymbols, autoCreateIndices);
         this.rawSourceReference = rawSourceReference;
         this.excludes = excludes;
         this.partitionedBySymbols = partitionedBySymbols;

--- a/server/src/main/java/io/crate/execution/dsl/projection/SourceIndexWriterReturnSummaryProjection.java
+++ b/server/src/main/java/io/crate/execution/dsl/projection/SourceIndexWriterReturnSummaryProjection.java
@@ -44,6 +44,7 @@ public class SourceIndexWriterReturnSummaryProjection extends SourceIndexWriterP
     private final InputColumn lineNumber;
 
     public SourceIndexWriterReturnSummaryProjection(RelationName relationName,
+                                                    int tableOid,
                                                     @Nullable String partitionIdent,
                                                     Reference rawSourceReference,
                                                     InputColumn rawSourcePtr,
@@ -60,7 +61,7 @@ public class SourceIndexWriterReturnSummaryProjection extends SourceIndexWriterP
                                                     InputColumn sourceUriFailure,
                                                     InputColumn sourceParsingFailure,
                                                     InputColumn lineNumber) {
-        super(relationName,partitionIdent, rawSourceReference, rawSourcePtr, primaryKeys, partitionedBySymbols,
+        super(relationName, tableOid, partitionIdent, rawSourceReference, rawSourcePtr, primaryKeys, partitionedBySymbols,
             clusteredByColumn, settings, excludes, idSymbols, clusteredBySymbol, outputs, autoCreateIndices);
         this.sourceUri = sourceUri;
         this.sourceUriFailure = sourceUriFailure;

--- a/server/src/main/java/io/crate/metadata/Schemas.java
+++ b/server/src/main/java/io/crate/metadata/Schemas.java
@@ -504,6 +504,36 @@ public class Schemas extends AbstractLifecycleComponent implements Iterable<Sche
     }
 
     /**
+     * Returns the RelationInfo for the given persisted OID.
+     * <p>
+     * Persisted relation OIDs were introduced in 6.3. Callers must handle
+     * relations created before 6.3 separately.
+     */
+    @SuppressWarnings("unchecked")
+    public <T extends RelationInfo> T getRelationInfo(int persistedOid) {
+        assert persistedOid > Metadata.OID_UNASSIGNED && persistedOid <= clusterService.state().metadata().currentMaxTableOid() :
+            "persisted table OID must be > OID_UNASSIGNED and <= currentMaxTableOid";
+        for (SchemaInfo schema : this) {
+            for (RelationInfo relation : schema.getTables()) {
+                if (persistedOid == relation.oid()) {
+                    return (T) relation;
+                }
+            }
+            for (ViewInfo view : schema.getViews()) {
+                if (persistedOid == view.oid()) {
+                    return (T) view;
+                }
+            }
+            for (RelationMetadata.ForeignTable foreignTable : schema.getForeignTables()) {
+                if (persistedOid == foreignTable.oid()) {
+                    return (T) foreignTable;
+                }
+            }
+        }
+        throw new RelationUnknown(String.format(Locale.ENGLISH, "Relation not found for oid=%s", persistedOid));
+    }
+
+    /**
      * Returns the OID assigned to the given relation.
      *
      * WARNING: All tables created before 6.3 are assigned OID_UNASSIGNED internally, meaning that all execution paths

--- a/server/src/main/java/io/crate/planner/consumer/InsertFromSubQueryPlanner.java
+++ b/server/src/main/java/io/crate/planner/consumer/InsertFromSubQueryPlanner.java
@@ -52,6 +52,7 @@ public final class InsertFromSubQueryPlanner {
 
         ColumnIndexWriterProjection indexWriterProjection = new ColumnIndexWriterProjection(
             statement.tableInfo().ident(),
+            statement.tableInfo().oid(),
             null,
             statement.tableInfo().primaryKey(),
             statement.columns(),

--- a/server/src/main/java/io/crate/planner/operators/InsertFromValues.java
+++ b/server/src/main/java/io/crate/planner/operators/InsertFromValues.java
@@ -139,9 +139,13 @@ public class InsertFromValues implements LogicalPlan {
                               RowConsumer consumer,
                               Row params,
                               SubQueryResults subQueryResults) {
-        DocTableInfo tableInfo = dependencies
-            .schemas()
-            .getTableInfo(writerProjection.tableIdent());
+        int tableOid = writerProjection.tableOid();
+        DocTableInfo tableInfo;
+        if (tableOid == Metadata.OID_UNASSIGNED) {
+            tableInfo = dependencies.schemas().getTableInfo(writerProjection.tableIdent());
+        } else {
+            tableInfo = dependencies.schemas().getRelationInfo(writerProjection.tableOid());
+        }
 
         // For instance, the target table of the insert from values
         // statement is the table with the following schema:
@@ -284,7 +288,7 @@ public class InsertFromValues implements LogicalPlan {
             var shardUpsertRequests = resolveAndGroupShardRequests(
                 shardedRequests,
                 dependencies.clusterService(),
-                tableInfo.oid()
+                writerProjection.tableOid()
             ).values();
             return execute(
                 dependencies.nodeLimits(),
@@ -312,9 +316,13 @@ public class InsertFromValues implements LogicalPlan {
                                                        PlannerContext plannerContext,
                                                        List<Row> bulkParams,
                                                        SubQueryResults subQueryResults) {
-        final DocTableInfo tableInfo = dependencies
-            .schemas()
-            .getTableInfo(writerProjection.tableIdent());
+        int tableOid = writerProjection.tableOid();
+        DocTableInfo tableInfo;
+        if (tableOid == Metadata.OID_UNASSIGNED) {
+            tableInfo = dependencies.schemas().getTableInfo(writerProjection.tableIdent());
+        } else {
+            tableInfo = dependencies.schemas().getRelationInfo(writerProjection.tableOid());
+        }
 
         String[] updateColumnNames;
         Assignments assignments;
@@ -754,9 +762,10 @@ public class InsertFromValues implements LogicalPlan {
                                                                             Set<PartitionName> partitions,
                                                                             ClusterService clusterService) {
         List<PartitionName> partitionsToCreate = new ArrayList<>();
+        Metadata metadata = clusterService.state().metadata();
         for (var partition : partitions) {
-            String indexUUID = clusterService.state().metadata()
-                .getIndex(tableInfo.ident(), partition.values(), true, IndexMetadata::getIndexUUID);
+            String indexUUID =
+                metadata.getIndex(tableInfo.ident(), partition.values(), true, IndexMetadata::getIndexUUID);
             if (indexUUID == null) {
                 partitionsToCreate.add(partition);
             }

--- a/server/src/main/java/io/crate/planner/statement/CopyFromPlan.java
+++ b/server/src/main/java/io/crate/planner/statement/CopyFromPlan.java
@@ -262,6 +262,7 @@ public final class CopyFromPlan implements Plan {
 
             sourceIndexWriterProjection = new SourceIndexWriterReturnSummaryProjection(
                 table.ident(),
+                table.oid(),
                 partitionIdent,
                 table.getReference(SysColumns.RAW),
                 new InputColumn(rawOrDocIdx, rawOrDoc.valueType()),
@@ -282,6 +283,7 @@ public final class CopyFromPlan implements Plan {
         } else {
             sourceIndexWriterProjection = new SourceIndexWriterProjection(
                 table.ident(),
+                table.oid(),
                 partitionIdent,
                 table.getReference(SysColumns.RAW),
                 new InputColumn(rawOrDocIdx, rawOrDoc.valueType()),

--- a/server/src/main/java/org/elasticsearch/Version.java
+++ b/server/src/main/java/org/elasticsearch/Version.java
@@ -244,9 +244,11 @@ public class Version implements Comparable<Version> {
     public static final Version V_6_3_4 = new Version(9_03_04_99, false, org.apache.lucene.util.Version.LUCENE_10_4_0);
     public static final Version V_6_3_5 = new Version(9_03_05_99, false, org.apache.lucene.util.Version.LUCENE_10_4_0);
     public static final Version V_6_3_6 = new Version(9_03_06_99, false, org.apache.lucene.util.Version.LUCENE_10_4_0);
+    public static final Version V_6_3_7 = new Version(9_03_07_99, true, org.apache.lucene.util.Version.LUCENE_10_4_0);
 
     public static final Version V_6_4_0 = new Version(9_04_00_99, false, org.apache.lucene.util.Version.LUCENE_10_4_0);
     public static final Version V_6_4_1 = new Version(9_04_01_99, false, org.apache.lucene.util.Version.LUCENE_10_4_0);
+    public static final Version V_6_4_2 = new Version(9_04_02_99, true, org.apache.lucene.util.Version.LUCENE_10_4_0);
 
     public static final Version V_6_5_0 = new Version(9_05_00_99, true, org.apache.lucene.util.Version.LUCENE_10_5_0);
 

--- a/server/src/test/java/io/crate/execution/dsl/projection/ColumnIndexWriterProjectionTest.java
+++ b/server/src/test/java/io/crate/execution/dsl/projection/ColumnIndexWriterProjectionTest.java
@@ -22,6 +22,7 @@
 package io.crate.execution.dsl.projection;
 
 import static io.crate.testing.Asserts.assertThat;
+import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -59,6 +60,7 @@ public class ColumnIndexWriterProjectionTest {
         }
         var projection = new ColumnIndexWriterProjection(
             relationName,
+            OID_UNASSIGNED,
             null,
             List.of(),
             targetColumns,

--- a/server/src/test/java/io/crate/execution/dsl/projection/SourceIndexWriterProjectionSerializationTest.java
+++ b/server/src/test/java/io/crate/execution/dsl/projection/SourceIndexWriterProjectionSerializationTest.java
@@ -75,6 +75,7 @@ public class SourceIndexWriterProjectionSerializationTest {
         // fail_fast property set to true
         SourceIndexWriterProjection expected = new SourceIndexWriterProjection(
             relationName,
+            OID_UNASSIGNED,
             partitionIdent,
             reference,
             inputColumn,

--- a/server/src/test/java/io/crate/integrationtests/PartitionedTableConcurrentIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/PartitionedTableConcurrentIntegrationTest.java
@@ -570,8 +570,7 @@ public class PartitionedTableConcurrentIntegrationTest extends IntegTestCase {
         Thread t2 = new Thread(() -> {
             try {
                 barrier.await();
-                for (int i = 0; i < 3; i++) {
-                    Thread.sleep(300); // to prevent swap queries to go through at once
+                for (int i = 0; i < 7; i++) {
                     execute("ALTER CLUSTER SWAP TABLE t1 TO t2");
                     if (t1.isAlive()) {
                         swapInterleaved[0] = true;


### PR DESCRIPTION
Once an INSERT is analyzed, the table OID captured must be used for subsequent table lookups throughout the execution for consistency.

## Summary of the changes / Why this improves CrateDB
Second attempt of https://github.com/crate/crate/pull/19716 which did not take into account for pre-6.3 tables with OID_UNASSIGNED.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes.
       If you're an external contributor you can give yourself attribution and include your name and Github handle.
       e.g.:
       ```
       `John Doe <https://github.com/John_Doe>`_ added support for ...
       ```
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
