### PR TITLE
Fix deadlock for nested joins

### DIFF
--- a/docs/appendices/release-notes/6.4.3.rst
+++ b/docs/appendices/release-notes/6.4.3.rst
@@ -165,3 +165,10 @@ Fixes
        UNION ALL
        SELECT * FROM a
      ) u ORDER BY k;
+
+- Fixed an issue that could cause a query containing two or more :ref:`joins
+  <sql_joins>` to hang indefinitely on a multi-node cluster. This happened when
+  both the outer and the inner join were executed distributed, and their inputs
+  were large enough to be transferred in more than one page between the nodes.
+  Nested joins are now always executed non-distributed, only the very outer join
+  is executed distributed. Note that this fix may cause performance degradation.

--- a/server/src/main/java/io/crate/planner/operators/HashJoin.java
+++ b/server/src/main/java/io/crate/planner/operators/HashJoin.java
@@ -27,6 +27,7 @@ import static io.crate.planner.operators.NestedLoopJoin.createJoinProjection;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -85,10 +86,15 @@ public class HashJoin extends AbstractJoinPlan {
                                @Nullable Integer pageSizeHint,
                                Row params,
                                SubQueryResults subQueryResults) {
+        // A nested join must not be executed distributed, otherwise its output would have to be
+        // re-shuffled for this join, which can deadlock. See PlanHint#AVOID_DISTRIBUTED_JOIN.
+        Set<PlanHint> sourceHints = EnumSet.of(PlanHint.AVOID_DISTRIBUTED_JOIN);
+        sourceHints.addAll(hints);
+
         ExecutionPlan leftExecutionPlan = lhs.build(
-            executor, plannerContext, hints, projectionBuilder, NO_LIMIT, 0, null, null, params, subQueryResults);
+            executor, plannerContext, sourceHints, projectionBuilder, NO_LIMIT, 0, null, null, params, subQueryResults);
         ExecutionPlan rightExecutionPlan = rhs.build(
-            executor, plannerContext, hints, projectionBuilder, NO_LIMIT, 0, null, null, params, subQueryResults);
+            executor, plannerContext, sourceHints, projectionBuilder, NO_LIMIT, 0, null, null, params, subQueryResults);
 
         SubQueryAndParamBinder paramBinder = new SubQueryAndParamBinder(params, subQueryResults);
         var hashSymbols = createHashSymbols(lhs.relationNames(), rhs.relationNames(), joinCondition);
