### PR TITLE
WIP - DocValuesAgg GROUP BY string

### DIFF
--- a/extensions/functions/src/main/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregation.java
+++ b/extensions/functions/src/main/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregation.java
@@ -33,6 +33,7 @@ import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.NumericUtils;
 import org.elasticsearch.Version;
+import org.elasticsearch.common.TriFunction;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.hash.MurmurHash3;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -195,6 +196,7 @@ public class HyperLogLogDistinctAggregation extends AggregationFunction<HyperLog
         if (reference == null) {
             return null;
         }
+        TriFunction<RamAccounting, HllState, HllState, HllState> reducer = this::reduce;
         DataType<?> valueType = reference.valueType();
         switch (valueType.id()) {
             case ByteType.ID:
@@ -213,7 +215,8 @@ public class HyperLogLogDistinctAggregation extends AggregationFunction<HyperLog
                         var hash = BitMixer.mix64(values.nextValue());
                         state.addHash(hash);
                         return state;
-                    }
+                    },
+                    reducer
                 );
             case DoubleType.ID:
                 return new SortedNumericDocValueAggregator<>(
@@ -232,7 +235,8 @@ public class HyperLogLogDistinctAggregation extends AggregationFunction<HyperLog
                         var hash = BitMixer.mix64(NumericUtils.sortableDoubleBits(values.nextValue()));
                         state.addHash(hash);
                         return state;
-                    }
+                    },
+                    reducer
                 );
             case FloatType.ID:
                 return new SortedNumericDocValueAggregator<>(
@@ -250,7 +254,8 @@ public class HyperLogLogDistinctAggregation extends AggregationFunction<HyperLog
                         var hash = BitMixer.mix64(doubleToLongBits(NumericUtils.sortableIntToFloat((int) values.nextValue())));
                         state.addHash(hash);
                         return state;
-                    }
+                    },
+                    reducer
                 );
             case StringType.ID:
             case CharacterType.ID:
@@ -263,6 +268,11 @@ public class HyperLogLogDistinctAggregation extends AggregationFunction<HyperLog
                             state.addHash(hash);
                         }
                         return state;
+                    }
+
+                    @Override
+                    public HllState reduce(RamAccounting ramAccounting, HllState state1, HllState state2) {
+                        return reducer.apply(ramAccounting, state1, state2);
                     }
                 };
             case IpType.ID:
@@ -277,6 +287,11 @@ public class HyperLogLogDistinctAggregation extends AggregationFunction<HyperLog
                             state.addHash(hash);
                         }
                         return state;
+                    }
+
+                    @Override
+                    public HllState reduce(RamAccounting ramAccounting, HllState state1, HllState state2) {
+                        return reducer.apply(ramAccounting, state1, state2);
                     }
                 };
             default:

--- a/server/src/main/java/io/crate/execution/engine/aggregation/AggregationFunction.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/AggregationFunction.java
@@ -30,6 +30,7 @@ import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.NumericUtils;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.CheckedTriFunction;
+import org.elasticsearch.common.TriFunction;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.jspecify.annotations.Nullable;
 
@@ -172,7 +173,8 @@ public abstract class AggregationFunction<TPartial, TFinal> implements FunctionI
      */
     protected DocValueAggregator<?> getNumericDocValueAggregator(
         List<Reference> aggregationReferences,
-        CheckedTriFunction<RamAccounting, TPartial, BigDecimal, TPartial, IOException> onDocValue) {
+        CheckedTriFunction<RamAccounting, TPartial, BigDecimal, TPartial, IOException> onDocValue,
+        TriFunction<RamAccounting, TPartial, TPartial, TPartial> reducer) {
 
         Reference reference = getAggReference(aggregationReferences);
         if (reference == null) {
@@ -201,7 +203,8 @@ public abstract class AggregationFunction<TPartial, TFinal> implements FunctionI
                     long docValue = values.nextValue();
                     BigDecimal value = BigDecimal.valueOf(docValue, scale);
                     return onDocValue.apply(ramAccounting, state, value);
-                }
+                },
+                reducer
             );
         } else {
             return new BinaryDocValueAggregator<>(
@@ -213,7 +216,8 @@ public abstract class AggregationFunction<TPartial, TFinal> implements FunctionI
                     BigInteger bigInteger = NumericUtils.sortableBytesToBigInt(bytesRef.bytes, bytesRef.offset, bytesRef.length);
                     BigDecimal value = new BigDecimal(bigInteger, scale);
                     return onDocValue.apply(ramAccounting, state, value);
-                }
+                },
+                reducer
             );
         }
     }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/DocValueAggregator.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/DocValueAggregator.java
@@ -51,4 +51,6 @@ public interface DocValueAggregator<T> {
     // → never return final value, but always partial result
     @Nullable
     Object partialResult(RamAccounting ramAccounting, T state);
+
+    T reduce(RamAccounting ramAccounting, T state1, T state2);
 }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/ArbitraryAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/ArbitraryAggregation.java
@@ -281,6 +281,14 @@ public class ArbitraryAggregation extends AggregationFunction<Object, Object> {
                 return null;
             }
         }
+
+        @Override
+        public MutableObject reduce(RamAccounting ramAccounting, MutableObject state1, MutableObject state2) {
+            if (state1 == null) {
+                return state2;
+            }
+            return state1;
+        }
     }
 
 
@@ -328,6 +336,14 @@ public class ArbitraryAggregation extends AggregationFunction<Object, Object> {
                 return null;
             }
         }
