### PR TITLE
Fix stddev/variance returning NULL or negative for large constant inputs

### DIFF
--- a/docs/appendices/release-notes/6.3.6.rst
+++ b/docs/appendices/release-notes/6.3.6.rst
@@ -52,3 +52,10 @@ Fixes
 
 - Fixed an issue that caused casts of foreign tables to ``REGCLASS`` to
   incorrectly return ``0``.
+
+- Fixed an issue that caused :ref:`stddev_pop() <aggregation-stddev-pop>`,
+  :ref:`stddev_samp() <aggregation-stddev-samp>`, :ref:`stddev()
+  <aggregation-stddev>` and :ref:`variance() <aggregation-variance>` to return
+  ``NULL`` (or, for ``variance``, a negative number) instead of ``0`` when
+  aggregating large-magnitude values with little or no spread, such as a
+  constant ``DATE`` or ``TIMESTAMP``.

--- a/server/src/main/java/io/crate/execution/engine/aggregation/statistics/Variance.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/statistics/Variance.java
@@ -36,26 +36,26 @@ public class Variance implements Writeable, Comparable<Variance> {
         return FIXED_SIZE;
     }
 
-    private double sumOfSqrs;
-    private double sum;
+    private double mean;
+    private double m2;
     private long count;
 
     public Variance() {
-        sumOfSqrs = 0.0;
-        sum = 0.0;
+        mean = 0.0;
+        m2 = 0.0;
         count = 0;
     }
 
     public Variance(StreamInput in) throws IOException {
-        sumOfSqrs = in.readDouble();
-        sum = in.readDouble();
+        mean = in.readDouble();
+        m2 = in.readDouble();
         count = in.readVLong();
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeDouble(sumOfSqrs);
-        out.writeDouble(sum);
+        out.writeDouble(mean);
+        out.writeDouble(m2);
         out.writeVLong(count);
     }
 
@@ -63,16 +63,30 @@ public class Variance implements Writeable, Comparable<Variance> {
         return count;
     }
 
+    /**
+     * Welford's online algorithm. Unlike the naive {@code sum(x^2) - sum(x)^2/n} formula it does
+     * not square the raw values, so it avoids the catastrophic cancellation that produced a
+     * negative variance (and therefore {@code NULL} standard deviations) for large-magnitude
+     * inputs such as a constant {@code DATE}/{@code TIMESTAMP}. See crate/crate#19760.
+     */
     public Variance increment(double value) {
-        sumOfSqrs += (value * value);
-        sum += value;
         count++;
+        double delta = value - mean;
+        mean += delta / count;
+        m2 += delta * (value - mean);
         return this;
     }
 
     public void decrement(double value) {
-        sumOfSqrs -= (value * value);
-        sum -= value;
+        if (count == 1) {
+            count = 0;
+            mean = 0.0;
+            m2 = 0.0;
+            return;
+        }
+        double meanPrev = (count * mean - value) / (count - 1);
+        m2 -= (value - mean) * (value - meanPrev);
+        mean = meanPrev;
         count--;
     }
 
@@ -80,13 +94,26 @@ public class Variance implements Writeable, Comparable<Variance> {
         if (count == 0) {
             return Double.NaN;
         }
-        return (sumOfSqrs - ((sum * sum) / count)) / count;
+        // m2 is non-negative by construction; clamp guards against tiny negative residues that
+        // can appear after a long sequence of decrements in sliding window frames.
+        return Math.max(m2, 0.0) / count;
     }
 
     public void merge(Variance other) {
-        sumOfSqrs += other.sumOfSqrs;
-        sum += other.sum;
-        count += other.count;
+        if (other.count == 0) {
+            return;
+        }
+        if (count == 0) {
+            mean = other.mean;
+            m2 = other.m2;
+            count = other.count;
+            return;
+        }
+        long newCount = count + other.count;
+        double delta = other.mean - mean;
+        m2 = m2 + other.m2 + delta * delta * count * other.count / newCount;
+        mean = mean + delta * other.count / newCount;
+        count = newCount;
     }
 
     @Override

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/StdDevPopAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/StdDevPopAggregationTest.java
@@ -150,6 +150,18 @@ public class StdDevPopAggregationTest extends AggregationTestCase {
     }
 
     @Test
