### PR TITLE
Order operands lexicographically to remove symmetrical duplicates in join conditions

### DIFF
--- a/docs/appendices/release-notes/6.5.0.rst
+++ b/docs/appendices/release-notes/6.5.0.rst
@@ -80,6 +80,12 @@ Breaking Changes
   it interpreted ``65`` as a character sequence, resulting in a ``"65"``
   string.
 
+- The query plan that :ref:`EXPLAIN <ref-explain>` displays no longer shows
+  operands in the order as written in the query. This is because operands are
+  now normalized to be in lexicographic order. This enables deduplication of
+  symmetrical join conditions (i.e. ``a = b`` is identical to ``b = a``).
+  Query results are not affected.
+
 Deprecations
 ============
 

--- a/docs/sql/statements/explain.rst
+++ b/docs/sql/statements/explain.rst
@@ -46,31 +46,31 @@ optimizer. An example output looks like this::
     | STEP                                                 | QUERY PLAN                                                           |
     +------------------------------------------------------+----------------------------------------------------------------------+
     | Initial logical plan                                 | Eval[id] (rows=3)                                                    |
-    |                                                      |   └ Filter[((dept_id = id) AND (name = 'IT'))] (rows=3)              |
+    |                                                      |   └ Filter[((id = dept_id) AND (name = 'IT'))] (rows=3)              |
     |                                                      |     └ Join[CROSS] (rows=108)                                         |
     |                                                      |       ├ Collect[doc.employees | [id, dept_id] | true] (rows=18)      |
     |                                                      |       └ Collect[doc.departments | [id, name] | true] (rows=6)        |
     | optimizer_rewrite_filter_on_cross_join_to_inner_join | Eval[id] (rows=0)                                                    |
     |                                                      |   └ Filter[(name = 'IT')] (rows=0)                                   |
-    |                                                      |     └ Join[INNER | (dept_id = id)] (rows=3)                          |
+    |                                                      |     └ Join[INNER | (id = dept_id)] (rows=3)                          |
     |                                                      |       ├ Collect[doc.employees | [id, dept_id] | true] (rows=18)      |
     |                                                      |       └ Collect[doc.departments | [id, name] | true] (rows=6)        |
     | optimizer_move_filter_beneath_join                   | Eval[id] (rows=3)                                                    |
-    |                                                      |   └ Join[INNER | (dept_id = id)] (rows=3)                            |
+    |                                                      |   └ Join[INNER | (id = dept_id)] (rows=3)                            |
     |                                                      |     ├ Collect[doc.employees | [id, dept_id] | true] (rows=18)        |
     |                                                      |     └ Filter[(name = 'IT')] (rows=1)                                 |
     |                                                      |       └ Collect[doc.departments | [id, name] | true] (rows=6)        |
     | optimizer_rewrite_join_plan                          | Eval[id] (rows=3)                                                    |
-    |                                                      |   └ HashJoin[INNER | (dept_id = id)] (rows=3)                        |
+    |                                                      |   └ HashJoin[INNER | (id = dept_id)] (rows=3)                        |
     |                                                      |     ├ Collect[doc.employees | [id, dept_id] | true] (rows=18)        |
     |                                                      |     └ Filter[(name = 'IT')] (rows=1)                                 |
     |                                                      |       └ Collect[doc.departments | [id, name] | true] (rows=6)        |
     | optimizer_merge_filter_and_collect                   | Eval[id] (rows=3)                                                    |
-    |                                                      |   └ HashJoin[INNER | (dept_id = id)] (rows=3)                        |
+    |                                                      |   └ HashJoin[INNER | (id = dept_id)] (rows=3)                        |
     |                                                      |     ├ Collect[doc.employees | [id, dept_id] | true] (rows=18)        |
     |                                                      |     └ Collect[doc.departments | [id, name] | (name = 'IT')] (rows=1) |
     | Final logical plan                                   | Eval[id] (rows=3)                                                    |
-    |                                                      |   └ HashJoin[INNER | (dept_id = id)] (rows=3)                        |
+    |                                                      |   └ HashJoin[INNER | (id = dept_id)] (rows=3)                        |
     |                                                      |     ├ Collect[doc.employees | [id, dept_id] | true] (rows=18)        |
     |                                                      |     └ Collect[doc.departments | [id] | (name = 'IT')] (rows=1)       |
     +------------------------------------------------------+----------------------------------------------------------------------+

--- a/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import org.joda.time.Period;
 import org.jspecify.annotations.Nullable;
