### PR TITLE
Fix table OID handling in pg_table_is_visible and has_table_privilege

### DIFF
--- a/docs/appendices/release-notes/6.3.7.rst
+++ b/docs/appendices/release-notes/6.3.7.rst
@@ -69,3 +69,9 @@ Fixes
   a SCRAM channel-binding downgrade in the driver. CrateDB isn't affected by
   default, since a foreign server only uses channel binding if a user
   explicitly sets ``channelBinding=require`` on its JDBC URL.
+
+- Fixed an issue that caused
+  :ref:`pg_table_is_visible <scalar-pg_table_is_visible>` and
+  :ref:`has_table_privilege <scalar-has-table-priv>` to return incorrect
+  results for OID ``0`` and for OIDs of tables created before
+  :ref:`version_6.3.0`.

--- a/docs/appendices/release-notes/6.4.2.rst
+++ b/docs/appendices/release-notes/6.4.2.rst
@@ -69,3 +69,9 @@ Fixes
   a SCRAM channel-binding downgrade in the driver. CrateDB isn't affected by
   default, since a foreign server only uses channel binding if a user
   explicitly sets ``channelBinding=require`` on its JDBC URL.
+
+- Fixed an issue that caused
+  :ref:`pg_table_is_visible <scalar-pg_table_is_visible>` and
+  :ref:`has_table_privilege <scalar-has-table-priv>` to return incorrect
+  results for OID ``0`` and for OIDs of tables created before
+  :ref:`version_6.3.0`.

--- a/server/src/main/java/io/crate/expression/scalar/HasTablePrivilegeFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/HasTablePrivilegeFunction.java
@@ -29,6 +29,8 @@ import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.Locale;
 
+import org.elasticsearch.cluster.metadata.Metadata;
+
 import io.crate.metadata.FunctionName;
 import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
@@ -66,7 +68,7 @@ public class HasTablePrivilegeFunction {
                                           Functions functions,
                                           SearchPath searchPath) {
         int tableOid = (int) table;
-        RelationName relationName = schemas.getRelationName(tableOid);
+        RelationName relationName = tableOid == Metadata.OID_UNASSIGNED ? null : schemas.getRelationName(tableOid);
         String tableFqn;
         if (relationName == null) {
             // Proceed to checkPrivileges with tableFqn as 'null' which will return 'true' for a superuser or a

--- a/server/src/main/java/io/crate/expression/scalar/postgres/PgTableIsVisibleFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/postgres/PgTableIsVisibleFunction.java
@@ -23,6 +23,8 @@ package io.crate.expression.scalar.postgres;
 
 import static io.crate.role.Permission.READ_WRITE_DEFINE;
 
+import org.elasticsearch.cluster.metadata.Metadata;
+
 import io.crate.data.Input;
 import io.crate.exceptions.RelationUnknown;
 import io.crate.expression.scalar.HasTablePrivilegeFunction;
@@ -73,7 +75,7 @@ public class PgTableIsVisibleFunction extends Scalar<Boolean, Integer> {
         }
 
         Schemas schemas = nodeContext.schemas();
-        RelationName relationName = schemas.getRelationName(tableOid);
+        RelationName relationName = tableOid == Metadata.OID_UNASSIGNED ? null : schemas.getRelationName(tableOid);
         if (relationName == null) {
             return false;
         }

--- a/server/src/main/java/io/crate/metadata/RelationLookup.java
+++ b/server/src/main/java/io/crate/metadata/RelationLookup.java
@@ -35,5 +35,5 @@ public interface RelationLookup {
     int getDisplayRelationOid(RelationName relationName);
 
     @Nullable
-    RelationName getRelationName(int oid);
+    RelationName getRelationName(int displayOid);
 }

--- a/server/src/main/java/io/crate/metadata/Schemas.java
+++ b/server/src/main/java/io/crate/metadata/Schemas.java
@@ -475,21 +475,27 @@ public class Schemas extends AbstractLifecycleComponent implements Iterable<Sche
         return viewInfo;
     }
 
+    /**
+     * Returns the RelationName for the given display OID.
+     * <p>
+     * For relations whose persisted OID is OID_UNASSIGNED, the display OID is derived from OidHash.
+     * This is needed for tables created before 6.3.
+     */
     @Nullable
-    public RelationName getRelationName(int oid) {
+    public RelationName getRelationName(int displayOid) {
         for (SchemaInfo schema : this) {
             for (RelationInfo relation : schema.getTables()) {
-                if (oid == relation.oid()) {
+                if (displayOid == displayOid(relation)) {
                     return relation.ident();
                 }
             }
             for (ViewInfo view : schema.getViews()) {
-                if (oid == view.oid()) {
+                if (displayOid == displayOid(view)) {
                     return view.ident();
                 }
             }
             for (RelationMetadata.ForeignTable foreignTable : schema.getForeignTables()) {
-                if (oid == foreignTable.oid()) {
+                if (displayOid == displayOid(foreignTable)) {
                     return foreignTable.ident();
                 }
             }
@@ -516,10 +522,14 @@ public class Schemas extends AbstractLifecycleComponent implements Iterable<Sche
                 }
             }
             if (relationInfo != null) {
-                int oid = relationInfo.oid();
-                return oid == Metadata.OID_UNASSIGNED ? OidHash.relationOid(relationInfo) : oid;
+                return displayOid(relationInfo);
             }
         }
         return OidHash.relationOid(OidHash.Type.TABLE, relationName);
+    }
+
+    private static int displayOid(RelationInfo relationInfo) {
+        int oid = relationInfo.oid();
+        return oid == Metadata.OID_UNASSIGNED ? OidHash.relationOid(relationInfo) : oid;
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
OID-based lookups such as `pg_table_is_visible` and `has_table_privilege` must be aware that all pre-6.3 tables are persisted as OID_UNASSIGNED but exposed OidHash generated OIDs.

Tables created before 6.3 must be resolved by OidHash generated OIDs and NOT by `0`.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes.
       If you're an external contributor you can give yourself attribution and include your name and Github handle.
       e.g.:
       ```
       `John Doe <https://github.com/John_Doe>`_ added support for ...
       ```
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
