### PR TITLE
Use doc value aggregators for group by on single string key

### DIFF
--- a/docs/appendices/release-notes/6.5.0.rst
+++ b/docs/appendices/release-notes/6.5.0.rst
@@ -131,6 +131,10 @@ Performance and Resilience Improvements
 - `Bing O'Dowd <https://github.com/bodowd>`_ improved query planning by
   deduplicating identical join conditions joined by the ``AND`` operator.
 
+- Improved the performance of ``GROUP BY`` queries on a single ``STRING`` column
+  with doc values enabled: aggregation values are now read directly from doc
+  values where possible.
+
 Administration and Operations
 -----------------------------
 

--- a/server/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
@@ -24,6 +24,7 @@ package io.crate.execution.engine.collect;
 import static io.crate.execution.engine.collect.LuceneShardCollectorProvider.formatSource;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -80,6 +81,7 @@ import io.crate.execution.dsl.projection.GroupProjection;
 import io.crate.execution.dsl.projection.Projection;
 import io.crate.execution.engine.aggregation.AggregationContext;
 import io.crate.execution.engine.aggregation.AggregationFunction;
+import io.crate.execution.engine.aggregation.DocValueAggregator;
 import io.crate.execution.engine.aggregation.impl.CountAggregation;
 import io.crate.execution.engine.fetch.ReaderContext;
 import io.crate.execution.jobs.SharedShardContext;
@@ -88,6 +90,7 @@ import io.crate.expression.InputFactory;
 import io.crate.expression.InputRow;
 import io.crate.expression.reference.doc.lucene.CollectorContext;
 import io.crate.expression.reference.doc.lucene.LuceneCollectorExpression;
+import io.crate.expression.reference.doc.lucene.LuceneReferenceResolver;
 import io.crate.expression.reference.doc.lucene.StoredRowLookup;
 import io.crate.expression.symbol.AggregateMode;
 import io.crate.expression.symbol.Aggregation;
@@ -98,6 +101,7 @@ import io.crate.expression.symbol.Symbols;
 import io.crate.lucene.LuceneQueryBuilder;
 import io.crate.memory.MemoryManager;
 import io.crate.metadata.DocReferences;
+import io.crate.metadata.Functions;
 import io.crate.metadata.IndexType;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
@@ -274,8 +278,11 @@ final class GroupByOptimizedIterator {
         return numDocs;
     }
 
+    @SuppressWarnings("rawtypes")
     @Nullable