+    public void test_repeated_large_values_return_zero() throws Exception {
+        // https://github.com/crate/crate/issues/19760
+        // Repeated large-magnitude values (e.g. a constant DATE/TIMESTAMP as epoch millis) used to
+        // trigger catastrophic cancellation in the variance accumulator, producing a negative
+        // variance and therefore NULL instead of 0.
+        long epochMillis = 1783468800000L; // DATE '2026-07-08'
+        assertThat(executeAggregation(DataTypes.LONG, new Object[][]{
+            {epochMillis}, {epochMillis}, {epochMillis}, {epochMillis}, {epochMillis}}))
+            .isEqualTo(0.0d);
+    }
+
+    @Test
     public void testUnsupportedType() {
         assertThatThrownBy(() -> executeAggregation(DataTypes.GEO_POINT, new Object[][]{}))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/StdDevSampAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/StdDevSampAggregationTest.java
@@ -153,6 +153,18 @@ public class StdDevSampAggregationTest extends AggregationTestCase {
     }
 
     @Test
+    public void test_repeated_large_values_return_zero() throws Exception {
+        // https://github.com/crate/crate/issues/19760
+        // Repeated large-magnitude values (e.g. a constant DATE/TIMESTAMP as epoch millis) used to
+        // trigger catastrophic cancellation in the variance accumulator, producing a negative
+        // variance and therefore NULL instead of 0.
+        long epochMillis = 1783468800000L; // DATE '2026-07-08'
+        assertThat(executeAggregation(DataTypes.LONG, new Object[][]{
+            {epochMillis}, {epochMillis}, {epochMillis}, {epochMillis}, {epochMillis}}))
+            .isEqualTo(0.0d);
+    }
+
+    @Test
     public void testUnsupportedType() {
         assertThatThrownBy(() -> executeAggregation(DataTypes.GEO_POINT, new Object[][]{}))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/VarianceAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/VarianceAggregationTest.java
@@ -122,6 +122,17 @@ public class VarianceAggregationTest extends AggregationTestCase {
     }
 
     @Test
+    public void test_repeated_large_values_return_zero() throws Exception {
+        // https://github.com/crate/crate/issues/19760
+        // Repeated large-magnitude values (e.g. a constant DATE/TIMESTAMP as epoch millis) used to
+        // trigger catastrophic cancellation, producing a negative variance instead of 0.
+        long epochMillis = 1783468800000L; // DATE '2026-07-08'
+        Object result = executeAggregation(DataTypes.LONG, new Object[][]{
+            {epochMillis}, {epochMillis}, {epochMillis}, {epochMillis}, {epochMillis}});
+        assertThat(result).isEqualTo(0.0d);
+    }
+
+    @Test
     public void testUnsupportedType() throws Exception {
         assertThatThrownBy(() -> executeAggregation(DataTypes.GEO_POINT, new Object[][] {}))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)

--- a/server/src/test/java/io/crate/execution/engine/window/AggregationWindowFunctionsTest.java
+++ b/server/src/test/java/io/crate/execution/engine/window/AggregationWindowFunctionsTest.java
@@ -131,7 +131,9 @@ public class AggregationWindowFunctionsTest extends AbstractWindowFunctionTest {
 
     @Test
     public void testVarianceOverUnboundedFollowingFrames() throws Throwable {
-        Object[] expected = new Object[]{0.22222222222222202, 0.0, 0.0, 0.6666666666666666, 0.25, 0.0, null};
+        // First element is the correctly-rounded double of 2/9; the numerically stable accumulator
+        // (crate/crate#19760) rounds it more accurately than the previous 0.22222222222222202.
+        Object[] expected = new Object[]{0.2222222222222222, 0.0, 0.0, 0.6666666666666666, 0.25, 0.0, null};
         assertEvaluate(
             "variance(x) OVER(" +
             "   PARTITION BY x>2 ORDER BY x RANGE BETWEEN CURRENT ROW and UNBOUNDED FOLLOWING" +
@@ -143,7 +145,9 @@ public class AggregationWindowFunctionsTest extends AbstractWindowFunctionTest {
 
     @Test
     public void testStdDevPopOverUnboundedFollowingFrames() throws Throwable {
-        Object[] expected = new Object[]{0.47140452079103146, 0.0, 0.0, 0.816496580927726, 0.5, 0.0, null};
+        // First element is rounded more accurately by the numerically stable accumulator
+        // (crate/crate#19760) than the previous 0.47140452079103146.
+        Object[] expected = new Object[]{0.4714045207910317, 0.0, 0.0, 0.816496580927726, 0.5, 0.0, null};
         assertEvaluate(
             "stddev_pop(x) OVER(" +
             "   PARTITION BY x>2 ORDER BY x RANGE BETWEEN CURRENT ROW and UNBOUNDED FOLLOWING" +


### PR DESCRIPTION
**Draft for benchmarking** — opened at @matriv's request in #19760 so `stddev_pop` can be
benchmarked end-to-end with crate-benchmarks before we settle the final approach/target version.
Not ready to merge yet (see "Open questions" below).

## Problem

`stddev_pop`, `stddev_samp`, `stddev` and `variance` return `NULL` (or, for `variance`, a
negative number) instead of `0` when aggregating large-magnitude values with little or no spread —
most visibly a constant `DATE`/`TIMESTAMP`:

```sql
SELECT STDDEV_POP(DATE '2026-07-08')
FROM (VALUES (1), (2), (3), (4), (5)) AS t(x);
-- returns NULL, expected 0.0
```

## Root cause

`Variance` accumulates with the naive `(sum(x^2) - sum(x)^2/n) / n` formula. A `DATE` is stored as
epoch millis (~1.78e12), so `x^2` (~3.2e24) overflows the exact range of a double; `sum(x^2)` and
`sum(x)^2/n` round differently and their subtraction (catastrophic cancellation) yields a small
negative variance instead of `0`. `sqrt(negative)` is `NaN`, which `terminatePartial` maps to
`NULL`. Full analysis and reproduction in #19760.

## Change

Replace the accumulator with Welford's online algorithm (`count`, `mean`, `m2`), the approach used
by PostgreSQL, MySQL, DuckDB and Spark. It never squares the raw values, so the cancellation can't
occur: for identical inputs `m2` stays exactly `0.0` at any magnitude, and `variance` can no longer
go negative. `merge` uses the Chan et al. parallel formula; `decrement` (sliding window frames)
uses the reverse update with `m2` clamped at `>= 0`.

## Tests

- Reproduction tests for `stddev_pop`, `stddev_samp`, `variance` over repeated epoch-millis values
  (previously `NULL`/negative, now `0.0`).
- Two `AggregationWindowFunctionsTest` expectations move to the correctly-rounded doubles
  (e.g. `0.22222222222222202` → `0.2222222222222222`, the exact double of 2/9).

## Open questions (why this is a draft)

- **Target version / approach** still under discussion in #19760 (Welford directly vs. clamp-only
  hotfix + Welford in 6.5.0), pending benchmarks and @mfussenegger's input.
- **Mixed-version clusters:** the partial aggregation state's wire layout changes with the new
  fields. Version-gating for rolling upgrades is **not** included here yet — to be added once the
  target version is decided.

Refs #19760
