### PR TITLE
Add information_schema.constraint_column_usage table

### DIFF
--- a/docs/appendices/release-notes/6.5.0.rst
+++ b/docs/appendices/release-notes/6.5.0.rst
@@ -127,3 +127,10 @@ Client interfaces
 -----------------
 
 None
+
+SQL Standard and PostgreSQL Compatibility
+-----------------------------------------
+
+- `Somil Jain <https://github.com/somiljain2006>`_ added the
+  ``information_schema.constraint_column_usage`` view to improve PostgreSQL
+  compatibility with tools that introspect database metadata.

--- a/docs/general/information-schema.rst
+++ b/docs/general/information-schema.rst
@@ -79,6 +79,7 @@ number of replicas.
     | information_schema | character_sets                    | BASE TABLE |             NULL | NULL               |
     | information_schema | collations                        | BASE TABLE |             NULL | NULL               |
     | information_schema | columns                           | BASE TABLE |             NULL | NULL               |
+    | information_schema | constraint_column_usage           | BASE TABLE |             NULL | NULL               |
     | information_schema | enabled_roles                     | BASE TABLE |             NULL | NULL               |
     | information_schema | foreign_server_options            | BASE TABLE |             NULL | NULL               |
     | information_schema | foreign_servers                   | BASE TABLE |             NULL | NULL               |
@@ -152,7 +153,7 @@ number of replicas.
     | sys                | summits                           | BASE TABLE |             NULL | NULL               |
     | sys                | users                             | BASE TABLE |             NULL | NULL               |
     +--------------------+-----------------------------------+------------+------------------+--------------------+
-    SELECT 81 rows in set (... sec)
+    SELECT 82 rows in set (... sec)
 
 
 The table also contains additional information such as the specified

--- a/server/src/main/java/io/crate/execution/engine/collect/sources/InformationSchemaIterables.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/sources/InformationSchemaIterables.java
@@ -28,7 +28,9 @@ import static java.util.stream.Stream.concat;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.PrimitiveIterator;
@@ -61,7 +63,9 @@ import io.crate.metadata.RelationName;
 import io.crate.metadata.RoutineInfo;
 import io.crate.metadata.RoutineInfos;
 import io.crate.metadata.Schemas;
+import io.crate.metadata.SystemTable;
 import io.crate.metadata.blob.BlobSchemaInfo;
+import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.information.InformationSchemaInfo;
 import io.crate.metadata.information.InformationSchemaViewColumnUsage.ViewColumn;
 import io.crate.metadata.information.UserMappingOptionsTableInfo;
@@ -609,5 +613,67 @@ public class InformationSchemaIterables {
                     .map(ref -> new ViewColumn(viewInfo.ident(), ref))
             )
             .iterator();
+    }
+
+    public record ConstraintColumnUsage(RelationName relName, String columnName, String constraintName) {}
+
+    public Iterable<ConstraintColumnUsage> constraintColumnUsage() {
+        LinkedHashSet<ConstraintColumnUsage> result = new LinkedHashSet<>();
+        for (var relation : relations()) {
+            if (relation instanceof DocTableInfo table) {
+                // 1. Primary Key Constraints
+                RelationName relName = table.ident();
+                if (!table.primaryKey().isEmpty()) {
+                    String pkName = relName.name() + "_pkey";
+                    for (ColumnIdent pk : table.primaryKey()) {
+                        result.add(new ConstraintColumnUsage(relName, pk.name(), pkName));
+                    }
+                }
+
+                // 2. Not Null Constraints (Includes explicit NOT NULL and implicit PK columns)
+                for (Reference ref : table) {
+                    if (!ref.isNullable() && !ref.column().isSystemColumn()) {
+                        String constraintName = relName.schema() + "_" + relName.name() + "_" + ref.column().name() + "_not_null";
+                        result.add(new ConstraintColumnUsage(relName, ref.column().name(), constraintName));
+                    }
+                }
+
+                // 3. Check Constraints
+                if (table.checkConstraints() != null) {
+                    for (var check : table.checkConstraints()) {
+                        Set<String> checkColumns = new HashSet<>();
+                        check.expression().visit(Reference.class, ref -> checkColumns.add(ref.column().name()));
+
+                        for (String colName : checkColumns) {
+                            result.add(new ConstraintColumnUsage(relName, colName, check.name()));
+                        }
+                    }
+                }
+            } else if (relation instanceof SystemTable<?> table) {
+                // information_schema tables are excluded
+                if (!InformationSchemaInfo.NAME.equals(table.ident().schema())) {
+                    RelationName relName = table.ident();
+                    // 1. Primary Key Constraints
+                    if (!table.primaryKey().isEmpty()) {
+                        String pkName = relName.name() + "_pkey";
+                        for (ColumnIdent pk : table.primaryKey()) {
+                            result.add(new ConstraintColumnUsage(relName, pk.name(), pkName));
+                            // sys & pg_catalog tables don't specify not null for pk cols
+                            String constraintName = relName.schema() + "_" + relName.name() + "_" + pk.name() + "_not_null";
+                            result.add(new ConstraintColumnUsage(relName, pk.name(), constraintName));
+                        }
+                    }
+
+                    // 2. Not Null Constraints (only explicit)
+                    for (Reference ref : table.rootColumns()) {
+                        if (!ref.isNullable() && !ref.column().isSystemColumn()) {
+                            String constraintName = relName.schema() + "_" + relName.name() + "_" + ref.column().name() + "_not_null";
+                            result.add(new ConstraintColumnUsage(relName, ref.column().name(), constraintName));
+                        }
+                    }
+                }
+            }
+        }
+        return result;
     }
 }

