### PR TITLE
Monkeypatch for https://github.com/crate/crate/issues/19723

### DIFF
--- a/docs/appendices/release-notes/6.4.2.rst
+++ b/docs/appendices/release-notes/6.4.2.rst
@@ -75,3 +75,9 @@ Fixes
   :ref:`has_table_privilege <scalar-has-table-priv>` to return incorrect
   results for OID ``0`` and for OIDs of tables created before
   :ref:`version_6.3.0`.
+
+- Fixed an issue that caused a ``NullPointerException`` on aarch64 Linux when
+  writing to ``s3``, ``azure`` or ``gcs`` snapshot repositories or when using
+  ``COPY TO`` with S3 or Azure targets. The error was caused by a native method
+  signature mismatch in the OpenDAL Java binding and made ``CREATE REPOSITORY``
+  fail with ``Unable to verify the repository``.

--- a/libs/opendal/src/main/java/org/apache/opendal/OperatorOutputStream.java
+++ b/libs/opendal/src/main/java/org/apache/opendal/OperatorOutputStream.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.opendal;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Arrays;
+
+/* TEMPORARY MONKEYPATCH
+ *
+ * Patched copy of the class shipped in opendal-0.48.2.jar. It shadows the
+ * original via classpath order (crate-libs-opendal precedes the opendal jar
+ * both in the {@code lib/*.jar} glob used by bin/crate and on Maven test
+ * classpaths).
+ *
+ * <p>The original declares {@code native byte[] writeBytes(...)} while the
+ * Rust JNI implementation returns void. The JVM then interprets the garbage
+ * return register as a JNI object handle, which on aarch64 Linux surfaces as
+ * a bare NullPointerException on every write, breaking S3/Azure/GCS/file
+ * snapshot repositories and {@code COPY TO}. This copy corrects the native
+ * method declarations to match the Rust implementation. See
+ * https://github.com/crate/crate/issues/19723 and
+ * https://github.com/apache/opendal/pull/7906
+ * 
+ * <p>Remove this class (and its exemption in JarHell#checkClass) once OpenDAL
+ * releases version 0.58.1 whose Java binding declares these natives
+ * as void.
+ */
+public class OperatorOutputStream extends OutputStream {
+    private static class Writer extends NativeObject {
+        private Writer(long nativeHandle) {
+            super(nativeHandle);
+        }
+
+        @Override
+        protected void disposeInternal(long handle) {
+            disposeWriter(handle);
+        }
+    }
+
+    private static final int DEFAULT_MAX_BYTES = 16384;
+
+    private final Writer writer;
+    private final byte[] bytes;
+    private final int maxBytes;
+
+    private int offset = 0;
+
+    public OperatorOutputStream(Operator operator, String path) {
+        this(operator, path, DEFAULT_MAX_BYTES);
+    }
+
+    public OperatorOutputStream(Operator operator, String path, int maxBytes) {
+        final long op = operator.nativeHandle;
+        this.writer = new Writer(constructWriter(op, path));
+        this.maxBytes = maxBytes;
+        this.bytes = new byte[maxBytes];
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+        bytes[offset++] = (byte) b;
+        if (offset >= maxBytes) {
+            flush();
+        }
+    }
+
+    @Override
+    public void flush() throws IOException {
+        if (offset > maxBytes) {
+            throw new IOException("INTERNAL ERROR: " + offset + " > " + maxBytes);
+        } else if (offset < maxBytes) {
+            final byte[] bytes = Arrays.copyOf(this.bytes, offset);
+            writeBytes(writer.nativeHandle, bytes);
+        } else {
+            writeBytes(writer.nativeHandle, bytes);
+        }
+        offset = 0;
+    }
+
+    @Override
+    public void close() throws IOException {
+        flush();
+        writer.close();
+    }
+
+    private static native long constructWriter(long op, String path);
+
+    private static native void disposeWriter(long writer);
+
+    private static native void writeBytes(long writer, byte[] bytes);
+}

--- a/server/src/main/java/org/elasticsearch/bootstrap/JarHell.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/JarHell.java
@@ -272,6 +272,11 @@ public class JarHell {
                 if (clazz.startsWith("org.apache.lucene.index.AssertingLeafReader")) {
                     return; // overwritten to disable thread-change assertion
                 }
+                if (clazz.startsWith("org.apache.opendal.OperatorOutputStream")) {
+                    // patched copy in crate-libs-opendal fixes a JNI signature
+                    // mismatch in the opendal binding, see https://github.com/crate/crate/issues/19723
+                    return;
+                }
                 throw new IllegalStateException("jar hell!" + System.lineSeparator() +
                         "class: " + clazz + System.lineSeparator() +
                         "jar1: " + previous + System.lineSeparator() +


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Resolves Snapshots fail with NullPointerException on Linux ARM64
https://github.com/crate/crate/issues/19723

**needs** to be backported in 6.4 branch

## Checklist

 - [X] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes.
       If you're an external contributor you can give yourself attribution and include your name and Github handle.
       e.g.:
       ```
       `John Doe <https://github.com/John_Doe>`_ added support for ...
       ```
 - [X] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [X] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
