### PR TITLE
Handle `distinct` only in aggregate operators

### DIFF
--- a/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
@@ -59,7 +59,6 @@ import io.crate.analyze.validator.SemanticSortValidator;
 import io.crate.common.collections.Lists;
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.exceptions.ConversionException;
-import io.crate.execution.engine.aggregation.impl.CollectSetAggregation;
 import io.crate.expression.eval.EvaluatingNormalizer;
 import io.crate.expression.operator.AndOperator;
 import io.crate.expression.operator.EqOperator;
@@ -298,33 +297,21 @@ public class ExpressionAnalyzer {
             .map(expression -> convert(expression, context))
             .orElse(null);
 
-        WindowDefinition windowDefinition = getWindowDefinition(node.getWindow(), context);
-        if (node.isDistinct()) {
-            if (arguments.size() > 1) {
-                throw new UnsupportedOperationException(String.format(Locale.ENGLISH,
-                    "%s(DISTINCT x) does not accept more than one argument", node.getName()));
-            }
-            Symbol collectSetFunction = allocateFunction(
-                CollectSetAggregation.NAME,
-                arguments,
-                filter,
-                context,
-                coordinatorTxnCtx,
-                nodeCtx);
-
-            // define the outer function which contains the inner function as argument.
-            String nodeName = "collection_" + name;
-            List<Symbol> outerArguments = List.of(collectSetFunction);
-            try {
-                return allocateBuiltinOrUdfFunction(
-                    schema, nodeName, outerArguments, null, node.ignoreNulls(), windowDefinition, context);
-            } catch (UnsupportedOperationException ex) {
-                throw new UnsupportedOperationException(String.format(Locale.ENGLISH,
-                    "unknown function %s(DISTINCT %s)", name, arguments.get(0).valueType()), ex);
-            }
-        } else {
-            return allocateBuiltinOrUdfFunction(schema, name, arguments, filter, node.ignoreNulls(), windowDefinition, context);
+        if (node.isDistinct() && arguments.size() > 1) {
+            throw new UnsupportedOperationException(String.format(Locale.ENGLISH,
+                "%s(DISTINCT x) does not accept more than one argument", name));
         }
+
+        return allocateBuiltinOrUdfFunction(
+            schema,
+            name,
+            arguments,
+            filter,
+            node.ignoreNulls(),
+            node.isDistinct(),
+            getWindowDefinition(node.getWindow(), context),
+            context
+        );
     }
 
     @Nullable
@@ -1265,10 +1252,12 @@ public class ExpressionAnalyzer {
                                                 List<Symbol> arguments,
                                                 Symbol filter,
                                                 @Nullable Boolean ignoreNulls,
+                                                boolean distinct,
                                                 WindowDefinition windowDefinition,
                                                 ExpressionAnalysisContext context) {
         return allocateBuiltinOrUdfFunction(
-            schema, functionName, arguments, filter, ignoreNulls, context, windowDefinition, coordinatorTxnCtx, nodeCtx);
+            schema, functionName, arguments, filter, ignoreNulls, context, distinct, windowDefinition, coordinatorTxnCtx, nodeCtx
+        );
     }
 
     public Symbol allocateFunction(String functionName,
@@ -1284,7 +1273,8 @@ public class ExpressionAnalyzer {
                                             TransactionContext txnCtx,
                                             NodeContext nodeCtx) {
         return allocateBuiltinOrUdfFunction(
-            null, functionName, arguments, filter, null, context, null, txnCtx, nodeCtx);
+            null, functionName, arguments, filter, null, context, false, null, txnCtx, nodeCtx
+        );
     }
 
     /**
@@ -1301,12 +1291,13 @@ public class ExpressionAnalyzer {
      * @param nodeCtx The {@link NodeContext} to normalize constant expressions.
      * @return The supplied {@link Function} or a {@link Literal} in case of constant folding.
      */