--- a/server/src/main/java/io/crate/metadata/information/InformationConstraintColumnUsageTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/information/InformationConstraintColumnUsageTableInfo.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.metadata.information;
+
+import static io.crate.types.DataTypes.STRING;
+
+import io.crate.Constants;
+import io.crate.execution.engine.collect.sources.InformationSchemaIterables;
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.RelationName;
+import io.crate.metadata.SystemTable;
+
+/**
+ * Table which contains the columns used by constraints (Primary Keys, Not Null, and Check constraints).
+ */
+public class InformationConstraintColumnUsageTableInfo {
+
+    public static final String NAME = "constraint_column_usage";
+    public static final RelationName IDENT = new RelationName(InformationSchemaInfo.NAME, NAME);
+
+    public static SystemTable<InformationSchemaIterables.ConstraintColumnUsage> INSTANCE = SystemTable.<InformationSchemaIterables.ConstraintColumnUsage>builder(IDENT)
+        .add("table_catalog", STRING, _ -> Constants.DB_NAME)
+        .add("table_schema", STRING, ccu -> ccu.relName().schema())
+        .add("table_name", STRING, ccu -> ccu.relName().name())
+        .add("column_name", STRING, InformationSchemaIterables.ConstraintColumnUsage::columnName)
+        .add("constraint_catalog", STRING, _ -> Constants.DB_NAME)
+        .add("constraint_schema", STRING, ccu -> ccu.relName().schema())
+        .add("constraint_name", STRING, InformationSchemaIterables.ConstraintColumnUsage::constraintName)
+        .setPrimaryKeys(
+            ColumnIdent.of("constraint_catalog"),
+            ColumnIdent.of("constraint_schema"),
+            ColumnIdent.of("constraint_name"),
+            ColumnIdent.of("column_name")
+        )
+        .build();
+}

