### PR TITLE
Fix issue with SUM agg and overflows/NaN

### DIFF
--- a/docs/appendices/release-notes/6.3.7.rst
+++ b/docs/appendices/release-notes/6.3.7.rst
@@ -46,6 +46,12 @@ series.
 Fixes
 =====
 
+- Fixed an issue that could cause ``SUM`` over ``DOUBLE PRECISION`` or ``FLOAT``
+  values to return ``NaN`` instead of ``Infinity`` for a grouped result, when a
+  different group in the same query overflowed the floating point range. The
+  result of ``SUM`` no longer depends on the order in which groups are
+  processed.
+
 - Fixed a rare issue that causes queries involving foreign tables to throw
   ``UnsupportedOperationException``.
 

--- a/docs/appendices/release-notes/6.4.2.rst
+++ b/docs/appendices/release-notes/6.4.2.rst
@@ -46,6 +46,12 @@ series.
 Fixes
 =====
 
+- Fixed an issue that could cause ``SUM`` over ``DOUBLE PRECISION`` or ``FLOAT``
+  values to return ``NaN`` instead of ``Infinity`` for a grouped result, when a
+  different group in the same query overflowed the floating point range. The
+  result of ``SUM`` no longer depends on the order in which groups are
+  processed.
+
 - Fixed a rare issue that causes queries involving foreign tables to throw
   ``UnsupportedOperationException``.
 

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/util/KahanSummationForDouble.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/util/KahanSummationForDouble.java
@@ -28,7 +28,13 @@ public class KahanSummationForDouble {
     public double sum(double sum, double value) {
         var correctedValue = value - error;
         var newSum = sum + correctedValue;
-        error = (newSum - sum) - correctedValue;
+        var newError = (newSum - sum) - correctedValue;
+        // Guard against a non-finite error. When the running sum overflows to
+        // (+/-)Infinity, or a value/sum is NaN, `newError` becomes Infinity or NaN
+        // (e.g. Infinity - Infinity => NaN). A non-finite error is meaningless and,
+        // if kept, it affects every subsequent addition made, as a single instance
+        // is reused across all GROUP BY keys.
+        error = Double.isFinite(newError) ? newError : 0.0d;
         return newSum;
     }
 }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/util/KahanSummationForFloat.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/util/KahanSummationForFloat.java
@@ -28,7 +28,13 @@ public class KahanSummationForFloat {
     public float sum(float sum, float value) {
         var correctedValue = value - error;
         var newSum = sum + correctedValue;
-        error = (newSum - sum) - correctedValue;
+        var newError = (newSum - sum) - correctedValue;
+        // Guard against a non-finite error. When the running sum overflows to
+        // (+/-)Infinity, or a value/sum is NaN, `newError` becomes Infinity or NaN
+        // (e.g. Infinity - Infinity => NaN). A non-finite error is meaningless and,
+        // if kept, it affects every subsequent addition made, as a single instance
+        // is reused across all GROUP BY keys.
+        error = Float.isFinite(newError) ? newError : 0.0f;
         return newSum;
     }
 }

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/KahanSummationForDoubleTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/KahanSummationForDoubleTest.java
@@ -48,4 +48,41 @@ public class KahanSummationForDoubleTest extends AggregationTestCase {
         // The same operations using '+' returns 1.9999999999999998
         assertThat(total).isEqualTo(2.0d);
     }
+
+    // See https://github.com/crate/crate/issues/19761
+    @Test
+    public void test_infinite_compensation_does_not_leak_into_next_summation() {
+        // A single instance is reused across all GROUP BY keys. An overflow in one summation
+        // must not contaminate a consequent, independent, non-overflowing summation.
+        var kahanSummation = new KahanSummationForDouble();
+
+        double overflowed = 0;
+        overflowed = kahanSummation.sum(overflowed, Double.MAX_VALUE);
+        overflowed = kahanSummation.sum(overflowed, Double.MAX_VALUE);
+        assertThat(overflowed).isEqualTo(Double.POSITIVE_INFINITY);
+
+        double clean = 0;
+        clean = kahanSummation.sum(clean, 0.1d);
+        clean = kahanSummation.sum(clean, 0.2d);
+        clean = kahanSummation.sum(clean, 0.3d);
+        assertThat(clean).isEqualTo(0.6d);
+    }
+
+    // See https://github.com/crate/crate/issues/19761
+    @Test
+    public void test_nan_value_does_not_leak_into_next_summation() {
+        // A single instance is reused across all GROUP BY keys. An NaN error
+        // must not contaminate a consequent, independent, non-overflowing summation.
+        var kahanSummation = new KahanSummationForDouble();
+
+        double withNaN = 0;
+        withNaN = kahanSummation.sum(withNaN, 1.0d);
+        withNaN = kahanSummation.sum(withNaN, Double.NaN);
+        assertThat(withNaN).isNaN();
+
+        double clean = 0;
+        clean = kahanSummation.sum(clean, 0.7d);
+        clean = kahanSummation.sum(clean, 0.3d);
+        assertThat(clean).isEqualTo(1.0d);
+    }
 }

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/KahanSummationForFloatTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/KahanSummationForFloatTest.java
@@ -48,4 +48,41 @@ public class KahanSummationForFloatTest extends AggregationTestCase {
         // The same operations using '+' returns 2.0000002
         assertThat(total).isEqualTo(2.0f);
     }
+
+    // See https://github.com/crate/crate/issues/19761
+    @Test
+    public void test_non_finite_compensation_does_not_leak_into_next_summation() {
+        // A single instance is reused across all GROUP BY keys. An overflow in one summation
+        // must not contaminate a consequent, independent, non-overflowing summation.
+        var kahanSummation = new KahanSummationForFloat();
+
+        float overflowed = 0;
+        overflowed = kahanSummation.sum(overflowed, Float.MAX_VALUE);
+        overflowed = kahanSummation.sum(overflowed, Float.MAX_VALUE);
+        assertThat(overflowed).isEqualTo(Float.POSITIVE_INFINITY);
+
+        float clean = 0;
+        clean = kahanSummation.sum(clean, 0.1f);
+        clean = kahanSummation.sum(clean, 0.2f);
+        clean = kahanSummation.sum(clean, 0.3f);
+        assertThat(clean).isEqualTo(0.6f);
+    }
+
+    // See https://github.com/crate/crate/issues/19761
+    @Test
+    public void test_nan_value_does_not_leak_into_next_summation() {
+        // A single instance is reused across all GROUP BY keys. An NaN error
+        // must not contaminate a consequent, independent, non-overflowing summation.
+        var kahanSummation = new KahanSummationForFloat();
+
+        float withNaN = 0;
+        withNaN = kahanSummation.sum(withNaN, 1.0f);
+        withNaN = kahanSummation.sum(withNaN, Float.NaN);
+        assertThat(withNaN).isNaN();
+
+        float clean = 0;
+        clean = kahanSummation.sum(clean, 0.7f);
+        clean = kahanSummation.sum(clean, 0.3f);
+        assertThat(clean).isEqualTo(1.0f);
+    }
 }


### PR DESCRIPTION
Previously an overfloat to Infinity or a NaN would affect subsequent groupings because the `error` of the KahanSummationFor<Float/Double> is a single instnace which is reused over the groupings.

Fixes: #19761