@@ -108,9 +114,14 @@ public class HashJoin extends AbstractJoinPlan {
         // We can only run the join distributed if no remaining limit or offset must be applied on the source relations.
         // Because on distributed joins, every join is running on a slice (modulo) set of the data and so no limit/offset
         // could be applied. Limit/offset can only be applied on the whole data set after all partial rows from the
-        // shards are merged
+        // shards are merged.
+        //
+        // A nested join must not be executed distributed, otherwise its outputs
+        // would have to be re-shuffled for this join, which can lead to deadlock.
+        // See PlanHint#AVOID_DISTRIBUTED_JOIN for details
         boolean isDistributed = leftResultDesc.hasRemainingLimitOrOffset() == false
-                                && rightResultDesc.hasRemainingLimitOrOffset() == false;
+                                && rightResultDesc.hasRemainingLimitOrOffset() == false
+                                && hints.contains(PlanHint.AVOID_DISTRIBUTED_JOIN) == false;
 
         if (joinExecutionNodes.isEmpty()) {
             // The left source might have zero execution nodes, for example in the case of `sys.shards` without any tables

--- a/server/src/main/java/io/crate/planner/operators/HashJoin.java
+++ b/server/src/main/java/io/crate/planner/operators/HashJoin.java
@@ -27,6 +27,7 @@ import static io.crate.planner.operators.NestedLoopJoin.createJoinProjection;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -85,10 +86,15 @@ public class HashJoin extends AbstractJoinPlan {
                                @Nullable Integer pageSizeHint,
                                Row params,
                                SubQueryResults subQueryResults) {
+        // A nested join must not be executed distributed, otherwise its output would have to be
+        // re-shuffled for this join, which can deadlock. See PlanHint#AVOID_DISTRIBUTED_JOIN.
+        Set<PlanHint> sourceHints = EnumSet.of(PlanHint.AVOID_DISTRIBUTED_JOIN);
+        sourceHints.addAll(hints);
+
         ExecutionPlan leftExecutionPlan = lhs.build(
-            executor, plannerContext, hints, projectionBuilder, NO_LIMIT, 0, null, null, params, subQueryResults);
+            executor, plannerContext, sourceHints, projectionBuilder, NO_LIMIT, 0, null, null, params, subQueryResults);
         ExecutionPlan rightExecutionPlan = rhs.build(
-            executor, plannerContext, hints, projectionBuilder, NO_LIMIT, 0, null, null, params, subQueryResults);
+            executor, plannerContext, sourceHints, projectionBuilder, NO_LIMIT, 0, null, null, params, subQueryResults);
 
         SubQueryAndParamBinder paramBinder = new SubQueryAndParamBinder(params, subQueryResults);
         var hashSymbols = createHashSymbols(lhs.relationNames(), rhs.relationNames(), joinCondition);
@@ -109,8 +115,11 @@ public class HashJoin extends AbstractJoinPlan {
         // Because on distributed joins, every join is running on a slice (modulo) set of the data and so no limit/offset
         // could be applied. Limit/offset can only be applied on the whole data set after all partial rows from the
         // shards are merged
+        // A parent join sets AVOID_DISTRIBUTED_JOIN on the hints it passes down, because a
+        // distributed nested join can deadlock. See PlanHint#AVOID_DISTRIBUTED_JOIN.
         boolean isDistributed = leftResultDesc.hasRemainingLimitOrOffset() == false
-                                && rightResultDesc.hasRemainingLimitOrOffset() == false;
+                                && rightResultDesc.hasRemainingLimitOrOffset() == false
+                                && hints.contains(PlanHint.AVOID_DISTRIBUTED_JOIN) == false;
 
         if (joinExecutionNodes.isEmpty()) {
             // The left source might have zero execution nodes, for example in the case of `sys.shards` without any tables

--- a/server/src/main/java/io/crate/planner/operators/NestedLoopJoin.java
+++ b/server/src/main/java/io/crate/planner/operators/NestedLoopJoin.java
@@ -27,6 +27,7 @@ import static io.crate.planner.operators.Limit.limitAndOffset;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -125,12 +126,20 @@ public class NestedLoopJoin extends AbstractJoinPlan {
             ? limitAndOffset(limit, offset)
             : null;
 
-        ExecutionPlan left = lhs.build(
-            executor, plannerContext, hints, projectionBuilder, NO_LIMIT, 0, null, childPageSizeHint, params, subQueryResults);
-        ExecutionPlan right = rhs.build(
-            executor, plannerContext, hints, projectionBuilder, NO_LIMIT, 0, null, childPageSizeHint, params, subQueryResults);
+        // A nested join must not be executed distributed, otherwise its output would have to be
+        // re-shuffled for this join, which can deadlock. See PlanHint#AVOID_DISTRIBUTED_JOIN.
+        Set<PlanHint> sourceHints = EnumSet.of(PlanHint.AVOID_DISTRIBUTED_JOIN);
+        sourceHints.addAll(hints);
 
-        boolean isDistributed = supportsDistributedReads() && isFiltered && !joinType.isOuter();
+        ExecutionPlan left = lhs.build(
+            executor, plannerContext, sourceHints, projectionBuilder, NO_LIMIT, 0, null, childPageSizeHint, params, subQueryResults);
+        ExecutionPlan right = rhs.build(
+            executor, plannerContext, sourceHints, projectionBuilder, NO_LIMIT, 0, null, childPageSizeHint, params, subQueryResults);
+
+        boolean isDistributed = supportsDistributedReads()
+                                && isFiltered
+                                && !joinType.isOuter()
+                                && hints.contains(PlanHint.AVOID_DISTRIBUTED_JOIN) == false;
 
         LogicalPlan leftLogicalPlan = lhs;
         LogicalPlan rightLogicalPlan = rhs;

--- a/server/src/main/java/io/crate/planner/operators/NestedLoopJoin.java
+++ b/server/src/main/java/io/crate/planner/operators/NestedLoopJoin.java
@@ -27,6 +27,7 @@ import static io.crate.planner.operators.Limit.limitAndOffset;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -125,12 +126,21 @@ public class NestedLoopJoin extends AbstractJoinPlan {
             ? limitAndOffset(limit, offset)
             : null;
 
-        ExecutionPlan left = lhs.build(
-            executor, plannerContext, hints, projectionBuilder, NO_LIMIT, 0, null, childPageSizeHint, params, subQueryResults);
-        ExecutionPlan right = rhs.build(
-            executor, plannerContext, hints, projectionBuilder, NO_LIMIT, 0, null, childPageSizeHint, params, subQueryResults);
+        // A nested join must not be executed distributed, otherwise its outputs
+        // would have to be re-shuffled for this join, which can lead to deadlock.
+        // See PlanHint#AVOID_DISTRIBUTED_JOIN for details
+        Set<PlanHint> sourceHints = EnumSet.of(PlanHint.AVOID_DISTRIBUTED_JOIN);
+        sourceHints.addAll(hints);
 
-        boolean isDistributed = supportsDistributedReads() && isFiltered && !joinType.isOuter();
+        ExecutionPlan left = lhs.build(
+            executor, plannerContext, sourceHints, projectionBuilder, NO_LIMIT, 0, null, childPageSizeHint, params, subQueryResults);
+        ExecutionPlan right = rhs.build(
+            executor, plannerContext, sourceHints, projectionBuilder, NO_LIMIT, 0, null, childPageSizeHint, params, subQueryResults);
+
+        boolean isDistributed = supportsDistributedReads()
+                                && isFiltered
+                                && !joinType.isOuter()
+                                && hints.contains(PlanHint.AVOID_DISTRIBUTED_JOIN) == false;
 
         LogicalPlan leftLogicalPlan = lhs;
         LogicalPlan rightLogicalPlan = rhs;

--- a/server/src/main/java/io/crate/planner/operators/PlanHint.java
+++ b/server/src/main/java/io/crate/planner/operators/PlanHint.java
@@ -22,5 +22,50 @@
 package io.crate.planner.operators;
 
 public enum PlanHint {
-    PREFER_SOURCE_LOOKUP
+    PREFER_SOURCE_LOOKUP,
+
+    /// Indicates that the next Join operator must not build a distributed execution plan.
+    /// Used to avoid a deadlock. For example, a logical plan like:
+    ///
+    /// ```
+    ///   t1    t2
+    ///     \  /
+    ///     join  t3
+    ///       \   /
+    ///       join
+    /// ```
+    ///
+    /// Would result in an execution plan as follows without this hint:
+    /// - numeric node prefixes are the phase ids
+    /// - n1 and n2 are the nodes involved
+    ///
+    /// ```
+    ///      t1             t2                  t3
+    ///   0-collect      1-collect          5-collect
+    ///    n1   n2        n1   n2            n1    n2
+    ///
+    ///
+    ///    n1   n2       n1   n2
+    ///   2-l-merge     3-r-merge
+    ///         4-h-join (t1<->t2)
+    ///           n1   n2
+    ///
+    ///
+    ///              n1   n2       n1   n2
+    ///             6-l-merge    7-r-merge
+    ///                 8-h-join
+    ///
+    /// ```
+    ///
+    /// This deadlocks for example if:
+    ///
+    /// - t3/5-collect, t2/1-collect, 3-r-merge, 7-r-merge all complete in a single page and are unproblematic
+    /// - n1 and n2 of 0-collect produce a full page and send it to n1 and n2 of 2-l-merge
+    /// - n1 of 2-l-merge/4-h-join produces a full page and sends it to n1 and n2 of 6-l-merge
+    /// - n2 of 2-l-merge/4-h-join does _not_ produce a full page and requests more data from n1 and n2 of 0-collect
+    /// - n2 of 0-collect waits for a result response from n1 of 2-l-merge
+    /// - n1 of 2-l-merge doesn't send a result response until it knows if it
+    ///   needs more data, which it won't until it's downstream communicates with it
+    /// - 6-l-merge waits for data from n2, which it won't get because n2/4-h-join is waiting for data
+    AVOID_DISTRIBUTED_JOIN
 }

--- a/server/src/main/java/io/crate/planner/operators/PlanHint.java
+++ b/server/src/main/java/io/crate/planner/operators/PlanHint.java
@@ -22,5 +22,35 @@
 package io.crate.planner.operators;
 
 public enum PlanHint {
-    PREFER_SOURCE_LOOKUP
+    PREFER_SOURCE_LOOKUP,
+
+    /**
+     * Set by a join on the plans it builds for its own sources, to prevent a nested join from being
+     * executed as distributed.
+     * <p>
+     * A distributed join re-shuffles (modulo) its inputs across nodes. If a nested join is also
+     * distributed, its output has to be re-shuffled again for the parent join, which makes the two
+     * joins mutually dependent across nodes and can deadlock:
+     * <ul>
+     *   <li>the parent join's receiver only completes a page once it has a bucket from *every*
+     *       nested-join instance ({@code CumulativePageBucketReceiver} requires
+     *       {@code bucketsByIdx.size() == numBuckets}), and</li>
+     *   <li>a nested-join instance that filled its own output page stops consuming its input until
+     *       all of its downstreams acknowledged
+     *       ({@code DistributingConsumer#countdownAndMaybeContinue} resumes only once
+     *       {@code numActiveRequests} reaches 0).</li>
+     * </ul>
+     * With paging inputs these two barriers can form a cycle: instance A is blocked on its output
+     * while still holding an unacknowledged input page, so the shared upstream never sends the next
+     * page that instance B needs in order to emit the bucket A's downstream is waiting for.
+     * <p>
+     * Keeping nested joins non-distributed means a nested join produces a single bucket per
+     * downstream input, so the cycle cannot form. The outermost join is unaffected -- nothing above
+     * it sets this hint -- so it can still be executed distributed.
+     * <p>
+     * Because hints are propagated down through every operator's
+     * {@code build(...)}, this also covers joins that are not direct children, e.g. a join
+     * underneath an {@code Eval} or {@code Rename}.
+     */
+    AVOID_DISTRIBUTED_JOIN
 }

--- a/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
@@ -24,7 +24,6 @@ package io.crate.integrationtests;
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
 import static io.crate.testing.Asserts.assertThat;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Arrays;
@@ -32,6 +31,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.stream.Collectors;
 
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.index.IndexNotFoundException;
@@ -40,6 +40,7 @@ import org.elasticsearch.test.IntegTestCase;
 import org.junit.After;
 import org.junit.Test;
 
+import io.crate.data.Paging;
 import io.crate.execution.engine.join.RamBlockSizeCalculator;
 import io.crate.execution.engine.sort.OrderingByPosition;
 import io.crate.metadata.RelationName;
@@ -1843,5 +1844,53 @@ public class JoinIntegrationTest extends IntegTestCase {
 
         execute(query);
         assertThat(response.rows()).isEmpty();
+    }
+
+    @Test
+    @UseHashJoins(1)
+    @UseRandomizedSchema(random = false)
+    @UseRandomizedOptimizerRules(0)
+    public void test_nested_hash_join_with_inputs_spanning_multiple_pages() throws Exception {
+        // A nested join must not be executed distributed, otherwise its output has to be re-shuffled
+        // for the parent join, which can lead to a deadlock once the inputs span more than one page.
+        // See PlanHint.AVOID_DISTRIBUTED_JOIN
+        int originalPageSize = Paging.PAGE_SIZE;
+        Paging.PAGE_SIZE = 2;
+        try {
+            execute("create table t1 (x int) clustered into 2 shards with (number_of_replicas = 0)");
+            execute("create table t2 (x int) clustered into 2 shards with (number_of_replicas = 0)");
+            execute("create table t3 (x int) clustered into 2 shards with (number_of_replicas = 0)");
+
+            Object[][] bulkArgs = new Object[20][];
+            for (int i = 0; i < bulkArgs.length; i++) {
+                bulkArgs[i] = new Object[] { i };
+            }
+            execute("insert into t1 (x) values (?)", bulkArgs);
+            execute("insert into t2 (x) values (?)", bulkArgs);
+            execute("insert into t3 (x) values (?)", bulkArgs);
+            execute("refresh table t1, t2, t3");
+
+            String stmt = """
+                SELECT count(*)
+                FROM t1
+                    INNER JOIN t2 ON t2.x = t1.x
+                    INNER JOIN t3 ON t3.x = t2.x
+                """;
+            // ensure that the query is using the execution plan we want to test
+            // This should prevent the test case from becoming invalid
+            execute("EXPLAIN (COSTS FALSE)" + stmt);
+            String plan = Arrays.stream(response.rows())
+                .map(row -> (String) row[0])
+                .collect(Collectors.joining("\n"));
+            assertThat(plan.lines().filter(line -> line.contains("Join[")).count())
+                .as("the query must be executed as a join nested inside another join, but was:%n%s", plan)
+                .isEqualTo(2);
+
+            // Without the fix this query never completes and fails with a timeout
+            execute(stmt);
+            assertThat(response).hasRows("20");
+        } finally {
+            Paging.PAGE_SIZE = originalPageSize;
+        }
     }
 }

--- a/server/src/test/java/io/crate/planner/SelectPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/SelectPlannerTest.java
@@ -24,7 +24,6 @@ package io.crate.planner;
 import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.Asserts.isReference;
 import static java.util.Collections.singletonList;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Collection;
@@ -831,16 +830,14 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
             .build()
             .addTable(TableDefinitions.USER_TABLE_DEFINITION);
 
-        Merge plan = e.plan("select count(*) from users t1, users t2, users t3 " +
+        Join outerNL = e.plan("select count(*) from users t1, users t2, users t3 " +
                             "where t1.id = t2.id and t2.id = t3.id");
-        assertThat(plan.subPlan()).isExactlyInstanceOf(Join.class);
-        Join outerNL = (Join)plan.subPlan();
         assertThat(outerNL.joinPhase().joinCondition()).isSQL("(INPUT(1) = INPUT(2))");
         assertThat(outerNL.joinPhase().projections()).hasSize(2);
         assertThat(outerNL.joinPhase().projections().get(0)).isExactlyInstanceOf(EvalProjection.class);
         assertThat(outerNL.joinPhase().projections().get(1)).isExactlyInstanceOf(AggregationProjection.class);
         assertThat(outerNL.joinPhase().outputTypes()).hasSize(1);
-        assertThat(outerNL.joinPhase().outputTypes().get(0)).isEqualTo(CountAggregation.LongStateType.INSTANCE);
+        assertThat(outerNL.joinPhase().outputTypes().get(0)).isEqualTo(DataTypes.LONG);
 
         Join innerNL = (Join) outerNL.left();
         assertThat(innerNL.joinPhase().joinCondition()).isSQL("(INPUT(0) = INPUT(1))");
@@ -849,16 +846,14 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(innerNL.joinPhase().outputTypes()).hasSize(2);
         assertThat(innerNL.joinPhase().outputTypes().get(0)).isEqualTo(DataTypes.LONG);
 
-        plan = e.plan("select count(t1.other_id) from users t1, users t2, users t3 " +
+        outerNL = e.plan("select count(t1.other_id) from users t1, users t2, users t3 " +
                       "where t1.id = t2.id and t2.id = t3.id");
-        assertThat(plan.subPlan()).isExactlyInstanceOf(Join.class);
-        outerNL = (Join)plan.subPlan();
         assertThat(outerNL.joinPhase().joinCondition()).isSQL("(INPUT(2) = INPUT(3))");
         assertThat(outerNL.joinPhase().projections()).hasSize(2);
         assertThat(outerNL.joinPhase().projections().get(0)).isExactlyInstanceOf(EvalProjection.class);
         assertThat(outerNL.joinPhase().projections().get(1)).isExactlyInstanceOf(AggregationProjection.class);
         assertThat(outerNL.joinPhase().outputTypes()).hasSize(1);
-        assertThat(outerNL.joinPhase().outputTypes().get(0)).isEqualTo(CountAggregation.LongStateType.INSTANCE);
+        assertThat(outerNL.joinPhase().outputTypes().get(0)).isEqualTo(DataTypes.LONG);
 
         innerNL = (Join) outerNL.left();
         assertThat(innerNL.joinPhase().joinCondition()).isSQL("(INPUT(1) = INPUT(2))");

--- a/server/src/test/java/io/crate/planner/operators/JoinTest.java
+++ b/server/src/test/java/io/crate/planner/operators/JoinTest.java
@@ -28,7 +28,6 @@ import static io.crate.analyze.TableDefinitions.USER_TABLE_IDENT;
 import static io.crate.testing.Asserts.assertList;
 import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.Asserts.isInputColumn;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
@@ -56,6 +55,8 @@ import io.crate.planner.ExecutionPlan;
 import io.crate.planner.Merge;
 import io.crate.planner.PlannerContext;
 import io.crate.planner.SubqueryPlanner;
+import io.crate.planner.distribution.DistributionInfo;
+import io.crate.planner.distribution.DistributionType;
 import io.crate.planner.node.dql.Collect;
 import io.crate.planner.node.dql.join.Join;
 import io.crate.sql.tree.JoinType;
@@ -363,6 +364,65 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
         assertThat(join.joinPhase()).isExactlyInstanceOf(HashJoinPhase.class);
         assertThat(join.left()).isExactlyInstanceOf(Join.class);
         assertThat(((Join)join.left()).joinPhase()).isExactlyInstanceOf(HashJoinPhase.class);
+    }
+
+    @Test
+    public void test_nested_hash_join_is_not_executed_distributed() {
+        QueriedSelectRelation mss = e.analyze("select * " +
+                                              "from t1 inner join t2 on t1.a = t2.b " +
+                                              "inner join t3 on t3.c = t2.b");
+
+        var plannerCtx = e.getPlannerContext();
+        Join join = plan(mss, plannerCtx);
+        Join nestedJoin = (Join) join.left();
+
+        assertThat(nestedJoin.joinPhase().nodeIds())
+            .as("A nested join is executed on the handler node only, see PlanHint.AVOID_DISTRIBUTED_JOIN")
+            .containsExactly(plannerCtx.handlerNode());
+        assertThat(((Collect) nestedJoin.left()).collectPhase().distributionInfo())
+            .isEqualTo(DistributionInfo.DEFAULT_BROADCAST);
+        assertThat(((Collect) nestedJoin.right()).collectPhase().distributionInfo())
+            .isEqualTo(DistributionInfo.DEFAULT_BROADCAST);
+
+        assertThat(((Collect) join.right()).collectPhase().distributionInfo().distributionType())
+            .as("The outermost join is still executed distributed")
+            .isEqualTo(DistributionType.MODULO);
+        assertThat(nestedJoin.joinPhase().distributionInfo().distributionType())
+            .as("The outermost join re-distributes the output of the nested join")
+            .isEqualTo(DistributionType.MODULO);
+    }
+
+    @Test
+    public void test_nested_nested_loop_join_is_not_executed_distributed() {
+        // Explicit join conditions are required, an implicit cross join with a filter on top is
+        // never executed distributed, because `isFiltered` is false
+        QueriedSelectRelation mss = e.analyze("select * " +
+                                              "from t1 inner join t2 on t1.a > t2.b " +
+                                              "inner join t3 on t3.c > t2.b");
+
+        var plannerCtx = e.getPlannerContext();
+        plannerCtx.transactionContext().sessionSettings().setHashJoinEnabled(false);
+        Join join = plan(mss, plannerCtx);
+        Join nestedJoin = (Join) join.left();
+
+        assertThat(nestedJoin.joinPhase().name())
+            .as("A nested join is not executed distributed, see PlanHint.AVOID_DISTRIBUTED_JOIN")
+            .isEqualTo("nested-loop");
+        assertThat(join.joinPhase().name())
+            .as("The outermost join is still executed distributed")
+            .isEqualTo("distributed-nested-loop");
+    }
+
+    @Test
+    public void test_nested_loop_join_without_a_parent_join_is_executed_distributed() {
+        // Simple join doesn't set PlanHint.AVOID_DISTRIBUTED_JOIN, so it is still executed distributed
+        QueriedSelectRelation mss = e.analyze("select * from t1 inner join t2 on t1.a > t2.b");
+
+        var plannerCtx = e.getPlannerContext();
+        plannerCtx.transactionContext().sessionSettings().setHashJoinEnabled(false);
+        Join join = plan(mss, plannerCtx);
+
+        assertThat(join.joinPhase().name()).isEqualTo("distributed-nested-loop");
     }
 
     @Test


### PR DESCRIPTION
A distributed join re-shuffles its inputs across the cluster by modulo.
If a join that is itself the input of another join is also executed
distributed, its output has to be re-shuffled again for the parent join,
which makes the two joins mutually dependent across nodes and can
deadlock:

  - The parent join's receiver only completes a page once it has a
    bucket from every nested-join instance
    (CumulativePageBucketReceiver requires bucketsByIdx.size() ==
    numBuckets), and
  - a nested-join instance that filled its own output page stops
    consuming its input until all of its downstreams acknowledged
    (DistributingConsumer#countdownAndMaybeContinue resumes only once
    numActiveRequests reaches 0).

With paging inputs these two barriers can form a cycle: instance A is
blocked on its output while still holding an unacknowledged input page,
so the shared upstream never sends the next page that instance B needs
in order to emit the bucket A's downstream is waiting for. The query
then hangs indefinitely.

Add PlanHint.AVOID_DISTRIBUTED_JOIN, which HashJoin and NestedLoopJoin
set on the hints they pass down when building their sources, and check
it when deciding whether to run distributed. A nested join then produces
a single bucket per downstream input, so the cycle cannot form. The
outermost join is unaffected -- nothing above it sets the hint -- so it
is still executed distributed.

Because hints are propagated through every operator's build(), this also
covers joins that are not direct children, e.g. below an Eval or Rename.