--- a/server/src/main/java/io/crate/metadata/information/InformationSchemaInfo.java
+++ b/server/src/main/java/io/crate/metadata/information/InformationSchemaInfo.java
@@ -44,6 +44,7 @@ public class InformationSchemaInfo implements SchemaInfo {
             .put(InformationViewsTableInfo.NAME, InformationViewsTableInfo.INSTANCE)
             .put(InformationColumnsTableInfo.NAME, InformationColumnsTableInfo.INSTANCE)
             .put(InformationKeyColumnUsageTableInfo.NAME, InformationKeyColumnUsageTableInfo.INSTANCE)
+            .put(InformationConstraintColumnUsageTableInfo.NAME, InformationConstraintColumnUsageTableInfo.INSTANCE)
             .put(InformationPartitionsTableInfo.NAME, InformationPartitionsTableInfo.INSTANCE)
             .put(InformationTableConstraintsTableInfo.NAME, InformationTableConstraintsTableInfo.INSTANCE)
             .put(InformationReferentialConstraintsTableInfo.NAME, InformationReferentialConstraintsTableInfo.INSTANCE)

--- a/server/src/main/java/io/crate/metadata/information/InformationSchemaTableDefinitions.java
+++ b/server/src/main/java/io/crate/metadata/information/InformationSchemaTableDefinitions.java
@@ -123,6 +123,14 @@ public class InformationSchemaTableDefinitions {
                 )
             ),
             Map.entry(
+                InformationConstraintColumnUsageTableInfo.IDENT,
+                new StaticTableDefinition<>(
+                    informationSchemaIterables::constraintColumnUsage,
+                    (user, ccu) -> roles.hasAnyPrivilege(user, Securable.TABLE, ccu.relName().fqn()),
+                    InformationConstraintColumnUsageTableInfo.INSTANCE.expressions()
+                )
+            ),
+            Map.entry(
                 InformationReferentialConstraintsTableInfo.IDENT,
                 new StaticTableDefinition<>(
                     (_, _) -> completedFuture(informationSchemaIterables.referentialConstraintsInfos()),

--- a/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -24,7 +24,6 @@ package io.crate.integrationtests;
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
 import static io.crate.testing.Asserts.assertThat;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Collections;
 import java.util.List;
@@ -65,6 +64,7 @@ public class InformationSchemaTest extends IntegTestCase {
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| crate| character_sets| information_schema| BASE TABLE| NULL",
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| crate| collations| information_schema| BASE TABLE| NULL",
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| crate| columns| information_schema| BASE TABLE| NULL",
+            "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| crate| constraint_column_usage| information_schema| BASE TABLE| NULL",
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| crate| enabled_roles| information_schema| BASE TABLE| NULL",
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| crate| foreign_server_options| information_schema| BASE TABLE| NULL",
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| crate| foreign_servers| information_schema| BASE TABLE| NULL",
@@ -223,12 +223,12 @@ public class InformationSchemaTest extends IntegTestCase {
     @Test
     public void testSearchInformationSchemaTablesRefresh() {
         execute("select * from information_schema.tables");
-        assertThat(response.rowCount()).isEqualTo(77L);
+        assertThat(response.rowCount()).isEqualTo(78L);
 
         execute("create table t4 (col1 integer, col2 string) with(number_of_replicas=0)");
 
         execute("select * from information_schema.tables");
-        assertThat(response.rowCount()).isEqualTo(78L);
+        assertThat(response.rowCount()).isEqualTo(79L);
     }
 
     @Test
@@ -424,6 +424,7 @@ public class InformationSchemaTest extends IntegTestCase {
             "information_schema_columns_table_catalog_not_null| CHECK| columns| information_schema",
             "information_schema_columns_table_name_not_null| CHECK| columns| information_schema",
             "information_schema_columns_table_schema_not_null| CHECK| columns| information_schema",
+            "constraint_column_usage_pkey| PRIMARY KEY| constraint_column_usage| information_schema",
             "key_column_usage_pkey| PRIMARY KEY| key_column_usage| information_schema",
             "referential_constraints_pkey| PRIMARY KEY| referential_constraints| information_schema",
             "schemata_pkey| PRIMARY KEY| schemata| information_schema",
@@ -582,7 +583,7 @@ public class InformationSchemaTest extends IntegTestCase {
     @Test
     public void testDefaultColumns() {
         execute("select * from information_schema.columns order by table_schema, table_name");
-        assertThat(response.rowCount()).isEqualTo(1110);
+        assertThat(response.rowCount()).isEqualTo(1117);
     }
 
     @Test
@@ -922,7 +923,7 @@ public class InformationSchemaTest extends IntegTestCase {
         execute("create table t3 (id integer, col1 string) clustered into 3 shards with(number_of_replicas=0)");
         execute("select count(*) from information_schema.tables");
         assertThat(response.rowCount()).isEqualTo(1);
-        assertThat(response.rows()[0][0]).isEqualTo(80L);
+        assertThat(response.rows()[0][0]).isEqualTo(81L);
     }
 
     @Test
@@ -1459,6 +1460,25 @@ public class InformationSchemaTest extends IntegTestCase {
             "v2| t3| name",
             "v2| v1| x",
             "v2| v1| y"
+        );
+    }
+
+    @Test
+    public void testConstraintColumnUsage() {
+        execute("create table my_schema.tbl (a int, b int, c int not null, d int constraint tbl_d_check check (d > 0), primary key(a,b))");
+
+        execute("select * from information_schema.constraint_column_usage " +
+            "where table_name IN ('tbl', 'nodes') order by table_name, constraint_name, column_name");
+
+        assertThat(response).hasRows(
+            "id| crate| nodes_pkey| sys| crate| nodes| sys",
+            "id| crate| sys_nodes_id_not_null| sys| crate| nodes| sys",
+            "a| crate| my_schema_tbl_a_not_null| my_schema| crate| tbl| my_schema",
+            "b| crate| my_schema_tbl_b_not_null| my_schema| crate| tbl| my_schema",
+            "c| crate| my_schema_tbl_c_not_null| my_schema| crate| tbl| my_schema",
+            "d| crate| tbl_d_check| my_schema| crate| tbl| my_schema",
+            "a| crate| tbl_pkey| my_schema| crate| tbl| my_schema",
+            "b| crate| tbl_pkey| my_schema| crate| tbl| my_schema"
         );
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
@@ -186,7 +186,7 @@ public class PgCatalogITest extends IntegTestCase {
     @Test
     public void testPgIndexTable() {
         execute("select count(*) from pg_catalog.pg_index");
-        assertThat(response).hasRows("25");
+        assertThat(response).hasRows("26");
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/PrivilegesIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/PrivilegesIntegrationTest.java
@@ -509,6 +509,8 @@ public class PrivilegesIntegrationTest extends BaseRolesIntegrationTest {
             "collations",
             "columns",
             "columns_pkey",
+            "constraint_column_usage",
+            "constraint_column_usage_pkey",
             "enabled_roles",
             "foreign_server_options",
             "foreign_servers",
@@ -662,7 +664,7 @@ public class PrivilegesIntegrationTest extends BaseRolesIntegrationTest {
         //make sure a new user has default accesses to pg tables with information and pg catalog schema related entries
         try (Session testUserSession = testUserSession()) {
             execute("select * from pg_catalog.pg_attribute order by attname", null, testUserSession);
-            assertThat(response).hasRowCount(616L);
+            assertThat(response).hasRowCount(623L);
 
             //create a table with an attribute that a new user is not privileged to access
             executeAsSuperuser("create table test_schema.my_table (my_col int)");
@@ -696,6 +698,7 @@ public class PrivilegesIntegrationTest extends BaseRolesIntegrationTest {
             execute("select conname from pg_catalog.pg_constraint order by conname", null, testUserSession);
             assertThat(response).hasRows(
                     "columns_pkey",
+                    "constraint_column_usage_pkey",
                     "key_column_usage_pkey",
                     "referential_constraints_pkey",
                     "schemata_pkey",

--- a/server/src/test/java/io/crate/integrationtests/TableSettingsTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TableSettingsTest.java
@@ -92,10 +92,10 @@ public class TableSettingsTest extends IntegTestCase {
     }
 
     @Test
-    public void testFilterOnNull() throws Exception {
+    public void testFilterOnNull() {
         execute("select * from information_schema.tables " +
                 "where settings IS NULL");
-        assertThat(response.rowCount()).isEqualTo(77L);
+        assertThat(response.rowCount()).isEqualTo(78L);
         execute("select * from information_schema.tables " +
                 "where table_name = 'settings_table' and settings['blocks']['read'] IS NULL");
         assertThat(response.rowCount()).isEqualTo(0);


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Fixes #19026 

Add information_schema.constraint_column_usage compatibility view. Introduce the information_schema.constraint_column_usage system table to improve PostgreSQL information schema compatibility. Reuse the existing key column usage metadata to expose columns referenced by primary key constraints and register the new view in the information schema. Add a regression test covering the lazysql introspection query to ensure it no longer fails due to the missing relation.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes.
       If you're an external contributor you can give yourself attribution and include your name and Github handle.
       e.g.:
       ```
       `John Doe <https://github.com/John_Doe>`_ added support for ...
       ```
 - [x] Updated documentation & `sql_features` table for user-facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g., AdminUI)