@@ -87,6 +88,7 @@ import io.crate.expression.scalar.timestamp.CurrentTimeFunction;
 import io.crate.expression.scalar.timestamp.CurrentTimestampFunction;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
+import io.crate.expression.symbol.ScopedColumn;
 import io.crate.expression.symbol.ScopedSymbol;
 import io.crate.expression.symbol.SelectSymbol;
 import io.crate.expression.symbol.Symbol;
@@ -190,6 +192,15 @@ public class ExpressionAnalyzer {
         ComparisonExpression.Type.GREATER_THAN_OR_EQUAL, ComparisonExpression.Type.LESS_THAN_OR_EQUAL,
         ComparisonExpression.Type.LESS_THAN_OR_EQUAL, ComparisonExpression.Type.GREATER_THAN_OR_EQUAL
     );
+
+    private static final Set<ComparisonExpression.Type> SWAPPABLE_EXPRESSIONS = Set
+            .of(ComparisonExpression.Type.EQUAL,
+                ComparisonExpression.Type.NOT_EQUAL,
+                ComparisonExpression.Type.LESS_THAN,
+                ComparisonExpression.Type.LESS_THAN_OR_EQUAL,
+                ComparisonExpression.Type.IS_DISTINCT_FROM,
+                ComparisonExpression.Type.GREATER_THAN,
+                ComparisonExpression.Type.GREATER_THAN_OR_EQUAL);
 
     private final CoordinatorTxnCtx coordinatorTxnCtx;
     private final ParamTypeHints paramTypeHints;
@@ -1438,14 +1449,29 @@ public class ExpressionAnalyzer {
         }
 
         /**
-         * swaps the comparison so that references and fields are on the left side.
+         * Canonicalizes the order of references and fields.
+         * Ensures that references and fields are on the left side.
          * e.g.:
          * eq(2, name)  becomes  eq(name, 2)
+         *
+         * If both sides are references, ensures they are in lexicographic order.
+         * e.g.: eq(y, x) becomes eq(x, y)
          */
         private void swapIfNecessary() {
-            if ((!(right instanceof Reference || right instanceof ScopedSymbol)
-                || left instanceof Reference || left instanceof ScopedSymbol)
-                && left.valueType().id() != DataTypes.UNDEFINED.id()) {
+            if (!SWAPPABLE_EXPRESSIONS.contains(comparisonExpressionType)) {
+                return;
+            }
+
+            boolean rightIsReference = right instanceof Reference || right instanceof ScopedSymbol;
+            boolean leftIsReference = left instanceof Reference || left instanceof ScopedSymbol;
+
+            if (rightIsReference && leftIsReference) {
+                ScopedColumn lhs = (ScopedColumn) left;
+                ScopedColumn rhs = (ScopedColumn) right;
+                if (lhs.compareTo(rhs) <= 0) {
+                    return;
+                }
+            } else if ((!rightIsReference || leftIsReference) && left.valueType().id() != DataTypes.UNDEFINED.id()) {
                 return;
             }
             ComparisonExpression.Type type = SWAP_OPERATOR_TABLE.get(comparisonExpressionType);

--- a/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
@@ -1458,14 +1458,12 @@ public class ExpressionAnalyzer {
          * e.g.: eq(y, x) becomes eq(x, y)
          */
         private void swapIfNecessary() {
-            if (!SWAPPABLE_EXPRESSIONS.contains(comparisonExpressionType)) {
-                return;
-            }
-
-            boolean rightIsReference = right instanceof Reference || right instanceof ScopedSymbol;
-            boolean leftIsReference = left instanceof Reference || left instanceof ScopedSymbol;
-
+            boolean rightIsReference = right instanceof ScopedColumn;
+            boolean leftIsReference = left instanceof ScopedColumn;
             if (rightIsReference && leftIsReference) {
+                if (!SWAPPABLE_EXPRESSIONS.contains(comparisonExpressionType)) {
+                    return;
+                }
                 ScopedColumn lhs = (ScopedColumn) left;
                 ScopedColumn rhs = (ScopedColumn) right;
                 if (lhs.compareTo(rhs) <= 0) {

--- a/server/src/main/java/io/crate/expression/symbol/ScopedColumn.java
+++ b/server/src/main/java/io/crate/expression/symbol/ScopedColumn.java
@@ -25,9 +25,18 @@ package io.crate.expression.symbol;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.RelationName;
 
-public interface ScopedColumn {
+public interface ScopedColumn extends Comparable<ScopedColumn> {
 
     RelationName relation();
 
     ColumnIdent column();
+
+    @Override
+    default int compareTo(ScopedColumn o) {
+        int relationComparison = relation().compareTo(o.relation());
+        if (relationComparison == 0) {
+            return column().compareTo(o.column());
+        }
+        return relationComparison;
+    }
 }

--- a/server/src/main/java/io/crate/metadata/RelationName.java
+++ b/server/src/main/java/io/crate/metadata/RelationName.java
@@ -43,7 +43,7 @@ import io.crate.sql.Identifiers;
 import io.crate.sql.tree.QualifiedName;
 import io.crate.sql.tree.Table;
 
-public final class RelationName implements Writeable, Accountable {
+public final class RelationName implements Writeable, Accountable, Comparable<RelationName> {
 
     private static final long SHALLOW_SIZE = RamUsageEstimator.shallowSizeOfInstance(RelationName.class);
 
@@ -228,6 +228,24 @@ public final class RelationName implements Writeable, Accountable {
         int result = schema != null ? schema.hashCode() : 0;
         result = 31 * result + name.hashCode();
         return result;
+    }
+
+    @Override
+    public int compareTo(RelationName o) {
+        if (schema == null && o.schema == null) {
+            return name.compareTo(o.name());
+        }
+        if (schema == null) {
+            return 1;
+        }
+        if (o.schema == null) {
+            return -1;
+        }
+        int schemaComparison = schema.compareTo(o.schema);
+        if (schemaComparison == 0) {
+            return name.compareTo(o.name());
+        }
+        return schemaComparison;
     }
 
     @Override

--- a/server/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
@@ -63,6 +63,7 @@ import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.ParameterSymbol;
 import io.crate.expression.symbol.ScopedSymbol;
 import io.crate.expression.symbol.Symbol;
+import io.crate.expression.symbol.format.Style;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.RelationName;
@@ -188,6 +189,22 @@ public class ExpressionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         // the comparison was swapped so the field is on the left side
         assertThat(cmp.name()).isEqualTo("op_<");
         assertThat(cmp.arguments().get(0)).isReference().hasName("x");
+    }
+
+    @Test
+    public void testOrdersReferencesOnBothSidesLexicographically() throws Exception {
+        Function cmp = (Function) expressions.normalize(executor.asSymbol("t2.i > t1.i"));
+        assertThat(cmp.name()).isEqualTo("op_<");
+        assertThat(cmp.arguments().get(0).toString(Style.QUALIFIED)).isEqualTo("doc.t1.i");
+        assertThat(cmp.arguments().get(1).toString(Style.QUALIFIED)).isEqualTo("doc.t2.i");
+    }
+
+    @Test
+    public void testDoesNotSwapExpressionIfNotSwappable() throws Exception {
+        Function cmp = (Function) expressions.normalize(executor.asSymbol("t2.b ~ t1.a"));
+        assertThat(cmp.name()).isEqualTo("op_~");
+        assertThat(cmp.arguments().get(0)).isReference().hasName("b");
+        assertThat(cmp.arguments().get(1)).isReference().hasName("a");
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/operator/EqOperatorTest.java
+++ b/server/src/test/java/io/crate/expression/operator/EqOperatorTest.java
@@ -182,8 +182,8 @@ public class EqOperatorTest extends ScalarTestCase {
         assertEvaluate("numeric_4_2 = 100", false, Literal.of(new BigDecimal("100.01")));
         assertEvaluate("numeric_4_2 = 100", true, Literal.of(new BigDecimal("100.00")));
         assertEvaluate(
-            "numeric_4_2 = double_val",
+            "double_val = numeric_4_2",
             false,
-            Literal.of(new BigDecimal("1.11")), Literal.of(1.111));
+            Literal.of(1.111), Literal.of(new BigDecimal("1.11")));
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/CorrelatedSubqueryITest.java
+++ b/server/src/test/java/io/crate/integrationtests/CorrelatedSubqueryITest.java
@@ -311,14 +311,14 @@ public class CorrelatedSubqueryITest extends IntegTestCase {
             "    └ OrderBy[table_name ASC column_name DESC]\n" +
             "      └ Filter[(attrelid = (SELECT oid FROM (pg_catalog.pg_class, pg_catalog.pg_namespace)))]\n" +
             "        └ CorrelatedJoin[table_name, column_name, table_schema, attname, attrelid, (SELECT oid FROM (pg_catalog.pg_class, pg_catalog.pg_namespace))]\n" +
-            "          └ NestedLoopJoin[LEFT | (attname = column_name)]\n" +
+            "          └ NestedLoopJoin[LEFT | (column_name = attname)]\n" +
             "            ├ Collect[information_schema.columns | [table_name, column_name, table_schema] | true]\n" +
             "            └ Rename[attname, attrelid] AS col_attr\n" +
             "              └ Collect[pg_catalog.pg_attribute | [attname, attrelid] | true]\n" +
             "          └ SubPlan\n" +
             "            └ Eval[oid]\n" +
             "              └ Limit[2::bigint;0::bigint]\n" +
-            "                └ NestedLoopJoin[INNER | (oid = relnamespace)]\n" +
+            "                └ NestedLoopJoin[INNER | (relnamespace = oid)]\n" +
             "                  ├ Collect[pg_catalog.pg_class | [oid, relnamespace] | (relname = table_name)]\n" +
             "                  └ Collect[pg_catalog.pg_namespace | [oid] | (nspname = table_schema)]\n"
         );
@@ -365,14 +365,14 @@ public class CorrelatedSubqueryITest extends IntegTestCase {
             "      └ Filter[((attrelid = (SELECT oid FROM (pg_catalog.pg_class, pg_catalog.pg_namespace))) AND (attrelid = (SELECT attrelid FROM (empty_row))))]\n" +
             "        └ CorrelatedJoin[table_name, column_name, table_schema, attname, attrelid, (SELECT oid FROM (pg_catalog.pg_class, pg_catalog.pg_namespace)), (SELECT attrelid FROM (empty_row))]\n" +
             "          └ CorrelatedJoin[table_name, column_name, table_schema, attname, attrelid, (SELECT oid FROM (pg_catalog.pg_class, pg_catalog.pg_namespace))]\n" +
-            "            └ NestedLoopJoin[LEFT | (attname = column_name)]\n" +
+            "            └ NestedLoopJoin[LEFT | (column_name = attname)]\n" +
             "              ├ Collect[information_schema.columns | [table_name, column_name, table_schema] | true]\n" +
             "              └ Rename[attname, attrelid] AS col_attr\n" +
             "                └ Collect[pg_catalog.pg_attribute | [attname, attrelid] | true]\n" +
             "            └ SubPlan\n" +
             "              └ Eval[oid]\n" +
             "                └ Limit[2::bigint;0::bigint]\n" +
-            "                  └ NestedLoopJoin[INNER | (oid = relnamespace)]\n" +
+            "                  └ NestedLoopJoin[INNER | (relnamespace = oid)]\n" +
             "                    ├ Collect[pg_catalog.pg_class | [oid, relnamespace] | (relname = table_name)]\n" +
             "                    └ Collect[pg_catalog.pg_namespace | [oid] | (nspname = table_schema)]\n" +
             "          └ SubPlan\n" +

--- a/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
@@ -1330,8 +1330,8 @@ public class JoinIntegrationTest extends IntegTestCase {
         execute("EXPLAIN (COSTS FALSE)" + stmt);
         assertThat(response).hasLines(
             "Eval[id, reference]",
-            "  └ HashJoin[LEFT | (cluster_id = id)]",
-            "    ├ HashJoin[INNER | (cluster_id = id)]",
+            "  └ HashJoin[LEFT | (id = cluster_id)]",
+            "    ├ HashJoin[INNER | (id = cluster_id)]",
             "    │  ├ HashJoin[INNER | (subscription_id = id)]",
             "    │  │  ├ Collect[doc.t3 | [id, reference] | (reference = 'bazinga')]",
             "    │  │  └ Collect[doc.t1 | [id, subscription_id] | true]",
@@ -1384,7 +1384,7 @@ public class JoinIntegrationTest extends IntegTestCase {
         execute("EXPLAIN (COSTS FALSE)" + stmt);
         assertThat(response).hasLines(
                    "OrderBy[z ASC x ASC]",
-                   "  └ NestedLoopJoin[LEFT | (z = x)]",
+                   "  └ NestedLoopJoin[LEFT | (x = z)]",
                    "    ├ Rename[z] AS d",
                    "    │  └ Rename[z] AS generated",
                    "    │    └ Rename[z] AS z",
@@ -1566,7 +1566,7 @@ public class JoinIntegrationTest extends IntegTestCase {
 
         assertThat(response).hasLines(
             "Eval[x, y, z]",
-            "  └ HashJoin[INNER | (z = y)]",
+            "  └ HashJoin[INNER | (y = z)]",
             "    ├ HashJoin[INNER | (x = z)]",
             "    │  ├ Collect[doc.t1 | [x] | true]",
             "    │  └ Collect[doc.t3 | [z] | true]",
@@ -1588,7 +1588,7 @@ public class JoinIntegrationTest extends IntegTestCase {
 
         assertThat(response).hasLines(
             "Eval[x, y, z]",
-            "  └ HashJoin[INNER | (z = y)]",
+            "  └ HashJoin[INNER | (y = z)]",
             "    ├ HashJoin[INNER | (x = z)]",
             "    │  ├ Collect[doc.t1 | [x] | (x > 1)]",
             "    │  └ Collect[doc.t3 | [z] | true]",
@@ -1617,7 +1617,7 @@ public class JoinIntegrationTest extends IntegTestCase {
         execute("explain (costs false) " + stmt);
 
         assertThat(response).hasLines(
-            "HashJoin[INNER | ((c = a) AND (c = b))]",
+            "HashJoin[INNER | ((a = c) AND (b = c))]",
             "  ├ HashJoin[INNER | ((a = b) AND (x = y))]",
             "  │  ├ Collect[doc.t1 | [a, x] | true]",
             "  │  └ Collect[doc.t2 | [b, y] | true]",

--- a/server/src/test/java/io/crate/planner/SelectPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/SelectPlannerTest.java
@@ -693,7 +693,7 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
                                     "  and u2.name = u1.name");
         Join innerJoin = (Join) outerJoin.right();
 
-        assertThat(innerJoin.joinPhase().joinCondition()).isSQL("((INPUT(0) = INPUT(2)) AND (INPUT(1) = INPUT(3)))");
+        assertThat(innerJoin.joinPhase().joinCondition()).isSQL("((INPUT(2) = INPUT(0)) AND (INPUT(3) = INPUT(1)))");
         assertThat(innerJoin.joinPhase().projections()).hasSize(2);
         assertThat(innerJoin.joinPhase().projections().get(0)).isExactlyInstanceOf(EvalProjection.class);
 

--- a/server/src/test/java/io/crate/planner/operators/JoinTest.java
+++ b/server/src/test/java/io/crate/planner/operators/JoinTest.java
@@ -724,8 +724,8 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
             """);
         assertThat(logicalPlan).hasOperators(
             "Eval[a, x, i, b, y, i, c, z]",
-            "  └ HashJoin[INNER | (z = y)]",
-            "    ├ HashJoin[INNER | (z = x)]",
+            "  └ HashJoin[INNER | (y = z)]",
+            "    ├ HashJoin[INNER | (x = z)]",
             "    │  ├ Collect[doc.t1 | [a, x, i] | true]",
             "    │  └ Collect[doc.t3 | [c, z] | true]",
             "    └ Collect[doc.t2 | [b, y, i] | true]"
@@ -884,7 +884,7 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
                   """);
 
         assertThat(logicalPlan).hasOperators(
-            "HashJoin[INNER | ((foo = i) AND (i = foo))]",
+            "HashJoin[INNER | ((i = foo) AND (i = foo))]",
             "  ├ HashJoin[INNER | (i = i)]",
             "  │  ├ Collect[doc.t1 | [a, x, i] | true]",
             "  │  └ Collect[doc.t2 | [b, y, i] | true]",
@@ -937,9 +937,9 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
         assertThat(logicalPlan).hasOperators(
             "Eval[oid, attnum, attname, relname, nspname, (attnotnull OR ((typtype = 'd') AND typnotnull)), ((NOT (attidentity = '')) OR (pg_catalog.pg_get_expr(adbin, adrelid) LIKE '%nextval(%'))]",
             "  └ HashJoin[INNER | ((oid = cast(oid AS REGCLASS)) AND (attnum = attnum))]",
-            "    ├ HashJoin[LEFT | ((adrelid = attrelid) AND (adnum = attnum))]",
+            "    ├ HashJoin[LEFT | ((attrelid = adrelid) AND (attnum = adnum))]",
             "    │  ├ HashJoin[INNER | (atttypid = oid)]",
-            "    │  │  ├ HashJoin[INNER | (oid = attrelid)]",
+            "    │  │  ├ HashJoin[INNER | (attrelid = oid)]",
             "    │  │  │  ├ HashJoin[INNER | (relnamespace = oid)]",
             "    │  │  │  │  ├ Rename[oid, relname, relnamespace] AS c",
             "    │  │  │  │  │  └ Collect[pg_catalog.pg_class | [oid, relname, relnamespace] | true]",
@@ -991,7 +991,7 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
             "      └ HashJoin[INNER | (y = x)]",
             "        ├ Collect[doc.b | [y] | true]",
             "        └ Rename[z, x] AS temp1",
-            "          └ HashJoin[INNER | (z = x)]",
+            "          └ HashJoin[INNER | (x = z)]",
             "            ├ Collect[doc.c | [z] | true]",
             "            └ Collect[doc.a | [x] | true]"
         );

--- a/server/src/test/java/io/crate/planner/operators/PushDownTest.java
+++ b/server/src/test/java/io/crate/planner/operators/PushDownTest.java
@@ -114,7 +114,7 @@ public class PushDownTest extends CrateDummyClusterServiceUnitTest {
             """);
         assertThat(plan).isEqualTo(
             """
-            NestedLoopJoin[INNER | (a = b)]
+            NestedLoopJoin[INNER | (b = a)]
               ├ NestedLoopJoin[INNER | (a = b)]
               │  ├ OrderBy[a ASC]
               │  │  └ Collect[doc.t1 | [a] | true]

--- a/server/src/test/java/io/crate/planner/operators/SelectDistinctLogicalPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/operators/SelectDistinctLogicalPlannerTest.java
@@ -98,7 +98,7 @@ public class SelectDistinctLogicalPlannerTest extends CrateDummyClusterServiceUn
             """
             GroupHashAggregate[count(id)]
               └ GroupHashAggregate[name | count(id)]
-                └ HashJoin[INNER | (department_id = id)]
+                └ HashJoin[INNER | (id = department_id)]
                   ├ Collect[doc.users | [id, department_id] | true]
                   └ Collect[doc.departments | [name, id] | true]
             """
@@ -118,7 +118,7 @@ public class SelectDistinctLogicalPlannerTest extends CrateDummyClusterServiceUn
             """
             OrderBy[name ASC]
               └ GroupHashAggregate[name]
-                └ HashJoin[INNER | (department_id = id)]
+                └ HashJoin[INNER | (id = department_id)]
                   ├ Collect[doc.users | [department_id] | true]
                   └ Collect[doc.departments | [name, id] | true]
             """

--- a/server/src/test/java/io/crate/planner/optimizer/rule/DeduplicateJoinConditionsTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/rule/DeduplicateJoinConditionsTest.java
@@ -147,7 +147,7 @@ public class DeduplicateJoinConditionsTest extends CrateDummyClusterServiceUnitT
         JoinPlan plan = new JoinPlan(t1, t2, JoinType.INNER, orConjunction);
 
         assertThat(plan).hasOperators(
-                "Join[INNER | (((a = b) AND (a = b)) OR (c > a))]",
+                "Join[INNER | (((a = b) AND (a = b)) OR (a < c))]",
                 "  ├ Collect[doc.t1 | [a] | true]",
                 "  └ Collect[doc.t2 | [b] | true]");
 
@@ -158,7 +158,7 @@ public class DeduplicateJoinConditionsTest extends CrateDummyClusterServiceUnitT
 
         LogicalPlan result = rule.apply(plan, match.captures(), e.ruleContext());
         assertThat(result).hasOperators(
-                "Join[INNER | ((a = b) OR (c > a))]",
+                "Join[INNER | ((a = b) OR (a < c))]",
                 "  ├ Collect[doc.t1 | [a] | true]",
                 "  └ Collect[doc.t2 | [b] | true]");
     }

--- a/server/src/test/java/io/crate/planner/optimizer/rule/DeduplicateJoinConditionsTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/rule/DeduplicateJoinConditionsTest.java
@@ -163,4 +163,29 @@ public class DeduplicateJoinConditionsTest extends CrateDummyClusterServiceUnitT
                 "  └ Collect[doc.t2 | [b] | true]");
     }
 
+    @Test
+    public void test_deduplicates_symmetrical_duplicate() {
+        Symbol joinCondition1 = e.asSymbol("doc.t1.a = doc.t2.b");
+        Symbol joinCondition2 = e.asSymbol("doc.t2.b = doc.t1.a");
+        JoinPlan plan = new JoinPlan(t1, t2, JoinType.INNER,
+                AndOperator.join(List.of(joinCondition1, joinCondition2)));
+
+        assertThat(plan).hasOperators(
+                "Join[INNER | ((a = b) AND (a = b))]",
+                "  ├ Collect[doc.t1 | [a] | true]",
+                "  └ Collect[doc.t2 | [b] | true]");
+
+        Rule<JoinPlan> rule = new DeduplicateJoinConditions();
+        Match<JoinPlan> match = rule.pattern().accept(plan, Captures.empty());
+        assertThat(match.isPresent()).isTrue();
+        assertThat(match.value()).isEqualTo(plan);
+
+        LogicalPlan result = rule.apply(plan, match.captures(), e.ruleContext());
+        assertThat(result).hasOperators(
+                "Join[INNER | (a = b)]",
+                "  ├ Collect[doc.t1 | [a] | true]",
+                "  └ Collect[doc.t2 | [b] | true]");
+
+    }
+
 }

--- a/server/src/test/java/io/crate/planner/optimizer/rule/EliminateCrossJoinTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/rule/EliminateCrossJoinTest.java
@@ -268,7 +268,7 @@ public class EliminateCrossJoinTest extends CrateDummyClusterServiceUnitTest {
         var join = new JoinPlan(firstJoin, c, JoinType.INNER, joinCondition);
 
         assertThat(join).hasOperators(
-            "Join[INNER | ((z = x) AND (z = y))]",
+            "Join[INNER | ((x = z) AND (y = z))]",
             "  ├ Join[CROSS]",
             "  │  ├ Collect[doc.a | [x] | true]",
             "  │  └ Collect[doc.b | [y] | true]",
@@ -293,8 +293,8 @@ public class EliminateCrossJoinTest extends CrateDummyClusterServiceUnitTest {
 
         assertThat(result).hasOperators(
             "Eval[x, y, z]",
-            "  └ Join[INNER | (z = y)]",
-            "    ├ Join[INNER | (z = x)]",
+            "  └ Join[INNER | (y = z)]",
+            "    ├ Join[INNER | (x = z)]",
             "    │  ├ Collect[doc.a | [x] | true]",
             "    │  └ Collect[doc.c | [z] | true]",
             "    └ Collect[doc.b | [y] | true]"
@@ -307,7 +307,7 @@ public class EliminateCrossJoinTest extends CrateDummyClusterServiceUnitTest {
         var join = new JoinPlan(firstJoin, b, JoinType.INNER, joinCondition);
 
         assertThat(join).hasOperators(
-            "Join[INNER | ((z = x) AND (z = y))]",
+            "Join[INNER | ((x = z) AND (y = z))]",
             "  ├ Join[CROSS]",
             "  │  ├ Collect[doc.a | [x] | true]",
             "  │  └ Collect[doc.c | [z] | true]",
@@ -330,8 +330,8 @@ public class EliminateCrossJoinTest extends CrateDummyClusterServiceUnitTest {
             e.ruleContext());
 
         assertThat(result).hasOperators(
-            "Join[INNER | (z = y)]",
-            "  ├ Join[INNER | (z = x)]",
+            "Join[INNER | (y = z)]",
+            "  ├ Join[INNER | (x = z)]",
             "  │  ├ Collect[doc.a | [x] | true]",
             "  │  └ Collect[doc.c | [z] | true]",
             "  └ Collect[doc.b | [y] | true]"
@@ -344,7 +344,7 @@ public class EliminateCrossJoinTest extends CrateDummyClusterServiceUnitTest {
         var join = new JoinPlan(firstJoin, c, JoinType.LEFT, joinCondition);
 
         assertThat(join).hasOperators(
-            "Join[LEFT | ((z = x) AND (z = y))]",
+            "Join[LEFT | ((x = z) AND (y = z))]",
             "  ├ Join[CROSS]",
             "  │  ├ Collect[doc.a | [x] | true]",
             "  │  └ Collect[doc.b | [y] | true]",

--- a/server/src/test/java/io/crate/planner/optimizer/rule/MoveEquiJoinFilterIntoInnerJoinTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/rule/MoveEquiJoinFilterIntoInnerJoinTest.java
@@ -62,8 +62,8 @@ public class MoveEquiJoinFilterIntoInnerJoinTest extends CrateDummyClusterServic
         var filter = new Filter(join2, e.asSymbol("doc.t3.c = doc.t2.b"));
 
         assertThat(filter).hasOperators(
-            "Filter[(c = b)]",
-            "  └ Join[INNER | (c = a)]",
+            "Filter[(b = c)]",
+            "  └ Join[INNER | (a = c)]",
             "    ├ Collect[doc.t3 | [c] | true]",
             "    └ Join[INNER | (a = b)]",
             "      ├ Collect[doc.t1 | [a] | true]",
@@ -81,7 +81,7 @@ public class MoveEquiJoinFilterIntoInnerJoinTest extends CrateDummyClusterServic
             e.ruleContext());
 
         assertThat(result).hasOperators(
-            "Join[INNER | ((c = a) AND (c = b))]",
+            "Join[INNER | ((a = c) AND (b = c))]",
             "  ├ Collect[doc.t3 | [c] | true]",
             "  └ Join[INNER | (a = b)]",
             "    ├ Collect[doc.t1 | [a] | true]",
@@ -97,7 +97,7 @@ public class MoveEquiJoinFilterIntoInnerJoinTest extends CrateDummyClusterServic
 
         assertThat(filter).hasOperators(
             "Filter[(c = 1)]",
-            "  └ Join[INNER | (c = a)]",
+            "  └ Join[INNER | (a = c)]",
             "    ├ Collect[doc.t3 | [c] | true]",
             "    └ Join[INNER | (a = b)]",
             "      ├ Collect[doc.t1 | [a] | true]",
@@ -117,8 +117,8 @@ public class MoveEquiJoinFilterIntoInnerJoinTest extends CrateDummyClusterServic
         var filter = new Filter(join2, e.asSymbol("doc.t3.c = doc.t2.b AND doc.t3.c = 1"));
 
         assertThat(filter).hasOperators(
-            "Filter[((c = b) AND (c = 1))]",
-            "  └ Join[INNER | (c = a)]",
+            "Filter[((b = c) AND (c = 1))]",
+            "  └ Join[INNER | (a = c)]",
             "    ├ Collect[doc.t3 | [c] | true]",
             "    └ Join[INNER | (a = b)]",
             "      ├ Collect[doc.t1 | [a] | true]",
@@ -137,7 +137,7 @@ public class MoveEquiJoinFilterIntoInnerJoinTest extends CrateDummyClusterServic
 
         assertThat(result).hasOperators(
             "Filter[(c = 1)]",
-            "  └ Join[INNER | ((c = a) AND (c = b))]",
+            "  └ Join[INNER | ((a = c) AND (b = c))]",
             "    ├ Collect[doc.t3 | [c] | true]",
             "    └ Join[INNER | (a = b)]",
             "      ├ Collect[doc.t1 | [a] | true]",

--- a/server/src/test/java/io/crate/planner/optimizer/rule/MoveFilterBeneathJoinTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/rule/MoveFilterBeneathJoinTest.java
@@ -176,7 +176,7 @@ public class MoveFilterBeneathJoinTest extends CrateDummyClusterServiceUnitTest 
 
         assertThat(filter).hasOperators(
             "Filter[(a > 1)]",
-            "  └ Join[INNER | (b = a)]",
+            "  └ Join[INNER | (a = b)]",
             "    ├ Join[INNER | (a = b)]",
             "    │  ├ Collect[doc.t1 | [a] | true]",
             "    │  └ Collect[doc.t2 | [b] | true]",
@@ -212,7 +212,7 @@ public class MoveFilterBeneathJoinTest extends CrateDummyClusterServiceUnitTest 
 
         assertThat(filter).hasOperators(
             "Filter[(((a > 1) AND (b < 10)) AND (c = 1))]",
-            "  └ Join[INNER | (b = a)]",
+            "  └ Join[INNER | (a = b)]",
             "    ├ Join[INNER | (a = b)]",
             "    │  ├ Collect[doc.t1 | [a] | true]",
             "    │  └ Collect[doc.t2 | [b] | true]",
@@ -233,7 +233,7 @@ public class MoveFilterBeneathJoinTest extends CrateDummyClusterServiceUnitTest 
 
         assertThat(result).hasOperators(
             "Filter[(a > 1)]",
-            "  └ Join[INNER | (b = a)]",
+            "  └ Join[INNER | (a = b)]",
             "    ├ Filter[(b < 10)]",
             "    │  └ Join[INNER | (a = b)]",
             "    │    ├ Collect[doc.t1 | [a] | true]",


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Follows https://github.com/crate/crate/pull/19656 and related to https://github.com/crate/crate/issues/13810

 In https://github.com/crate/crate/pull/19656, we introduced an optimizer rule to deduplicate join conditions joined by `AND`.
 However, join conditions containing something like x = y and y = x do not get deduplicated currently.

We now canonicalize the order of the left and right sides of some expressions to be in lexicographic order in the ExpressionAnalyzer. This will enable us to detect, for example, that x = y and y = x are the same and deduplicate them.

A side effect of these changes is that users will see slightly different query plans than before these changes. In the query plan, operands will no longer appear in the order as written in the query.


## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes.
       If you're an external contributor you can give yourself attribution and include your name and Github handle.
       e.g.:
       ```
       `John Doe <https://github.com/John_Doe>`_ added support for ...
       ```
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
