### PR TITLE
Recommend setting `cluster.routing.allocation.enable` to `primaries` for safe rolling upgrades

### DIFF
--- a/docs/config/cluster.rst
+++ b/docs/config/cluster.rst
@@ -604,13 +604,13 @@ Routing allocation
 
   ``primaries`` only primaries can be moved or created. This includes existing
   primary shards.
+  Whenever you want to perform a zero-downtime upgrade of your cluster you need
+  to set this value before gracefully stopping the first node and reset it to
+  ``all`` after starting the last updated node.
 
   ``new_primaries`` allows allocations for new primary shards only. This means
   that for example a newly added node will not allocate any replicas. However
-  it is still possible to allocate new primary shards for new indices. Whenever
-  you want to perform a zero downtime upgrade of your cluster you need to set
-  this value before gracefully stopping the first node and reset it to ``all``
-  after starting the last updated node.
+  it is still possible to allocate new primary shards for new indices.
 
 .. NOTE::
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

See #19751 for a reproduction where setting `cluster.routing.allocation.enable` to `new_primaries` causes unavailability of data during a rolling upgrade.

This change aligns with Elasticsearch [recommendations](https://www.elastic.co/docs/deploy-manage/upgrade/deployment-or-cluster/elasticsearch) that also use `primaries` during rolling upgrades.

Fixes #19751

## Checklist

 - [X] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes.
       If you're an external contributor you can give yourself attribution and include your name and Github handle.
       e.g.:
       ```
       `John Doe <https://github.com/John_Doe>`_ added support for ...
       ```
 - [X] Updated documentation & `sql_features` table for user facing changes
 - [X] Touched code is covered by tests
 - [X] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