-    private static Function allocateBuiltinOrUdfFunction(@Nullable String schema,
+    public static Function allocateBuiltinOrUdfFunction(@Nullable String schema,
                                                          String functionName,
                                                          List<Symbol> arguments,
                                                          @Nullable Symbol filter,
                                                          @Nullable Boolean ignoreNulls,
                                                          ExpressionAnalysisContext context,
+                                                         boolean distinct,
                                                          @Nullable WindowDefinition windowDefinition,
                                                          TransactionContext txnCtx,
                                                          NodeContext nodeCtx) {
@@ -1327,10 +1318,21 @@ public class ExpressionAnalyzer {
         Function newFunction;
         if (windowDefinition == null) {
             if (signature.getType() == FunctionType.AGGREGATE) {
-                context.indicateAggregates();
-            } else if (filter != null) {
-                throw new UnsupportedOperationException(
-                    "Only aggregate functions allow a FILTER clause");
+                // There is no context when a function is allocated while building an execution plan.
+                if (context != null) {
+                    context.indicateAggregates();
+                }
+            } else {
+                if (filter != null) {
+                    throw new UnsupportedOperationException(
+                        "Only aggregate functions allow a FILTER clause");
+                }
+                if (distinct) {
+                    throw new UnsupportedOperationException(String.format(
+                        Locale.ENGLISH,
+                        "DISTINCT is not supported for non-aggregate function %s",
+                        functionName));
+                }
             }
             if (ignoreNulls != null) {
                 throw new IllegalArgumentException(String.format(
@@ -1338,8 +1340,18 @@ public class ExpressionAnalyzer {
                     "%s cannot accept RESPECT or IGNORE NULLS flag.",
                     functionName));
             }
-            newFunction = new Function(signature, castArguments, boundSignature.returnType(), filter);
+            newFunction = new Function(
+                signature,
+                castArguments,
+                boundSignature.returnType(),
+                filter,
+                distinct
+            );
         } else {
+            if (distinct) {
+                throw new UnsupportedOperationException(
+                    "DISTINCT is not implemented for window functions");
+            }
             if (signature.getType() != FunctionType.WINDOW) {
                 if (signature.getType() != FunctionType.AGGREGATE) {
                     throw new IllegalArgumentException(String.format(
@@ -1364,7 +1376,8 @@ public class ExpressionAnalyzer {
                 boundSignature.returnType(),
                 filter,
                 windowDefinition,
-                ignoreNulls);
+                ignoreNulls
+            );
         }
         return newFunction;
     }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/CountAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/CountAggregation.java
@@ -149,7 +149,7 @@ public class CountAggregation extends AggregationFunction<MutableLong, Long> {
     public Symbol normalizeSymbol(Function function, TransactionContext txnCtx, NodeContext nodeCtx) {
         assert function.arguments().size() <= 1 : "function's number of arguments must be 0 or 1";
 
-        if (function.arguments().size() == 1) {
+        if (function.arguments().size() == 1 && !function.distinct()) {
             Symbol arg = function.arguments().get(0);
             if (arg instanceof Input<?> input) {
                 if (input.value() == null) {

--- a/server/src/main/java/io/crate/expression/symbol/Function.java
+++ b/server/src/main/java/io/crate/expression/symbol/Function.java
@@ -30,6 +30,7 @@ import java.util.Objects;
 import java.util.function.Predicate;
 
 import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.jspecify.annotations.Nullable;
@@ -91,16 +92,22 @@ public class Function implements Symbol, Cloneable {
     protected final Signature signature;
     @Nullable
     protected final Symbol filter;
+    protected final boolean distinct;
 
     public Function(Signature signature, List<Symbol> arguments, DataType<?> returnType) {
-        this(signature, arguments, returnType, null);
+        this(signature, arguments, returnType, null, false);
     }
 
     public Function(Signature signature, List<Symbol> arguments, DataType<?> returnType, @Nullable Symbol filter) {
+        this(signature, arguments, returnType, filter, false);
+    }
+
+    public Function(Signature signature, List<Symbol> arguments, DataType<?> returnType, @Nullable Symbol filter, boolean distinct) {
         this.signature = signature;
         this.arguments = List.copyOf(arguments);
         this.returnType = returnType;
         this.filter = filter;
+        this.distinct = distinct;
     }
 
     public Function(StreamInput in) throws IOException {
@@ -108,6 +115,11 @@ public class Function implements Symbol, Cloneable {
         arguments = List.copyOf(Symbols.fromStream(in));
         signature = new Signature(in);
         returnType = DataTypes.fromStream(in);
+        if (in.getVersion().before(Version.V_6_5_0)) {
+            distinct = false;
+        } else {
+            distinct = in.readBoolean();
+        }
     }
 
     @Override
@@ -116,6 +128,9 @@ public class Function implements Symbol, Cloneable {
         Symbols.toStream(arguments, out);
         signature.writeTo(out);
         DataTypes.toStream(returnType, out);
+        if (out.getVersion().onOrAfter(Version.V_6_5_0)) {
+            out.writeBoolean(distinct());
+        }
     }
 
     public List<Symbol> arguments() {
@@ -138,6 +153,10 @@ public class Function implements Symbol, Cloneable {
     @Override
     public DataType<?> valueType() {
         return returnType;
+    }
+
+    public boolean distinct() {
+        return distinct;
     }
 
     @Override
@@ -204,7 +223,7 @@ public class Function implements Symbol, Cloneable {
                 throw new ConversionException(returnType, targetType);
             }
         }
-        return new Function(signature, newArgs, targetType, null);
+        return new Function(signature, newArgs, targetType, null, distinct);
     }
 
     public boolean isCast() {
@@ -252,7 +271,8 @@ public class Function implements Symbol, Cloneable {
         return Objects.equals(arguments, function.arguments) &&
                Objects.equals(signature, function.signature) &&
                Objects.equals(filter, function.filter) &&
-               Objects.equals(returnType, function.returnType);
+               Objects.equals(returnType, function.returnType) &&
+               Objects.equals(distinct, function.distinct);
     }
 
     @Override
@@ -261,6 +281,7 @@ public class Function implements Symbol, Cloneable {
         result = 31 * result + signature.hashCode();
         result = 31 * result + (filter == null ? 0 : filter.hashCode());
         result = 31 * result + returnType.hashCode();
+        result = 31 * result + Boolean.hashCode(distinct);
         return result;
     }
 
@@ -537,6 +558,9 @@ public class Function implements Symbol, Cloneable {
         FunctionName functionName = signature.getName();
         builder.append(functionName.displayName());
         builder.append("(");
+        if (distinct) {
+            builder.append("DISTINCT ");
+        }
         for (int i = 0; i < arguments.size(); i++) {
             Symbol argument = arguments.get(i);
             builder.append(argument.toString(style));

--- a/server/src/main/java/io/crate/expression/symbol/FunctionCopyVisitor.java
+++ b/server/src/main/java/io/crate/expression/symbol/FunctionCopyVisitor.java
@@ -82,7 +82,7 @@ public abstract class FunctionCopyVisitor<C> extends SymbolVisitor<C, Symbol> {
         if (changed) {
             var signature = func.signature();
             assert signature != null : "Expecting signature not to be null";
-            return new Function(signature, newArgs, func.valueType(), newFilter);
+            return new Function(signature, newArgs, func.valueType(), newFilter, func.distinct());
         }
         return func;
     }
@@ -105,7 +105,7 @@ public abstract class FunctionCopyVisitor<C> extends SymbolVisitor<C, Symbol> {
         }
         var signature = func.signature();
         assert signature != null : "Expecting signature not to be null";
-        return new Function(signature, List.of(newArg1, newArg2), func.valueType(), newFilter);
+        return new Function(signature, List.of(newArg1, newArg2), func.valueType(), newFilter, func.distinct());
     }
 
     private Function zeroArg(Function func, C context) {
@@ -122,7 +122,7 @@ public abstract class FunctionCopyVisitor<C> extends SymbolVisitor<C, Symbol> {
         }
         var signature = func.signature();
         assert signature != null : "Expecting signature not to be null";
-        return new Function(signature, List.of(), func.valueType(), newFilter);
+        return new Function(signature, List.of(), func.valueType(), newFilter, func.distinct());
     }
 
     private Function oneArg(Function func, C context) {
@@ -138,7 +138,7 @@ public abstract class FunctionCopyVisitor<C> extends SymbolVisitor<C, Symbol> {
         }
         var signature = func.signature();
         assert signature != null : "Expecting signature not to be null";
-        return new Function(signature, List.of(newArg), func.valueType(), newFilter);
+        return new Function(signature, List.of(newArg), func.valueType(), newFilter, func.distinct());
     }
 
     @Nullable

--- a/server/src/main/java/io/crate/expression/symbol/WindowFunction.java
+++ b/server/src/main/java/io/crate/expression/symbol/WindowFunction.java
@@ -54,7 +54,7 @@ public class WindowFunction extends Function {
                           @Nullable Symbol filter,
                           WindowDefinition windowDefinition,
                           @Nullable Boolean ignoreNulls) {
-        super(signature, arguments, returnType, filter);
+        super(signature, arguments, returnType, filter, false);
         assert signature.getType() == WINDOW || signature.getType() == AGGREGATE :
             "only window and aggregate functions are allowed to be modelled over a window";
         this.windowDefinition = windowDefinition;

--- a/server/src/main/java/io/crate/planner/operators/DistinctRewriter.java
+++ b/server/src/main/java/io/crate/planner/operators/DistinctRewriter.java
@@ -1,0 +1,212 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.operators;
+
+import static io.crate.analyze.expressions.ExpressionAnalyzer.allocateBuiltinOrUdfFunction;
+import static io.crate.analyze.expressions.ExpressionAnalyzer.allocateFunction;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.function.UnaryOperator;
+
+import org.jspecify.annotations.Nullable;
+
+import io.crate.common.collections.Lists;
+import io.crate.execution.dsl.projection.EvalProjection;
+import io.crate.execution.dsl.projection.builder.InputColumns;
+import io.crate.execution.engine.aggregation.impl.CollectSetAggregation;
+import io.crate.expression.symbol.AliasSymbol;
+import io.crate.expression.symbol.Function;
+import io.crate.expression.symbol.Symbol;
+import io.crate.expression.symbol.SymbolVisitor;
+import io.crate.metadata.CoordinatorTxnCtx;
+import io.crate.metadata.NodeContext;
+
+/// Implements the default rewrite of distinct functions in global and group aggregate operators, which is to replace
+/// them with `collect_set()` (in aggregation/group projections) and `collection_agg_func(collect_set(x))` (in a final
+/// `EvalProjection`).
+/// The visitor context is the rewrite that [#visitFunction] applies to a distinct function, so either
+/// [#toCollectSet] or [#toCollectionFunction].
+class DistinctRewriter extends SymbolVisitor<UnaryOperator<Function>, Symbol> {
+    record Result(
+        List<Function> aggregates,
+        List<? extends Symbol> outputs,
+        @Nullable EvalProjection evalProjection
+    ) {}
+
+    private final CoordinatorTxnCtx txnCtx;
+    private final NodeContext nodeCtx;
+
+    private DistinctRewriter(CoordinatorTxnCtx txnCtx, NodeContext nodeCtx) {
+        this.txnCtx = txnCtx;
+        this.nodeCtx = nodeCtx;
+    }
+
+    /// Rewrites the given `aggregates` and `outputs` so that they can be used in aggregation and group projections.
+    /// Also returns a matching [EvalProjection].
+    ///
+    /// Distinct functions in `aggregates` and `outputs` are replaced with `collect_set(x)`.
+    /// This is the form used for aggregation/group projections in global/group aggregate operators.
+    ///
+    /// The returned `EvalProjection` contains a `collection_agg_func(collect_set(x))` for each distinct `agg_func()`
+    /// in given `outputs`. For example, `count(distinct x)` becomes `collection_count(collect_set(x))`.
+    /// @param aggregates Aggregate functions to be rewritten.
+    /// @param outputs Output symbols to be rewritten. Same as `aggregates` for global aggregations. Group aggregations
+    ///                also add the grouping keys to `outputs`.
+    static Result rewrite(List<Function> aggregates,
+                          List<? extends Symbol> outputs,
+                          UnaryOperator<Symbol> paramBinder,
+                          CoordinatorTxnCtx txnCtx,
+                          NodeContext nodeCtx) {
+        // If there are no distinct functions, return aggregates/outputs as they are.
+        boolean noneDistinct = aggregates.stream()
+            .noneMatch(agg -> agg.any(sym -> sym instanceof Function fn && fn.distinct()));
+
+        if (noneDistinct) {
+            return new Result(aggregates, outputs, null);
+        }
+
+        List<Function> aggregatesCollectSet = toCollectSet(aggregates, txnCtx, nodeCtx);
+        List<? extends Symbol> outputsCollectSet = toCollectSet(outputs, txnCtx, nodeCtx);
+
+        List<? extends Symbol> outputsCollectSetBound = Lists.map(outputsCollectSet, paramBinder);
+        List<? extends Symbol> outputsCollectionFuncsBound = Lists.map(toCollectionFunctions(outputs, txnCtx, nodeCtx), paramBinder);
+
+        var evalProj = new EvalProjection(
+            InputColumns.create(outputsCollectionFuncsBound, new InputColumns.SourceSymbols(outputsCollectSetBound))
+        );
+
+        return new Result(aggregatesCollectSet, outputsCollectSet, evalProj);
+    }
+
+    /// Replaces distinct functions with the aggregate that collects their values.
+    /// `count(distinct x)` -> `collect_set(x)`
+    private static <T extends Symbol> List<T> toCollectSet(List<T> symbols,
+                                                   CoordinatorTxnCtx txnCtx,
+                                                   NodeContext nodeCtx) {
+        var rewriter = new DistinctRewriter(txnCtx, nodeCtx);
+        return rewriter.rewrite(symbols, rewriter::toCollectSet);
+    }
+
+    /// Replaces distinct functions with the scalar applied over the collected values.
+    /// `count(distinct x)` -> `collection_count(collect_set(x))`
+    private static <T extends Symbol> List<T> toCollectionFunctions(List<T> symbols,
+                                                                    CoordinatorTxnCtx txnCtx,
+                                                                    NodeContext nodeCtx) {
+        var rewriter = new DistinctRewriter(txnCtx, nodeCtx);
+        return rewriter.rewrite(symbols, rewriter::toCollectionFunction);
+    }
+
+    // Safe because every visitXYZ() method returns a symbol of the same type.
+    @SuppressWarnings("unchecked")
+    private <T extends Symbol> List<T> rewrite(List<T> symbols, UnaryOperator<Function> rewriteDistinct) {
+        return symbols.stream()
+            .map(symbol -> (T) symbol.accept(this, rewriteDistinct))
+            .toList();
+    }
+
+    @Override
+    public Symbol visitAlias(AliasSymbol aliasSymbol, UnaryOperator<Function> rewriteDistinct) {
+        Symbol rewritten = aliasSymbol.symbol().accept(this, rewriteDistinct);
+        return rewritten == aliasSymbol.symbol()
+            ? aliasSymbol
+            : new AliasSymbol(aliasSymbol.alias(), rewritten);
+    }
+
+    @Override
+    protected Symbol visitSymbol(Symbol symbol, UnaryOperator<Function> rewriteDistinct) {
+        return symbol;
+    }
+
+    @Override
+    public Symbol visitFunction(Function fn, UnaryOperator<Function> rewriteDistinct) {
+        boolean changed = false;
+        List<Symbol> newArgs = new ArrayList<>(fn.arguments().size());
+        for (Symbol arg : fn.arguments()) {
+            Symbol rewritten = arg.accept(this, rewriteDistinct);
+            changed |= rewritten != arg;
+            newArgs.add(rewritten);
+        }
+
+        // Keep `fn` when nothing was rewritten.
+        // `rewrite()` builds the `EvalProjection` from `InputColumns.SourceSymbols`,
+        // which keys non-deterministic functions by identity.
+        if (!fn.distinct()) {
+            return changed
+                ? new Function(fn.signature(), newArgs, fn.valueType(), fn.filter(), false)
+                : fn;
+        }
+
+        return rewriteDistinct.apply(new Function(
+            fn.signature(),
+            newArgs,
+            fn.valueType(),
+            fn.filter(),
+            // the rewrite replaces the function, so the flag is not needed anymore
+            false
+        ));
+    }
+
+    /// `agg_func(distinct x)` -> `collection_agg_func(collect_set(x))`. Only aggregates with a matching
+    /// `collection_*` scalar are supported, e.g. `count` and `avg`; anything else throws.
+    private Function toCollectionFunction(Function original) {
+        String name = original.name();
+
+        String collectionFuncName = "collection_" + name;
+        List<Symbol> args = List.of(toCollectSet(original));
+        try {
+            // No window definition or ignore-nulls flag is passed on, because a `WindowFunction` is
+            // always built with `distinct = false` and therefore never reaches this method.
+            return allocateBuiltinOrUdfFunction(
+                original.signature().getName().schema(),
+                collectionFuncName,
+                args,
+                null,
+                null,
+                null,
+                false,
+                null,
+                txnCtx,
+                nodeCtx
+            );
+        } catch (UnsupportedOperationException ex) {
+            throw new UnsupportedOperationException(String.format(Locale.ENGLISH,
+                "unknown function %s(DISTINCT %s)",
+                name,
+                original.arguments().get(0).valueType()), ex
+            );
+        }
+    }
+
+    /// `count(distinct x)` -> `collect_set(x)`
+    private Function toCollectSet(Function original) {
+        return allocateFunction(
+            CollectSetAggregation.NAME,
+            original.arguments(),
+            original.filter(),
+            null,
+            txnCtx,
+            nodeCtx
+        );
+    }
+}

--- a/server/src/main/java/io/crate/planner/operators/GroupHashAggregate.java
+++ b/server/src/main/java/io/crate/planner/operators/GroupHashAggregate.java
@@ -26,7 +26,6 @@ import static io.crate.execution.engine.pipeline.LimitAndOffset.NO_LIMIT;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -151,17 +150,28 @@ public class GroupHashAggregate extends ForwardingLogicalPlan {
         }
         SubQueryAndParamBinder paramBinder = new SubQueryAndParamBinder(params, subQueryResults);
 
+        DistinctRewriter.Result rewritten = DistinctRewriter.rewrite(
+            aggregates,
+            outputs,
+            paramBinder,
+            plannerContext.transactionContext(),
+            plannerContext.nodeContext()
+        );
+
         List<Symbol> sourceOutputs = source.outputs();
         if (shardsContainAllGroupKeyValues()) {
             GroupProjection groupProjection = projectionBuilder.groupProjection(
                 sourceOutputs,
                 groupKeys,
-                aggregates,
+                rewritten.aggregates(),
                 paramBinder,
                 AggregateMode.ITER_FINAL,
                 source.preferShardProjections() ? RowGranularity.SHARD : RowGranularity.CLUSTER
             );
             executionPlan.addProjection(groupProjection, NO_LIMIT, 0, null);
+            if (rewritten.evalProjection() != null) {
+                executionPlan.addProjection(rewritten.evalProjection());
+            }
             return executionPlan;
         }
 
@@ -171,7 +181,7 @@ public class GroupHashAggregate extends ForwardingLogicalPlan {
                     projectionBuilder.groupProjection(
                         sourceOutputs,
                         groupKeys,
-                        aggregates,
+                        rewritten.aggregates(),
                         paramBinder,
                         AggregateMode.ITER_PARTIAL,
                         RowGranularity.SHARD
@@ -179,9 +189,9 @@ public class GroupHashAggregate extends ForwardingLogicalPlan {
                 );
                 executionPlan.addProjection(
                     projectionBuilder.groupProjection(
-                        outputs,
+                        rewritten.outputs(),
                         groupKeys,
-                        aggregates,
+                        rewritten.aggregates(),
                         paramBinder,
                         AggregateMode.PARTIAL_FINAL,
                         RowGranularity.NODE
@@ -190,13 +200,16 @@ public class GroupHashAggregate extends ForwardingLogicalPlan {
                     0,
                     null
                 );
+                if (rewritten.evalProjection() != null) {
+                    executionPlan.addProjection(rewritten.evalProjection());
+                }
                 return executionPlan;
             } else {
                 executionPlan.addProjection(
                     projectionBuilder.groupProjection(
                         sourceOutputs,
                         groupKeys,
-                        aggregates,
+                        rewritten.aggregates(),
                         paramBinder,
                         AggregateMode.ITER_FINAL,
                         RowGranularity.NODE
@@ -205,6 +218,9 @@ public class GroupHashAggregate extends ForwardingLogicalPlan {
                     0,
                     null
                 );
+                if (rewritten.evalProjection() != null) {
+                    executionPlan.addProjection(rewritten.evalProjection());
+                }
                 return executionPlan;
             }
         }
@@ -212,7 +228,7 @@ public class GroupHashAggregate extends ForwardingLogicalPlan {
         GroupProjection toPartial = projectionBuilder.groupProjection(
             sourceOutputs,
             groupKeys,
-            aggregates,
+            rewritten.aggregates(),
             paramBinder,
             AggregateMode.ITER_PARTIAL,
             source.preferShardProjections() ? RowGranularity.SHARD : RowGranularity.NODE
@@ -221,9 +237,9 @@ public class GroupHashAggregate extends ForwardingLogicalPlan {
         executionPlan.setDistributionInfo(DistributionInfo.DEFAULT_MODULO);
 
         GroupProjection toFinal = projectionBuilder.groupProjection(
-            outputs,
+            rewritten.outputs(),
             groupKeys,
-            aggregates,
+            rewritten.aggregates(),
             paramBinder,
             AggregateMode.PARTIAL_FINAL,
             RowGranularity.CLUSTER
@@ -231,7 +247,7 @@ public class GroupHashAggregate extends ForwardingLogicalPlan {
         return createMerge(
             plannerContext,
             executionPlan,
-            Collections.singletonList(toFinal),
+            rewritten.evalProjection() == null ? List.of(toFinal) : List.of(toFinal, rewritten.evalProjection()),
             executionPlan.resultDescription().nodeIds()
         );
     }

--- a/server/src/main/java/io/crate/planner/operators/HashAggregate.java
+++ b/server/src/main/java/io/crate/planner/operators/HashAggregate.java
@@ -90,6 +90,14 @@ public class HashAggregate extends ForwardingLogicalPlan {
         AggregationOutputValidator.validateOutputs(aggregates);
         var paramBinder = new SubQueryAndParamBinder(params, subQueryResults);
 
+        DistinctRewriter.Result rewritten = DistinctRewriter.rewrite(
+            aggregates,
+            aggregates,
+            paramBinder,
+            plannerContext.transactionContext(),
+            plannerContext.nodeContext()
+        );
+
         var sourceOutputs = source.outputs();
         if (executionPlan.resultDescription().hasRemainingLimitOrOffset()) {
             executionPlan = Merge.ensureOnHandler(executionPlan, plannerContext);
@@ -99,7 +107,7 @@ public class HashAggregate extends ForwardingLogicalPlan {
                 executionPlan.addProjection(
                     projectionBuilder.aggregationProjection(
                         sourceOutputs,
-                        aggregates,
+                        rewritten.aggregates(),
                         paramBinder,
                         AggregateMode.ITER_PARTIAL,
                         RowGranularity.SHARD
@@ -107,28 +115,34 @@ public class HashAggregate extends ForwardingLogicalPlan {
                 );
                 executionPlan.addProjection(
                     projectionBuilder.aggregationProjection(
-                        aggregates,
-                        aggregates,
+                        rewritten.aggregates(),
+                        rewritten.aggregates(),
                         paramBinder,
                         AggregateMode.PARTIAL_FINAL,
                         RowGranularity.CLUSTER
                     )
                 );
+                if (rewritten.evalProjection() != null) {
+                    executionPlan.addProjection(rewritten.evalProjection());
+                }
                 return executionPlan;
             }
             AggregationProjection fullAggregation = projectionBuilder.aggregationProjection(
                 sourceOutputs,
-                aggregates,
+                rewritten.aggregates(),
                 paramBinder,
                 AggregateMode.ITER_FINAL,
                 RowGranularity.CLUSTER
             );
             executionPlan.addProjection(fullAggregation);
+            if (rewritten.evalProjection() != null) {
+                executionPlan.addProjection(rewritten.evalProjection());
+            }
             return executionPlan;
         }
         AggregationProjection toPartial = projectionBuilder.aggregationProjection(
             sourceOutputs,
-            aggregates,
+            rewritten.aggregates(),
             paramBinder,
             AggregateMode.ITER_PARTIAL,
             source.preferShardProjections() ? RowGranularity.SHARD : RowGranularity.NODE
@@ -136,8 +150,8 @@ public class HashAggregate extends ForwardingLogicalPlan {
         executionPlan.addProjection(toPartial);
 
         AggregationProjection toFinal = projectionBuilder.aggregationProjection(
-            aggregates,
-            aggregates,
+            rewritten.aggregates(),
+            rewritten.aggregates(),
             paramBinder,
             AggregateMode.PARTIAL_FINAL,
             RowGranularity.CLUSTER
@@ -153,7 +167,7 @@ public class HashAggregate extends ForwardingLogicalPlan {
                 1,
                 Collections.singletonList(plannerContext.handlerNode()),
                 resultDescription.streamOutputs(),
-                Collections.singletonList(toFinal),
+                rewritten.evalProjection() == null ? List.of(toFinal) : List.of(toFinal, rewritten.evalProjection()),
                 resultDescription.nodeIds(),
                 DistributionInfo.DEFAULT_BROADCAST,
                 null

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MergeAggregateAndCollectToCount.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MergeAggregateAndCollectToCount.java
@@ -62,7 +62,9 @@ public final class MergeAggregateAndCollectToCount implements Rule<HashAggregate
         if (signature.equals(CountAggregation.COUNT_STAR_SIGNATURE)) {
             return true;
         }
+        // `count(distinct x)` counts distinct values, so it cannot be replaced with a row count.
         return signature.getName().equals(CountAggregation.SIGNATURE.getName())
+            && aggregate.distinct() == false
             && aggregate.arguments().get(0) instanceof Reference ref
             && !ref.isNullable();
     }

--- a/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -34,7 +34,6 @@ import static io.crate.testing.Asserts.isScopedSymbol;
 import static io.crate.testing.Asserts.toCondition;
 import static io.crate.types.ArrayType.makeArray;
 import static org.assertj.core.api.Assertions.anyOf;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
@@ -536,18 +535,12 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         AnalyzedRelation relation = executor.analyze("select count(distinct load['1']) from sys.nodes");
 
         Symbol output = relation.outputs().getFirst();
-        assertThat(output).isFunction("collection_count");
+        assertThat(output).isFunction("count");
 
-        Function collectionCount = (Function) output;
-        assertThat(collectionCount.arguments()).hasSize(1);
-        Symbol symbol = collectionCount.arguments().getFirst();
-        assertThat(symbol).isFunction("collect_set");
-
-        Function collectSet = (Function) symbol;
-        assertThat(collectSet.signature().getType()).isEqualTo(FunctionType.AGGREGATE);
-
-        assertThat(collectSet.arguments()).hasSize(1);
-        assertThat(collectSet.arguments().getFirst()).isReference().hasName("load['1']");
+        Function countFn = (Function) output;
+        assertThat(countFn.arguments()).hasSize(1);
+        Symbol symbol = countFn.arguments().getFirst();
+        assertThat(symbol).isReference().hasName("load['1']");
     }
 
     @Test
@@ -556,7 +549,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
             .addTable("create table tbl (name varchar(10))");
 
         Symbol symbol = executor.asSymbol("count(distinct name)");
-        assertThat(symbol).isFunction("collection_count", List.of(new ArrayType<>(StringType.of(10))));
+        assertThat(symbol).isFunction("count", List.of(StringType.of(10)));
     }
 
     @Test

--- a/server/src/test/java/io/crate/analyze/SelectWindowFunctionAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/SelectWindowFunctionAnalyzerTest.java
@@ -93,6 +93,13 @@ public class SelectWindowFunctionAnalyzerTest extends CrateDummyClusterServiceUn
     }
 
     @Test
+    public void test_distinct_is_not_supported_with_over() {
+        assertThatThrownBy(() -> e.analyze("select count(distinct x) OVER() from t"))
+            .isExactlyInstanceOf(UnsupportedOperationException.class)
+            .hasMessage("DISTINCT is not implemented for window functions");
+    }
+
+    @Test
     public void testOnlyAggregatesAndWindowFunctionsAreAllowedWithOver() {
         assertThatThrownBy(() -> e.analyze("select abs(x) OVER() from t"))
             .isExactlyInstanceOf(IllegalArgumentException.class)

--- a/server/src/test/java/io/crate/analyze/expressions/AggregateExpressionAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/expressions/AggregateExpressionAnalyzerTest.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.SelectSymbol;
+import io.crate.metadata.SimpleReference;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 
@@ -60,10 +61,12 @@ public class AggregateExpressionAnalyzerTest extends CrateDummyClusterServiceUni
         var symbol = e.asSymbol(functionName + "(distinct t.x) filter (where t.x < 1)");
         assertThat(symbol).isExactlyInstanceOf(Function.class);
 
-        var outerFunc = (Function) symbol;
-        assertThat(outerFunc.arguments()).hasSize(1);
-        var innerFunc = (Function) outerFunc.arguments().get(0);
-        assertThat(innerFunc.filter()).isFunction("op_<", isReference("x"), isLiteral(1));
+        var func = (Function) symbol;
+        assertThat(func.arguments()).hasSize(1);
+        assertThat(func.filter()).isFunction("op_<", isReference("x"), isLiteral(1));
+
+        var arg = (SimpleReference) func.arguments().get(0);
+        assertThat(arg).hasName("x");
     }
 
     @Test
@@ -99,5 +102,26 @@ public class AggregateExpressionAnalyzerTest extends CrateDummyClusterServiceUni
             .isExactlyInstanceOf(UnsupportedOperationException.class)
             .hasMessage("Only aggregate functions allow a FILTER clause");
 
+    }
+
+    @Test
+    public void test_distinct_cannot_be_used_with_scalar_function() {
+        assertThatThrownBy(() -> e.asSymbol("ln(distinct t.x)"))
+            .isExactlyInstanceOf(UnsupportedOperationException.class)
+            .hasMessage("DISTINCT is not supported for non-aggregate function ln");
+    }
+
+    @Test
+    public void test_distinct_cannot_be_used_with_table_function() {
+        assertThatThrownBy(() -> e.asSymbol("unnest(distinct [1, 2])"))
+            .isExactlyInstanceOf(UnsupportedOperationException.class)
+            .hasMessage("DISTINCT is not supported for non-aggregate function unnest");
+    }
+
+    @Test
+    public void test_distinct_does_not_accept_more_than_one_argument() {
+        assertThatThrownBy(() -> e.asSymbol("count(distinct t.x, t.x)"))
+            .isExactlyInstanceOf(UnsupportedOperationException.class)
+            .hasMessage("count(DISTINCT x) does not accept more than one argument");
     }
 }

--- a/server/src/test/java/io/crate/expression/symbol/FunctionTest.java
+++ b/server/src/test/java/io/crate/expression/symbol/FunctionTest.java
@@ -25,10 +25,12 @@ import static com.carrotsearch.randomizedtesting.RandomizedTest.randomAsciiLette
 import static io.crate.testing.TestingHelpers.createReference;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.IOException;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.test.ESTestCase;
@@ -86,6 +88,45 @@ public class FunctionTest extends ESTestCase {
 
         assertThat(fn2.filter()).isNotNull();
         assertThat(fn).isEqualTo(fn2);
+    }
+
+    @Test
+    public void test_serialization_distinct_field() throws IOException {
+        Function fn = new Function(
+            signature,
+            List.of(createReference(randomAsciiLettersOfLength(2), DataTypes.BOOLEAN)),
+            returnType,
+            Literal.of(true),
+            true
+        );
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        Symbol.toStream(fn, out);
+
+        // read in older version, distinct defaults to false
+        StreamInput in = out.bytes().streamInput();
+        in.setVersion(Version.V_6_4_0);
+
+        Function expected = new Function(fn.signature(), fn.arguments(), fn.valueType(), fn.filter(), false);
+        assertThat(Symbol.fromStream(in)).isEqualTo(expected);
+
+        // read current version
+        in = out.bytes().streamInput();
+        assertThat(Symbol.fromStream(in)).isEqualTo(fn);
+        assertThat(in.available()).isZero();
+
+        // write to older version
+        out = new BytesStreamOutput();
+        out.setVersion(Version.V_6_4_0);
+        Symbol.toStream(fn, out);
+
+        in = out.bytes().streamInput();
+        in.setVersion(Version.V_6_4_0);
+
+        assertThat(Symbol.fromStream(in)).isEqualTo(expected);
+        // The flag must not be written for older versions, otherwise the leftover byte
+        // shifts everything that is read from the stream after this symbol.
+        assertThat(in.available()).isZero();
     }
 
     private static Set<Scalar.Feature> randomFeatures() {

--- a/server/src/test/java/io/crate/expression/symbol/format/SymbolPrinterTest.java
+++ b/server/src/test/java/io/crate/expression/symbol/format/SymbolPrinterTest.java
@@ -22,7 +22,6 @@
 package io.crate.expression.symbol.format;
 
 import static io.crate.testing.Asserts.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -102,7 +101,6 @@ public class SymbolPrinterTest extends CrateDummyClusterServiceUnitTest {
     private void assertPrintingRoundTrip(String sql, String expected) {
         Symbol sym = sqlExpressions.asSymbol(sql);
         assertPrint(sym, expected);
-        assertPrint(sym, expected);
         assertPrintIsParseable(sql);
     }
 
@@ -134,6 +132,11 @@ public class SymbolPrinterTest extends CrateDummyClusterServiceUnitTest {
     public void testWindowFunction() {
         Symbol f = sqlExpressions.asSymbol("avg(idx) over (partition by idx order by foo)");
         assertPrint(f, "avg(doc.formatter.idx) OVER (PARTITION BY doc.formatter.idx ORDER BY doc.formatter.foo ASC)");
+    }
+
+    @Test
+    public void testDistinctAggregation() {
+        assertPrintingRoundTrip("count(distinct idx)", "count(DISTINCT doc.formatter.idx)");
     }
 
     @Test

--- a/server/src/test/java/io/crate/planner/consumer/GroupByPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/consumer/GroupByPlannerTest.java
@@ -353,6 +353,8 @@ public class GroupByPlannerTest extends CrateDummyClusterServiceUnitTest {
         MergePhase mergePhase = reducerMerge.mergePhase();
         assertThat(mergePhase.projections()).satisfiesExactly(
             p -> assertThat(p).isExactlyInstanceOf(GroupProjection.class),
+            // Turns the `collect_set(id)` of the group projection into `collection_count(collect_set(id))`
+            p -> assertThat(p).isExactlyInstanceOf(EvalProjection.class),
             p -> assertThat(p).isExactlyInstanceOf(OrderedLimitAndOffsetProjection.class),
             p -> assertThat(p).isExactlyInstanceOf(EvalProjection.class));
 
@@ -363,8 +365,13 @@ public class GroupByPlannerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(groupProjection.mode()).isEqualTo(AggregateMode.PARTIAL_FINAL);
         assertThat(groupProjection.values().getFirst()).isExactlyInstanceOf(Aggregation.class);
 
+        EvalProjection distinctFinalizer = (EvalProjection) mergePhase.projections().get(1);
+        Asserts.assertThat(distinctFinalizer.outputs()).satisfiesExactly(
+            s -> Asserts.assertThat(s).isInputColumn(0),
+            s -> Asserts.assertThat(s).isFunction("collection_count"));
+
         OrderedLimitAndOffsetProjection limitAndOffsetProjection =
-            (OrderedLimitAndOffsetProjection) mergePhase.projections().get(1);
+            (OrderedLimitAndOffsetProjection) mergePhase.projections().get(2);
         Symbol collection_count = limitAndOffsetProjection.outputs().getFirst();
         Asserts.assertThat(collection_count).isInputColumn(0);
 

--- a/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
@@ -248,6 +248,20 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
     }
 
     @Test
+    public void test_select_count_distinct_on_non_nullable_column_is_not_optimized_to_count() {
+        // `MergeAggregateAndCollectToCount` turns `count(ref)` into a `Count` operator if `ref` is not nullable,
+        // because counting non-null values is then the same as counting rows. That does not hold for
+        // `count(distinct ref)`, which counts distinct values.
+        LogicalPlan plan = plan("SELECT count(distinct id) FROM users");
+        assertThat(plan).isEqualTo(
+            """
+            HashAggregate[count(DISTINCT id)]
+              └ Collect[doc.users | [id] | true]
+            """
+        );
+    }
+
+    @Test
     public void test_select_count_star_is_optimized_if_there_is_a_single_agg_in_select_list() {
         LogicalPlan plan = plan("SELECT COUNT(*), COUNT(x) FROM t1 WHERE x > 10");
         assertThat(plan).isEqualTo(


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Relates to https://github.com/crate/crate/issues/13818. As per [this comment](https://github.com/crate/crate/pull/19715#pullrequestreview-4654833329), we're investigating how **not** to handle the `distinct` keyword in the `ExpressionAnalyzer`.

One path (handling `distinct` when building the logical plan) was #19725. An alternative approach to that is  based on an earlier conversation with Mathias and Marios, which is to handle `distinct` in aggregate operators, while building an execution plan. In #19794 we have PoC of how it would look like if we were to mirror the current behavior closely (identical logical and operators, each operator takes care of `distinct` on its own).

This PR takes a different approach (thanks Mathias for suggesting it), and that is to let **only** the aggregate operators handle `distinct` and, if needed, add an evaluation projection.

## Checklist

 - [ ] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes.
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes
