### PR TITLE
Fix wrong order of token/char filters for custom analyzer

### DIFF
--- a/docs/appendices/release-notes/6.3.7.rst
+++ b/docs/appendices/release-notes/6.3.7.rst
@@ -46,6 +46,11 @@ series.
 Fixes
 =====
 
+- Fixed an issue that could cause a :ref:`CREATE ANALYZER <ref-create-analyzer>`
+  statement to not preserve the order of ``TOKEN_FILTERS`` and ``CHAR_FILTERS``.
+  As the filters are applied as an ordered chain, this could silently change
+  analysis results.
+
 - Fixed an issue that could cause ``SUM`` over ``DOUBLE PRECISION`` or ``FLOAT``
   values to return ``NaN`` instead of ``Infinity`` for a grouped result, when a
   different group in the same query overflowed the floating point range. The

--- a/docs/appendices/release-notes/6.4.2.rst
+++ b/docs/appendices/release-notes/6.4.2.rst
@@ -46,6 +46,11 @@ series.
 Fixes
 =====
 
+- Fixed an issue that could cause a :ref:`CREATE ANALYZER <ref-create-analyzer>`
+  statement to not preserve the order of ``TOKEN_FILTERS`` and ``CHAR_FILTERS``.
+  As the filters are applied as an ordered chain, this could silently change
+  analysis results.
+
 - Fixed an issue that could cause ``SUM`` over ``DOUBLE PRECISION`` or ``FLOAT``
   values to return ``NaN`` instead of ``Infinity`` for a grouped result, when a
   different group in the same query overflowed the floating point range. The

--- a/plugins/es-analysis-common/src/test/java/io/crate/analyze/CreateAnalyzerAnalyzerTest.java
+++ b/plugins/es-analysis-common/src/test/java/io/crate/analyze/CreateAnalyzerAnalyzerTest.java
@@ -150,6 +150,52 @@ public class CreateAnalyzerAnalyzerTest extends CrateDummyClusterServiceUnitTest
             .hasEntry("index.analysis.filter.a11_mystop.stopword", "[the, over]");
     }
 