+
+        @Override
+        public MutableObject reduce(RamAccounting ramAccounting, MutableObject state1, MutableObject state2) {
+            if (state1 == null) {
+                return state2;
+            }
+            return state1;
+        }
     }
 
     private static class ArbitraryIPDocValueAggregator implements DocValueAggregator<MutableObject> {
@@ -372,6 +388,14 @@ public class ArbitraryAggregation extends AggregationFunction<Object, Object> {
             } else {
                 return null;
             }
+        }
+
+        @Override
+        public MutableObject reduce(RamAccounting ramAccounting, MutableObject state1, MutableObject state2) {
+            if (state1 == null) {
+                return state2;
+            }
+            return state1;
         }
     }
 }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/CmpByAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/CmpByAggregation.java
@@ -378,5 +378,13 @@ public final class CmpByAggregation extends AggregationFunction<CmpByAggregation
             }
             return compareBy;
         }
+
+        @Override
+        public CmpByLongState reduce(RamAccounting ramAccounting, CmpByLongState state1, CmpByLongState state2) {
+            if (hasPrecedence(state2.cmpValue, state1.cmpValue)) {
+                return state2;
+            }
+            return state1;
+        }
     }
 }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/CountAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/CountAggregation.java
@@ -268,7 +268,8 @@ public class CountAggregation extends AggregationFunction<MutableLong, Long> {
                         ramAccounting.addBytes(LongStateType.INSTANCE.fixedSize());
                         return new MutableLong(0L);
                     },
-                    (_, _, state) -> state.add(1L)
+                    (_, _, state) -> state.add(1L),
+                    this::reduce
                 );
             case IpType.ID, StringType.ID, BitStringType.ID -> new BinaryDocValueAggregator<>(
                 ref.storageIdent(),
@@ -276,7 +277,8 @@ public class CountAggregation extends AggregationFunction<MutableLong, Long> {
                     ramAccounting.addBytes(LongStateType.INSTANCE.fixedSize());
                     return new MutableLong(0L);
                 },
-                (_, _, state) -> state.add(1L)
+                (_, _, state) -> state.add(1L),
+                this::reduce
             );
             default -> null;
         };

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/GeometricMeanAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/GeometricMeanAggregation.java
@@ -328,7 +328,8 @@ public class GeometricMeanAggregation extends AggregationFunction<GeometricMeanA
                         ramAccounting.addBytes(GeometricMeanStateType.INSTANCE.fixedSize());
                         return new GeometricMeanState();
                     },
-                    (_, values, state) -> state.addValue(values.nextValue())
+                    (_, values, state) -> state.addValue(values.nextValue()),
+                    this::reduce
                 );
             case FloatType.ID:
                 return new SortedNumericDocValueAggregator<>(
@@ -340,7 +341,8 @@ public class GeometricMeanAggregation extends AggregationFunction<GeometricMeanA
                     (_, values, state) -> {
                         var value = NumericUtils.sortableIntToFloat((int) values.nextValue());
                         return state.addValue(value);
-                    }
+                    },
+                    this::reduce
                 );
             case DoubleType.ID:
                 return new SortedNumericDocValueAggregator<>(
@@ -352,7 +354,8 @@ public class GeometricMeanAggregation extends AggregationFunction<GeometricMeanA
                     (_, values, state) -> {
                         var value = NumericUtils.sortableLongToDouble((values.nextValue()));
                         return state.addValue(value);
-                    }
+                    },
+                    this::reduce
                 );
             default:
                 return null;

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/MaximumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/MaximumAggregation.java
@@ -130,6 +130,14 @@ public abstract class MaximumAggregation extends AggregationFunction<Object, Obj
                 return null;
             }
         }
+
+        @Override
+        public MutableLong reduce(RamAccounting ramAccounting, MutableLong state1, MutableLong state2) {
+            if (state2.value() >= state1.value()) {
+                return state2;
+            }
+            return state1;
+        }
     }
 
 
@@ -172,6 +180,14 @@ public abstract class MaximumAggregation extends AggregationFunction<Object, Obj
                 return null;
             }
         }
+
+        @Override
+        public MutableDouble reduce(RamAccounting ramAccounting, MutableDouble state1, MutableDouble state2) {
+            if (state2.value() >= state1.value()) {
+                return state2;
+            }
+            return state1;
+        }
     }
 
 
@@ -213,6 +229,14 @@ public abstract class MaximumAggregation extends AggregationFunction<Object, Obj
             } else {
                 return null;
             }
+        }
+
+        @Override
+        public MutableFloat reduce(RamAccounting ramAccounting, MutableFloat state1, MutableFloat state2) {
+            if (state2.value() >= state1.value()) {
+                return state2;
+            }
+            return state1;
         }
     }
 
@@ -328,7 +352,7 @@ public abstract class MaximumAggregation extends AggregationFunction<Object, Obj
             }
             DataType<?> valueType = reference.valueType();
             if (valueType instanceof NumericType) {
-                return getNumericDocValueAggregator(aggregationReferences, this::reduce);
+                return getNumericDocValueAggregator(aggregationReferences, this::reduce, this::reduce);
             }
             return null;
         }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/MinimumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/MinimumAggregation.java
@@ -129,6 +129,14 @@ public abstract class MinimumAggregation extends AggregationFunction<Object, Obj
                 return null;
             }
         }
+
+        @Override
+        public MutableLong reduce(RamAccounting ramAccounting, MutableLong state1, MutableLong state2) {
+            if (state2.value() < state1.value()) {
+                return state2;
+            }
+            return state1;
+        }
     }
 
 
@@ -171,6 +179,14 @@ public abstract class MinimumAggregation extends AggregationFunction<Object, Obj
                 return null;
             }
         }
+
+        @Override
+        public MutableDouble reduce(RamAccounting ramAccounting, MutableDouble state1, MutableDouble state2) {
+            if (state2.value() < state1.value()) {
+                return state2;
+            }
+            return state1;
+        }
     }
 
     private static class FloatMin implements DocValueAggregator<MutableFloat> {
@@ -211,6 +227,14 @@ public abstract class MinimumAggregation extends AggregationFunction<Object, Obj
             } else {
                 return null;
             }
+        }
+
+        @Override
+        public MutableFloat reduce(RamAccounting ramAccounting, MutableFloat state1, MutableFloat state2) {
+            if (state2.value() < state1.value()) {
+                return state2;
+            }
+            return state1;
         }
     }
 
@@ -261,7 +285,7 @@ public abstract class MinimumAggregation extends AggregationFunction<Object, Obj
             }
             DataType<?> valueType = reference.valueType();
             if (valueType instanceof NumericType) {
-                return getNumericDocValueAggregator(aggregationReferences, this::reduce);
+                return getNumericDocValueAggregator(aggregationReferences, this::reduce, this::reduce);
             }
             return null;
         }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/NumericStandardDeviationAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/NumericStandardDeviationAggregation.java
@@ -169,6 +169,7 @@ public abstract class NumericStandardDeviationAggregation<V extends NumericVaria
                 long sizeAfter = state.size();
                 ramAccounting.addBytes(sizeBefore - sizeAfter);
                 return state;
-            });
+            },
+            this::reduce);
     }
 }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/NumericSumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/NumericSumAggregation.java
@@ -237,6 +237,16 @@ public class NumericSumAggregation extends AggregationFunction<BigDecimal, BigDe
                 return null;
             }
         }
+
+        @Override
+        public OverflowAwareMutableLong reduce(RamAccounting ramAccounting,
+                                               OverflowAwareMutableLong state1,
+                                               OverflowAwareMutableLong state2) {
+            if (state1 == null) {
+                return state2;
+            }
+            return state1.merge(state2);
+        }
     }
 
     static class SumDouble implements DocValueAggregator<BigDecimal> {
@@ -282,6 +292,13 @@ public class NumericSumAggregation extends AggregationFunction<BigDecimal, BigDe
         public Object partialResult(RamAccounting ramAccounting, BigDecimal state) {
             return returnType.implicitCast(state);
         }
+
+        @Override
+        public BigDecimal reduce(RamAccounting ramAccounting, BigDecimal state1, BigDecimal state2) {
+            BigDecimal newValue = state1.add(state2);
+            ramAccounting.addBytes(NumericType.sizeDiff(newValue, state1));
+            return newValue;
+        }
     }
 
     static class SumFloat implements DocValueAggregator<BigDecimal> {
@@ -324,6 +341,13 @@ public class NumericSumAggregation extends AggregationFunction<BigDecimal, BigDe
         @Override
         public Object partialResult(RamAccounting ramAccounting, BigDecimal state) {
             return state;
+        }
+
+        @Override
+        public BigDecimal reduce(RamAccounting ramAccounting, BigDecimal state1, BigDecimal state2) {
+            BigDecimal newValue = state1.add(state2);
+            ramAccounting.addBytes(NumericType.sizeDiff(newValue, state1));
+            return newValue;
         }
     }
 }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/StandardDeviationAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/StandardDeviationAggregation.java
@@ -184,7 +184,8 @@ public abstract class StandardDeviationAggregation<V extends Variance> extends A
                      (_, values, state) -> {
                          state.increment(values.nextValue());
                          return state;
-                     }
+                     },
+                     this::reduce
             );
             case FloatType.ID -> new SortedNumericDocValueAggregator<>(
                 reference.storageIdent(),
@@ -196,7 +197,8 @@ public abstract class StandardDeviationAggregation<V extends Variance> extends A
                     var value = NumericUtils.sortableIntToFloat((int) values.nextValue());
                     state.increment(value);
                     return state;
-                }
+                },
+                this::reduce
             );
             case DoubleType.ID -> new SortedNumericDocValueAggregator<>(
                 reference.storageIdent(),
@@ -208,7 +210,8 @@ public abstract class StandardDeviationAggregation<V extends Variance> extends A
                     var value = NumericUtils.sortableLongToDouble((values.nextValue()));
                     state.increment(value);
                     return state;
-                }
+                },
+                this::reduce
             );
             default -> null;
         };

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/SumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/SumAggregation.java
@@ -280,6 +280,17 @@ public class SumAggregation<T extends Number> extends AggregationFunction<T, T> 
         public Long partialResult(RamAccounting ramAccounting, MutableLong state) {
             return state.hasValue() ? state.value() : null;
         }
+
+        @Override
+        public MutableLong reduce(RamAccounting ramAccounting, MutableLong state1, MutableLong state2) {
+            if (state1 == null || state1.hasValue() == false) {
+                return state2;
+            } else if (state2 == null || state2.hasValue() == false) {
+                return state1;
+            }
+            state1.setValue(Math.addExact(state1.value(), state2.value()));
+            return state1;
+        }
     }
 
     static class SumDouble implements DocValueAggregator<MutableDouble> {
@@ -319,6 +330,17 @@ public class SumAggregation<T extends Number> extends AggregationFunction<T, T> 
         public Object partialResult(RamAccounting ramAccounting, MutableDouble state) {
             return state.hasValue() ? state.value() : null;
         }
+
+        @Override
+        public MutableDouble reduce(RamAccounting ramAccounting, MutableDouble state1, MutableDouble state2) {
+            if (state1 == null || state1.hasValue() == false) {
+                return state2;
+            } else if (state2 == null || state2.hasValue() == false) {
+                return state1;
+            }
+            state1.setValue(kahanSummation.sum(state1.value(), state2.value()));
+            return state1;
+        }
     }
 
     static class SumFloat implements DocValueAggregator<MutableFloat> {
@@ -357,6 +379,17 @@ public class SumAggregation<T extends Number> extends AggregationFunction<T, T> 
         @Override
         public Object partialResult(RamAccounting ramAccounting, MutableFloat state) {
             return state.hasValue() ? state.value() : null;
+        }
+
+        @Override
+        public MutableFloat reduce(RamAccounting ramAccounting, MutableFloat state1, MutableFloat state2) {
+            if (state1 == null || state1.hasValue() == false) {
+                return state2;
+            } else if (state2 == null || state2.hasValue() == false) {
+                return state1;
+            }
+            state1.setValue(kahanSummation.sum(state1.value(), state2.value()));
+            return state1;
         }
     }
 }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/TopKAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/TopKAggregation.java
