### PR TITLE
Replace shardSizes HashMap with ObjectLongHashMap

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/ClusterInfo.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterInfo.java
@@ -31,6 +31,9 @@ import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.store.StoreStats;
 
+import com.carrotsearch.hppc.ObjectLongHashMap;
+import com.carrotsearch.hppc.ObjectLongMap;
+
 /**
  * ClusterInfo is an object representing a map of nodes to {@link DiskUsage}
  * and a map of shard ids to shard sizes, see
@@ -41,7 +44,7 @@ public class ClusterInfo implements Writeable {
 
     private final Map<String, DiskUsage> leastAvailableSpaceUsage;
     private final Map<String, DiskUsage> mostAvailableSpaceUsage;
-    final Map<String, Long> shardSizes;
+    final ObjectLongMap<String> shardSizes;
     public static final ClusterInfo EMPTY = new ClusterInfo();
     final Map<ShardRouting, String> routingToDataPath;
     final Map<NodeAndPath, ReservedSpace> reservedSpace;
@@ -50,7 +53,7 @@ public class ClusterInfo implements Writeable {
         this(
             Map.of(),
             Map.of(),
-            Map.of(),
+            new ObjectLongHashMap<>(0),
             Map.of(),
             Map.of());
     }
@@ -67,7 +70,7 @@ public class ClusterInfo implements Writeable {
      */
     public ClusterInfo(Map<String, DiskUsage> leastAvailableSpaceUsage,
                        Map<String, DiskUsage> mostAvailableSpaceUsage,
-                       Map<String, Long> shardSizes,
+                       ObjectLongMap<String> shardSizes,
                        Map<ShardRouting, String> routingToDataPath,
                        Map<NodeAndPath, ReservedSpace> reservedSpace) {
         this.leastAvailableSpaceUsage = leastAvailableSpaceUsage;
@@ -80,7 +83,13 @@ public class ClusterInfo implements Writeable {
     public ClusterInfo(StreamInput in) throws IOException {
         final Map<String, DiskUsage> leastMap = in.readMap(StreamInput::readString, DiskUsage::of);
         final Map<String, DiskUsage> mostMap = in.readMap(StreamInput::readString, DiskUsage::of);
-        final Map<String, Long> sizeMap = in.readMap(StreamInput::readString, StreamInput::readLong);
+        int numShardSizes = in.readVInt();
+        this.shardSizes = new ObjectLongHashMap<>(numShardSizes);
+        for (int i = 0; i < numShardSizes; i++) {
+            String key = in.readString();
+            long size = in.readLong();
+            shardSizes.put(key, size);
+        }
         final Map<ShardRouting, String> routingMap = in.readMap(ShardRouting::new, StreamInput::readString);
         Map<NodeAndPath, ReservedSpace> reservedSpaceMap;
         if (in.getVersion().onOrAfter(StoreStats.RESERVED_BYTES_VERSION)) {
@@ -91,7 +100,6 @@ public class ClusterInfo implements Writeable {
 
         this.leastAvailableSpaceUsage = Collections.unmodifiableMap(leastMap);
         this.mostAvailableSpaceUsage = Collections.unmodifiableMap(mostMap);
-        this.shardSizes = Collections.unmodifiableMap(sizeMap);
         this.routingToDataPath = Collections.unmodifiableMap(routingMap);
         this.reservedSpace = Collections.unmodifiableMap(reservedSpaceMap);
     }
@@ -104,7 +112,13 @@ public class ClusterInfo implements Writeable {
             c.getValue().writeTo(out);
         }
         out.writeMap(this.mostAvailableSpaceUsage, StreamOutput::writeString, (o, v) -> v.writeTo(o));
-        out.writeMap(this.shardSizes, StreamOutput::writeString, (o, v) -> out.writeLong(v == null ? -1 : v));
+        out.writeVInt(this.shardSizes.size());
+        for (var cursor : shardSizes) {
+            String key = cursor.key;
+            long size = cursor.value;
+            out.writeString(key);
+            out.writeLong(size);
+        }
         out.writeMap(this.routingToDataPath, (o, k) -> k.writeTo(o), StreamOutput::writeString);
         if (out.getVersion().onOrAfter(StoreStats.RESERVED_BYTES_VERSION)) {
             out.writeWritableMap(this.reservedSpace);
@@ -129,10 +143,17 @@ public class ClusterInfo implements Writeable {
     }
 
     /**
-     * Returns the shard size for the given shard routing or <code>null</code> it that metric is not available.
+     * Returns the shard size for the given shard routing or <code>0</code> it that metric is not available.
      */
-    public Long getShardSize(ShardRouting shardRouting) {
+    public long getShardSize(ShardRouting shardRouting) {
         return shardSizes.get(shardIdentifierFromRouting(shardRouting));
+    }
+
+    /**
+     * Returns the shard size for the given shard routing or <code>defaultValue</code> it that metric is not available.
+     */
+    public long getShardSize(ShardRouting shardRouting, long defaultValue) {
+        return shardSizes.getOrDefault(shardIdentifierFromRouting(shardRouting), defaultValue);
     }
 
     /**
@@ -140,14 +161,6 @@ public class ClusterInfo implements Writeable {
      */
     public String getDataPath(ShardRouting shardRouting) {
         return routingToDataPath.get(shardRouting);
-    }
-
-    /**
-     * Returns the shard size for the given shard routing or <code>defaultValue</code> it that metric is not available.
-     */
-    public long getShardSize(ShardRouting shardRouting, long defaultValue) {
-        Long shardSize = getShardSize(shardRouting);
-        return shardSize == null ? defaultValue : shardSize;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/cluster/InternalClusterInfoService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/InternalClusterInfoService.java
@@ -52,6 +52,9 @@ import org.elasticsearch.index.store.StoreStats;
 import org.elasticsearch.monitor.fs.FsInfo;
 import org.elasticsearch.threadpool.ThreadPool;
 
+import com.carrotsearch.hppc.ObjectLongHashMap;
+import com.carrotsearch.hppc.ObjectLongMap;
+
 import io.crate.common.collections.MapBuilder;
 import io.crate.common.unit.TimeValue;
 import io.crate.exceptions.SQLExceptions;
@@ -295,7 +298,7 @@ public class InternalClusterInfoService implements ClusterInfoService, ClusterSt
     }
 
     static IndicesStatsSummary buildStatsSummary(ShardStats[] stats) {
-        final HashMap<String, Long> shardSizeByIdentifier = new HashMap<>();
+        final ObjectLongHashMap<String> shardSizeByIdentifier = new ObjectLongHashMap<>();
         final HashMap<ShardRouting, String> dataPathByShardRouting = new HashMap<>();
         final HashMap<ClusterInfo.NodeAndPath, ClusterInfo.ReservedSpace.Builder> reservedSpaceBuilders = new HashMap<>();
         for (ShardStats s : stats) {
@@ -325,7 +328,7 @@ public class InternalClusterInfoService implements ClusterInfoService, ClusterSt
         reservedSpaceBuilders.forEach((nodeAndPath, builder) -> rsrvdSpace.put(nodeAndPath, builder.build()));
 
         return new IndicesStatsSummary(
-            Collections.unmodifiableMap(shardSizeByIdentifier),
+            shardSizeByIdentifier,
             Collections.unmodifiableMap(dataPathByShardRouting),
             Collections.unmodifiableMap(rsrvdSpace)
         );
@@ -395,11 +398,11 @@ public class InternalClusterInfoService implements ClusterInfoService, ClusterSt
         }
     }
 
-    private record IndicesStatsSummary(Map<String, Long> shardSizes,
+    private record IndicesStatsSummary(ObjectLongMap<String> shardSizes,
                                        Map<ShardRouting, String> shardRoutingToDataPath,
                                        Map<ClusterInfo.NodeAndPath, ClusterInfo.ReservedSpace> reservedSpace) {
 
-        static final IndicesStatsSummary EMPTY = new IndicesStatsSummary(Map.of(), Map.of(), Map.of());
+        static final IndicesStatsSummary EMPTY = new IndicesStatsSummary(new ObjectLongHashMap<>(), Map.of(), Map.of());
     }
 
 

--- a/server/src/test/java/org/elasticsearch/cluster/ClusterInfoServiceIT.java
+++ b/server/src/test/java/org/elasticsearch/cluster/ClusterInfoServiceIT.java
@@ -34,6 +34,8 @@ import org.elasticsearch.test.IntegTestCase;
 import org.elasticsearch.test.TestCluster;
 import org.junit.Test;
 
+import com.carrotsearch.hppc.ObjectLongMap;
+
 import io.crate.common.unit.TimeValue;
 import io.crate.testing.UseRandomizedSchema;
 
@@ -68,7 +70,7 @@ public class ClusterInfoServiceIT extends IntegTestCase {
         assertThat(info).as("info should not be null").isNotNull();
         Map<String, DiskUsage> leastUsages = info.getNodeLeastAvailableDiskUsages();
         Map<String, DiskUsage> mostUsages = info.getNodeMostAvailableDiskUsages();
-        Map<String, Long> shardSizes = info.shardSizes;
+        ObjectLongMap<String> shardSizes = info.shardSizes;
         assertThat(leastUsages).isNotNull();
         assertThat(shardSizes).isNotNull();
         assertThat(leastUsages.values())
@@ -83,7 +85,8 @@ public class ClusterInfoServiceIT extends IntegTestCase {
             logger.info("--> usage: {}", usage);
             assertThat(usage.freeBytes()).as("usage has be retrieved").isGreaterThan(0L);
         }
-        for (Long size : shardSizes.values()) {
+        for (var cursor : shardSizes.values()) {
+            long size = cursor.value;
             logger.info("--> shard size: {}", size);
             assertThat(size).as("shard size is greater than 0:").isGreaterThanOrEqualTo(0L);
         }

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderTests.java
@@ -65,6 +65,9 @@ import org.elasticsearch.snapshots.EmptySnapshotsInfoService;
 import org.elasticsearch.test.gateway.TestGatewayAllocator;
 import org.junit.Test;
 
+import com.carrotsearch.hppc.ObjectLongHashMap;
+import com.carrotsearch.hppc.ObjectLongMap;
+
 public class DiskThresholdDeciderTests extends ESAllocationTestCase {
 
     private DiskThresholdDecider makeDecider(Settings settings) {
@@ -85,7 +88,7 @@ public class DiskThresholdDeciderTests extends ESAllocationTestCase {
         usages.put("node3", new DiskUsage("node3", "node3", "/dev/null", 100, 60)); // 40% used
         usages.put("node4", new DiskUsage("node4", "node4", "/dev/null", 100, 80)); // 20% used
 
-        HashMap<String, Long> shardSizes = new HashMap<>();
+        ObjectLongMap<String> shardSizes = new ObjectLongHashMap<>();
         shardSizes.put("[test][0][p]", 10L); // 10 bytes
         shardSizes.put("[test][0][r]", 10L);
         final ClusterInfo clusterInfo = new DevNullClusterInfo(usages, usages, shardSizes);
@@ -267,7 +270,7 @@ public class DiskThresholdDeciderTests extends ESAllocationTestCase {
         usages.put("node4", new DiskUsage("node4", "n4", "/dev/null", 100, 80)); // 20% used
         usages.put("node5", new DiskUsage("node5", "n5", "/dev/null", 100, 85)); // 15% used
 
-        HashMap<String, Long> shardSizes = new HashMap<>();
+        ObjectLongMap<String> shardSizes = new ObjectLongHashMap<>();
         shardSizes.put("[test][0][p]", 10L); // 10 bytes
         shardSizes.put("[test][0][r]", 10L);
         final ClusterInfo clusterInfo = new DevNullClusterInfo(usages, usages, shardSizes);
@@ -508,7 +511,7 @@ public class DiskThresholdDeciderTests extends ESAllocationTestCase {
         usages.put("node1", new DiskUsage("node1", "n1", "/dev/null", 100, 31)); // 69% used
         usages.put("node2", new DiskUsage("node2", "n2", "/dev/null", 100, 1));  // 99% used
 
-        HashMap<String, Long> shardSizes = new HashMap<>();
+        ObjectLongMap<String> shardSizes = new ObjectLongHashMap<>();
         shardSizes.put("[test/test][0][p]", 10L); // 10 bytes
         final ClusterInfo clusterInfo = new DevNullClusterInfo(usages, usages, shardSizes);
 
@@ -574,7 +577,7 @@ public class DiskThresholdDeciderTests extends ESAllocationTestCase {
         usages.put("node2", new DiskUsage("node2", "node2", "/dev/null", 100, 50)); // 50% used
         usages.put("node3", new DiskUsage("node3", "node3", "/dev/null", 100, 0));  // 100% used
 
-        HashMap<String, Long> shardSizes = new HashMap<>();
+        ObjectLongMap<String> shardSizes = new ObjectLongHashMap<>();
         shardSizes.put("[test][0][p]", 10L); // 10 bytes
         shardSizes.put("[test][0][r]", 10L); // 10 bytes
         final ClusterInfo clusterInfo = new DevNullClusterInfo(usages, usages, shardSizes);
@@ -677,7 +680,7 @@ public class DiskThresholdDeciderTests extends ESAllocationTestCase {
         usages.put("node1", new DiskUsage("node1", "n1", "/dev/null", 100, 20)); // 80% used
         usages.put("node2", new DiskUsage("node2", "n2", "/dev/null", 100, 100)); // 0% used
 
-        HashMap<String, Long> shardSizes = new HashMap<>();
+        ObjectLongMap<String> shardSizes = new ObjectLongHashMap<>();
         shardSizes.put("[_na_/test][0][p]", 40L);
         shardSizes.put("[_na_/test][1][p]", 40L);
         shardSizes.put("[_na_/foo][0][p]", 10L);
@@ -813,7 +816,7 @@ public class DiskThresholdDeciderTests extends ESAllocationTestCase {
         usages.put("data", new DiskUsage("data", "data", "/dev/null", 100, 20));  // 80% used
 
         // We have an index with 1 primary shard, taking 40 bytes. The single data node has only 20 bytes free.
-        HashMap<String, Long> shardSizes = new HashMap<>();
+        ObjectLongMap<String> shardSizes = new ObjectLongHashMap<>();
         shardSizes.put("[test][0][p]", 40L);
         final ClusterInfo clusterInfo = new DevNullClusterInfo(usages, usages, shardSizes);
 
@@ -929,13 +932,13 @@ public class DiskThresholdDeciderTests extends ESAllocationTestCase {
     static class DevNullClusterInfo extends ClusterInfo {
         DevNullClusterInfo(Map<String, DiskUsage> leastAvailableSpaceUsage,
                            Map<String, DiskUsage> mostAvailableSpaceUsage,
-                           Map<String, Long> shardSizes) {
+                           ObjectLongMap<String> shardSizes) {
             this(leastAvailableSpaceUsage, mostAvailableSpaceUsage, shardSizes, Map.of());
         }
 
         DevNullClusterInfo(Map<String, DiskUsage> leastAvailableSpaceUsage,
                            Map<String, DiskUsage> mostAvailableSpaceUsage,
-                           Map<String, Long> shardSizes,
+                           ObjectLongMap<String> shardSizes,
                            Map<NodeAndPath, ReservedSpace> reservedSpace) {
             super(leastAvailableSpaceUsage, mostAvailableSpaceUsage, shardSizes, null, reservedSpace);
         }

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderUnitTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderUnitTests.java
@@ -27,7 +27,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 
@@ -59,6 +58,9 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.shard.ShardId;
 import org.junit.Test;
+
+import com.carrotsearch.hppc.ObjectLongHashMap;
+import com.carrotsearch.hppc.ObjectLongMap;
 
 import io.crate.common.collections.MapBuilder;
 
@@ -105,12 +107,12 @@ public class DiskThresholdDeciderUnitTests extends ESAllocationTestCase {
         // this is weird and smells like a bug! it should be up to 20%?
         mostAvailableUsage.put("node_1", new DiskUsage("node_1", "node_1", "_na_", 100, randomIntBetween(0, 10)));
 
-        MapBuilder<String, Long> shardSizes = MapBuilder.newMapBuilder();
+        ObjectLongMap<String> shardSizes = new ObjectLongHashMap<>();
         shardSizes.put("[_na_/test][0][p]", 10L); // 10 bytes
         final ClusterInfo clusterInfo = new ClusterInfo(
             leastAvailableUsages.immutableMap(),
             mostAvailableUsage.immutableMap(),
-            shardSizes.immutableMap(),
+            shardSizes,
             Map.of(),
             Map.of()
         );
@@ -166,14 +168,14 @@ public class DiskThresholdDeciderUnitTests extends ESAllocationTestCase {
         final int freeBytes = randomIntBetween(20, 100);
         mostAvailableUsage.put("node_0", new DiskUsage("node_0", "node_0", "_na_", 100, freeBytes));
 
-        MapBuilder<String, Long> shardSizes = MapBuilder.newMapBuilder();
+        ObjectLongMap<String> shardSizes = new ObjectLongHashMap<>();
         // way bigger than available space
         final long shardSize = randomIntBetween(110, 1000);
         shardSizes.put("[test/test][0][p]", shardSize);
         ClusterInfo clusterInfo = new ClusterInfo(
             leastAvailableUsages.immutableMap(),
             mostAvailableUsage.immutableMap(),
-            shardSizes.immutableMap(),
+            shardSizes,
             Map.of(),
             Map.of());
         RoutingAllocation allocation = new RoutingAllocation(new AllocationDeciders(Collections.singleton(decider)),
@@ -251,7 +253,7 @@ public class DiskThresholdDeciderUnitTests extends ESAllocationTestCase {
         mostAvailableUsage.put("node_0", new DiskUsage("node_0", "node_0", "/node0/most", 100, 90)); // 10% used
         mostAvailableUsage.put("node_1", new DiskUsage("node_1", "node_1", "/node1/most", 100, 90)); // 10% used
 
-        MapBuilder<String, Long> shardSizes = MapBuilder.newMapBuilder();
+        ObjectLongMap<String> shardSizes = new ObjectLongHashMap<>();
         shardSizes.put("[_na_/test][0][p]", 10L); // 10 bytes
         shardSizes.put("[_na_/test][1][p]", 10L);
         shardSizes.put("[_na_/test][2][p]", 10L);
@@ -259,7 +261,7 @@ public class DiskThresholdDeciderUnitTests extends ESAllocationTestCase {
         final ClusterInfo clusterInfo = new ClusterInfo(
             leastAvailableUsages.immutableMap(),
             mostAvailableUsage.immutableMap(),
-            shardSizes.immutableMap(),
+            shardSizes,
             shardRoutingMap.immutableMap(),
             Map.of()
         );
@@ -302,7 +304,7 @@ public class DiskThresholdDeciderUnitTests extends ESAllocationTestCase {
 
     @Test
     public void testShardSizeAndRelocatingSize() {
-        HashMap<String, Long> shardSizes = new HashMap<>();
+        ObjectLongMap<String> shardSizes = new ObjectLongHashMap<>();
         shardSizes.put("[test/1234][0][r]", 10L);
         shardSizes.put("[test/1234][1][r]", 100L);
         shardSizes.put("[test/1234][2][r]", 1000L);
@@ -409,7 +411,7 @@ public class DiskThresholdDeciderUnitTests extends ESAllocationTestCase {
 
     @Test
     public void testSizeShrinkIndex() {
-        Map<String, Long> shardSizes = new HashMap<>();
+        ObjectLongMap<String> shardSizes = new ObjectLongHashMap<>();
         shardSizes.put("[test/1234][0][p]", 10L);
         shardSizes.put("[test/1234][1][p]", 100L);
         shardSizes.put("[test/1234][2][p]", 500L);

--- a/server/src/testFixtures/java/org/elasticsearch/cluster/MockInternalClusterInfoService.java
+++ b/server/src/testFixtures/java/org/elasticsearch/cluster/MockInternalClusterInfoService.java
@@ -22,7 +22,7 @@ package org.elasticsearch.cluster;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiFunction;
-import java.util.function.Function;
+import java.util.function.ToLongFunction;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -53,7 +53,7 @@ public class MockInternalClusterInfoService extends InternalClusterInfoService {
     public static class TestPlugin extends Plugin {}
 
     @Nullable // if no fakery should take place
-    private volatile Function<ShardRouting, Long> shardSizeFunction;
+    private volatile ToLongFunction<ShardRouting> shardSizeFunction;
 
     @Nullable // if no fakery should take place
     private volatile BiFunction<DiscoveryNode, FsInfo.Path, FsInfo.Path> diskUsageFunction;
@@ -70,7 +70,7 @@ public class MockInternalClusterInfoService extends InternalClusterInfoService {
         refresh();
     }
 
-    public void setShardSizeFunctionAndRefresh(Function<ShardRouting, Long> shardSizeFunction) {
+    public void setShardSizeFunctionAndRefresh(ToLongFunction<ShardRouting> shardSizeFunction) {
         this.shardSizeFunction = shardSizeFunction;
         refresh();
     }
@@ -127,13 +127,18 @@ public class MockInternalClusterInfoService extends InternalClusterInfoService {
         }
 
         @Override
-        public Long getShardSize(ShardRouting shardRouting) {
-            final Function<ShardRouting, Long> shardSizeFunction = MockInternalClusterInfoService.this.shardSizeFunction;
+        public long getShardSize(ShardRouting shardRouting, long defaultValue) {
+            long size = this.getShardSize(shardRouting);
+            return size == 0 ? defaultValue : size;
+        }
+
+        @Override
+        public long getShardSize(ShardRouting shardRouting) {
+            final ToLongFunction<ShardRouting> shardSizeFunction = MockInternalClusterInfoService.this.shardSizeFunction;
             if (shardSizeFunction == null) {
                 return super.getShardSize(shardRouting);
             }
-
-            return shardSizeFunction.apply(shardRouting);
+            return shardSizeFunction.applyAsLong(shardRouting);
         }
     }
 


### PR DESCRIPTION
Should lower memory footprint a bit.
Relates to https://github.com/crate/support/issues/886
