### PR TITLE
Cache ViewInfo instances in DocSchemaInfo

### DIFF
--- a/docs/appendices/release-notes/6.5.0.rst
+++ b/docs/appendices/release-notes/6.5.0.rst
@@ -135,6 +135,10 @@ Performance and Resilience Improvements
   with doc values enabled: aggregation values are now read directly from doc
   values where possible.
 
+- `Somil Jain <https://github.com/somiljain2006>`_ improved metadata query
+  performance by caching analyzed ``ViewInfo`` instances, reducing repeated
+  analysis of view definitions when accessing ``information_schema`` views.
+
 Administration and Operations
 -----------------------------
 

--- a/server/src/main/java/io/crate/metadata/doc/DocSchemaInfo.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocSchemaInfo.java
@@ -113,7 +113,7 @@ public class DocSchemaInfo implements SchemaInfo {
     private final ViewInfoFactory viewInfoFactory;
 
     private final ConcurrentHashMap<String, DocTableInfo> docTableByName = new ConcurrentHashMap<>();
-
+    private final ConcurrentHashMap<String, ViewInfo> viewByName = new ConcurrentHashMap<>();
     public static final Predicate<String> NO_BLOB_NOR_DANGLING =
         index -> ! (BlobIndex.isBlobIndex(index) || IndexName.isDangling(index));
 
@@ -174,7 +174,19 @@ public class DocSchemaInfo implements SchemaInfo {
     @Nullable
     @Override
     public ViewInfo getViewInfo(String name) {
-        return viewInfoFactory.create(new RelationName(schemaName, name), clusterService.state());
+        ViewInfo cachedView = viewByName.get(name);
+        if (cachedView != null) {
+            return cachedView;
+        }
+        RelationName ident = new RelationName(schemaName, name);
+        ViewInfo newView = viewInfoFactory.create(ident, clusterService.state());
+        if (newView == null) {
+            return null;
+        }
+        if (newView.relation() != null) {
+            viewByName.put(name, newView);
+        }
+        return newView;
     }
 
     @Override
@@ -201,8 +213,11 @@ public class DocSchemaInfo implements SchemaInfo {
         // search indices with changed relations
         SchemaMetadata newSchemaMetadata = newMetadata.schemas().get(schemaName);
         SchemaMetadata prevSchemaMetadata = prevMetadata.schemas().get(schemaName);
+
+        boolean schemaChanged = false;
         if (newSchemaMetadata == null || prevSchemaMetadata == null) {
             docTableByName.clear();
+            schemaChanged = true;
         } else {
             Iterator<String> cachedTablesIt = docTableByName.keySet().iterator();
             while (cachedTablesIt.hasNext()) {
@@ -217,6 +232,13 @@ public class DocSchemaInfo implements SchemaInfo {
                     }
                 }
             }
+            if (!newSchemaMetadata.equals(prevSchemaMetadata)) {
+                schemaChanged = true;
+            }
+        }
+
+        if (schemaChanged) {
+            viewByName.clear();
         }
 
         PublicationsMetadata prevPublicationsMetadata = prevMetadata.custom(PublicationsMetadata.TYPE);

--- a/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -199,16 +199,22 @@ public class InformationSchemaTest extends IntegTestCase {
                 "FROM information_schema.views " +
                 "WHERE table_name LIKE 't1%' " +
                 "ORDER BY 1, 2");
+
+        rows = response.rows();
         assertThat(rows[0][0]).isEqualTo("t1_view1");
         assertThat(rows[0][1]).isEqualTo(
+            "/* Corrupted view, needs fix */\n" +
             "SELECT *\n" +
             "FROM \"t1\"\n" +
-            "WHERE \"name\" = 'foo'\n");
+            "WHERE \"name\" = 'foo'\n"
+        );
         assertThat(rows[1][0]).isEqualTo("t1_view2");
         assertThat(rows[1][1]).isEqualTo(
+            "/* Corrupted view, needs fix */\n" +
             "SELECT \"id\"\n" +
             "FROM \"t1\"\n" +
-            "WHERE \"name\" = 'foo'\n");
+            "WHERE \"name\" = 'foo'\n"
+        );
 
         execute("SELECT table_name, column_name " +
                 "FROM information_schema.columns " +

--- a/server/src/test/java/io/crate/metadata/doc/DocSchemaInfoTest.java
+++ b/server/src/test/java/io/crate/metadata/doc/DocSchemaInfoTest.java
@@ -31,6 +31,8 @@ import java.util.Map;
 import java.util.Set;
 
 import org.elasticsearch.Version;
+import org.elasticsearch.cluster.ClusterChangedEvent;
+import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.settings.Settings;
@@ -43,11 +45,13 @@ import io.crate.common.collections.Lists;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.table.Operation;
+import io.crate.metadata.view.ViewInfo;
 import io.crate.metadata.view.ViewInfoFactory;
 import io.crate.replication.logical.metadata.Publication;
 import io.crate.replication.logical.metadata.PublicationsMetadata;
 import io.crate.sql.tree.ColumnPolicy;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.SQLExecutor;
 
 public class DocSchemaInfoTest extends CrateDummyClusterServiceUnitTest {
 
@@ -158,6 +162,34 @@ public class DocSchemaInfoTest extends CrateDummyClusterServiceUnitTest {
 
         assertThat(getTablesAffectedByPublicationsChange(prevMetadata, newMetadata, state)).isEmpty();
         assertThat(getTablesAffectedByPublicationsChange(null, null, state)).isEmpty();
+    }
+
+    @Test
+    public void test_getViewInfo_caching() throws Exception {
+        SQLExecutor e = SQLExecutor.of(clusterService);
+        RelationName v1 = new RelationName("doc", "v1");
+        e.addView(v1, "select 1");
+        ViewInfo first = docSchemaInfo.getViewInfo("v1");
+        ViewInfo second = docSchemaInfo.getViewInfo("v1");
+        assertThat(first).isSameAs(second);
+        ClusterState state1 = clusterService.state();
+        e.addTable("create table other.t1 (x int)");
+        ClusterState state2 = clusterService.state();
+        // noop update doesn't clear cache
+        docSchemaInfo.update(new ClusterChangedEvent("dummy", state2, state1));
+        ViewInfo third = docSchemaInfo.getViewInfo("v1");
+        assertThat(third).isSameAs(first);
+        ClusterState state3 = ClusterState.builder(state1)
+            .metadata(
+                Metadata.builder(state1.metadata())
+                    .dropRelation(v1)
+            )
+            .build();
+        docSchemaInfo.update(new ClusterChangedEvent("dummy", state3, state1));
+        // still returns a view because the newState with the dropped relation wasn't published
+        // but a new instance, because docSchemaInfo.update cleared the cache
+        ViewInfo fourth = docSchemaInfo.getViewInfo("v1");
+        assertThat(fourth).isNotSameAs(first);
     }
 
     private PublicationsMetadata publicationsMetadata(String name, boolean allTables, List<String> tables) {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Fixes #18787 

Cache ViewInfo instances in DocSchemaInfo to avoid repeated view analysis. Add a ViewInfo cache backed by a ConcurrentHashMap, reuse cached ViewInfo objects across metadata lookups, invalidate the cache on schema metadata changes to ensure correctness (including SELECT * views), and add tests covering cache reuse and invalidation behavior.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes.
       If you're an external contributor you can give yourself attribution and include your name and Github handle.
       e.g.:
       ```
       `John Doe <https://github.com/John_Doe>`_ added support for ...
       ```
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