+    // See https://github.com/crate/crate/issues/19757
+    @Test
+    public void test_token_filter_order_is_preserved() throws Exception {
+        ClusterUpdateSettingsRequest request = analyze(
+            "CREATE ANALYZER my_analyzer (" +
+            "  TOKENIZER whitespace," +
+            "  TOKEN_FILTERS (" +
+            "    function_filter WITH (" +
+            "      type='word_delimiter'," +
+            "      split_on_case_change=true," +
+            "      preserve_original=true" +
+            "    )," +
+            "    lowercase" +
+            "  )" +
+            ")");
+
+        assertThat(extractAnalyzerSettings("my_analyzer", request.persistentSettings()))
+            .hasEntry("index.analysis.analyzer.my_analyzer.tokenizer", "whitespace")
+            .hasEntry("index.analysis.analyzer.my_analyzer.filter", "[my_analyzer_function_filter, lowercase]");
+
+        var tokenFiltersSettings = FulltextAnalyzerResolver.decodeSettings(
+            request.persistentSettings().get(TOKEN_FILTER.buildSettingName("my_analyzer_function_filter")));
+        assertThat(tokenFiltersSettings)
+            .hasEntry("index.analysis.filter.my_analyzer_function_filter.type", "word_delimiter")
+            .hasEntry("index.analysis.filter.my_analyzer_function_filter.split_on_case_change", "true");
+    }
+
+    // See https://github.com/crate/crate/issues/19757
+    @Test
+    public void test_char_filter_order_is_preserved() throws Exception {
+        ClusterUpdateSettingsRequest request = analyze(
+            "CREATE ANALYZER my_analyzer (" +
+            "   TOKENIZER whitespace," +
+            "   CHAR_FILTERS (" +
+            "       my_mapping WITH (" +
+            "           type='mapping'," +
+            "           mappings=['a=>b']" +
+            "       )," +
+            "       \"html_strip\"" +
+            "   )" +
+            ")");
+
+        assertThat(extractAnalyzerSettings("my_analyzer", request.persistentSettings()))
+            .hasEntry("index.analysis.analyzer.my_analyzer.char_filter", "[my_analyzer_my_mapping, html_strip]");
+    }
+
     @Test
     public void testCreateAnalyzerExtendingBuiltin() throws Exception {
         ClusterUpdateSettingsRequest request = analyze(

--- a/plugins/es-analysis-common/src/test/java/io/crate/planner/node/ddl/CreateAnalyzerPlanTest.java
+++ b/plugins/es-analysis-common/src/test/java/io/crate/planner/node/ddl/CreateAnalyzerPlanTest.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.node.ddl;
+
+import static io.crate.metadata.FulltextAnalyzerResolver.CustomType.ANALYZER;
+import static io.crate.testing.Asserts.assertThat;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest;
+import org.elasticsearch.analysis.common.CommonAnalysisPlugin;
+import org.elasticsearch.common.settings.Settings;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.crate.analyze.AnalyzedCreateAnalyzer;
+import io.crate.data.RowN;
+import io.crate.metadata.FulltextAnalyzerResolver;
+import io.crate.planner.PlannerContext;
+import io.crate.planner.operators.SubQueryResults;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.SQLExecutor;
+
+public class CreateAnalyzerPlanTest extends CrateDummyClusterServiceUnitTest {
+
+    private SQLExecutor e;
+    private PlannerContext plannerContext;
+
+    @Before
+    public void prepare() {
+        e = SQLExecutor.builder(clusterService)
+            .setAnalysisPlugins(List.of(new CommonAnalysisPlugin()))
+            .build();
+        plannerContext = e.getPlannerContext();
+    }
+
+    private ClusterUpdateSettingsRequest createRequest(String stmt, Object... arguments) {
+        Object plan = e.plan(stmt);
+        org.assertj.core.api.Assertions.assertThat(plan).isExactlyInstanceOf(CreateAnalyzerPlan.class);
+
+        AnalyzedCreateAnalyzer analyzedStatement = e.analyze(stmt);
+        return CreateAnalyzerPlan.createRequest(
+            analyzedStatement,
+            plannerContext.transactionContext(),
+            plannerContext.nodeContext(),
+            new RowN(arguments),
+            SubQueryResults.EMPTY,
+            e.fulltextAnalyzerResolver());
+    }
+
+    private static Settings extractAnalyzerSettings(String name, Settings persistentSettings) throws IOException {
+        return FulltextAnalyzerResolver.decodeSettings(persistentSettings.get(ANALYZER.buildSettingName(name)));
+    }
+
+    // See https://github.com/crate/crate/issues/19757
+    @Test
+    public void test_planner_preserves_token_filter_chain_order() throws Exception {
+        ClusterUpdateSettingsRequest request = createRequest(
+            "CREATE ANALYZER my_analyzer (" +
+            "  TOKENIZER whitespace," +
+            "  TOKEN_FILTERS (" +
+            "    function_filter WITH (" +
+            "      type='word_delimiter'," +
+            "      split_on_case_change=true," +
+            "      preserve_original=true" +
+            "    )," +
+            "    lowercase" +
+            "  )" +
+            ")");
+
+        assertThat(extractAnalyzerSettings("my_analyzer", request.persistentSettings()))
+            .hasEntry("index.analysis.analyzer.my_analyzer.filter", "[my_analyzer_function_filter, lowercase]");
+    }
+
+    // See https://github.com/crate/crate/issues/19757
+    @Test
+    public void test_planner_preserves_char_filter_chain_order() throws Exception {
+        ClusterUpdateSettingsRequest request = createRequest(
+            "CREATE ANALYZER my_analyzer (" +
+            "  TOKENIZER whitespace," +
+            "  CHAR_FILTERS (" +
+            "    my_mapping WITH (" +
+            "      type='mapping'," +
+            "      mappings=['a=>b']" +
+            "    )," +
+            "    \"html_strip\"" +
+            "  )" +
+            ")");
+
+        assertThat(extractAnalyzerSettings("my_analyzer", request.persistentSettings()))
+            .hasEntry("index.analysis.analyzer.my_analyzer.char_filter", "[my_analyzer_my_mapping, html_strip]");
+    }
+}

--- a/server/src/main/java/io/crate/analyze/CreateAnalyzerStatementAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/CreateAnalyzerStatementAnalyzer.java
@@ -22,6 +22,7 @@
 package io.crate.analyze;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
 
@@ -72,8 +73,10 @@ class CreateAnalyzerStatementAnalyzer {
                 NodeContext nodeCtx,
                 ParamTypeHints paramTypeHints) {
             this.genericAnalyzerProperties = new HashMap<>();
-            this.charFilters = new HashMap<>();
-            this.tokenFilters = new HashMap<>();
+            // Use insertion-ordered maps so that the order of char-filters / token-filters as
+            // specified by the user in the CREATE ANALYZER statement is preserved.
+            this.charFilters = new LinkedHashMap<>();
+            this.tokenFilters = new LinkedHashMap<>();
 
             this.exprContext = new ExpressionAnalysisContext(transactionContext.sessionSettings());
             this.exprAnalyzerWithFieldsAsString = new ExpressionAnalyzer(

--- a/server/src/main/java/io/crate/planner/node/ddl/CreateAnalyzerPlan.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/CreateAnalyzerPlan.java
@@ -27,7 +27,7 @@ import static io.crate.metadata.FulltextAnalyzerResolver.CustomType.TOKENIZER;
 import static io.crate.metadata.FulltextAnalyzerResolver.CustomType.TOKEN_FILTER;
 import static io.crate.metadata.FulltextAnalyzerResolver.encodeSettings;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -217,7 +217,8 @@ public class CreateAnalyzerPlan implements Plan {
                                                           String analyzerIdent,
                                                           Function<? super Symbol, Object> eval,
                                                           FulltextAnalyzerResolver ftResolver) {
-        HashMap<String, Settings> boundTokenFilters = HashMap.newHashMap(tokenFilters.size());
+        // Keep the user-specified order of token-filters
+        LinkedHashMap<String, Settings> boundTokenFilters = LinkedHashMap.newLinkedHashMap(tokenFilters.size());
 
         for (Map.Entry<String, GenericProperties<Symbol>> tokenFilter : tokenFilters.entrySet()) {
             var name = tokenFilter.getKey();
@@ -268,7 +269,8 @@ public class CreateAnalyzerPlan implements Plan {
                                                          String analyzerIdent,
                                                          Function<? super Symbol, Object> eval,
                                                          FulltextAnalyzerResolver ftResolver) {
-        HashMap<String, Settings> boundedCharFilters = HashMap.newHashMap(charFilters.size());
+        // Keep the user-specified order of char-filters
+        LinkedHashMap<String, Settings> boundedCharFilters = LinkedHashMap.newLinkedHashMap(charFilters.size());
 
         for (Map.Entry<String, GenericProperties<Symbol>> charFilter : charFilters.entrySet()) {
             var name = charFilter.getKey();


### PR DESCRIPTION
Use LinkedHashMap to ensure the order is kept in analysis and plan phases.

Fixes: #19757