@@ -264,7 +264,8 @@ public class TopKAggregation extends AggregationFunction<TopKAggregation.State, 
                 (_, values, state) -> {
                     state.update(values.nextValue(), type);
                     return state;
-                }
+                },
+                this::reduce
             );
         } else if (type.id() == StringType.ID) {
             return new BinaryDocValueAggregator<>(
@@ -275,7 +276,8 @@ public class TopKAggregation extends AggregationFunction<TopKAggregation.State, 
                     BytesRef value = values.lookupOrd(ord);
                     state.update(value.utf8ToString(), type);
                     return state;
-                });
+                },
+                this::reduce);
         } else if (type.id() == IpType.ID) {
             return new BinaryDocValueAggregator<>(
                 ref.storageIdent(),
@@ -285,7 +287,8 @@ public class TopKAggregation extends AggregationFunction<TopKAggregation.State, 
                     BytesRef value = values.lookupOrd(ord);
                     state.update(NetworkUtils.formatIPBytes(value), type);
                     return state;
-                });
+                },
+                this::reduce);
         }
         return null;
     }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/VarianceAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/VarianceAggregation.java
@@ -247,7 +247,8 @@ public class VarianceAggregation extends AggregationFunction<Variance, Double> {
                         ramAccounting.addBytes(VarianceStateType.INSTANCE.fixedSize());
                         return new Variance();
                     },
-                    (_, values, state) -> state.increment(values.nextValue())
+                    (_, values, state) -> state.increment(values.nextValue()),
+                    this::reduce
                 );
             case FloatType.ID:
                 return new SortedNumericDocValueAggregator<>(
@@ -259,7 +260,8 @@ public class VarianceAggregation extends AggregationFunction<Variance, Double> {
                     (_, values, state) -> {
                         var value = NumericUtils.sortableIntToFloat((int) values.nextValue());
                         return state.increment(value);
-                    }
+                    },
+                    this::reduce
                 );
             case DoubleType.ID:
                 return new SortedNumericDocValueAggregator<>(
@@ -271,7 +273,8 @@ public class VarianceAggregation extends AggregationFunction<Variance, Double> {
                     (_, values, state) -> {
                         var value = NumericUtils.sortableLongToDouble((values.nextValue()));
                         return state.increment(value);
-                    }
+                    },
+                    this::reduce
                 );
             default:
                 return null;

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/average/AverageAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/average/AverageAggregation.java
@@ -325,7 +325,8 @@ public class AverageAggregation extends AggregationFunction<AverageAggregation.A
                 },
                 (_, values, state) -> {
                     return state.addNumber(values.nextValue(), true);
-                }
+                },
+                this::reduce
             );
             case FloatType.ID -> new SortedNumericDocValueAggregator<>(
                 reference.storageIdent(),
@@ -336,7 +337,8 @@ public class AverageAggregation extends AggregationFunction<AverageAggregation.A
                 (_, values, state) -> {
                     var value = NumericUtils.sortableIntToFloat((int) values.nextValue());
                     return state.addNumber(value, false);
-                }
+                },
+                this::reduce
             );
             case DoubleType.ID -> new SortedNumericDocValueAggregator<>(
                 reference.storageIdent(),
@@ -347,7 +349,8 @@ public class AverageAggregation extends AggregationFunction<AverageAggregation.A
                 (_, values, state) -> {
                     var value = NumericUtils.sortableLongToDouble((values.nextValue()));
                     return state.addNumber(value, false); // Mutates state.
-                }
+                },
+                this::reduce
             );
             default -> null;
         };

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/average/numeric/NumericAverageAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/average/numeric/NumericAverageAggregation.java
@@ -191,6 +191,7 @@ public class NumericAverageAggregation extends AggregationFunction<NumericAverag
                 state.sum = newValue;
                 state.count++;
                 return state;
-            });
+            },
+            this::reduce);
     }
 }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/templates/BinaryDocValueAggregator.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/templates/BinaryDocValueAggregator.java
