### PR TITLE
Clamp negative variance to zero for large constant inputs

### DIFF
--- a/docs/appendices/release-notes/6.3.7.rst
+++ b/docs/appendices/release-notes/6.3.7.rst
@@ -78,3 +78,11 @@ Fixes
   :ref:`has_table_privilege <scalar-has-table-priv>` to return incorrect
   results for OID ``0`` and for OIDs of tables created before
   :ref:`version_6.3.0`.
+
+- `Dhruv Patel <https://github.com/DHRUV6029>`_  fixed an issue that caused
+  :ref:`stddev_pop() <aggregation-stddev-pop>`, :ref:`stddev_samp()
+  <aggregation-stddev-samp>`, :ref:`stddev() <aggregation-stddev>` and
+  :ref:`variance() <aggregation-variance>` to return ``NULL`` (or, for
+  ``variance``, a negative number) instead of ``0`` when aggregating
+  large-magnitude values with little or no spread, such as a constant ``DATE``
+  or ``TIMESTAMP``.

--- a/docs/appendices/release-notes/6.4.2.rst
+++ b/docs/appendices/release-notes/6.4.2.rst
@@ -78,3 +78,11 @@ Fixes
   :ref:`has_table_privilege <scalar-has-table-priv>` to return incorrect
   results for OID ``0`` and for OIDs of tables created before
   :ref:`version_6.3.0`.
+
+- `Dhruv Patel <https://github.com/DHRUV6029>`_  fixed an issue that caused
+  :ref:`stddev_pop() <aggregation-stddev-pop>`, :ref:`stddev_samp()
+  <aggregation-stddev-samp>`, :ref:`stddev() <aggregation-stddev>` and
+  :ref:`variance() <aggregation-variance>` to return ``NULL`` (or, for
+  ``variance``, a negative number) instead of ``0`` when aggregating
+  large-magnitude values with little or no spread, such as a constant ``DATE``
+  or ``TIMESTAMP``.

