### PR TITLE
Fix `<pre-6.3-table>::regclass` to return OidHash instead of OID_UNASSIGNED

### DIFF
--- a/docs/appendices/release-notes/6.3.7.rst
+++ b/docs/appendices/release-notes/6.3.7.rst
@@ -48,3 +48,6 @@ Fixes
 
 - Fixed a rare issue that causes queries involving foreign tables to throw
   ``UnsupportedOperationException``.
+
+- Fixed an issue that caused casts of tables created before ``6.3`` to
+  ``REGCLASS`` to incorrectly return ``0``.

--- a/docs/appendices/release-notes/6.4.2.rst
+++ b/docs/appendices/release-notes/6.4.2.rst
@@ -48,3 +48,6 @@ Fixes
 
 - Fixed a rare issue that causes queries involving foreign tables to throw
   ``UnsupportedOperationException``.
+
+- Fixed an issue that caused casts of tables created before ``6.3`` to
+  ``REGCLASS`` to incorrectly return ``0``.

--- a/server/src/main/java/io/crate/metadata/RelationLookup.java
+++ b/server/src/main/java/io/crate/metadata/RelationLookup.java
@@ -25,7 +25,14 @@ import org.jspecify.annotations.Nullable;
 
 public interface RelationLookup {
 
-    int getRelationOid(RelationName relationName);
+    /**
+     * Returns the OID assigned to the given relation.
+     *
+     * WARNING: All tables created before 6.3 are assigned OID_UNASSIGNED internally, meaning that all execution paths
+     * must be aware of and properly handle duplicate assignments of OID_UNASSIGNED. When exposing OIDs, we must expose
+     * OidHash-based OIDs for backward compatibility.
+     */
+    int getDisplayRelationOid(RelationName relationName);
 
     @Nullable
     RelationName getRelationName(int oid);

--- a/server/src/main/java/io/crate/metadata/Schemas.java
+++ b/server/src/main/java/io/crate/metadata/Schemas.java
@@ -497,8 +497,29 @@ public class Schemas extends AbstractLifecycleComponent implements Iterable<Sche
         return null;
     }
 
-    public int getRelationOid(RelationName relationName) {
-        RelationMetadata relationMetadata = clusterService.state().metadata().getRelation(relationName);
-        return relationMetadata == null ? OidHash.relationOid(OidHash.Type.TABLE, relationName) : relationMetadata.oid();
+    /**
+     * Returns the OID assigned to the given relation.
+     *
+     * WARNING: All tables created before 6.3 are assigned OID_UNASSIGNED internally, meaning that all execution paths
+     * must be aware of and properly handle duplicate assignments of OID_UNASSIGNED. When exposing OIDs, we must expose
+     * OidHash-based OIDs for backward compatibility.
+     */
+    public int getDisplayRelationOid(RelationName relationName) {
+        SchemaInfo schemaInfo = this.getSchemaInfo(relationName.schema());
+        if (schemaInfo != null) {
+            String name = relationName.name();
+            RelationInfo relationInfo = schemaInfo.getViewInfo(name);
+            if (relationInfo == null) {
+                relationInfo = schemaInfo.getForeignTableInfo(name);
+                if (relationInfo == null) {
+                    relationInfo = schemaInfo.getTableInfo(name);
+                }
+            }
+            if (relationInfo != null) {
+                int oid = relationInfo.oid();
+                return oid == Metadata.OID_UNASSIGNED ? OidHash.relationOid(relationInfo) : oid;
+            }
+        }
+        return OidHash.relationOid(OidHash.Type.TABLE, relationName);
     }
 }

--- a/server/src/main/java/io/crate/metadata/doc/DocTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocTableInfo.java
@@ -1414,6 +1414,12 @@ public class DocTableInfo implements TableInfo, ShardedTable, StoredTable {
         return Lists.concat(Lists.concat(allColumns.values(), droppedColumns), indexColumns.values());
     }
 
+    /**
+     * Returns the persisted table OID.
+     *
+     * Tables created before 6.3 are assigned OID_UNASSIGNED. Use RelationLookup#getDisplayRelationOid when exposing
+     * relation OIDs to users.
+     */
     @Override
     public int oid() {
         return tableOID;

--- a/server/src/main/java/io/crate/protocols/postgres/types/RegclassType.java
+++ b/server/src/main/java/io/crate/protocols/postgres/types/RegclassType.java
@@ -83,7 +83,7 @@ public class RegclassType extends PGType<Regclass> {
         } catch (NumberFormatException e) {
             var indexParts = IndexName.decode(oidStr);
             RelationName relationName = indexParts.toRelationName();
-            int oid = relationLookup.getRelationOid(relationName);
+            int oid = relationLookup.getDisplayRelationOid(relationName);
             return new Regclass(oid, relationName.fqn());
         }
     }

--- a/server/src/main/java/io/crate/types/RegclassType.java
+++ b/server/src/main/java/io/crate/types/RegclassType.java
@@ -124,7 +124,7 @@ public final class RegclassType extends DataType<Regclass> implements Streamer<R
             try {
                 var qualifiedNameReference = (QualifiedNameReference) SqlParser.createExpression(s);
                 var relationName = RelationName.of(qualifiedNameReference.getName(), currentSchema);
-                return new Regclass(relationLookup.getRelationOid(relationName), relationName.fqn());
+                return new Regclass(relationLookup.getDisplayRelationOid(relationName), relationName.fqn());
             } catch (ParsingException e) {
                 throw new InvalidRelationName(s, e);
             }