-    static BatchIterator<Row> tryOptimizeSingleStringKey(IndexShard indexShard,
+    static BatchIterator<Row> tryOptimizeSingleStringKey(Functions functions,
+                                                         LuceneReferenceResolver referenceResolver,
+                                                         IndexShard indexShard,
                                                          DocTableInfo table,
                                                          List<String> partitionValues,
                                                          LuceneQueryBuilder luceneQueryBuilder,
@@ -313,6 +320,45 @@ final class GroupByOptimizedIterator {
         collectTask.addSearcher(sharedShardContext.readerId(), searcher);
 
         IndexService indexService = sharedShardContext.indexService();
+        Version shardCreatedVersion = indexShard.getVersionCreated();
+        RamAccounting ramAccounting = collectTask.getRamAccounting();
+
+        LuceneQueryBuilder.Context queryContext = luceneQueryBuilder.convert(
+            collectPhase.where(),
+            collectTask.txnCtx(),
+            partitionValues,
+            indexService.indexAnalyzers(),
+            table,
+            shardCreatedVersion,
+            indexService.cache(),
+            collectTask.killToken()::raiseIfKilled
+        );
+
+        // Combine the 2-phase ordinal key optimization with doc-value based aggregation, same as
+        // DocValuesGroupByOptimizedIterator does for the generic single/many key case. A DocValueAggregator
+        // always yields a partial result; for ITER_FINAL the partial results are finished here via
+        // AggregateMode#finishCollect (terminatePartial), same as the generic group-by path in getRows().
+        List<DocValueAggregator> docValueAggregators = DocValuesAggregates.createAggregators(
+            functions,
+            referenceResolver,
+            groupProjection.values(),
+            collectPhase.toCollect(),
+            table,
+            shardCreatedVersion
+        );
+        if (docValueAggregators != null) {
+            return getIteratorWithDocValueAggregators(
+                searcher.item(),
+                keyRef.storageIdent(),
+                docValueAggregators,
+                aggregationFunctions(functions, groupProjection.values()),
+                groupProjection.mode(),
+                ramAccounting,
+                collectTask.memoryManager(),
+                collectTask.minNodeVersion(),
+                queryContext.query()
+            );
+        }
 
         InputFactory.Context<? extends LuceneCollectorExpression<?>> docCtx = docInputFactory.getCtx(collectTask.txnCtx());
         docCtx.add(collectPhase.toCollect().stream()::iterator);
@@ -325,23 +371,9 @@ final class GroupByOptimizedIterator {
         List<AggregationContext> aggregations = ctxForAggregations.aggregations();
         List<? extends LuceneCollectorExpression<?>> expressions = docCtx.expressions();
 
-        RamAccounting ramAccounting = collectTask.getRamAccounting();
-
-        Version shardCreatedVersion = indexShard.getVersionCreated();
         CollectorContext collectorContext
             = new CollectorContext(sharedShardContext.readerId(), () -> StoredRowLookup.create(shardCreatedVersion, table, partitionValues));
         InputRow inputRow = new InputRow(docCtx.topLevelInputs());
-
-        LuceneQueryBuilder.Context queryContext = luceneQueryBuilder.convert(
-            collectPhase.where(),
-            collectTask.txnCtx(),
-            partitionValues,
-            indexService.indexAnalyzers(),
-            table,
-            shardCreatedVersion,
-            indexService.cache(),
-            collectTask.killToken()::raiseIfKilled
-        );
 
         return getIterator(
             bigArrays,
@@ -357,6 +389,183 @@ final class GroupByOptimizedIterator {
             queryContext.query(),
             collectorContext,
             groupProjection.mode());
+    }
+
+    /// Combines the 2-phase ordinal-value lookup (see {@link #applyAggregatesGroupedByKey}) with the
+    /// doc-value-aggregators optimization (see {@link DocValuesGroupByOptimizedIterator}): the group key is
+    /// still resolved from Lucene ordinals in 2 phases (cheap long-keyed grouping first, resolving to the
+    /// actual term value only once per distinct term per segment), but the aggregation values are computed
+    /// directly from doc values via {@link DocValueAggregator}.
+    @SuppressWarnings("rawtypes")
+    private static BatchIterator<Row> getIteratorWithDocValueAggregators(IndexSearcher indexSearcher,
+                                                                         String keyColumnName,
+                                                                         List<DocValueAggregator> aggregators,
+                                                                         List<AggregationFunction> aggregationFunctions,
+                                                                         AggregateMode mode,
+                                                                         RamAccounting ramAccounting,
+                                                                         MemoryManager memoryManager,
+                                                                         Version minNodeVersion,
+                                                                         Query query) {
+        Killable.Token killToken = new Token();
+        return CollectingBatchIterator.newInstance(
+            killToken,
+            () -> getRowsFromDocValueAggregatorStates(
+                applyDocValueAggregatorsGroupedByKey(
+                    indexSearcher,
+                    keyColumnName,
+                    aggregators,
+                    ramAccounting,
+                    memoryManager,
+                    minNodeVersion,
+                    query,
+                    killToken
+                ),
+                aggregators,
+                aggregationFunctions,
+                mode,
+                ramAccounting
+            ),
+            true
+        );
+    }
+
+    @SuppressWarnings("rawtypes")
+    private static List<AggregationFunction> aggregationFunctions(Functions functions, List<Aggregation> aggregations) {
+        List<AggregationFunction> aggregationFunctions = new ArrayList<>(aggregations.size());
+        for (int i = 0; i < aggregations.size(); i++) {
+            aggregationFunctions.add((AggregationFunction<?, ?>) functions.getQualified(aggregations.get(i)));
+        }
+        return aggregationFunctions;
+    }
+
+    @SuppressWarnings("rawtypes")
+    private static Iterable<Row> getRowsFromDocValueAggregatorStates(Map<BytesRef, Object[]> groupedStates,
+                                                                     List<DocValueAggregator> aggregators,
+                                                                     List<AggregationFunction> aggregationFunctions,
+                                                                     AggregateMode mode,
+                                                                     RamAccounting ramAccounting) {
+        return () -> groupedStates.entrySet().stream()
+            .map(new Function<Map.Entry<BytesRef, Object[]>, Row>() {
+
+                final Object[] cells = new Object[1 + aggregators.size()];
+                final RowN row = new RowN(cells);
+
+                @SuppressWarnings("unchecked")
+                @Override
+                public Row apply(Map.Entry<BytesRef, Object[]> entry) {
+                    cells[0] = BytesRefs.toString(entry.getKey());
+                    Object[] states = entry.getValue();
+                    for (int i = 0, c = 1; i < states.length; i++, c++) {
+                        // A DocValueAggregator always yields a partial result; finishCollect returns it
+                        // as-is for ITER_PARTIAL and finishes it (terminatePartial) for ITER_FINAL.
+                        Object partial = aggregators.get(i).partialResult(ramAccounting, states[i]);
+                        cells[c] = mode.finishCollect(ramAccounting, aggregationFunctions.get(i), partial);
+                    }
+                    return row;
+                }
+            })
+            .iterator();
+    }
+
+    /// Groups docs matching `query` by the ordinal of `keyColumnName`'s `SortedSetDocValues` (phase 1) and
+    /// aggregates them using `aggregators`. The ordinal is only resolved to the actual term value (phase 2)
+    /// the first time it is encountered within a segment; the resulting state is then cached (by ordinal) for
+    /// the remainder of that segment and shared with the global, cross-segment map keyed by the resolved term,
+    /// so that further docs matching the same term - whether in this segment or another one - keep mutating the
+    /// same aggregation state directly, without a separate merge/reduce step.
+    @SuppressWarnings("rawtypes")
+    private static Map<BytesRef, Object[]> applyDocValueAggregatorsGroupedByKey(IndexSearcher indexSearcher,
+                                                                                String keyColumnName,
+                                                                                List<DocValueAggregator> aggregators,
+                                                                                RamAccounting ramAccounting,
+                                                                                MemoryManager memoryManager,
+                                                                                Version minNodeVersion,
+                                                                                Query query,
+                                                                                Token killToken) throws IOException {
+        final HashMap<BytesRef, Object[]> statesByKey = new HashMap<>();
+        final Weight weight = indexSearcher.createWeight(indexSearcher.rewrite(query), ScoreMode.COMPLETE_NO_SCORES, 1f);
+        final List<LeafReaderContext> leaves = indexSearcher.getTopReaderContext().leaves();
+        Object[] nullStates = null;
+
+        LongObjectHashMap<Object[]> stateByOrdInLeaf = new LongObjectHashMap<>();
+        for (LeafReaderContext leaf : leaves) {
+            killToken.raiseIfKilled();
+            Scorer scorer = weight.scorer(leaf);
+            if (scorer == null) {
+                continue;
+            }
+            for (int i = 0, aggregatorsSize = aggregators.size(); i < aggregatorsSize; i++) {
+                aggregators.get(i).loadDocValues(leaf);
+            }
+            SortedSetDocValues values = DocValues.getSortedSet(leaf.reader(), keyColumnName);
+            DocIdSetIterator docs = scorer.iterator();
+            Bits liveDocs = leaf.reader().getLiveDocs();
+            stateByOrdInLeaf.clear();
+            for (int doc = docs.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = docs.nextDoc()) {
+                killToken.raiseIfKilled();
+                if (docDeleted(liveDocs, doc)) {
+                    continue;
+                }
+                if (values.advanceExact(doc)) {
+                    long ord = values.nextOrd();
+                    Object[] states = stateByOrdInLeaf.get(ord);
+                    if (states == null) {
+                        BytesRef sharedKey = values.lookupOrd(ord);
+                        states = statesByKey.get(sharedKey);
+                        if (states == null) {
+                            states = initDocValueAggregatorStates(aggregators, ramAccounting, memoryManager, minNodeVersion, doc);
+                            BytesRef key = BytesRef.deepCopyOf(sharedKey);
+                            ramAccounting.addBytes(BYTES_REF_SHALLOW_SIZE + key.length + HASH_MAP_ENTRY_OVERHEAD);
+                            statesByKey.put(key, states);
+                        } else {
+                            applyDocValueAggregators(aggregators, ramAccounting, doc, states);
+                        }
+                        stateByOrdInLeaf.put(ord, states);
+                    } else {
+                        applyDocValueAggregators(aggregators, ramAccounting, doc, states);
+                    }
+                    if (values.docValueCount() > 1) {
+                        throw new ArrayViaDocValuesUnsupportedException(keyColumnName);
+                    }
+                } else {
+                    if (nullStates == null) {
+                        nullStates = initDocValueAggregatorStates(aggregators, ramAccounting, memoryManager, minNodeVersion, doc);
+                    } else {
+                        applyDocValueAggregators(aggregators, ramAccounting, doc, nullStates);
+                    }
+                }
+            }
+        }
+        if (nullStates != null) {
+            statesByKey.put(null, nullStates);
+        }
+        return statesByKey;
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private static Object[] initDocValueAggregatorStates(List<DocValueAggregator> aggregators,
+                                                         RamAccounting ramAccounting,
+                                                         MemoryManager memoryManager,
+                                                         Version minNodeVersion,
+                                                         int doc) throws IOException {
+        Object[] states = new Object[aggregators.size()];
+        for (int i = 0; i < aggregators.size(); i++) {
+            var aggregator = aggregators.get(i);
+            Object state = aggregator.initialState(ramAccounting, memoryManager, minNodeVersion);
+            state = aggregator.apply(ramAccounting, doc, state);
+            states[i] = state;
+        }
+        return states;
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private static void applyDocValueAggregators(List<DocValueAggregator> aggregators,
+                                                 RamAccounting ramAccounting,
+                                                 int doc,
+                                                 Object[] states) throws IOException {
+        for (int i = 0; i < aggregators.size(); i++) {
+            states[i] = aggregators.get(i).apply(ramAccounting, doc, states[i]);
+        }
     }
 
     static BatchIterator<Row> getIterator(BigArrays bigArrays,

--- a/server/src/main/java/io/crate/execution/engine/collect/LuceneShardCollectorProvider.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/LuceneShardCollectorProvider.java
@@ -174,6 +174,8 @@ public class LuceneShardCollectorProvider extends ShardCollectorProvider {
             return it;
         }
         it = GroupByOptimizedIterator.tryOptimizeSingleStringKey(
+            nodeCtx.functions(),
+            referenceResolver,
             indexShard,
             table,
             partitionName.values(),

--- a/server/src/test/java/io/crate/execution/engine/collect/GroupByOptimizedIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/GroupByOptimizedIteratorTest.java
@@ -67,22 +67,26 @@ import io.crate.execution.dml.StringIndexer;
 import io.crate.execution.dsl.projection.GroupProjection;
 import io.crate.execution.engine.aggregation.AggregationContext;
 import io.crate.execution.engine.aggregation.impl.CountAggregation;
+import io.crate.execution.engine.aggregation.impl.SumAggregation;
 import io.crate.execution.engine.fetch.ReaderContext;
 import io.crate.expression.InputRow;
 import io.crate.expression.reference.doc.lucene.CollectorContext;
 import io.crate.expression.reference.doc.lucene.LuceneCollectorExpression;
 import io.crate.expression.reference.doc.lucene.LuceneReferenceResolver;
 import io.crate.expression.symbol.AggregateMode;
+import io.crate.expression.symbol.Aggregation;
 import io.crate.expression.symbol.InputColumn;
 import io.crate.lucene.LuceneQueryBuilder;
 import io.crate.memory.OnHeapMemoryManager;
 import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.IndexType;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.SimpleReference;
 import io.crate.metadata.doc.DocTableInfo;
+import io.crate.metadata.functions.Signature;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.TestingHelpers;
 import io.crate.types.DataTypes;
@@ -234,18 +238,100 @@ public class GroupByOptimizedIteratorTest extends CrateDummyClusterServiceUnitTe
         var collectPhase = createCollectPhase(List.of(reference), List.of(groupProjection));
         var collectTask = createCollectTask(shard, collectPhase, Version.CURRENT);
         var nodeCtx = createNodeContext();
+        var referenceResolver = new LuceneReferenceResolver(PARTITION_NAME.values(), List.of(), List.of(), Version.CURRENT, (_) -> false);
 
         var it = GroupByOptimizedIterator.tryOptimizeSingleStringKey(
+            nodeCtx.functions(),
+            referenceResolver,
             shard,
             mock(DocTableInfo.class),
             PARTITION_NAME.values(),
             new LuceneQueryBuilder(nodeCtx),
             mock(BigArrays.class),
             nodeCtx,
-            new DocInputFactory(
-                nodeCtx,
-                new LuceneReferenceResolver(PARTITION_NAME.values(), List.of(), List.of(), Version.CURRENT, (_) -> false)
-            ),
+            new DocInputFactory(nodeCtx, referenceResolver),
+            collectPhase,
+            collectTask
+        );
+        assertThat(it).isNotNull();
+
+        collectTask.kill(JobKilledException.of(null));
+        closeShard(shard);
+    }
+
+    @Test
+    public void test_create_optimized_iterator_for_single_string_key_using_doc_value_agg_iter_partial() throws Exception {
+        assertOptimizedIteratorForSingleStringKeyUsingDocValueAgg(AggregateMode.ITER_PARTIAL);
+    }
+
+    @Test
+    public void test_create_optimized_iterator_for_single_string_key_using_doc_value_agg_iter_final() throws Exception {
+        assertOptimizedIteratorForSingleStringKeyUsingDocValueAgg(AggregateMode.ITER_FINAL);
+    }
+
+    private void assertOptimizedIteratorForSingleStringKeyUsingDocValueAgg(AggregateMode mode) throws Exception {
+        List<Aggregation> aggregations = List.of(
+            new Aggregation(
+                Signature.builder(SumAggregation.NAME, FunctionType.AGGREGATE)
+                    .argumentTypes(DataTypes.LONG.getTypeSignature())
+                    .returnType(DataTypes.LONG.getTypeSignature())
+                    .build(),
+                DataTypes.LONG,
+                Collections.singletonList(new InputColumn(1)))
+        );
+
+        GroupProjection groupProjection = new GroupProjection(
+            List.of(new InputColumn(0, DataTypes.STRING)),
+            aggregations,
+            mode,
+            RowGranularity.SHARD
+        );
+        var groupRef = new SimpleReference(
+            new RelationName("doc", "test"),
+            ColumnIdent.of("x"),
+            RowGranularity.DOC,
+            DataTypes.STRING,
+            IndexType.PLAIN,
+            true,
+            true,
+            0,
+            111,
+            false,
+            null
+        );
+        var aggRef = new SimpleReference(
+            new RelationName("doc", "test"),
+            ColumnIdent.of("y"),
+            RowGranularity.DOC,
+            DataTypes.LONG,
+            IndexType.PLAIN,
+            true,
+            true,
+            1,
+            112,
+            false,
+            null
+        );
+        IndexShard shard = newStartedPrimaryShard(
+            TestingHelpers.createNodeContext(),
+            List.of(groupRef, aggRef),
+            THREAD_POOL
+        );
+        var collectPhase = createCollectPhase(List.of(groupRef, aggRef), List.of(groupProjection));
+        var collectTask = createCollectTask(shard, collectPhase, Version.CURRENT);
+        var nodeCtx = createNodeContext();
+
+        var referenceResolver = new LuceneReferenceResolver(PARTITION_NAME.values(), List.of(), List.of(), Version.CURRENT, (_) -> false);
+        var it = GroupByOptimizedIterator.tryOptimizeSingleStringKey(
+            nodeCtx.functions(),
+            referenceResolver,
+            shard,
+            mock(DocTableInfo.class),
+            PARTITION_NAME.values(),
+            new LuceneQueryBuilder(nodeCtx),
+            mock(BigArrays.class),
+            nodeCtx,
+            new DocInputFactory(nodeCtx, referenceResolver),
             collectPhase,
             collectTask
         );


### PR DESCRIPTION
The optimized group-by iterator for a single string key (2-phase
ordinal-based grouping) previously always computed aggregation values
via the generic aggregation path, evaluating input expressions row by
row.

Combine the 2-phase ordinal key optimization with the doc-value based
aggregation used by DocValuesGroupByOptimizedIterator: the group key is
still resolved from Lucene ordinals (cheap long-keyed grouping first,
resolving the term value only once per distinct term per segment),
while the aggregation values are read directly from doc values via
DocValueAggregator where possible.

This also covers ITER_FINAL mode (used when shards contain all values
of the group key, e.g. when grouping on the clustered-by column):
DocValueAggregator always yields a partial result, so the partial
states are finished via AggregateMode#finishCollect (terminatePartial),
same as the generic group-by path already did.

Alt approach to: https://github.com/crate/crate/pull/19789

Closes: https://github.com/crate/crate/issues/19421

Using the following spec:
```
[setup]
statement_files = ["sql/uservisits.sql"]
statements = [
    "copy uservisits from 'https://cdn.crate.io/downloads/datasets/amplab/1node/uservisits/part-00001.gz' with (compression = 'gzip')",
    "copy uservisits from 'https://cdn.crate.io/downloads/datasets/amplab/1node/uservisits/part-00002.gz' with (compression = 'gzip')",
    "copy uservisits from 'https://cdn.crate.io/downloads/datasets/amplab/1node/uservisits/part-00003.gz' with (compression = 'gzip')",
    "copy uservisits from 'https://cdn.crate.io/downloads/datasets/amplab/1node/uservisits/part-00004.gz' with (compression = 'gzip')",
    "copy uservisits from 'https://cdn.crate.io/downloads/datasets/amplab/1node/uservisits/part-00005.gz' with (compression = 'gzip')",
    "copy uservisits from 'https://cdn.crate.io/downloads/datasets/amplab/1node/uservisits/part-00006.gz' with (compression = 'gzip')",
    "copy uservisits from 'https://cdn.crate.io/downloads/datasets/amplab/1node/uservisits/part-00007.gz' with (compression = 'gzip')",
    "copy uservisits from 'https://cdn.crate.io/downloads/datasets/amplab/1node/uservisits/part-00008.gz' with (compression = 'gzip')",
    "copy uservisits from 'https://cdn.crate.io/downloads/datasets/amplab/1node/uservisits/part-00009.gz' with (compression = 'gzip')",
    "copy uservisits from 'https://cdn.crate.io/downloads/datasets/amplab/1node/uservisits/part-00010.gz' with (compression = 'gzip')",
    "refresh table uservisits"
]

[[queries]]
name = "count star and group by a single string key"
statement = '''select "cCode", count(*) from uservisits group by "cCode"'''
concurrency = 10
iterations = 10000

[[queries]]
name = "count and group by a single string key and where filter"
statement = '''select "cCode", count("sourceIP") from uservisits WHERE "adRevenue" > 0.2 group by "cCode"'''
concurrency = 10
iterations = 10000

[teardown]
statements = ["drop table if exists uservisits"]
```
compare with master:
```
Q: select "cCode", count("sourceIP") from uservisits WHERE "adRevenue" > 0.2 group by "cCode"
C: 10
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |      490.674 ±  252.069 |    115.657 |    454.356 |    724.292 |   1210.134 |
|   V2    |      105.673 ±   54.670 |     26.890 |     94.124 |    152.213 |    502.460 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               - 129.12%                           - 131.36%
There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 129.12%
The test has statistical significance
```

compare with the other approach: https://github.com/crate/crate/pull/19789
```
Q: select "cCode", count("sourceIP") from uservisits WHERE "adRevenue" > 0.2 group by "cCode"
C: 10
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |      125.984 ±   63.120 |     29.440 |    115.494 |    185.291 |    296.051 |
|   V2    |      105.673 ±   54.670 |     26.890 |     94.124 |    152.213 |    502.460 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -  17.54%                           -  20.39%
There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 17.54%
The test has statistical significance
```

against master:
```
Q: select "cCode", avg(duration), avg("adRevenue") from uservisits WHERE "adRevenue" > 0.2 group by "cCode"
C: 10
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |      184.327 ±  108.049 |     48.637 |    159.699 |    271.477 |    891.232 |
|   V2    |       81.085 ±   56.260 |     20.859 |     70.578 |    108.244 |    580.077 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -  77.80%                           -  77.40%
There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 77.80%
The test has statistical significance
```