--- a/server/src/main/java/io/crate/execution/engine/aggregation/statistics/Variance.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/statistics/Variance.java
@@ -80,7 +80,12 @@ public class Variance implements Writeable, Comparable<Variance> {
         if (count == 0) {
             return Double.NaN;
         }
-        return (sumOfSqrs - ((sum * sum) / count)) / count;
+        double variance = (sumOfSqrs - ((sum * sum) / count)) / count;
+        // The naive sum-of-squares formula can produce a small negative result for
+        // large-magnitude inputs with little spread (e.g. a constant DATE/TIMESTAMP) due to
+        // floating point cancellation. A variance is never negative, so clamp it; otherwise
+        // sqrt() in the stddev variants would yield NaN (returned to the user as NULL).
+        return variance < 0 ? 0 : variance;
     }
 
     public void merge(Variance other) {

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/StdDevPopAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/StdDevPopAggregationTest.java
@@ -150,6 +150,17 @@ public class StdDevPopAggregationTest extends AggregationTestCase {
     }
 
     @Test
+    public void test_repeated_large_values_return_zero() throws Exception {
+        // Repeated large-magnitude values (e.g. a constant DATE/TIMESTAMP as epoch millis) used to
+        // trigger catastrophic cancellation in the variance accumulator, producing a negative
+        // variance and therefore NULL instead of 0.
+        long epochMillis = 1783468800000L; // DATE '2026-07-08'
+        assertThat(executeAggregation(DataTypes.LONG, new Object[][]{
+            {epochMillis}, {epochMillis}, {epochMillis}, {epochMillis}, {epochMillis}}))
+            .isEqualTo(0.0d);
+    }
+
+    @Test
     public void testUnsupportedType() {
         assertThatThrownBy(() -> executeAggregation(DataTypes.GEO_POINT, new Object[][]{}))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/StdDevSampAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/StdDevSampAggregationTest.java
@@ -153,6 +153,17 @@ public class StdDevSampAggregationTest extends AggregationTestCase {
     }
 
     @Test
+    public void test_repeated_large_values_return_zero() throws Exception {
+        // Repeated large-magnitude values (e.g. a constant DATE/TIMESTAMP as epoch millis) used to
+        // trigger catastrophic cancellation in the variance accumulator, producing a negative
+        // variance and therefore NULL instead of 0.
+        long epochMillis = 1783468800000L; // DATE '2026-07-08'
+        assertThat(executeAggregation(DataTypes.LONG, new Object[][]{
+            {epochMillis}, {epochMillis}, {epochMillis}, {epochMillis}, {epochMillis}}))
+            .isEqualTo(0.0d);
+    }
+
+    @Test
     public void testUnsupportedType() {
         assertThatThrownBy(() -> executeAggregation(DataTypes.GEO_POINT, new Object[][]{}))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/VarianceAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/VarianceAggregationTest.java
@@ -122,6 +122,16 @@ public class VarianceAggregationTest extends AggregationTestCase {
     }
 
     @Test
+    public void test_repeated_large_values_return_zero() throws Exception {
+        // Repeated large-magnitude values (e.g. a constant DATE/TIMESTAMP as epoch millis) used to
+        // trigger catastrophic cancellation, producing a negative variance instead of 0.
+        long epochMillis = 1783468800000L; // DATE '2026-07-08'
+        Object result = executeAggregation(DataTypes.LONG, new Object[][]{
+            {epochMillis}, {epochMillis}, {epochMillis}, {epochMillis}, {epochMillis}});
+        assertThat(result).isEqualTo(0.0d);
+    }
+
+    @Test
     public void testUnsupportedType() throws Exception {
         assertThatThrownBy(() -> executeAggregation(DataTypes.GEO_POINT, new Object[][] {}))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)


### PR DESCRIPTION
Backport hotfix for #19760, targeting the **6.4** release line (to be cherry-picked to 6.3 as well). The numerically stable rewrite (Welford) lands separately on master for 6.5.0 in #19782.

## Problem

`stddev_pop`, `stddev_samp`, `stddev` and `variance` return `NULL` (or, for `variance`, a negative number) instead of `0` when aggregating large-magnitude values with little or no spread — most visibly a constant `DATE`/`TIMESTAMP`:

```sql
SELECT STDDEV_POP(DATE '2026-07-08')
FROM (VALUES (1), (2), (3), (4), (5)) AS t(x);
-- returns NULL, expected 0.0
```

## Root cause

`Variance` accumulates with the naive `(sum(x^2) - sum(x)^2/n) / n` formula. A `DATE` is stored as epoch millis (~1.78e12), so `x^2` (~3.2e24) exceeds the exact range of a double; `sum(x^2)` and `sum(x)^2/n` round differently and their subtraction (catastrophic cancellation) yields a small negative variance instead of `0`. `sqrt(negative)` is `NaN`, which is returned to the user as `NULL`.

## Fix

Clamp the computed variance at `>= 0` in `Variance.result()` (`return variance < 0 ? 0 : variance;`) — the same guard PostgreSQL and Elasticsearch apply to this accumulator. It is a minimal, allocation-free change with no effect on the aggregation state or its wire format, so it is safe to backport and for rolling upgrades, and has no per-row cost.

## Why the clamp here, and Welford for 6.5

The proper fix is to replace the accumulator with a numerically stable (Welford) algorithm, which also improves precision for genuinely spread-out large-magnitude inputs — that is #19782, for 6.5.0. But benchmarks on that PR (crate-benchmarks over `uservisits`) showed Welford is **~2–5% slower** and statistically significant, because a numerically stable one-pass algorithm does a floating-point division per row. To avoid a perf regression in a backport, the plan agreed in #19760 / #19782 is to ship this cheap clamp on the 6.3/6.4 lines and the Welford rewrite on 6.5.0.

## Tests

Added reproduction tests for `stddev_pop`, `stddev_samp` and `variance` over five repeated epoch-millis values. Confirmed they fail without the fix (`stddev_*` → `NULL`, `variance` → `-4.294967296E8`) and pass with it. No existing test values change — the clamp only affects the previously broken negative case.

Refs #19760