--- a/server/src/test/java/io/crate/expression/scalar/postgres/PgTableIsVisibleFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/postgres/PgTableIsVisibleFunctionTest.java
@@ -68,7 +68,7 @@ public class PgTableIsVisibleFunctionTest extends ScalarTestCase {
         sqlExpressions = new SqlExpressions(tableSources, null, RolesHelper.userOf("dummy_user"), List.of(), schemas, searchPaths);
 
         final RelationName usersTable = new RelationName("my_schema", "my_table");
-        final int usersTableOid = schemas.getRelationOid(usersTable);
+        final int usersTableOid = schemas.getDisplayRelationOid(usersTable);
 
         assertEvaluate("pg_table_is_visible(" + usersTableOid + ")", false);
     }
@@ -92,7 +92,7 @@ public class PgTableIsVisibleFunctionTest extends ScalarTestCase {
             schemas,
             searchPaths);
         final RelationName usersTable = new RelationName("my_schema", "my_table");
-        final int usersTableOid = schemas.getRelationOid(usersTable);
+        final int usersTableOid = schemas.getDisplayRelationOid(usersTable);
         assertEvaluate("pg_table_is_visible(" + usersTableOid + ")", true);
 
         // DML
@@ -145,13 +145,13 @@ public class PgTableIsVisibleFunctionTest extends ScalarTestCase {
 
         // my_schema1.my_table is visible
         final RelationName mySchema1MyTable = new RelationName("my_schema1", "my_table");
-        final int mySchema1MyTableOid = schemas.getRelationOid(mySchema1MyTable);
+        final int mySchema1MyTableOid = schemas.getDisplayRelationOid(mySchema1MyTable);
         assertEvaluate("pg_table_is_visible(" + mySchema1MyTableOid + ")", true);
 
         // since my_schema1.my_table is visible(my_schema1 appears earlier in searchPaths),
         // my_schema2.my_table is not visible
         final RelationName mySchema2MyTable = new RelationName("my_schema2", "my_table");
-        final int mySchema2MyTableOid = schemas.getRelationOid(mySchema2MyTable);
+        final int mySchema2MyTableOid = schemas.getDisplayRelationOid(mySchema2MyTable);
         assertEvaluate("pg_table_is_visible(" + mySchema2MyTableOid + ")", false);
     }
 
@@ -177,12 +177,12 @@ public class PgTableIsVisibleFunctionTest extends ScalarTestCase {
 
         // my_schema1.my_table is NOT visible, user is missing privileges
         final RelationName mySchema1MyTable = new RelationName("my_schema1", "my_table");
-        final int mySchema1MyTableOid = schemas.getRelationOid(mySchema1MyTable);
+        final int mySchema1MyTableOid = schemas.getDisplayRelationOid(mySchema1MyTable);
         assertEvaluate("pg_table_is_visible(" + mySchema1MyTableOid + ")", false);
 
         // since my_schema1.my_table is NOT visible, my_schema2.my_table is visible
         final RelationName mySchema2MyTable = new RelationName("my_schema2", "my_table");
-        final int mySchema2MyTableOid = schemas.getRelationOid(mySchema2MyTable);
+        final int mySchema2MyTableOid = schemas.getDisplayRelationOid(mySchema2MyTable);
         assertEvaluate("pg_table_is_visible(" + mySchema2MyTableOid + ")", true);
     }
 }

--- a/server/src/test/java/io/crate/types/RegclassTypeTest.java
+++ b/server/src/test/java/io/crate/types/RegclassTypeTest.java
@@ -61,7 +61,7 @@ public class RegclassTypeTest extends DataTypeTestCase<Regclass> {
     public void test_cast_from_string_uses_current_schema() {
         RelationLookup relationLookup = new RelationLookup() {
             @Override
-            public int getRelationOid(RelationName relationName) {
+            public int getDisplayRelationOid(RelationName relationName) {
                 if (relationName.equals(new RelationName("my_schema", "my_table"))) {
                     return 123;
                 }
@@ -82,7 +82,7 @@ public class RegclassTypeTest extends DataTypeTestCase<Regclass> {
     public void test_cast_from_quoted_string_identifier() {
         RelationLookup relationLookup = new RelationLookup() {
             @Override
-            public int getRelationOid(RelationName relationName) {
+            public int getDisplayRelationOid(RelationName relationName) {
                 if (relationName.equals(new RelationName("doc", "my_table"))) {
                     return 123;
                 }
@@ -102,7 +102,7 @@ public class RegclassTypeTest extends DataTypeTestCase<Regclass> {
     public void test_cast_from_string_unquoted_ignores_capital_case() {
         RelationLookup relationLookup = new RelationLookup() {
             @Override
-            public int getRelationOid(RelationName relationName) {
+            public int getDisplayRelationOid(RelationName relationName) {
                 if (relationName.equals(new RelationName("doc", "my_table"))) {
                     return 123;
                 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Similar to https://github.com/crate/crate/pull/19733, we need to fix pre-6.3 tables. Internally they are mapped to OID_UNASSIGNED but must expose OidHash based OIDs not OID_UNASSIGNED.

Relates to https://github.com/crate/crate/pull/19732 which clarifies `oid > relationName` lookup for pre-6.3 OID_UNASSIGNED tables, while this PR is for `relationName > oid` lookup.

Thank you for catching @matriv . This PR is for https://github.com/crate/crate/pull/19732#issuecomment-4993783556. 

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes.
       If you're an external contributor you can give yourself attribution and include your name and Github handle.
       e.g.:
       ```
       `John Doe <https://github.com/John_Doe>`_ added support for ...
       ```
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