@@ -40,17 +40,20 @@ public class BinaryDocValueAggregator<T> implements DocValueAggregator<T> {
     private final String columnName;
     private final TriFunction<RamAccounting, MemoryManager, Version, T> newState;
     private final CheckedTriFunction<RamAccounting, SortedSetDocValues, T, T, IOException> onValue;
+    private final TriFunction<RamAccounting, T, T, T> reducer;
 
     protected SortedSetDocValues values;
 
     public BinaryDocValueAggregator(
         String columnName,
         TriFunction<RamAccounting, MemoryManager, Version, T> newState,
-        CheckedTriFunction<RamAccounting, SortedSetDocValues, T, T, IOException> onValue) {
+        CheckedTriFunction<RamAccounting, SortedSetDocValues, T, T, IOException> onValue,
+        TriFunction<RamAccounting, T, T, T> reducer) {
 
         this.columnName = columnName;
         this.newState = newState;
         this.onValue = onValue;
+        this.reducer = reducer;
     }
 
     @Override
@@ -75,5 +78,10 @@ public class BinaryDocValueAggregator<T> implements DocValueAggregator<T> {
     @Override
     public Object partialResult(RamAccounting ramAccounting, T state) {
         return state;
+    }
+
+    @Override
+    public T reduce(RamAccounting ramAccounting, T state1, T state2) {
+        return reducer.apply(ramAccounting, state1, state2);
     }
 }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/templates/SortedNumericDocValueAggregator.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/templates/SortedNumericDocValueAggregator.java
@@ -40,17 +40,20 @@ public class SortedNumericDocValueAggregator<T> implements DocValueAggregator<T>
     private final String columnName;
     private final TriFunction<RamAccounting, MemoryManager, Version, T> newState;
     private final CheckedTriFunction<RamAccounting, SortedNumericDocValues, T, T, IOException> onValue;
+    private final TriFunction<RamAccounting, T, T, T> reducer;
 
     private SortedNumericDocValues values;
 
     public SortedNumericDocValueAggregator(
         String columnName,
         TriFunction<RamAccounting, MemoryManager,Version, T> newState,
-        CheckedTriFunction<RamAccounting, SortedNumericDocValues, T, T, IOException> onValue) {
+        CheckedTriFunction<RamAccounting, SortedNumericDocValues, T, T, IOException> onValue,
+        TriFunction<RamAccounting, T, T, T> reducer) {
 
         this.columnName = columnName;
         this.newState = newState;
         this.onValue = onValue;
+        this.reducer = reducer;
     }
 
     @Override
@@ -75,5 +78,10 @@ public class SortedNumericDocValueAggregator<T> implements DocValueAggregator<T>
     @Override
     public Object partialResult(RamAccounting ramAccounting, T state) {
         return state;
+    }
+
+    @Override
+    public T reduce(RamAccounting ramAccounting, T state1, T state2) {
+        return reducer.apply(ramAccounting, state1, state2);
     }
 }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/util/OverflowAwareMutableLong.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/util/OverflowAwareMutableLong.java
@@ -21,10 +21,11 @@
 
 package io.crate.execution.engine.aggregation.impl.util;
 
-import io.crate.common.annotations.VisibleForTesting;
+import java.math.BigDecimal;
 
 import org.jspecify.annotations.Nullable;
