### PR TITLE
Fix Schemas#getTableInfo to be able to get ForeignTable

### DIFF
--- a/docs/appendices/release-notes/6.3.7.rst
+++ b/docs/appendices/release-notes/6.3.7.rst
@@ -46,4 +46,5 @@ series.
 Fixes
 =====
 
-None
+- Fixed a rare issue that causes queries involving foreign tables to throw
+  ``UnsupportedOperationException``.

--- a/docs/appendices/release-notes/6.4.2.rst
+++ b/docs/appendices/release-notes/6.4.2.rst
@@ -46,4 +46,5 @@ series.
 Fixes
 =====
 
-None
+- Fixed a rare issue that causes queries involving foreign tables to throw
+  ``UnsupportedOperationException``.

--- a/server/src/main/java/io/crate/metadata/Schemas.java
+++ b/server/src/main/java/io/crate/metadata/Schemas.java
@@ -306,9 +306,10 @@ public class Schemas extends AbstractLifecycleComponent implements Iterable<Sche
         if (schemaInfo == null) {
             throw new SchemaUnknownException(schemaName);
         }
-        TableInfo info = schemaInfo.getTableInfo(ident.name());
+        String name = ident.name();
+        TableInfo info = schemaInfo.getForeignTableInfo(name);
         if (info == null) {
-            info = schemaInfo.getForeignTableInfo(ident.name());
+            info = schemaInfo.getTableInfo(name);
             if (info == null) {
                 throw new RelationUnknown(ident);
             }

--- a/server/src/test/java/io/crate/metadata/SchemasTest.java
+++ b/server/src/test/java/io/crate/metadata/SchemasTest.java
@@ -33,6 +33,7 @@ import java.util.Set;
 
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.metadata.MetadataUpgradeService;
+import org.elasticsearch.cluster.metadata.RelationMetadata;
 import org.elasticsearch.common.settings.IndexScopedSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.junit.Before;
@@ -174,5 +175,17 @@ public class SchemasTest extends CrateDummyClusterServiceUnitTest {
         RelationName relation = tableInfo.ident();
         assertThat(relation.schema()).isEqualTo("schema");
         assertThat(relation.name()).isEqualTo("t");
+    }
+
+    @Test
+    public void test_getTableInfo_can_resolve_foreign_table() throws Exception {
+        Settings options = Settings.builder()
+            .put("url", "jdbc:postgresql://localhost:5432/")
+            .build();
+        var e = SQLExecutor.of(clusterService)
+            .addServer("pg", "jdbc", "crate", options)
+            .addForeignTable("create foreign table tbl (x int) server pg options (schema_name 'doc')");
+        TableInfo tableInfo = e.schemas().getTableInfo(new RelationName("doc", "tbl"));
+        assertThat(tableInfo).isExactlyInstanceOf(RelationMetadata.ForeignTable.class);
     }
 }


### PR DESCRIPTION
Similar to https://github.com/crate/crate/blob/4255e2e403a43b5fbaa7eb73fda7af33bd2df521/server/src/main/java/io/crate/metadata/Schemas.java#L191-L202

, update the search order such that before
```
java.lang.UnsupportedOperationException: Unsupported relation type: ForeignTable

	at __randomizedtesting.SeedInfo.seed([963ECB2FD8A1F781:9232565928876D6E]:0)
	at io.crate.metadata.doc.DocTableInfoFactory.create(DocTableInfoFactory.java:129)
	at io.crate.metadata.doc.DocSchemaInfo.lambda$getTableInfo$0(DocSchemaInfo.java:144)
	at java.base/java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1735)
	at io.crate.metadata.doc.DocSchemaInfo.getTableInfo(DocSchemaInfo.java:142)
	at io.crate.metadata.Schemas.getTableInfo(Schemas.java:309)
	at io.crate.metadata.SchemasITest.test_getTableInfo_foreign_table(SchemasITest.java:162)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
```
is thrown from the call to `getTableInfo` we should call `getForeignTableInfo`.