### PR TITLE
Bump pgjdbc version to address a rare security issue.

### DIFF
--- a/docs/appendices/release-notes/6.3.7.rst
+++ b/docs/appendices/release-notes/6.3.7.rst
@@ -62,3 +62,10 @@ Fixes
 
 - Fixed an issue that caused casts of tables created before ``6.3`` to
   ``REGCLASS`` to incorrectly return ``0``.
+
+- Bumped the PostgreSQL JDBC driver used by the
+  :ref:`JDBC foreign data wrapper <administration-fdw-jdbc>` to ``42.7.13``
+  because of `CVE-2026-54291 <https://nvd.nist.gov/vuln/detail/CVE-2026-54291>`_,
+  a SCRAM channel-binding downgrade in the driver. CrateDB isn't affected by
+  default, since a foreign server only uses channel binding if a user
+  explicitly sets ``channelBinding=require`` on its JDBC URL.

--- a/docs/appendices/release-notes/6.4.2.rst
+++ b/docs/appendices/release-notes/6.4.2.rst
@@ -62,3 +62,10 @@ Fixes
 
 - Fixed an issue that caused casts of tables created before ``6.3`` to
   ``REGCLASS`` to incorrectly return ``0``.
+
+- Bumped the PostgreSQL JDBC driver used by the
+  :ref:`JDBC foreign data wrapper <administration-fdw-jdbc>` to ``42.7.13``
+  because of `CVE-2026-54291 <https://nvd.nist.gov/vuln/detail/CVE-2026-54291>`_,
+  a SCRAM channel-binding downgrade in the driver. CrateDB isn't affected by
+  default, since a foreign server only uses channel binding if a user
+  explicitly sets ``channelBinding=require`` on its JDBC URL.

--- a/pom.xml
+++ b/pom.xml
@@ -355,7 +355,7 @@
         <versions.hamcrest>2.2</versions.hamcrest>
         <versions.mockito>5.23.0</versions.mockito>
         <versions.jqwik>1.10.1</versions.jqwik>
-        <versions.jdbc>42.7.11</versions.jdbc>
+        <versions.jdbc>42.7.13</versions.jdbc>
 
         <versions.jmh>1.37</versions.jmh>
 


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2026-54291 can rise if users create foreign servers with `channelBinding=require`.
