### PR TITLE
Avoid re-resolving tables by name via `Schemas.getTableInfo`

### DIFF
--- a/server/src/main/java/io/crate/analyze/ShowStatementAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/ShowStatementAnalyzer.java
@@ -138,7 +138,7 @@ class ShowStatementAnalyzer {
     /// ```
     QueriedSelectRelation analyzeShowSetting(ShowSessionParameter node) {
         QualifiedName parameter = node.parameter();
-        TableInfo tableInfo = schemas.getTableInfo(PgSettingsTable.IDENT);
+        TableInfo tableInfo = PgSettingsTable.INSTANCE;
         TableRelation tableRelation = new TableRelation(tableInfo);
         List<Symbol> outputs;
         List<String> outputNames;

--- a/server/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
+++ b/server/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
@@ -40,6 +40,7 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
 import org.elasticsearch.common.lucene.uid.Versions;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.Index;
 import org.elasticsearch.index.VersionType;
 import org.elasticsearch.index.engine.DocumentMissingException;
 import org.elasticsearch.index.engine.Engine;
@@ -460,7 +461,7 @@ public class TransportShardUpsertAction extends TransportShardAction<
                 boolean isRetry = retryCount > 0 || request.isRetry();
                 AtomicLong version = new AtomicLong();
                 // Get most-recent table info, could have changed (new columns, dropped columns)
-                DocTableInfo actual = isRetry ? schemas.getTableInfo(tableInfo.ident()) : tableInfo;
+                DocTableInfo actual = isRetry ? schemas.getTableInfo(indexShard.shardId().getIndex()) : tableInfo;
                 String id = item.id();
                 Object[] excluded = item.insertValues();
                 final long startTime = System.nanoTime();
@@ -484,7 +485,11 @@ public class TransportShardUpsertAction extends TransportShardAction<
                 );
                 List<Reference> newColumns = indexer.collectSchemaUpdates(newIndexItem);
                 if (newColumns.isEmpty() == false) {
-                    DocTableInfo actualTable = updateSchema(tableInfo.ident(), newColumns);
+                    DocTableInfo actualTable = updateSchema(
+                        tableInfo.ident(),
+                        indexShard.shardId().getIndex(),
+                        newColumns
+                    );
                     indexer.updateTargets(actualTable);
                 }
                 ParsedDocument parsedDoc = indexer.index(newIndexItem);
@@ -541,7 +546,7 @@ public class TransportShardUpsertAction extends TransportShardAction<
             ? indexer.collectSchemaUpdates(item)
             : rawIndexer.collectSchemaUpdates(item);
         if (newColumns.isEmpty() == false) {
-            DocTableInfo actualTable = updateSchema(tableName, newColumns);
+            DocTableInfo actualTable = updateSchema(tableName, indexShard.shardId().getIndex(), newColumns);
             if (rawIndexer == null) {
                 indexer.updateTargets(actualTable);
             } else {
@@ -558,6 +563,7 @@ public class TransportShardUpsertAction extends TransportShardAction<
 
 
     private DocTableInfo updateSchema(RelationName tableName,
+                                      Index index,
                                       List<Reference> newColumns) throws InterruptedException, ExecutionException {
         var addColumnRequest = new AddColumnRequest(
             tableName,
@@ -566,7 +572,7 @@ public class TransportShardUpsertAction extends TransportShardAction<
             new IntArrayList(0)
         );
         addColumnAction.execute(addColumnRequest).get();
-        return schemas.getTableInfo(tableName);
+        return schemas.getTableInfo(index);
     }
 
     private IndexItemResult indexParsedDoc(ParsedDocument parsedDocument,

--- a/server/src/main/java/io/crate/execution/engine/collect/LuceneShardCollectorProvider.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/LuceneShardCollectorProvider.java
@@ -106,7 +106,7 @@ public class LuceneShardCollectorProvider extends ShardCollectorProvider {
         // As this instance is cached but the relation name or table schema may change for the same index UUID,
         // we must not store the partition name or table info inside the instance but resolve on the fly instead.
         PartitionName partitionName = clusterService.state().metadata().getPartitionName(indexShard.shardId().getIndexUUID());
-        DocTableInfo table = nodeCtx.schemas().getTableInfo(partitionName.relationName());
+        DocTableInfo table = nodeCtx.schemas().getTableInfo(indexShard.shardId().getIndex());
         this.referenceResolver = new LuceneReferenceResolver(
             partitionName.values(),
             table.partitionedByColumns(),
@@ -134,7 +134,7 @@ public class LuceneShardCollectorProvider extends ShardCollectorProvider {
         }
         IndexService indexService = sharedShardContext.indexService();
         PartitionName partitionName = clusterService.state().metadata().getPartitionName(indexShard.shardId().getIndexUUID());
-        DocTableInfo table = nodeCtx.schemas().getTableInfo(partitionName.relationName());
+        DocTableInfo table = nodeCtx.schemas().getTableInfo(indexShard.shardId().getIndex());
         Version shardCreatedVersion = indexShard.getVersionCreated();
         LuceneQueryBuilder.Context queryContext = luceneQueryBuilder.convert(
             collectPhase.where(),
@@ -164,7 +164,7 @@ public class LuceneShardCollectorProvider extends ShardCollectorProvider {
     @Override
     protected BatchIterator<Row> getProjectionFusedIterator(RoutedCollectPhase normalizedPhase, CollectTask collectTask) {
         PartitionName partitionName = clusterService.state().metadata().getPartitionName(indexShard.shardId().getIndexUUID());
-        DocTableInfo table = nodeCtx.schemas().getTableInfo(partitionName.relationName());
+        DocTableInfo table = nodeCtx.schemas().getTableInfo(indexShard.shardId().getIndex());
         var it = GroupByOptimizedIterator.tryUseTermFrequencies(
             indexShard,
             normalizedPhase,
@@ -226,7 +226,7 @@ public class LuceneShardCollectorProvider extends ShardCollectorProvider {
         collectTask.addSearcher(sharedShardContext.readerId(), searcher);
         IndexService indexService = sharedShardContext.indexService();
         PartitionName partitionName = clusterService.state().metadata().getPartitionName(indexShard.shardId().getIndexUUID());
-        DocTableInfo table = nodeCtx.schemas().getTableInfo(partitionName.relationName());
+        DocTableInfo table = nodeCtx.schemas().getTableInfo(indexShard.shardId().getIndex());
         Version shardCreatedVersion = indexShard.getVersionCreated();
         final var queryContext = luceneQueryBuilder.convert(
             phase.where(),

--- a/server/src/main/java/io/crate/execution/engine/collect/PKLookupOperation.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/PKLookupOperation.java
@@ -36,6 +36,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.VersionType;
@@ -67,7 +68,6 @@ import io.crate.expression.reference.doc.lucene.StoredRowLookup;
 import io.crate.expression.symbol.Symbol;
 import io.crate.memory.MemoryManager;
 import io.crate.metadata.PartitionName;
-import io.crate.metadata.RelationName;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.planner.operators.PKAndVersion;
@@ -150,7 +150,7 @@ public final class PKLookupOperation {
                                      Collection<? extends Projection> projections,
                                      boolean requiresScroll,
                                      Function<Doc, Row> resultToRow,
-                                     Function<RelationName, DocTableInfo> getTableInfo,
+                                     Function<Index, DocTableInfo> getTableInfo,
                                      Function<String, PartitionName> getPartitionName,
                                      List<Symbol> columns) {
         ArrayList<BatchIterator<Row>> iterators = new ArrayList<>(idsByShard.size());
@@ -173,7 +173,7 @@ public final class PKLookupOperation {
 
             String indexUUID = shardId.getIndexUUID();
             PartitionName partitionName = getPartitionName.apply(indexUUID);
-            DocTableInfo table = getTableInfo.apply(partitionName.relationName());
+            DocTableInfo table = getTableInfo.apply(shardId.getIndex());
 
             Stream<Row> rowStream = idsByShardEntry.getValue().stream()
                 .map(pkAndVersion -> withDoc(

--- a/server/src/main/java/io/crate/execution/engine/collect/count/CountOperation.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/count/CountOperation.java
@@ -161,7 +161,7 @@ public class CountOperation {
         };
         try (Engine.Searcher searcher = indexShard.acquireSearcher("count-operation")) {
             PartitionName partitionName = clusterService.state().metadata().getPartitionName(indexShard.shardId().getIndexUUID());
-            DocTableInfo table = schemas.getTableInfo(partitionName.relationName());
+            DocTableInfo table = schemas.getTableInfo(indexShard.shardId().getIndex());
             LuceneQueryBuilder.Context queryCtx = queryBuilder.convert(
                 filter,
                 txnCtx,

--- a/server/src/main/java/io/crate/execution/engine/fetch/FetchTask.java
+++ b/server/src/main/java/io/crate/execution/engine/fetch/FetchTask.java
@@ -76,7 +76,7 @@ public class FetchTask implements Task {
     private final List<? extends Routing> routings;
     private final Map<RelationName, Collection<Reference>> toFetch;
     private final UUID jobId;
-    private final Function<RelationName, DocTableInfo> getTableInfo;
+    private final Function<Index, DocTableInfo> getTableInfo;
     private final CompletableFuture<Void> result = new CompletableFuture<>();
 
 
@@ -92,7 +92,7 @@ public class FetchTask implements Task {
                      String localNodeId,
                      SharedShardContexts sharedShardContexts,
                      Metadata metadata,
-                     Function<RelationName, DocTableInfo> getTableInfo,
+                     Function<Index, DocTableInfo> getTableInfo,
                      List<? extends Routing> routings) {
         this.jobId = jobId;
         this.phase = phase;
@@ -143,11 +143,13 @@ public class FetchTask implements Task {
     }
 
     public DocTableInfo table(int readerId) {
-        var partitionName = tableIdent(readerId);
-        var relationName = partitionName.relationName();
-        var table = getTableInfo.apply(relationName);
+        SharedShardContext sharedShardContext = shardContexts.get(readerId);
+        if (sharedShardContext == null) {
+            throw new IllegalArgumentException(String.format(Locale.ENGLISH, "Reader with id %d not found", readerId));
+        }
+        var table = getTableInfo.apply(sharedShardContext.indexShard().shardId().getIndex());
         if (table == null) {
-            throw new IllegalStateException("TableInfo missing for relation " + relationName);
+            throw new IllegalStateException("TableInfo missing for readerId=" + readerId);
         }
         return table;
     }

--- a/server/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
+++ b/server/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
@@ -40,6 +40,7 @@ import java.util.stream.Collector;
 
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.lucene.uid.Versions;
@@ -411,7 +412,13 @@ public class ProjectionToProjectorVisitor
         }
         Input<?> sourceInput = ctx.add(projection.rawSource());
         ClusterState state = clusterService.state();
-        DocTableInfo tableInfo = nodeCtx.schemas().getTableInfo(projection.tableIdent());
+        int tableOid = projection.tableOid();
+        DocTableInfo tableInfo;
+        if (tableOid == Metadata.OID_UNASSIGNED) {
+            tableInfo = nodeCtx.schemas().getTableInfo(projection.tableIdent());
+        } else {
+            tableInfo = nodeCtx.schemas().getRelationInfo(tableOid);
+        }
 
         int targetTableNumShards = tableInfo.numberOfShards();
         int targetTableNumReplicas = NumberOfReplicas.effectiveNumReplicas(tableInfo.parameters(), state.nodes());
@@ -477,21 +484,35 @@ public class ProjectionToProjectorVisitor
             insertInputs.add(ctx.add(symbol));
         }
         ClusterState state = clusterService.state();
-        DocTableInfo tableInfo = nodeCtx.schemas().getTableInfo(projection.tableIdent());
+        int tableOid = projection.tableOid();
+        DocTableInfo tableInfo;
+        if (tableOid == Metadata.OID_UNASSIGNED) {
+            tableInfo = nodeCtx.schemas().getTableInfo(projection.tableIdent());
+        } else {
+            tableInfo = nodeCtx.schemas().getRelationInfo(tableOid);
+        }
 
         int targetTableNumShards = tableInfo.numberOfShards();
         int targetTableNumReplicas = NumberOfReplicas.effectiveNumReplicas(tableInfo.parameters(), state.nodes());
 
         final Map<PartitionName, Consumer<IndexItem>> validatorsCache = new HashMap<>();
-        BiConsumer<PartitionName, IndexItem> constraintsChecker = (partition, indexItem) -> checkConstraints(
-            indexItem,
-            partition,
-            nodeCtx.schemas().getTableInfo(projection.tableIdent()),
-            context.txnCtx,
-            nodeCtx,
-            validatorsCache,
-            projection.allTargetColumns()
-        );
+        BiConsumer<PartitionName, IndexItem> constraintsChecker = (partition, indexItem) -> {
+            DocTableInfo t;
+            if (tableOid == Metadata.OID_UNASSIGNED) {
+                t = nodeCtx.schemas().getTableInfo(projection.tableIdent());
+            } else {
+                t = nodeCtx.schemas().getRelationInfo(tableOid);
+            }
+            checkConstraints(
+                indexItem,
+                partition,
+                t,
+                context.txnCtx,
+                nodeCtx,
+                validatorsCache,
+                projection.allTargetColumns()
+            );
+        };
         return new ColumnIndexWriterProjector(
             clusterService,
             constraintsChecker,

--- a/server/src/main/java/io/crate/execution/jobs/JobSetup.java
+++ b/server/src/main/java/io/crate/execution/jobs/JobSetup.java
@@ -850,7 +850,7 @@ public class JobSetup {
                 localNodeId,
                 context.sharedShardContexts,
                 clusterService.state().metadata(),
-                relationName -> schemas.getTableInfo(relationName),
+                schemas::getTableInfo,
                 routings));
             return null;
         }

--- a/server/src/main/java/io/crate/execution/jobs/PKLookupTask.java
+++ b/server/src/main/java/io/crate/execution/jobs/PKLookupTask.java
@@ -30,6 +30,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
+import org.elasticsearch.index.Index;
 import org.elasticsearch.index.shard.ShardId;
 
 import io.crate.data.BatchIterator;
@@ -48,7 +49,6 @@ import io.crate.expression.symbol.Symbol;
 import io.crate.memory.MemoryManager;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.PartitionName;
-import io.crate.metadata.RelationName;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.planner.operators.PKAndVersion;
@@ -70,7 +70,7 @@ public final class PKLookupTask extends AbstractTask {
     private final Function<RamAccounting, MemoryManager> memoryManagerFactory;
     private final int ramAccountingBlockSizeInBytes;
     private final ArrayList<MemoryManager> memoryManagers = new ArrayList<>();
-    private final Function<RelationName, DocTableInfo> getTableInfo;
+    private final Function<Index, DocTableInfo> getTableInfo;
     private final Function<String, PartitionName> getPartitionName;
     private long totalBytes = -1;
 
@@ -81,7 +81,7 @@ public final class PKLookupTask extends AbstractTask {
                  Function<RamAccounting, MemoryManager> memoryManagerFactory,
                  int ramAccountingBlockSizeInBytes,
                  TransactionContext txnCtx,
-                 Function<RelationName, DocTableInfo> getTableInfo,
+                 Function<Index, DocTableInfo> getTableInfo,
                  Function<String, PartitionName> getPartitionName,
                  InputFactory inputFactory,
                  PKLookupOperation pkLookupOperation,

--- a/server/src/main/java/io/crate/metadata/Schemas.java
+++ b/server/src/main/java/io/crate/metadata/Schemas.java
@@ -262,10 +262,13 @@ public class Schemas extends AbstractLifecycleComponent implements Iterable<Sche
     public DocTableInfo getTableInfo(Index index) {
         Metadata metadata = clusterService.state().metadata();
         RelationMetadata relation = metadata.getRelation(index.uuid());
-        if (relation == null) {
-            throw new IndexNotFoundException(index);
+        if (relation instanceof RelationMetadata.Table table) {
+            if (table.oid() == Metadata.OID_UNASSIGNED) {
+                return getTableInfo(table.name());
+            }
+            return getRelationInfo(table.oid());
         }
-        return getTableInfo(relation.name());
+        throw new IndexNotFoundException(index);
     }
 
     /**

--- a/server/src/main/java/io/crate/metadata/shard/ShardReferenceResolver.java
+++ b/server/src/main/java/io/crate/metadata/shard/ShardReferenceResolver.java
@@ -59,7 +59,7 @@ public class ShardReferenceResolver implements ReferenceResolver<NestableInput<?
     private static ReferenceResolver<NestableInput<?>> createPartitionColumnResolver(Index index, RelationName name, List<String> partitionValues, Schemas schemas) {
         DocTableInfo info;
         try {
-            info = schemas.getTableInfo(name);
+            info = schemas.getTableInfo(index);
         } catch (Exception e) {
             if (e instanceof ResourceUnknownException) {
                 LOGGER.error("Orphaned partition '{}' with missing table '{}' found", index, name);

--- a/server/src/main/java/io/crate/statistics/FetchSampleRequest.java
+++ b/server/src/main/java/io/crate/statistics/FetchSampleRequest.java
@@ -21,6 +21,8 @@
 
 package io.crate.statistics;
 
+import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
+
 import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
 
@@ -37,10 +39,15 @@ import java.util.Objects;
 public final class FetchSampleRequest extends TransportRequest {
 
     private final RelationName relationName;
+    private final int tableOid;
     private final List<Reference> columns;
 
-    public FetchSampleRequest(RelationName relationName, List<Reference> columns, Version nodeVersion) {
+    public FetchSampleRequest(RelationName relationName,
+                              int tableOid,
+                              List<Reference> columns,
+                              Version nodeVersion) {
         this.relationName = relationName;
+        this.tableOid = tableOid;
         this.columns = columns;
         if (nodeVersion.before(Version.V_5_7_0)) {
             throw new UnsupportedOperationException("Cannot run ANALYZE request in a mixed cluster with nodes older than 5.7.0");
@@ -52,6 +59,12 @@ public final class FetchSampleRequest extends TransportRequest {
             throw new UnsupportedOperationException("Cannot run ANALYZE request in a mixed cluster with nodes older than 5.7.0");
         }
         this.relationName = new RelationName(in);
+        if ((in.getVersion().before(Version.V_6_4_0) && in.getVersion().onOrAfter(Version.V_6_3_7))
+            || in.getVersion().onOrAfter(Version.V_6_4_2)) {
+            this.tableOid = in.readInt();
+        } else {
+            this.tableOid = OID_UNASSIGNED;
+        }
         if (in.getVersion().before(Version.V_5_7_0)) {
             in.readVInt();  // Old max samples value
         }
@@ -65,6 +78,10 @@ public final class FetchSampleRequest extends TransportRequest {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         relationName.writeTo(out);
+        if ((out.getVersion().before(Version.V_6_4_0) && out.getVersion().onOrAfter(Version.V_6_3_7))
+            || out.getVersion().onOrAfter(Version.V_6_4_2)) {
+            out.writeInt(tableOid);
+        }
         if (out.getVersion().before(Version.V_5_7_0)) {
             out.writeVInt(30_000);  // Old max samples value
         }
@@ -78,13 +95,17 @@ public final class FetchSampleRequest extends TransportRequest {
         return relationName;
     }
 
+    public int tableOid() {
+        return tableOid;
+    }
+
     public List<Reference> columns() {
         return columns;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(relationName, columns);
+        return Objects.hash(relationName, tableOid, columns);
     }
 
     @Override
@@ -98,6 +119,8 @@ public final class FetchSampleRequest extends TransportRequest {
         if (!(obj instanceof FetchSampleRequest other)) {
             return false;
         }
-        return relationName.equals(other.relation()) && columns.equals(other.columns());
+        return relationName.equals(other.relation()) &&
+               tableOid == other.tableOid() &&
+               columns.equals(other.columns());
     }
 }

--- a/server/src/main/java/io/crate/statistics/ReservoirSampler.java
+++ b/server/src/main/java/io/crate/statistics/ReservoirSampler.java
@@ -132,10 +132,11 @@ public final class ReservoirSampler {
         rateLimiter.setMBPerSec(newReadLimit.getMbFrac()); // mbPerSec is volatile in SimpleRateLimiter, one volatile write
     }
 
-    Samples getSamples(RelationName relationName, List<Reference> columns) {
+    Samples getSamples(RelationName relationName, int tableOid, List<Reference> columns) {
         TableInfo table;
         try {
-            table = schemas.getTableInfo(relationName);
+            table = tableOid == Metadata.OID_UNASSIGNED ?
+                schemas.getTableInfo(relationName) : schemas.getRelationInfo(tableOid);
         } catch (RelationUnknown e) {
             return Samples.EMPTY;
         }

--- a/server/src/main/java/io/crate/statistics/TransportAnalyzeAction.java
+++ b/server/src/main/java/io/crate/statistics/TransportAnalyzeAction.java
@@ -97,7 +97,7 @@ public final class TransportAnalyzeAction {
 
                     if (previous == null) {
                         newSamples.completeAsync(
-                            () -> reservoirSampler.getSamples(req.relation(), req.columns()),
+                            () -> reservoirSampler.getSamples(req.relation(), req.tableOid(), req.columns()),
                             executor
                         );
                         return newSamples
@@ -140,7 +140,11 @@ public final class TransportAnalyzeAction {
                     .toList();
 
                 currentFetch = currentFetch
-                    .thenCompose(ignored -> fetchSamples(table.ident(), primitiveColumns))
+                    .thenCompose(ignored -> fetchSamples(
+                        table.ident(),
+                        table.oid(),
+                        primitiveColumns
+                    ))
                     .thenAccept(samples -> {
                         entries.put(table.ident(), samples.createTableStats(primitiveColumns));
                     });
@@ -174,7 +178,9 @@ public final class TransportAnalyzeAction {
         return listener;
     }
 
-    private CompletableFuture<Samples> fetchSamples(RelationName relationName, List<Reference> columns) {
+    private CompletableFuture<Samples> fetchSamples(RelationName relationName,
+                                                    int tableOid,
+                                                    List<Reference> columns) {
         FutureActionListener<FetchSampleResponse> listener = new FutureActionListener<>();
         DiscoveryNodes discoveryNodes = clusterService.state().nodes();
         MultiActionListener<FetchSampleResponse, ?, FetchSampleResponse> multiListener = new MultiActionListener<>(
@@ -194,7 +200,7 @@ public final class TransportAnalyzeAction {
             transportService.sendRequest(
                 node,
                 FETCH_SAMPLES,
-                new FetchSampleRequest(relationName, columns, node.getVersion()),
+                new FetchSampleRequest(relationName, tableOid, columns, node.getVersion()),
                 responseHandler
             );
         }

--- a/server/src/test/java/io/crate/statistics/FetchSampleRequestTest.java
+++ b/server/src/test/java/io/crate/statistics/FetchSampleRequestTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.statistics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
+
+import java.util.List;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.junit.Test;
+
+import io.crate.metadata.RelationName;
+
+public class FetchSampleRequestTest {
+
+    @Test
+    public void test_streaming_table_oids() throws Exception {
+        // streaming to nodes with supported versions
+        for (Version version : List.of(Version.V_6_3_7, Version.V_6_4_2, Version.CURRENT)) {
+            RelationName relation = new RelationName("doc", "tbl");
+            int tableOid = 1234;
+            FetchSampleRequest request = new FetchSampleRequest(relation, tableOid, List.of(), version);
+
+            var out = new BytesStreamOutput();
+            out.setVersion(version);
+            request.writeTo(out);
+
+            var in = out.bytes().streamInput();
+            in.setVersion(version);
+            FetchSampleRequest streamed = new FetchSampleRequest(in);
+
+            assertThat(streamed.tableOid()).isEqualTo(tableOid);
+        }
+
+        // streaming to nodes with unsupported versions
+        for (Version version : List.of(Version.V_6_3_6, Version.V_6_4_0, Version.V_6_4_1)) {
+            RelationName relation = new RelationName("doc", "tbl");
+            FetchSampleRequest request = new FetchSampleRequest(relation, 1234, List.of(), version);
+
+            var out = new BytesStreamOutput();
+            out.setVersion(version);
+            request.writeTo(out);
+
+            var in = out.bytes().streamInput();
+            in.setVersion(version);
+            FetchSampleRequest streamed = new FetchSampleRequest(in);
+
+            assertThat(streamed.tableOid()).isEqualTo(OID_UNASSIGNED);
+        }
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Concurrent `SWAP TABLE` can interfere with queries that re-resolve tables by name during execution. https://github.com/crate/crate/pull/19744 fixed this issue for `INSERT` only.

Instead of investigating this per query type, we can address it by reviewing table lookups by name. The candidates include:

- `Schemas.getTableInfo`
- `Metadata.getRelation`
- `Metadata.getIndex`
- `Metadata.getIndices`

The scope of this PR is limited to `Schemas.getTableInfo`. The others will be handled separately. This PR updates callers of `Schemas.getTableInfo` to resolve tables by OID first, falling back to name-based lookup only for relations with `OID_UNASSIGNED`.


## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes.
       If you're an external contributor you can give yourself attribution and include your name and Github handle.
       e.g.:
       ```
       `John Doe <https://github.com/John_Doe>`_ added support for ...
       ```
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