-import java.math.BigDecimal;
+
+import io.crate.common.annotations.VisibleForTesting;
 
 public class OverflowAwareMutableLong implements NumericValueHolder {
 
@@ -75,5 +76,19 @@ public class OverflowAwareMutableLong implements NumericValueHolder {
     @Override
     public void setValue(BigDecimal value) {
         throw new UnsupportedOperationException("setValue() is not supported");
+    }
+
+    public OverflowAwareMutableLong merge(@Nullable OverflowAwareMutableLong other) {
+        if (other == null) {
+            return this;
+        }
+        if (other.hasValue()) {
+            if (other.primitiveSum != 0) {
+                add(other.primitiveSum());
+            } else {
+                bigDecimalSum = bigDecimalSum.add(other.bigDecimalSum());
+            }
+        }
+        return this;
     }
 }

--- a/server/src/main/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIterator.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIterator.java
@@ -296,7 +296,7 @@ final class DocValuesGroupByOptimizedIterator {
         }
 
         @SuppressWarnings("rawtypes")
-        private static <K> Iterable<Row> getRows(Map<K, Object[]> groupedStates,
+        public static <K> Iterable<Row> getRows(Map<K, Object[]> groupedStates,
                                                  int numberOfKeys,
                                                  BiConsumer<K, Object[]> applyKeyToCells,
                                                  List<DocValueAggregator> aggregators,

--- a/server/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
@@ -80,6 +80,7 @@ import io.crate.execution.dsl.projection.GroupProjection;
 import io.crate.execution.dsl.projection.Projection;
 import io.crate.execution.engine.aggregation.AggregationContext;
 import io.crate.execution.engine.aggregation.AggregationFunction;
+import io.crate.execution.engine.aggregation.DocValueAggregator;
 import io.crate.execution.engine.aggregation.impl.CountAggregation;
 import io.crate.execution.engine.fetch.ReaderContext;
 import io.crate.execution.jobs.SharedShardContext;
@@ -88,6 +89,7 @@ import io.crate.expression.InputFactory;
 import io.crate.expression.InputRow;
 import io.crate.expression.reference.doc.lucene.CollectorContext;
 import io.crate.expression.reference.doc.lucene.LuceneCollectorExpression;
+import io.crate.expression.reference.doc.lucene.LuceneReferenceResolver;
 import io.crate.expression.reference.doc.lucene.StoredRowLookup;
 import io.crate.expression.symbol.AggregateMode;
 import io.crate.expression.symbol.Aggregation;
@@ -98,6 +100,7 @@ import io.crate.expression.symbol.Symbols;
 import io.crate.lucene.LuceneQueryBuilder;
 import io.crate.memory.MemoryManager;
 import io.crate.metadata.DocReferences;
+import io.crate.metadata.Functions;
 import io.crate.metadata.IndexType;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
@@ -274,6 +277,7 @@ final class GroupByOptimizedIterator {
         return numDocs;
     }
 
+    @SuppressWarnings("rawtypes")
     @Nullable
     static BatchIterator<Row> tryOptimizeSingleStringKey(IndexShard indexShard,
                                                          DocTableInfo table,
@@ -283,7 +287,9 @@ final class GroupByOptimizedIterator {
                                                          NodeContext nodeCtx,
                                                          DocInputFactory docInputFactory,
                                                          RoutedCollectPhase collectPhase,
-                                                         CollectTask collectTask) {
+                                                         CollectTask collectTask,
+                                                         Functions functions,
+                                                         LuceneReferenceResolver referenceResolver) {
         GroupProjection groupProjection = getSingleStringKeyGroupProjection(collectPhase.projections());
         if (groupProjection == null) {
             return null;
@@ -323,6 +329,17 @@ final class GroupByOptimizedIterator {
         final List<CollectExpression<Row, ?>> aggExpressions = ctxForAggregations.expressions();
 
         List<AggregationContext> aggregations = ctxForAggregations.aggregations();
+
+        List<DocValueAggregator> aggregators = DocValuesAggregates.createAggregators(
+            functions,
+            referenceResolver,
+            groupProjection.values(),
+            collectPhase.toCollect(),
+            table,
+            indexShard.getVersionCreated()
+        );
+
+
         List<? extends LuceneCollectorExpression<?>> expressions = docCtx.expressions();
 
         RamAccounting ramAccounting = collectTask.getRamAccounting();
@@ -348,6 +365,7 @@ final class GroupByOptimizedIterator {
             searcher.item(),
             keyRef.storageIdent(),
             aggregations,
+            aggregators,
             expressions,
             aggExpressions,
             ramAccounting,
@@ -359,10 +377,12 @@ final class GroupByOptimizedIterator {
             groupProjection.mode());
     }
 
+    @SuppressWarnings("rawtypes")
     static BatchIterator<Row> getIterator(BigArrays bigArrays,
                                           IndexSearcher indexSearcher,
                                           String keyColumnName,
                                           List<AggregationContext> aggregations,
+                                          @Nullable List<DocValueAggregator> aggregators,
                                           List<? extends LuceneCollectorExpression<?>> expressions,
                                           List<CollectExpression<Row, ?>> aggExpressions,
                                           RamAccounting ramAccounting,
@@ -375,6 +395,11 @@ final class GroupByOptimizedIterator {
         for (int i = 0, expressionsSize = expressions.size(); i < expressionsSize; i++) {
             expressions.get(i).startCollect(collectorContext);
         }
+        // Treat an empty aggregators list the same as null: nothing to dispatch to the
+        // doc-value-aggregator path, so fall back to the generic Input/AggregationContext path.
+        List<DocValueAggregator> effectiveAggregators = aggregators == null || aggregators.isEmpty()
+            ? null
+            : aggregators;
 
         Killable.Token killToken = new Token();
         return CollectingBatchIterator.newInstance(
@@ -385,6 +410,7 @@ final class GroupByOptimizedIterator {
                         indexSearcher,
                         keyColumnName,
                         aggregations,
+                        effectiveAggregators,
                         expressions,
                         aggExpressions,
                         ramAccounting,
@@ -396,10 +422,29 @@ final class GroupByOptimizedIterator {
                     ),
                 ramAccounting,
                 aggregations,
+                effectiveAggregators,
                 aggregateMode
             ),
             true
         );
+    }
+
+    @SuppressWarnings("rawtypes")
+    private static Iterable<Row> getRows(Map<BytesRef, Object[]> groupedStates,
+                                         RamAccounting ramAccounting,
+                                         List<AggregationContext> aggregations,
+                                         @Nullable List<DocValueAggregator> aggregators,
+                                         AggregateMode mode) {
+        if (aggregators != null) {
+            return DocValuesGroupByOptimizedIterator.GroupByIterator.getRows(
+                groupedStates,
+                1,
+                (key, cells) -> cells[0] = BytesRefs.toString(key),
+                aggregators,
+                ramAccounting
+            );
+        }
+        return getRows(groupedStates, ramAccounting, aggregations, mode);
     }
 
     private static Iterable<Row> getRows(Map<BytesRef, Object[]> groupedStates,
@@ -426,10 +471,12 @@ final class GroupByOptimizedIterator {
             .iterator();
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     private static Map<BytesRef, Object[]> applyAggregatesGroupedByKey(BigArrays bigArrays,
                                                                        IndexSearcher indexSearcher,
                                                                        String keyColumnName,
                                                                        List<AggregationContext> aggregations,
+                                                                       @Nullable List<DocValueAggregator> aggregators,
                                                                        List<? extends LuceneCollectorExpression<?>> expressions,
                                                                        List<CollectExpression<Row, ?>> aggExpressions,
                                                                        RamAccounting ramAccounting,
@@ -454,6 +501,11 @@ final class GroupByOptimizedIterator {
             for (int i = 0, expressionsSize = expressions.size(); i < expressionsSize; i++) {
                 expressions.get(i).setNextReader(readerContext);
             }
+            if (aggregators != null) {
+                for (int i = 0; i < aggregators.size(); i++) {
+                    aggregators.get(i).loadDocValues(leaf);
+                }
+            }
             SortedSetDocValues values = DocValues.getSortedSet(leaf.reader(), keyColumnName);
             DocIdSetIterator docs = scorer.iterator();
             Bits liveDocs = leaf.reader().getLiveDocs();
@@ -465,14 +517,22 @@ final class GroupByOptimizedIterator {
                 for (int i = 0, expressionsSize = expressions.size(); i < expressionsSize; i++) {
                     expressions.get(i).setNextDocId(doc);
                 }
-                for (int i = 0, expressionsSize = aggExpressions.size(); i < expressionsSize; i++) {
-                    aggExpressions.get(i).setNextRow(inputRow);
+                if (aggregators == null) {
+                    for (int i = 0, expressionsSize = aggExpressions.size(); i < expressionsSize; i++) {
+                        aggExpressions.get(i).setNextRow(inputRow);
+                    }
                 }
                 if (values.advanceExact(doc)) {
                     long ord = values.nextOrd();
                     Object[] states = statesByOrd.get(ord);
                     if (states == null) {
-                        statesByOrd.put(ord, initStates(aggregations, ramAccounting, memoryManager, minNodeVersion));
+                        statesByOrd.put(ord, aggregators != null
+                            ? initStates(aggregators, doc, ramAccounting, memoryManager, minNodeVersion)
+                            : initStates(aggregations, ramAccounting, memoryManager, minNodeVersion));
+                    } else if (aggregators != null) {
+                        for (int i = 0; i < aggregators.size(); i++) {
+                            states[i] = aggregators.get(i).apply(ramAccounting, doc, states[i]);
+                        }
                     } else {
                         aggregateValues(aggregations, ramAccounting, memoryManager, states);
                     }
@@ -481,7 +541,13 @@ final class GroupByOptimizedIterator {
                     }
                 } else {
                     if (nullStates == null) {
-                        nullStates = initStates(aggregations, ramAccounting, memoryManager, minNodeVersion);
+                        nullStates = aggregators != null
+                            ? initStates(aggregators, doc, ramAccounting, memoryManager, minNodeVersion)
+                            : initStates(aggregations, ramAccounting, memoryManager, minNodeVersion);
+                    } else if (aggregators != null) {
+                        for (int i = 0; i < aggregators.size(); i++) {
+                            nullStates[i] = aggregators.get(i).apply(ramAccounting, doc, nullStates[i]);
+                        }
                     } else {
                         aggregateValues(aggregations, ramAccounting, memoryManager, nullStates);
                     }
@@ -499,10 +565,13 @@ final class GroupByOptimizedIterator {
                 if (prevStates == null) {
                     ramAccounting.addBytes(BYTES_REF_SHALLOW_SIZE + sharedKey.length + HASH_MAP_ENTRY_OVERHEAD);
                     statesByKey.put(BytesRef.deepCopyOf(sharedKey), states);
+                } else if (aggregators != null) {
+                    for (int i = 0; i < aggregators.size(); i++) {
+                        prevStates[i] = aggregators.get(i).reduce(ramAccounting, prevStates[i], states[i]);
+                    }
                 } else {
                     for (int i = 0; i < aggregations.size(); i++) {
                         AggregationContext aggregation = aggregations.get(i);
-                        //noinspection unchecked
                         prevStates[i] = aggregation.function().reduce(
                             ramAccounting,
                             prevStates[i],
@@ -595,6 +664,25 @@ final class GroupByOptimizedIterator {
             } else {
                 states[i] = newState;
             }
+        }
+        return states;
+    }
+
+    @SuppressWarnings("rawtypes")
+    private static Object[] initStates(List<DocValueAggregator> aggregators,
+                                       int doc,
+                                       RamAccounting ramAccounting,
+                                       MemoryManager memoryManager,
+                                       Version minNodeVersion) throws IOException {
+        Object[] states = new Object[aggregators.size()];
+        for (int i = 0; i < aggregators.size(); i++) {
+            var aggregator = aggregators.get(i);
+
+            Object state = aggregator.initialState(ramAccounting, memoryManager, minNodeVersion);
+
+            //noinspection unchecked
+            state = aggregator.apply(ramAccounting, doc, state);
+            states[i] = state;
         }
         return states;
     }

--- a/server/src/main/java/io/crate/execution/engine/collect/LuceneShardCollectorProvider.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/LuceneShardCollectorProvider.java
@@ -182,7 +182,9 @@ public class LuceneShardCollectorProvider extends ShardCollectorProvider {
             nodeCtx,
             docInputFactory,
             normalizedPhase,
-            collectTask
+            collectTask,
+            nodeCtx.functions(),
+            referenceResolver
         );
         if (it != null) {
             return it;

--- a/server/src/test/java/io/crate/execution/engine/collect/GroupByOptimizedIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/GroupByOptimizedIteratorTest.java
@@ -67,22 +67,26 @@ import io.crate.execution.dml.StringIndexer;
 import io.crate.execution.dsl.projection.GroupProjection;
 import io.crate.execution.engine.aggregation.AggregationContext;
 import io.crate.execution.engine.aggregation.impl.CountAggregation;
+import io.crate.execution.engine.aggregation.impl.SumAggregation;
 import io.crate.execution.engine.fetch.ReaderContext;
 import io.crate.expression.InputRow;
 import io.crate.expression.reference.doc.lucene.CollectorContext;
 import io.crate.expression.reference.doc.lucene.LuceneCollectorExpression;
 import io.crate.expression.reference.doc.lucene.LuceneReferenceResolver;
 import io.crate.expression.symbol.AggregateMode;
+import io.crate.expression.symbol.Aggregation;
 import io.crate.expression.symbol.InputColumn;
 import io.crate.lucene.LuceneQueryBuilder;
 import io.crate.memory.OnHeapMemoryManager;
 import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.IndexType;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.SimpleReference;
 import io.crate.metadata.doc.DocTableInfo;
+import io.crate.metadata.functions.Signature;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.TestingHelpers;
 import io.crate.types.DataTypes;
@@ -126,6 +130,7 @@ public class GroupByOptimizedIteratorTest extends CrateDummyClusterServiceUnitTe
             indexSearcher,
             columnName,
             aggregationContexts,
+            List.of(),
             List.of(new LuceneCollectorExpression<Object>() {
 
                 @Override
@@ -235,6 +240,7 @@ public class GroupByOptimizedIteratorTest extends CrateDummyClusterServiceUnitTe
         var collectTask = createCollectTask(shard, collectPhase, Version.CURRENT);
         var nodeCtx = createNodeContext();
 
+        var referenceResolver = new LuceneReferenceResolver(PARTITION_NAME.values(), List.of(), List.of(), Version.CURRENT, (_) -> false);
         var it = GroupByOptimizedIterator.tryOptimizeSingleStringKey(
             shard,
             mock(DocTableInfo.class),
@@ -244,10 +250,88 @@ public class GroupByOptimizedIteratorTest extends CrateDummyClusterServiceUnitTe
             nodeCtx,
             new DocInputFactory(
                 nodeCtx,
-                new LuceneReferenceResolver(PARTITION_NAME.values(), List.of(), List.of(), Version.CURRENT, (_) -> false)
+                referenceResolver
             ),
             collectPhase,
-            collectTask
+            collectTask,
+            nodeCtx.functions(),
+            referenceResolver
+        );
+        assertThat(it).isNotNull();
+
+        collectTask.kill(JobKilledException.of(null));
+        closeShard(shard);
+    }
+
+    @Test
+    public void test_create_optimized_iterator_for_single_string_key_using_doc_value_agg() throws Exception {
+        List<Aggregation> aggregations = List.of(
+            new Aggregation(
+                Signature.builder(SumAggregation.NAME, FunctionType.AGGREGATE)
+                    .argumentTypes(DataTypes.LONG.getTypeSignature())
+                    .returnType(DataTypes.LONG.getTypeSignature())
+                    .build(),
+                DataTypes.LONG,
+                Collections.singletonList(new InputColumn(1)))
+        );
+
+        GroupProjection groupProjection = new GroupProjection(
+            List.of(new InputColumn(0, DataTypes.STRING)),
+            aggregations,
+            AggregateMode.ITER_PARTIAL,
+            RowGranularity.SHARD
+        );
+        var groupRef = new SimpleReference(
+            new RelationName("doc", "test"),
+            ColumnIdent.of("x"),
+            RowGranularity.DOC,
+            DataTypes.STRING,
+            IndexType.PLAIN,
+            true,
+            true,
+            0,
+            111,
+            false,
+            null
+        );
+        var aggRef = new SimpleReference(
+            new RelationName("doc", "test"),
+            ColumnIdent.of("y"),
+            RowGranularity.DOC,
+            DataTypes.LONG,
+            IndexType.PLAIN,
+            true,
+            true,
+            1,
+            112,
+            false,
+            null
+        );
+        IndexShard shard = newStartedPrimaryShard(
+            TestingHelpers.createNodeContext(),
+            List.of(groupRef, aggRef),
+            THREAD_POOL
+        );
+        var collectPhase = createCollectPhase(List.of(groupRef, aggRef), List.of(groupProjection));
+        var collectTask = createCollectTask(shard, collectPhase, Version.CURRENT);
+        var nodeCtx = createNodeContext();
+
+        var referenceResolver = new LuceneReferenceResolver(PARTITION_NAME.values(), List.of(), List.of(), Version.CURRENT, (_) -> false);
+        var it = GroupByOptimizedIterator.tryOptimizeSingleStringKey(
+            shard,
+            mock(DocTableInfo.class),
+            PARTITION_NAME.values(),
+            new LuceneQueryBuilder(nodeCtx),
+            mock(BigArrays.class),
+            nodeCtx,
+            new DocInputFactory(
+                nodeCtx,
+                referenceResolver
+            ),
+            collectPhase,
+            collectTask,
+            nodeCtx.functions(),
+            referenceResolver
         );
         assertThat(it).isNotNull();
 


### PR DESCRIPTION
Closes: https://github.com/crate/crate/issues/19421

Cleaned up from: https://github.com/crate/crate/commits/s/optimized-group-docval-aggs/

Using the following spec:
```
[setup]
statement_files = ["sql/uservisits.sql"]
statements = [
    "copy uservisits from 'https://cdn.crate.io/downloads/datasets/amplab/1node/uservisits/part-00001.gz' with (compression = 'gzip')",
    "copy uservisits from 'https://cdn.crate.io/downloads/datasets/amplab/1node/uservisits/part-00002.gz' with (compression = 'gzip')",
    "copy uservisits from 'https://cdn.crate.io/downloads/datasets/amplab/1node/uservisits/part-00003.gz' with (compression = 'gzip')",
    "copy uservisits from 'https://cdn.crate.io/downloads/datasets/amplab/1node/uservisits/part-00004.gz' with (compression = 'gzip')",
    "copy uservisits from 'https://cdn.crate.io/downloads/datasets/amplab/1node/uservisits/part-00005.gz' with (compression = 'gzip')",
    "copy uservisits from 'https://cdn.crate.io/downloads/datasets/amplab/1node/uservisits/part-00006.gz' with (compression = 'gzip')",
    "copy uservisits from 'https://cdn.crate.io/downloads/datasets/amplab/1node/uservisits/part-00007.gz' with (compression = 'gzip')",
    "copy uservisits from 'https://cdn.crate.io/downloads/datasets/amplab/1node/uservisits/part-00008.gz' with (compression = 'gzip')",
    "copy uservisits from 'https://cdn.crate.io/downloads/datasets/amplab/1node/uservisits/part-00009.gz' with (compression = 'gzip')",
    "copy uservisits from 'https://cdn.crate.io/downloads/datasets/amplab/1node/uservisits/part-00010.gz' with (compression = 'gzip')",
    "refresh table uservisits"
]

[[queries]]
name = "count star and group by a single string key"
statement = '''select "cCode", count(*) from uservisits group by "cCode"'''
concurrency = 10
iterations = 10000

[[queries]]
name = "count and group by a single string key and where filter"
statement = '''select "cCode", count("sourceIP") from uservisits WHERE "adRevenue" > 0.2 group by "cCode"'''
concurrency = 10
iterations = 10000

[teardown]
statements = ["drop table if exists uservisits"]
```
compare with master:
```
Q: select "cCode", count("sourceIP") from uservisits WHERE "adRevenue" > 0.2 group by "cCode"
C: 10
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |      490.674 ±  252.069 |    115.657 |    454.356 |    724.292 |   1210.134 |
|   V2    |      125.984 ±   63.120 |     29.440 |    115.494 |    185.291 |    296.051 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               - 118.28%                           - 118.93%
There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 118.28%
The test has statistical significance

```