### PR TITLE
Include table OIDs in TransportRequests carrying RelationName

### DIFF
--- a/server/src/main/java/io/crate/analyze/AlterTableAlterColumnDefaultAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/AlterTableAlterColumnDefaultAnalyzer.java
@@ -118,6 +118,6 @@ public class AlterTableAlterColumnDefaultAnalyzer {
             EnsureNoMatchPredicate.ensureNoMatchPredicate(newDefault, "Cannot use MATCH in DEFAULT expression");
         }
 
-        return new AnalyzedAlterTableAlterColumnDefault(tableInfo.ident(), ref, newDefault);
+        return new AnalyzedAlterTableAlterColumnDefault(tableInfo.ident(), tableInfo.oid(), ref, newDefault);
     }
 }

--- a/server/src/main/java/io/crate/analyze/AlterTableAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/AlterTableAnalyzer.java
@@ -103,7 +103,7 @@ class AlterTableAnalyzer {
         RelationName targetName = new RelationName(sourceName.schema(), newIdentParts.get(0));
         targetName.ensureValidForRelationCreation();
         boolean isPartitioned = source instanceof DocTableInfo docTable && docTable.isPartitioned();
-        return new AnalyzedAlterTableRenameTable(sourceName, targetName, isPartitioned);
+        return new AnalyzedAlterTableRenameTable(sourceName, source.oid(), targetName, isPartitioned);
     }
 
     public AnalyzedAlterTableOpenClose analyze(AlterTableOpenClose<Expression> node,

--- a/server/src/main/java/io/crate/analyze/AlterTableRenameColumnAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/AlterTableRenameColumnAnalyzer.java
@@ -104,7 +104,7 @@ public class AlterTableRenameColumnAnalyzer {
         }
 
         tableInfo.renameColumn(sourceRef, targetCol);
-        return new AnalyzedAlterTableRenameColumn(tableInfo.ident(), sourceRef, targetCol);
+        return new AnalyzedAlterTableRenameColumn(tableInfo.ident(), tableInfo.oid(), sourceRef, targetCol);
     }
 
     /** Returns DynamicReferences instead of throwing ColumnUnknownExceptions. */

--- a/server/src/main/java/io/crate/analyze/AnalyzedAlterTableAddColumn.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedAlterTableAddColumn.java
@@ -94,6 +94,7 @@ public record AnalyzedAlterTableAddColumn(
         }
         return new AddColumnRequest(
             table.ident(),
+            table.oid(),
             newColumns,
             checkConstraints,
             pkIndices

--- a/server/src/main/java/io/crate/analyze/AnalyzedAlterTableAlterColumnDefault.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedAlterTableAlterColumnDefault.java
@@ -30,6 +30,7 @@ import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
 
 public record AnalyzedAlterTableAlterColumnDefault(RelationName table,
+                                                   int tableOid,
                                                    Reference ref,
                                                    @Nullable Symbol newDefault) implements DDLStatement {
 

--- a/server/src/main/java/io/crate/analyze/AnalyzedAlterTableRenameColumn.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedAlterTableRenameColumn.java
@@ -29,6 +29,7 @@ import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
 
 public record AnalyzedAlterTableRenameColumn(RelationName table,
+                                             int tableOid,
                                              Reference refToRename,
                                              ColumnIdent newName) implements DDLStatement {
 

--- a/server/src/main/java/io/crate/analyze/AnalyzedAlterTableRenameTable.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedAlterTableRenameTable.java
@@ -29,17 +29,23 @@ import io.crate.metadata.RelationName;
 public class AnalyzedAlterTableRenameTable implements DDLStatement {
 
     private final RelationName sourceName;
+    private final int sourceOid;
     private final RelationName targetName;
     private final boolean isPartitioned;
 
-    AnalyzedAlterTableRenameTable(RelationName sourceName, RelationName targetName, boolean isPartitioned) {
+    AnalyzedAlterTableRenameTable(RelationName sourceName, int sourceOid, RelationName targetName, boolean isPartitioned) {
         this.sourceName = sourceName;
+        this.sourceOid = sourceOid;
         this.targetName = targetName;
         this.isPartitioned = isPartitioned;
     }
 
     public RelationName sourceName() {
         return sourceName;
+    }
+
+    public int sourceOid() {
+        return sourceOid;
     }
 
     public RelationName targetName() {

--- a/server/src/main/java/io/crate/analyze/AnalyzedDropTable.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedDropTable.java
@@ -31,12 +31,13 @@ public final class AnalyzedDropTable<T extends TableInfo> implements DDLStatemen
 
     private final boolean dropIfExists;
     private final RelationName tableName;
+    private final int tableOid;
 
-    AnalyzedDropTable(boolean dropIfExists, RelationName tableName) {
+    AnalyzedDropTable(boolean dropIfExists, RelationName tableName, int tableOid) {
         this.dropIfExists = dropIfExists;
         this.tableName = tableName;
+        this.tableOid = tableOid;
     }
-
 
     public boolean dropIfExists() {
         return dropIfExists;
@@ -44,6 +45,10 @@ public final class AnalyzedDropTable<T extends TableInfo> implements DDLStatemen
 
     public RelationName tableName() {
         return tableName;
+    }
+
+    public int tableOid() {
+        return tableOid;
     }
 
     @Override

--- a/server/src/main/java/io/crate/analyze/DropTableAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/DropTableAnalyzer.java
@@ -25,6 +25,7 @@ import java.util.List;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.service.ClusterService;
 
 import io.crate.exceptions.OperationOnInaccessibleRelationException;
@@ -73,6 +74,7 @@ class DropTableAnalyzer {
                                                                boolean dropIfExists,
                                                                CoordinatorSessionSettings sessionSettings) {
         RelationName tableName;
+        int tableOid = Metadata.OID_UNASSIGNED;
         try {
             TableInfo tableInfo = schemas.findRelation(
                 name,
@@ -81,6 +83,7 @@ class DropTableAnalyzer {
                 sessionSettings.searchPath()
             );
             tableName = tableInfo.ident();
+            tableOid = tableInfo.oid();
         } catch (SchemaUnknownException | RelationUnknown e) {
             tableName = RelationName.of(name, sessionSettings.searchPath().currentSchema());
             var metadata = clusterService.state().metadata();
@@ -101,6 +104,6 @@ class DropTableAnalyzer {
                 t
             );
         }
-        return new AnalyzedDropTable<>(dropIfExists, tableName);
+        return new AnalyzedDropTable<>(dropIfExists, tableName, tableOid);
     }
 }

--- a/server/src/main/java/io/crate/execution/ddl/RelationNameSwap.java
+++ b/server/src/main/java/io/crate/execution/ddl/RelationNameSwap.java
@@ -21,39 +21,68 @@
 
 package io.crate.execution.ddl;
 
-import io.crate.metadata.RelationName;
+import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
+
+import java.io.IOException;
+
+import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 
-import java.io.IOException;
+import io.crate.metadata.RelationName;
 
 public final class RelationNameSwap implements Writeable {
 
     private final RelationName source;
+    private final int sourceOid;
     private final RelationName target;
+    private final int targetOid;
 
-    public RelationNameSwap(RelationName source, RelationName target) {
+    public RelationNameSwap(RelationName source, int sourceOid, RelationName target, int targetOid) {
         this.source = source;
+        this.sourceOid = sourceOid;
         this.target = target;
+        this.targetOid = targetOid;
     }
 
     public RelationNameSwap(StreamInput in) throws IOException {
         this.source = new RelationName(in);
         this.target = new RelationName(in);
+        if ((in.getVersion().before(Version.V_6_4_0) && in.getVersion().onOrAfter(Version.V_6_3_7))
+            || in.getVersion().onOrAfter(Version.V_6_4_2)) {
+            this.sourceOid = in.readVInt();
+            this.targetOid = in.readVInt();
+        } else {
+            this.sourceOid = OID_UNASSIGNED;
+            this.targetOid = OID_UNASSIGNED;
+        }
     }
 
     public RelationName source() {
         return source;
     }
 
+    public int sourceOid() {
+        return sourceOid;
+    }
+
     public RelationName target() {
         return target;
+    }
+
+    public int targetOid() {
+        return targetOid;
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         source.writeTo(out);
         target.writeTo(out);
+        if ((out.getVersion().before(Version.V_6_4_0) && out.getVersion().onOrAfter(Version.V_6_3_7))
+            || out.getVersion().onOrAfter(Version.V_6_4_2)) {
+            out.writeVInt(sourceOid);
+            out.writeVInt(targetOid);
+        }
     }
 }

--- a/server/src/main/java/io/crate/execution/ddl/SwapRelationsRequest.java
+++ b/server/src/main/java/io/crate/execution/ddl/SwapRelationsRequest.java
@@ -21,20 +21,22 @@
 
 package io.crate.execution.ddl;
 
-import io.crate.metadata.RelationName;
+import java.io.IOException;
+import java.util.List;
+
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
-import java.io.IOException;
-import java.util.List;
+import io.crate.metadata.RelationName;
 
 public final class SwapRelationsRequest extends AcknowledgedRequest<SwapRelationsRequest> {
 
     private final List<RelationNameSwap> swapRelations;
     private final List<RelationName> dropRelations;
 
-    public SwapRelationsRequest(List<RelationNameSwap> swapRelations, List<RelationName> dropRelations) {
+    public SwapRelationsRequest(List<RelationNameSwap> swapRelations,
+                                List<RelationName> dropRelations) {
         this.swapRelations = swapRelations;
         this.dropRelations = dropRelations;
     }

--- a/server/src/main/java/io/crate/execution/ddl/tables/AddColumnRequest.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/AddColumnRequest.java
@@ -21,11 +21,14 @@
 
 package io.crate.execution.ddl.tables;
 
+import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
+
 import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -38,6 +41,7 @@ import io.crate.metadata.RelationName;
 public class AddColumnRequest extends AcknowledgedRequest<AddColumnRequest> {
 
     private final RelationName relationName;
+    private final int tableOid;
     private final List<Reference> colsToAdd;
     private final IntArrayList pKeyIndices;
     private final Map<String, String> checkConstraints;
@@ -46,10 +50,12 @@ public class AddColumnRequest extends AcknowledgedRequest<AddColumnRequest> {
      * @param checkConstraints must be accumulated map of all columns' constraints in case of adding multiple columns.
      */
     public AddColumnRequest(RelationName relationName,
+                            int tableOid,
                             List<Reference> colsToAdd,
                             Map<String, String> checkConstraints,
                             IntArrayList pKeyIndices) {
         this.relationName = relationName;
+        this.tableOid = tableOid;
         this.colsToAdd = colsToAdd;
         this.checkConstraints = checkConstraints;
         this.pKeyIndices = pKeyIndices;
@@ -59,6 +65,12 @@ public class AddColumnRequest extends AcknowledgedRequest<AddColumnRequest> {
     public AddColumnRequest(StreamInput in) throws IOException {
         super(in);
         this.relationName = new RelationName(in);
+        if ((in.getVersion().before(Version.V_6_4_0) && in.getVersion().onOrAfter(Version.V_6_3_7))
+            || in.getVersion().onOrAfter(Version.V_6_4_2)) {
+            this.tableOid = in.readVInt();
+        } else {
+            this.tableOid = OID_UNASSIGNED;
+        }
         this.checkConstraints = in.readMap(
             LinkedHashMap::new, StreamInput::readString, StreamInput::readString);
         this.colsToAdd = in.readList(Reference::fromStream);
@@ -73,6 +85,10 @@ public class AddColumnRequest extends AcknowledgedRequest<AddColumnRequest> {
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         relationName.writeTo(out);
+        if ((out.getVersion().before(Version.V_6_4_0) && out.getVersion().onOrAfter(Version.V_6_3_7))
+            || out.getVersion().onOrAfter(Version.V_6_4_2)) {
+            out.writeVInt(tableOid);
+        }
         out.writeMap(checkConstraints, StreamOutput::writeString, StreamOutput::writeString);
         out.writeCollection(colsToAdd, Reference::toStream);
         out.writeVInt(pKeyIndices.size());
@@ -83,6 +99,10 @@ public class AddColumnRequest extends AcknowledgedRequest<AddColumnRequest> {
 
     public RelationName relationName() {
         return this.relationName;
+    }
+
+    public int tableOid() {
+        return tableOid;
     }
 
     public Map<String, String> checkConstraints() {

--- a/server/src/main/java/io/crate/execution/ddl/tables/AlterColumnDefaultRequest.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/AlterColumnDefaultRequest.java
@@ -21,8 +21,11 @@
 
 package io.crate.execution.ddl.tables;
 
+import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
+
 import java.io.IOException;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -35,12 +38,14 @@ import io.crate.metadata.RelationName;
 public class AlterColumnDefaultRequest extends AcknowledgedRequest<AlterColumnDefaultRequest> {
 
     private final RelationName relationName;
+    private final int tableOid;
     private final Reference ref;
     @Nullable
     private final Symbol newDefault;
 
-    public AlterColumnDefaultRequest(RelationName relationName, Reference ref, @Nullable Symbol newDefault) {
+    public AlterColumnDefaultRequest(RelationName relationName, int tableOid, Reference ref, @Nullable Symbol newDefault) {
         this.relationName = relationName;
+        this.tableOid = tableOid;
         this.ref = ref;
         this.newDefault = newDefault;
     }
@@ -48,6 +53,12 @@ public class AlterColumnDefaultRequest extends AcknowledgedRequest<AlterColumnDe
     public AlterColumnDefaultRequest(StreamInput in) throws IOException {
         super(in);
         this.relationName = new RelationName(in);
+        if ((in.getVersion().before(Version.V_6_4_0) && in.getVersion().onOrAfter(Version.V_6_3_7))
+            || in.getVersion().onOrAfter(Version.V_6_4_2)) {
+            this.tableOid = in.readVInt();
+        } else {
+            this.tableOid = OID_UNASSIGNED;
+        }
         this.ref = Reference.fromStream(in);
         this.newDefault = Symbol.nullableFromStream(in);
     }
@@ -56,12 +67,20 @@ public class AlterColumnDefaultRequest extends AcknowledgedRequest<AlterColumnDe
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         relationName.writeTo(out);
+        if ((out.getVersion().before(Version.V_6_4_0) && out.getVersion().onOrAfter(Version.V_6_3_7))
+            || out.getVersion().onOrAfter(Version.V_6_4_2)) {
+            out.writeVInt(tableOid);
+        }
         Reference.toStream(out, ref);
         Symbol.nullableToStream(newDefault, out);
     }
 
     public RelationName relationName() {
         return relationName;
+    }
+
+    public int tableOid() {
+        return tableOid;
     }
 
     public Reference ref() {

--- a/server/src/main/java/io/crate/execution/ddl/tables/AlterTableClient.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/AlterTableClient.java
@@ -156,15 +156,16 @@ public class AlterTableClient {
     }
 
     public CompletableFuture<Long> closeOrOpen(RelationName relationName,
+                                               int tableOid,
                                                boolean openTable,
                                                @Nullable PartitionName partitionName) {
         if (openTable) {
             OpenTableRequest request = new OpenTableRequest(
-                relationName, partitionName == null ? List.of() : partitionName.values());
+                relationName, tableOid, partitionName == null ? List.of() : partitionName.values());
             return client.execute(TransportOpenTable.ACTION, request).thenApply(_ -> -1L);
         } else {
             CloseTableRequest request = new CloseTableRequest(
-                relationName, partitionName == null ? List.of() : partitionName.values());
+                relationName, tableOid, partitionName == null ? List.of() : partitionName.values());
             return client.execute(TransportCloseTable.ACTION, request).thenApply(_ -> -1L);
         }
     }
@@ -194,6 +195,7 @@ public class AlterTableClient {
             PartitionName partitionName = analysis.partitionName();
             AlterTableRequest request = new AlterTableRequest(
                 analysis.table().ident(),
+                analysis.table().oid(),
                 partitionName == null ? List.of() : partitionName.values(),
                 analysis.isPartitioned(),
                 analysis.excludePartitions(),
@@ -246,6 +248,7 @@ public class AlterTableClient {
 
             final ResizeRequest request = new ResizeRequest(
                 table.ident(),
+                table.oid(),
                 partitionName == null ? List.of() : partitionName.values(),
                 targetNumberOfShards
             );

--- a/server/src/main/java/io/crate/execution/ddl/tables/AlterTableRequest.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/AlterTableRequest.java
@@ -21,6 +21,7 @@
 
 package io.crate.execution.ddl.tables;
 
+import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
 import static org.elasticsearch.common.settings.Settings.readSettingsFromStream;
 import static org.elasticsearch.common.settings.Settings.writeSettingsToStream;
 
@@ -40,17 +41,20 @@ import io.crate.metadata.RelationName;
 public class AlterTableRequest extends AcknowledgedRequest<AlterTableRequest> {
 
     private final RelationName table;
+    private final int tableOid;
     private final List<String> partitionValues;
     private final boolean isPartitioned;
     private final boolean excludePartitions;
     private final Settings settings;
 
     public AlterTableRequest(RelationName table,
+                             int tableOid,
                              List<String> partitionValues,
                              boolean isPartitioned,
                              boolean excludePartitions,
                              Settings settings) throws IOException {
         this.table = table;
+        this.tableOid = tableOid;
         this.partitionValues = partitionValues;
         this.isPartitioned = isPartitioned;
         this.excludePartitions = excludePartitions;
@@ -60,6 +64,12 @@ public class AlterTableRequest extends AcknowledgedRequest<AlterTableRequest> {
     public AlterTableRequest(StreamInput in) throws IOException {
         super(in);
         table = new RelationName(in);
+        if ((in.getVersion().before(Version.V_6_4_0) && in.getVersion().onOrAfter(Version.V_6_3_7))
+            || in.getVersion().onOrAfter(Version.V_6_4_2)) {
+            tableOid = in.readVInt();
+        } else {
+            tableOid = OID_UNASSIGNED;
+        }
         boolean before510 = in.getVersion().before(Version.V_5_10_0);
         if (before510) {
             String partitionIndexName = in.readOptionalString();
@@ -85,6 +95,10 @@ public class AlterTableRequest extends AcknowledgedRequest<AlterTableRequest> {
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         table.writeTo(out);
+        if ((out.getVersion().before(Version.V_6_4_0) && out.getVersion().onOrAfter(Version.V_6_3_7))
+            || out.getVersion().onOrAfter(Version.V_6_4_2)) {
+            out.writeVInt(tableOid);
+        }
         boolean before510 = out.getVersion().before(Version.V_5_10_0);
         if (before510) {
             if (partitionValues.isEmpty()) {
@@ -111,6 +125,10 @@ public class AlterTableRequest extends AcknowledgedRequest<AlterTableRequest> {
         return table;
     }
 
+    public int tableOid() {
+        return tableOid;
+    }
+
     public List<String> partitionValues() {
         return partitionValues;
     }
@@ -132,6 +150,7 @@ public class AlterTableRequest extends AcknowledgedRequest<AlterTableRequest> {
         final int prime = 31;
         int result = 1;
         result = prime * result + table.hashCode();
+        result = prime * result + tableOid;
         result = prime * result + partitionValues.hashCode();
         result = prime * result + (isPartitioned ? 1231 : 1237);
         result = prime * result + (excludePartitions ? 1231 : 1237);
@@ -143,6 +162,7 @@ public class AlterTableRequest extends AcknowledgedRequest<AlterTableRequest> {
     public boolean equals(Object obj) {
         return obj instanceof AlterTableRequest other
             && table.equals(other.table)
+            && tableOid == other.tableOid
             && partitionValues.equals(other.partitionValues)
             && isPartitioned == other.isPartitioned
             && excludePartitions == other.excludePartitions

--- a/server/src/main/java/io/crate/execution/ddl/tables/CloseTableRequest.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/CloseTableRequest.java
@@ -22,6 +22,8 @@
 
 package io.crate.execution.ddl.tables;
 
+import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -37,16 +39,24 @@ import io.crate.metadata.RelationName;
 public final class CloseTableRequest extends AcknowledgedRequest<CloseTableRequest> {
 
     private final RelationName table;
+    private final int tableOid;
     private final List<String> partitionValues;
 
-    public CloseTableRequest(RelationName table, List<String> partitionValues) {
+    public CloseTableRequest(RelationName table, int tableOid, List<String> partitionValues) {
         this.table = table;
+        this.tableOid = tableOid;
         this.partitionValues = partitionValues;
     }
 
     public CloseTableRequest(StreamInput in) throws IOException {
         super(in);
         this.table = new RelationName(in);
+        if ((in.getVersion().before(Version.V_6_4_0) && in.getVersion().onOrAfter(Version.V_6_3_7))
+            || in.getVersion().onOrAfter(Version.V_6_4_2)) {
+            this.tableOid = in.readVInt();
+        } else {
+            this.tableOid = OID_UNASSIGNED;
+        }
         if (in.getVersion().onOrAfter(Version.V_5_10_0)) {
             int numValues = in.readVInt();
             this.partitionValues = new ArrayList<>(numValues);
@@ -67,6 +77,10 @@ public final class CloseTableRequest extends AcknowledgedRequest<CloseTableReque
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         table.writeTo(out);
+        if ((out.getVersion().before(Version.V_6_4_0) && out.getVersion().onOrAfter(Version.V_6_3_7))
+            || out.getVersion().onOrAfter(Version.V_6_4_2)) {
+            out.writeVInt(tableOid);
+        }
         if (out.getVersion().onOrAfter(Version.V_5_10_0)) {
             out.writeVInt(partitionValues.size());
             for (String value : partitionValues) {
@@ -85,6 +99,10 @@ public final class CloseTableRequest extends AcknowledgedRequest<CloseTableReque
 
     public RelationName table() {
         return table;
+    }
+
+    public int tableOid() {
+        return tableOid;
     }
 
     public List<String> partitionValues() {

--- a/server/src/main/java/io/crate/execution/ddl/tables/DropColumnRequest.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/DropColumnRequest.java
@@ -21,9 +21,12 @@
 
 package io.crate.execution.ddl.tables;
 
+import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
+
 import java.io.IOException;
 import java.util.List;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -34,17 +37,26 @@ import io.crate.metadata.RelationName;
 public class DropColumnRequest extends AcknowledgedRequest<DropColumnRequest> {
 
     private final RelationName relationName;
+    private final int tableOid;
     private final List<DropColumn> colsToDrop;
 
     public DropColumnRequest(RelationName relationName,
+                             int tableOid,
                              List<DropColumn> colsToDrop) {
         this.relationName = relationName;
+        this.tableOid = tableOid;
         this.colsToDrop = colsToDrop;
     }
 
     public DropColumnRequest(StreamInput in) throws IOException {
         super(in);
         this.relationName = new RelationName(in);
+        if ((in.getVersion().before(Version.V_6_4_0) && in.getVersion().onOrAfter(Version.V_6_3_7))
+            || in.getVersion().onOrAfter(Version.V_6_4_2)) {
+            this.tableOid = in.readVInt();
+        } else {
+            this.tableOid = OID_UNASSIGNED;
+        }
         this.colsToDrop = in.readList(DropColumn::new);
     }
 
@@ -52,11 +64,19 @@ public class DropColumnRequest extends AcknowledgedRequest<DropColumnRequest> {
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         relationName.writeTo(out);
+        if ((out.getVersion().before(Version.V_6_4_0) && out.getVersion().onOrAfter(Version.V_6_3_7))
+            || out.getVersion().onOrAfter(Version.V_6_4_2)) {
+            out.writeVInt(tableOid);
+        }
         out.writeCollection(colsToDrop);
     }
 
     public RelationName relationName() {
         return this.relationName;
+    }
+
+    public int tableOid() {
+        return tableOid;
     }
 
     public List<DropColumn> colsToDrop() {

--- a/server/src/main/java/io/crate/execution/ddl/tables/DropConstraintRequest.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/DropConstraintRequest.java
@@ -21,8 +21,11 @@
 
 package io.crate.execution.ddl.tables;
 
+import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
+
 import java.io.IOException;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -32,23 +35,36 @@ import io.crate.metadata.RelationName;
 public class DropConstraintRequest extends AcknowledgedRequest<DropConstraintRequest> {
 
     private final RelationName relationName;
+    private final int tableOid;
     private final String constraintName;
 
     public DropConstraintRequest(RelationName relationName,
+                                 int tableOid,
                                  String constraintName) {
         this.relationName = relationName;
+        this.tableOid = tableOid;
         this.constraintName = constraintName;
     }
 
     public DropConstraintRequest(StreamInput in) throws IOException {
         super(in);
         relationName = new RelationName(in);
+        if ((in.getVersion().before(Version.V_6_4_0) && in.getVersion().onOrAfter(Version.V_6_3_7))
+            || in.getVersion().onOrAfter(Version.V_6_4_2)) {
+            tableOid = in.readVInt();
+        } else {
+            tableOid = OID_UNASSIGNED;
+        }
         constraintName = in.readString();
     }
 
 
     public RelationName relationName() {
         return relationName;
+    }
+
+    public int tableOid() {
+        return tableOid;
     }
 
     public String constraintName() {
@@ -59,6 +75,10 @@ public class DropConstraintRequest extends AcknowledgedRequest<DropConstraintReq
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         relationName.writeTo(out);
+        if ((out.getVersion().before(Version.V_6_4_0) && out.getVersion().onOrAfter(Version.V_6_3_7))
+            || out.getVersion().onOrAfter(Version.V_6_4_2)) {
+            out.writeVInt(tableOid);
+        }
         out.writeString(constraintName);
     }
 }

--- a/server/src/main/java/io/crate/execution/ddl/tables/DropPartitionsRequest.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/DropPartitionsRequest.java
@@ -21,10 +21,13 @@
 
 package io.crate.execution.ddl.tables;
 
+import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -35,15 +38,21 @@ import io.crate.metadata.RelationName;
 public class DropPartitionsRequest extends AcknowledgedRequest<DropPartitionsRequest> {
 
     private final RelationName relationName;
+    private final int tableOid;
     private final List<PartitionName> partitions;
 
-    public DropPartitionsRequest(RelationName relationName, List<PartitionName> partitions) {
+    public DropPartitionsRequest(RelationName relationName, int tableOid, List<PartitionName> partitions) {
         this.relationName = relationName;
+        this.tableOid = tableOid;
         this.partitions = partitions;
     }
 
     public RelationName relationName() {
         return relationName;
+    }
+
+    public int tableOid() {
+        return tableOid;
     }
 
     public List<PartitionName> partitions() {
@@ -53,6 +62,12 @@ public class DropPartitionsRequest extends AcknowledgedRequest<DropPartitionsReq
     public DropPartitionsRequest(StreamInput in) throws IOException {
         super(in);
         relationName = new RelationName(in);
+        if ((in.getVersion().before(Version.V_6_4_0) && in.getVersion().onOrAfter(Version.V_6_3_7))
+            || in.getVersion().onOrAfter(Version.V_6_4_2)) {
+            tableOid = in.readVInt();
+        } else {
+            tableOid = OID_UNASSIGNED;
+        }
         int size = in.readVInt();
         partitions = new ArrayList<>(size);
         for (int i = 0; i < size; i++) {
@@ -69,6 +84,10 @@ public class DropPartitionsRequest extends AcknowledgedRequest<DropPartitionsReq
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         relationName.writeTo(out);
+        if ((out.getVersion().before(Version.V_6_4_0) && out.getVersion().onOrAfter(Version.V_6_3_7))
+            || out.getVersion().onOrAfter(Version.V_6_4_2)) {
+            out.writeVInt(tableOid);
+        }
         out.writeVInt(partitions.size());
         for (PartitionName partition : partitions) {
             assert partition.relationName().equals(relationName)

--- a/server/src/main/java/io/crate/execution/ddl/tables/DropTableRequest.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/DropTableRequest.java
@@ -21,6 +21,8 @@
 
 package io.crate.execution.ddl.tables;
 
+import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
+
 import java.io.IOException;
 
 import org.elasticsearch.Version;
@@ -33,18 +35,30 @@ import io.crate.metadata.RelationName;
 public class DropTableRequest extends AcknowledgedRequest<DropTableRequest> {
 
     private final RelationName relationName;
+    private final int tableOid;
 
-    public DropTableRequest(RelationName relationName) {
+    public DropTableRequest(RelationName relationName, int tableOid) {
         this.relationName = relationName;
+        this.tableOid = tableOid;
     }
 
     public RelationName tableIdent() {
         return relationName;
     }
 
+    public int tableOid() {
+        return tableOid;
+    }
+
     public DropTableRequest(StreamInput in) throws IOException {
         super(in);
         relationName = new RelationName(in);
+        if ((in.getVersion().before(Version.V_6_4_0) && in.getVersion().onOrAfter(Version.V_6_3_7))
+            || in.getVersion().onOrAfter(Version.V_6_4_2)) {
+            tableOid = in.readVInt();
+        } else {
+            tableOid = OID_UNASSIGNED;
+        }
         if (in.getVersion().before(Version.V_5_8_0)) {
             in.readBoolean(); // isPartitioned
         }
@@ -54,6 +68,10 @@ public class DropTableRequest extends AcknowledgedRequest<DropTableRequest> {
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         relationName.writeTo(out);
+        if ((out.getVersion().before(Version.V_6_4_0) && out.getVersion().onOrAfter(Version.V_6_3_7))
+            || out.getVersion().onOrAfter(Version.V_6_4_2)) {
+            out.writeVInt(tableOid);
+        }
         if (out.getVersion().before(Version.V_5_8_0)) {
             // sets isPartitioned to true,
             // which if wrong shouldn't cause much harm, as it will only result in a

--- a/server/src/main/java/io/crate/execution/ddl/tables/OpenTableRequest.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/OpenTableRequest.java
@@ -21,6 +21,8 @@
 
 package io.crate.execution.ddl.tables;
 
+import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -37,15 +39,21 @@ import io.crate.metadata.RelationName;
 public class OpenTableRequest extends AcknowledgedRequest<OpenTableRequest> {
 
     private final RelationName relation;
+    private final int tableOid;
     private final List<String> partitionValues;
 
-    public OpenTableRequest(RelationName relation, List<String> partitionValues) {
+    public OpenTableRequest(RelationName relation, int tableOid, List<String> partitionValues) {
         this.relation = relation;
+        this.tableOid = tableOid;
         this.partitionValues = partitionValues;
     }
 
     public RelationName relation() {
         return relation;
+    }
+
+    public int tableOid() {
+        return tableOid;
     }
 
     /**
@@ -62,6 +70,7 @@ public class OpenTableRequest extends AcknowledgedRequest<OpenTableRequest> {
         super(in);
         if (in.getVersion().before(Version.V_5_10_0)) {
             relation = new RelationName(in);
+            tableOid = OID_UNASSIGNED;
             String partitionIndexName = in.readOptionalString();
             if (partitionIndexName == null) {
                 partitionValues = List.of();
@@ -71,6 +80,12 @@ public class OpenTableRequest extends AcknowledgedRequest<OpenTableRequest> {
             in.readBoolean(); // openTable flag; before 4.3.0 the request was also used to close tables
         } else {
             relation = new RelationName(in);
+            if ((in.getVersion().before(Version.V_6_4_0) && in.getVersion().onOrAfter(Version.V_6_3_7))
+                || in.getVersion().onOrAfter(Version.V_6_4_2)) {
+                tableOid = in.readVInt();
+            } else {
+                tableOid = OID_UNASSIGNED;
+            }
             int numValues = in.readVInt();
             partitionValues = new ArrayList<>(numValues);
             for (int i = 0; i < numValues; i++) {
@@ -94,6 +109,10 @@ public class OpenTableRequest extends AcknowledgedRequest<OpenTableRequest> {
             out.writeBoolean(true); // openTable flag; before 4.3.0 the request was also used to close tables
         } else {
             relation.writeTo(out);
+            if ((out.getVersion().before(Version.V_6_4_0) && out.getVersion().onOrAfter(Version.V_6_3_7))
+                || out.getVersion().onOrAfter(Version.V_6_4_2)) {
+                out.writeVInt(tableOid);
+            }
             out.writeVInt(partitionValues.size());
             for (String partitionValue : partitionValues) {
                 out.writeOptionalString(partitionValue);

--- a/server/src/main/java/io/crate/execution/ddl/tables/RenameColumnRequest.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/RenameColumnRequest.java
@@ -21,8 +21,11 @@
 
 package io.crate.execution.ddl.tables;
 
+import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
+
 import java.io.IOException;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -35,11 +38,13 @@ import io.crate.metadata.RelationName;
 public class RenameColumnRequest extends AcknowledgedRequest<RenameColumnRequest> {
 
     private final RelationName relationName;
+    private final int tableOid;
     private final Reference refToRename;
     private final ColumnIdent newName;
 
-    public RenameColumnRequest(RelationName relationName, Reference refToRename, ColumnIdent newName) {
+    public RenameColumnRequest(RelationName relationName, int tableOid, Reference refToRename, ColumnIdent newName) {
         this.relationName = relationName;
+        this.tableOid = tableOid;
         this.refToRename = refToRename;
         this.newName = newName;
     }
@@ -47,6 +52,12 @@ public class RenameColumnRequest extends AcknowledgedRequest<RenameColumnRequest
     public RenameColumnRequest(StreamInput in) throws IOException {
         super(in);
         this.relationName = new RelationName(in);
+        if ((in.getVersion().before(Version.V_6_4_0) && in.getVersion().onOrAfter(Version.V_6_3_7))
+            || in.getVersion().onOrAfter(Version.V_6_4_2)) {
+            this.tableOid = in.readVInt();
+        } else {
+            this.tableOid = OID_UNASSIGNED;
+        }
         this.refToRename = (Reference) Symbol.fromStream(in);
         this.newName = ColumnIdent.of(in);
     }
@@ -55,12 +66,20 @@ public class RenameColumnRequest extends AcknowledgedRequest<RenameColumnRequest
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         relationName.writeTo(out);
+        if ((out.getVersion().before(Version.V_6_4_0) && out.getVersion().onOrAfter(Version.V_6_3_7))
+            || out.getVersion().onOrAfter(Version.V_6_4_2)) {
+            out.writeVInt(tableOid);
+        }
         Symbol.toStream(refToRename, out);
         newName.writeTo(out);
     }
 
     public RelationName relationName() {
         return relationName;
+    }
+
+    public int tableOid() {
+        return tableOid;
     }
 
     public Reference refToRename() {

--- a/server/src/main/java/io/crate/execution/ddl/tables/RenameTableRequest.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/RenameTableRequest.java
@@ -21,8 +21,11 @@
 
 package io.crate.execution.ddl.tables;
 
+import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
+
 import java.io.IOException;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -32,17 +35,23 @@ import io.crate.metadata.RelationName;
 public class RenameTableRequest extends AcknowledgedRequest<RenameTableRequest> {
 
     private final RelationName sourceName;
+    private final int sourceOid;
     private final RelationName targetName;
     private final boolean isPartitioned;
 
-    public RenameTableRequest(RelationName sourceName, RelationName targetName, boolean isPartitioned) {
+    public RenameTableRequest(RelationName sourceName, int sourceOid, RelationName targetName, boolean isPartitioned) {
         this.sourceName = sourceName;
+        this.sourceOid = sourceOid;
         this.targetName = targetName;
         this.isPartitioned = isPartitioned;
     }
 
     public RelationName sourceName() {
         return sourceName;
+    }
+
+    public int sourceOid() {
+        return sourceOid;
     }
 
     public RelationName targetName() {
@@ -56,6 +65,12 @@ public class RenameTableRequest extends AcknowledgedRequest<RenameTableRequest> 
     public RenameTableRequest(StreamInput in) throws IOException {
         super(in);
         sourceName = new RelationName(in);
+        if ((in.getVersion().before(Version.V_6_4_0) && in.getVersion().onOrAfter(Version.V_6_3_7))
+            || in.getVersion().onOrAfter(Version.V_6_4_2)) {
+            sourceOid = in.readVInt();
+        } else {
+            sourceOid = OID_UNASSIGNED;
+        }
         targetName = new RelationName(in);
         isPartitioned = in.readBoolean();
     }
@@ -64,6 +79,10 @@ public class RenameTableRequest extends AcknowledgedRequest<RenameTableRequest> 
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         sourceName.writeTo(out);
+        if ((out.getVersion().before(Version.V_6_4_0) && out.getVersion().onOrAfter(Version.V_6_3_7))
+            || out.getVersion().onOrAfter(Version.V_6_4_2)) {
+            out.writeVInt(sourceOid);
+        }
         targetName.writeTo(out);
         out.writeBoolean(isPartitioned);
     }

--- a/server/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
+++ b/server/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
@@ -565,8 +565,10 @@ public class TransportShardUpsertAction extends TransportShardAction<
     private DocTableInfo updateSchema(RelationName tableName,
                                       Index index,
                                       List<Reference> newColumns) throws InterruptedException, ExecutionException {
+        DocTableInfo tableInfo = schemas.getTableInfo(index);
         var addColumnRequest = new AddColumnRequest(
             tableName,
+            tableInfo.oid(),
             newColumns,
             Map.of(),
             new IntArrayList(0)

--- a/server/src/main/java/io/crate/planner/SwapTablePlan.java
+++ b/server/src/main/java/io/crate/planner/SwapTablePlan.java
@@ -72,7 +72,9 @@ public class SwapTablePlan implements Plan {
 
         RelationName source = swapTable.source().ident();
         SwapRelationsRequest request = new SwapRelationsRequest(
-            Collections.singletonList(new RelationNameSwap(source, swapTable.target().ident())),
+            Collections.singletonList(
+                new RelationNameSwap(source, swapTable.source().oid(), swapTable.target().ident(), swapTable.target().oid())
+            ),
             dropSource ? Collections.singletonList(source) : emptyList()
         );
         OneRowActionListener<AcknowledgedResponse> listener = new OneRowActionListener<>(

--- a/server/src/main/java/io/crate/planner/node/ddl/AlterTableAlterColumnDefaultPlan.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/AlterTableAlterColumnDefaultPlan.java
@@ -52,7 +52,12 @@ public class AlterTableAlterColumnDefaultPlan implements Plan {
                               RowConsumer consumer,
                               Row params,
                               SubQueryResults subQueryResults) throws Exception {
-        var request = new AlterColumnDefaultRequest(analyzed.table(), analyzed.ref(), analyzed.newDefault());
+        var request = new AlterColumnDefaultRequest(
+            analyzed.table(),
+            analyzed.tableOid(),
+            analyzed.ref(),
+            analyzed.newDefault()
+        );
         dependencies.client()
             .execute(TransportAlterColumnDefault.ACTION, request)
             .whenComplete(new OneRowActionListener<>(consumer, r -> r.isAcknowledged() ? new Row1(-1L) : new Row1(0L)));

--- a/server/src/main/java/io/crate/planner/node/ddl/AlterTableDropCheckConstraintPlan.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/AlterTableDropCheckConstraintPlan.java
@@ -55,6 +55,7 @@ public class AlterTableDropCheckConstraintPlan implements Plan {
                               SubQueryResults subQueryResults) {
         var request = new DropConstraintRequest(
             dropCheckConstraint.tableInfo().ident(),
+            dropCheckConstraint.tableInfo().oid(),
             dropCheckConstraint.name()
         );
 

--- a/server/src/main/java/io/crate/planner/node/ddl/AlterTableDropColumnPlan.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/AlterTableDropColumnPlan.java
@@ -53,7 +53,11 @@ public class AlterTableDropColumnPlan implements Plan {
                               RowConsumer consumer,
                               Row params,
                               SubQueryResults subQueryResults) throws Exception {
-        var dropColumnRequest = new DropColumnRequest(alterTable.table().ident(), alterTable.columns());
+        var dropColumnRequest = new DropColumnRequest(
+            alterTable.table().ident(),
+            alterTable.table().oid(),
+            alterTable.columns()
+        );
         dependencies.client().execute(TransportDropColumn.ACTION, dropColumnRequest)
             .whenComplete(new OneRowActionListener<>(consumer, _ -> ROW_COUNT_UNKNOWN));
     }

--- a/server/src/main/java/io/crate/planner/node/ddl/AlterTableOpenClosePlan.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/AlterTableOpenClosePlan.java
@@ -72,7 +72,7 @@ public class AlterTableOpenClosePlan implements Plan {
             : PartitionName.ofAssignments(tableInfo, table.partitionProperties(), plannerContext.clusterState().metadata());
 
         dependencies.alterTableClient()
-            .closeOrOpen(tableInfo.ident(), analyzedAlterTable.isOpenTable(), partitionName)
+            .closeOrOpen(tableInfo.ident(), tableInfo.oid(), analyzedAlterTable.isOpenTable(), partitionName)
             .whenComplete(new OneRowActionListener<>(consumer, rCount -> new Row1(rCount == null ? -1 : rCount)));
     }
 }

--- a/server/src/main/java/io/crate/planner/node/ddl/AlterTableRenameColumnPlan.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/AlterTableRenameColumnPlan.java
@@ -51,7 +51,12 @@ public class AlterTableRenameColumnPlan implements Plan {
                               RowConsumer consumer,
                               Row params,
                               SubQueryResults subQueryResults) throws Exception {
-        var renameColumnRequest = new RenameColumnRequest(renameColumn.table(), renameColumn.refToRename(), renameColumn.newName());
+        var renameColumnRequest = new RenameColumnRequest(
+            renameColumn.table(),
+            renameColumn.tableOid(),
+            renameColumn.refToRename(),
+            renameColumn.newName()
+        );
         dependencies.client()
             .execute(TransportRenameColumn.ACTION, renameColumnRequest)
             .whenComplete(new OneRowActionListener<>(consumer, r -> r.isAcknowledged() ? new Row1(-1L) : new Row1(0L)));

--- a/server/src/main/java/io/crate/planner/node/ddl/AlterTableRenameTablePlan.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/AlterTableRenameTablePlan.java
@@ -54,6 +54,7 @@ public class AlterTableRenameTablePlan implements Plan {
                               Row params, SubQueryResults subQueryResults) throws Exception {
         var request = new RenameTableRequest(
             analyzedAlterTableRenameTable.sourceName(),
+            analyzedAlterTableRenameTable.sourceOid(),
             analyzedAlterTableRenameTable.targetName(),
             analyzedAlterTableRenameTable.isPartitioned());
         dependencies.client().execute(TransportRenameTable.ACTION, request)

--- a/server/src/main/java/io/crate/planner/node/ddl/DeleteAllPartitions.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/DeleteAllPartitions.java
@@ -38,9 +38,11 @@ import io.crate.planner.operators.SubQueryResults;
 public final class DeleteAllPartitions implements Plan {
 
     private final RelationName relationName;
+    private final int tableOid;
 
-    public DeleteAllPartitions(RelationName relationName) {
+    public DeleteAllPartitions(RelationName relationName, int tableOid) {
         this.relationName = relationName;
+        this.tableOid = tableOid;
     }
 
     @Override
@@ -57,7 +59,7 @@ public final class DeleteAllPartitions implements Plan {
         var listener = new OneRowActionListener<>(consumer, ignoredResponse -> Row1.ROW_COUNT_UNKNOWN);
         dependencies.client().execute(
             TransportDropPartitionsAction.ACTION,
-            new DropPartitionsRequest(relationName, List.of())
+            new DropPartitionsRequest(relationName, tableOid, List.of())
         ).whenComplete(listener);
     }
 }

--- a/server/src/main/java/io/crate/planner/node/ddl/DeletePartitions.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/DeletePartitions.java
@@ -49,10 +49,12 @@ import io.crate.types.DataTypes;
 public class DeletePartitions implements Plan {
 
     private final RelationName relationName;
+    private final int tableOid;
     private final List<List<Symbol>> partitions;
 
-    public DeletePartitions(RelationName relationName, List<List<Symbol>> partitions) {
+    public DeletePartitions(RelationName relationName, int tableOid, List<List<Symbol>> partitions) {
         this.relationName = relationName;
+        this.tableOid = tableOid;
         this.partitions = partitions;
     }
 
@@ -76,7 +78,7 @@ public class DeletePartitions implements Plan {
             relationName, plannerContext.transactionContext(), dependencies.nodeContext(), params, subQueryResults);
         dependencies.client().execute(
             TransportDropPartitionsAction.ACTION,
-            new DropPartitionsRequest(relationName, partitionNames)
+            new DropPartitionsRequest(relationName, tableOid, partitionNames)
         ).whenComplete(new OneRowActionListener<>(consumer, ignoredResponse -> Row1.ROW_COUNT_UNKNOWN));
     }
 

--- a/server/src/main/java/io/crate/planner/node/ddl/DropTablePlan.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/DropTablePlan.java
@@ -71,7 +71,7 @@ public class DropTablePlan implements Plan {
                               RowConsumer consumer,
                               Row params,
                               SubQueryResults subQueryResults) {
-        var request = new DropTableRequest(dropTable.tableName());
+        var request = new DropTableRequest(dropTable.tableName(), dropTable.tableOid());
         dependencies.client().execute(TransportDropTable.ACTION, request).whenComplete((response, err) -> {
             if (err == null) {
                 if (!response.isAcknowledged() && LOGGER.isWarnEnabled()) {

--- a/server/src/main/java/io/crate/planner/statement/DeletePlanner.java
+++ b/server/src/main/java/io/crate/planner/statement/DeletePlanner.java
@@ -96,7 +96,7 @@ public final class DeletePlanner {
             // deleting whole partitions is only valid if the query only contains filters based on partition-by cols
             var hasNonPartitionReferences = query.any(s -> s instanceof Reference && table.partitionedByColumns().contains(s) == false);
             if (hasNonPartitionReferences == false) {
-                return new DeletePartitions(table.ident(), detailedQuery.partitions());
+                return new DeletePartitions(table.ident(), table.oid(), detailedQuery.partitions());
             }
         }
 
@@ -104,7 +104,7 @@ public final class DeletePlanner {
             return new DeleteById(tableRel.tableInfo(), detailedQuery.docKeys().get());
         }
         if (table.isPartitioned() && query instanceof Input<?> input && DataTypes.BOOLEAN.sanitizeValue(input.value())) {
-            return new DeleteAllPartitions(table.ident());
+            return new DeleteAllPartitions(table.ident(), table.oid());
         }
 
         return new Delete(tableRel, detailedQuery);
@@ -148,7 +148,7 @@ public final class DeletePlanner {
                 }
                 dependencies.client().execute(
                     TransportDropPartitionsAction.ACTION,
-                    new DropPartitionsRequest(table.relationName(), partitionValues)
+                    new DropPartitionsRequest(table.relationName(), table.tableInfo().oid(), partitionValues)
                 ).whenComplete(new OneRowActionListener<>(consumer, _ -> Row1.ROW_COUNT_UNKNOWN));
                 return;
             }

--- a/server/src/main/java/io/crate/statistics/FetchSampleRequest.java
+++ b/server/src/main/java/io/crate/statistics/FetchSampleRequest.java
@@ -61,7 +61,7 @@ public final class FetchSampleRequest extends TransportRequest {
         this.relationName = new RelationName(in);
         if ((in.getVersion().before(Version.V_6_4_0) && in.getVersion().onOrAfter(Version.V_6_3_7))
             || in.getVersion().onOrAfter(Version.V_6_4_2)) {
-            this.tableOid = in.readInt();
+            this.tableOid = in.readVInt();
         } else {
             this.tableOid = OID_UNASSIGNED;
         }
@@ -80,7 +80,7 @@ public final class FetchSampleRequest extends TransportRequest {
         relationName.writeTo(out);
         if ((out.getVersion().before(Version.V_6_4_0) && out.getVersion().onOrAfter(Version.V_6_3_7))
             || out.getVersion().onOrAfter(Version.V_6_4_2)) {
-            out.writeInt(tableOid);
+            out.writeVInt(tableOid);
         }
         if (out.getVersion().before(Version.V_5_7_0)) {
             out.writeVInt(30_000);  // Old max samples value

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/shrink/ResizeRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/shrink/ResizeRequest.java
@@ -19,6 +19,8 @@
 
 package org.elasticsearch.action.admin.indices.shrink;
 
+import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -40,12 +42,14 @@ import io.crate.metadata.RelationName;
 public class ResizeRequest extends AcknowledgedRequest<ResizeRequest> {
 
     private final RelationName table;
+    private final int tableOid;
     private final List<String> partitionValues;
     private final int newNumShards;
 
-    public ResizeRequest(RelationName table, List<String> partitionValues, int newNumShards) {
+    public ResizeRequest(RelationName table, int tableOid, List<String> partitionValues, int newNumShards) {
         super();
         this.table = table;
+        this.tableOid = tableOid;
         this.partitionValues = partitionValues;
         this.newNumShards = newNumShards;
         this.timeout = TimeValue.timeValueSeconds(this.timeout.seconds() * 2);
@@ -56,6 +60,12 @@ public class ResizeRequest extends AcknowledgedRequest<ResizeRequest> {
         super(in);
         if (in.getVersion().onOrAfter(Version.V_5_10_0)) {
             table = new RelationName(in);
+            if ((in.getVersion().before(Version.V_6_4_0) && in.getVersion().onOrAfter(Version.V_6_3_7))
+                || in.getVersion().onOrAfter(Version.V_6_4_2)) {
+                tableOid = in.readVInt();
+            } else {
+                tableOid = OID_UNASSIGNED;
+            }
             int numValues = in.readVInt();
             partitionValues = new ArrayList<>(numValues);
             for (int i = 0; i < numValues; i++) {
@@ -73,6 +83,10 @@ public class ResizeRequest extends AcknowledgedRequest<ResizeRequest> {
         super.writeTo(out);
         if (out.getVersion().onOrAfter(Version.V_5_10_0)) {
             table.writeTo(out);
+            if ((out.getVersion().before(Version.V_6_4_0) && out.getVersion().onOrAfter(Version.V_6_3_7))
+                || out.getVersion().onOrAfter(Version.V_6_4_2)) {
+                out.writeVInt(tableOid);
+            }
             out.writeVInt(partitionValues.size());
             for (String value : partitionValues) {
                 out.writeOptionalString(value);
@@ -86,6 +100,10 @@ public class ResizeRequest extends AcknowledgedRequest<ResizeRequest> {
 
     public RelationName table() {
         return table;
+    }
+
+    public int tableOid() {
+        return tableOid;
     }
 
     public List<String> partitionValues() {

--- a/server/src/test/java/io/crate/execution/ddl/SwapRelationsRequestTest.java
+++ b/server/src/test/java/io/crate/execution/ddl/SwapRelationsRequestTest.java
@@ -19,58 +19,33 @@
  * software solely pursuant to the terms of the relevant commercial agreement.
  */
 
-package io.crate.execution.ddl.tables;
+package io.crate.execution.ddl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
 
-import java.util.Arrays;
 import java.util.List;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
-import org.elasticsearch.common.settings.Settings;
 import org.junit.Test;
 
 import io.crate.metadata.RelationName;
 
-public class AlterTableRequestTest {
-
-    @Test
-    public void test_streaming_bwc() throws Exception {
-        RelationName tbl = new RelationName("doc", "tbl");
-        List<AlterTableRequest> requests = List.of(
-            new AlterTableRequest(tbl, OID_UNASSIGNED, List.of(), true, false, Settings.EMPTY),
-            new AlterTableRequest(tbl, OID_UNASSIGNED, Arrays.asList("1", null, "3"), true, false, Settings.EMPTY)
-        );
-        for (var request : requests) {
-            try (var out = new BytesStreamOutput()) {
-                request.writeTo(out);
-                try (var in = out.bytes().streamInput()) {
-                    AlterTableRequest inRequest = new AlterTableRequest(in);
-                    assertThat(inRequest).isEqualTo(request);
-                }
-            }
-            try (var out = new BytesStreamOutput()) {
-                out.setVersion(Version.V_5_9_4);
-                request.writeTo(out);
-                try (var in = out.bytes().streamInput()) {
-                    in.setVersion(Version.V_5_9_4);
-                    AlterTableRequest inRequest = new AlterTableRequest(in);
-                    assertThat(inRequest).isEqualTo(request);
-                }
-            }
-        }
-    }
+public class SwapRelationsRequestTest {
 
     @Test
     public void test_streaming_table_oids() throws Exception {
         // streaming to nodes with supported versions
         for (Version version : List.of(Version.V_6_3_7, Version.V_6_4_2, Version.CURRENT)) {
-            RelationName relation = new RelationName("doc", "tbl");
-            int tableOid = 1234;
-            AlterTableRequest request = new AlterTableRequest(
-                relation, tableOid, List.of(), false, false, Settings.EMPTY);
+            RelationName source = new RelationName("doc", "source");
+            RelationName target = new RelationName("doc", "target");
+            int sourceOid = 1234;
+            int targetOid = 5678;
+            SwapRelationsRequest request = new SwapRelationsRequest(
+                List.of(new RelationNameSwap(source, sourceOid, target, targetOid)),
+                List.of(source)
+            );
 
             var out = new BytesStreamOutput();
             out.setVersion(version);
@@ -78,16 +53,21 @@ public class AlterTableRequestTest {
 
             var in = out.bytes().streamInput();
             in.setVersion(version);
-            AlterTableRequest streamed = new AlterTableRequest(in);
+            SwapRelationsRequest streamed = new SwapRelationsRequest(in);
+            RelationNameSwap swap = streamed.swapActions().get(0);
 
-            assertThat(streamed.tableOid()).isEqualTo(tableOid);
+            assertThat(swap.sourceOid()).isEqualTo(sourceOid);
+            assertThat(swap.targetOid()).isEqualTo(targetOid);
         }
 
         // streaming to nodes with unsupported versions
         for (Version version : List.of(Version.V_6_3_6, Version.V_6_4_0, Version.V_6_4_1)) {
-            RelationName relation = new RelationName("doc", "tbl");
-            AlterTableRequest request = new AlterTableRequest(
-                relation, 1234, List.of(), false, false, Settings.EMPTY);
+            RelationName source = new RelationName("doc", "source");
+            RelationName target = new RelationName("doc", "target");
+            SwapRelationsRequest request = new SwapRelationsRequest(
+                List.of(new RelationNameSwap(source, 1234, target, 5678)),
+                List.of(source)
+            );
 
             var out = new BytesStreamOutput();
             out.setVersion(version);
@@ -95,9 +75,11 @@ public class AlterTableRequestTest {
 
             var in = out.bytes().streamInput();
             in.setVersion(version);
-            AlterTableRequest streamed = new AlterTableRequest(in);
+            SwapRelationsRequest streamed = new SwapRelationsRequest(in);
+            RelationNameSwap swap = streamed.swapActions().get(0);
 
-            assertThat(streamed.tableOid()).isEqualTo(OID_UNASSIGNED);
+            assertThat(swap.sourceOid()).isEqualTo(OID_UNASSIGNED);
+            assertThat(swap.targetOid()).isEqualTo(OID_UNASSIGNED);
         }
     }
 }

--- a/server/src/test/java/io/crate/execution/ddl/tables/AddColumnRequestTest.java
+++ b/server/src/test/java/io/crate/execution/ddl/tables/AddColumnRequestTest.java
@@ -25,48 +25,21 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
 
 import java.util.List;
+import java.util.Map;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.junit.Test;
 
+import com.carrotsearch.hppc.IntArrayList;
+
+import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.RelationName;
+import io.crate.metadata.RowGranularity;
+import io.crate.metadata.SimpleReference;
+import io.crate.types.DataTypes;
 
-public class CloseTableRequestTest {
-
-    @Test
-    public void test_bwc_streaming() throws Exception {
-        RelationName relation = new RelationName("foo", "bar");
-        List<CloseTableRequest> requests = List.of(
-            new CloseTableRequest(relation, OID_UNASSIGNED, List.of("1")),
-            new CloseTableRequest(relation, OID_UNASSIGNED, List.of())
-        );
-
-        for (var request : requests) {
-            {
-                BytesStreamOutput out = new BytesStreamOutput();
-                request.writeTo(out);
-
-                try (var in = out.bytes().streamInput()) {
-                    CloseTableRequest deserializedRequest = new CloseTableRequest(in);
-                    assertThat(deserializedRequest.table()).isEqualTo(relation);
-                    assertThat(deserializedRequest.partitionValues()).isEqualTo(request.partitionValues());
-                }
-            }
-            {
-                BytesStreamOutput out = new BytesStreamOutput();
-                out.setVersion(Version.V_5_9_0);
-                request.writeTo(out);
-
-                try (var in = out.bytes().streamInput()) {
-                    in.setVersion(Version.V_5_9_0);
-                    CloseTableRequest deserializedRequest = new CloseTableRequest(in);
-                    assertThat(deserializedRequest.table()).isEqualTo(relation);
-                    assertThat(deserializedRequest.partitionValues()).isEqualTo(request.partitionValues());
-                }
-            }
-        }
-    }
+public class AddColumnRequestTest {
 
     @Test
     public void test_streaming_table_oids() throws Exception {
@@ -74,7 +47,10 @@ public class CloseTableRequestTest {
         for (Version version : List.of(Version.V_6_3_7, Version.V_6_4_2, Version.CURRENT)) {
             RelationName relation = new RelationName("doc", "tbl");
             int tableOid = 1234;
-            CloseTableRequest request = new CloseTableRequest(relation, tableOid, List.of());
+            var ref = new SimpleReference(
+                relation, ColumnIdent.of("x"), RowGranularity.DOC, DataTypes.INTEGER, 1, null);
+            AddColumnRequest request = new AddColumnRequest(
+                relation, tableOid, List.of(ref), Map.of(), new IntArrayList());
 
             var out = new BytesStreamOutput();
             out.setVersion(version);
@@ -82,7 +58,7 @@ public class CloseTableRequestTest {
 
             var in = out.bytes().streamInput();
             in.setVersion(version);
-            CloseTableRequest streamed = new CloseTableRequest(in);
+            AddColumnRequest streamed = new AddColumnRequest(in);
 
             assertThat(streamed.tableOid()).isEqualTo(tableOid);
         }
@@ -90,7 +66,10 @@ public class CloseTableRequestTest {
         // streaming to nodes with unsupported versions
         for (Version version : List.of(Version.V_6_3_6, Version.V_6_4_0, Version.V_6_4_1)) {
             RelationName relation = new RelationName("doc", "tbl");
-            CloseTableRequest request = new CloseTableRequest(relation, 1234, List.of());
+            var ref = new SimpleReference(
+                relation, ColumnIdent.of("x"), RowGranularity.DOC, DataTypes.INTEGER, 1, null);
+            AddColumnRequest request = new AddColumnRequest(
+                relation, 1234, List.of(ref), Map.of(), new IntArrayList());
 
             var out = new BytesStreamOutput();
             out.setVersion(version);
@@ -98,7 +77,7 @@ public class CloseTableRequestTest {
 
             var in = out.bytes().streamInput();
             in.setVersion(version);
-            CloseTableRequest streamed = new CloseTableRequest(in);
+            AddColumnRequest streamed = new AddColumnRequest(in);
 
             assertThat(streamed.tableOid()).isEqualTo(OID_UNASSIGNED);
         }

--- a/server/src/test/java/io/crate/execution/ddl/tables/AddColumnTaskTest.java
+++ b/server/src/test/java/io/crate/execution/ddl/tables/AddColumnTaskTest.java
@@ -80,6 +80,7 @@ public class AddColumnTaskTest extends CrateDummyClusterServiceUnitTest {
         List<Reference> columns = List.of(newColumn);
         var request = new AddColumnRequest(
             tbl.ident(),
+            OID_UNASSIGNED,
             columns,
             Map.of(),
             new IntArrayList()
@@ -150,6 +151,7 @@ public class AddColumnTaskTest extends CrateDummyClusterServiceUnitTest {
         List<Reference> columns = List.of(geoShapeArrayRef, geoPointArrayRef);
         var request = new AddColumnRequest(
             tbl.ident(),
+            OID_UNASSIGNED,
             columns,
             Map.of(),
             new IntArrayList()
@@ -187,6 +189,7 @@ public class AddColumnTaskTest extends CrateDummyClusterServiceUnitTest {
         List<Reference> columns = List.of(newColumn);
         var request = new AddColumnRequest(
             tbl.ident(),
+            OID_UNASSIGNED,
             columns,
             Map.of(),
             new IntArrayList()
@@ -221,6 +224,7 @@ public class AddColumnTaskTest extends CrateDummyClusterServiceUnitTest {
         List<Reference> columns = List.of(newColumn1, newColumn2);
         var request = new AddColumnRequest(
             tbl.ident(),
+            OID_UNASSIGNED,
             columns,
             Map.of(),
             new IntArrayList()
@@ -248,6 +252,7 @@ public class AddColumnTaskTest extends CrateDummyClusterServiceUnitTest {
         List<Reference> columns = List.of(newColumn1);
         var request = new AddColumnRequest(
             tbl.ident(),
+            OID_UNASSIGNED,
             columns,
             Map.of(),
             new IntArrayList()
@@ -281,6 +286,7 @@ public class AddColumnTaskTest extends CrateDummyClusterServiceUnitTest {
         List<Reference> columns = List.of(colToAdd);
         var request = new AddColumnRequest(
             tbl.ident(),
+            OID_UNASSIGNED,
             columns,
             Map.of(),
             new IntArrayList()
@@ -310,6 +316,7 @@ public class AddColumnTaskTest extends CrateDummyClusterServiceUnitTest {
         List<Reference> columns = List.of(colToAdd);
         var request = new AddColumnRequest(
             tbl.ident(),
+            OID_UNASSIGNED,
             columns,
             Map.of(),
             new IntArrayList()

--- a/server/src/test/java/io/crate/execution/ddl/tables/AlterColumnDefaultRequestTest.java
+++ b/server/src/test/java/io/crate/execution/ddl/tables/AlterColumnDefaultRequestTest.java
@@ -30,43 +30,13 @@ import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.junit.Test;
 
+import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.RelationName;
+import io.crate.metadata.RowGranularity;
+import io.crate.metadata.SimpleReference;
+import io.crate.types.DataTypes;
 
-public class CloseTableRequestTest {
-
-    @Test
-    public void test_bwc_streaming() throws Exception {
-        RelationName relation = new RelationName("foo", "bar");
-        List<CloseTableRequest> requests = List.of(
-            new CloseTableRequest(relation, OID_UNASSIGNED, List.of("1")),
-            new CloseTableRequest(relation, OID_UNASSIGNED, List.of())
-        );
-
-        for (var request : requests) {
-            {
-                BytesStreamOutput out = new BytesStreamOutput();
-                request.writeTo(out);
-
-                try (var in = out.bytes().streamInput()) {
-                    CloseTableRequest deserializedRequest = new CloseTableRequest(in);
-                    assertThat(deserializedRequest.table()).isEqualTo(relation);
-                    assertThat(deserializedRequest.partitionValues()).isEqualTo(request.partitionValues());
-                }
-            }
-            {
-                BytesStreamOutput out = new BytesStreamOutput();
-                out.setVersion(Version.V_5_9_0);
-                request.writeTo(out);
-
-                try (var in = out.bytes().streamInput()) {
-                    in.setVersion(Version.V_5_9_0);
-                    CloseTableRequest deserializedRequest = new CloseTableRequest(in);
-                    assertThat(deserializedRequest.table()).isEqualTo(relation);
-                    assertThat(deserializedRequest.partitionValues()).isEqualTo(request.partitionValues());
-                }
-            }
-        }
-    }
+public class AlterColumnDefaultRequestTest {
 
     @Test
     public void test_streaming_table_oids() throws Exception {
@@ -74,7 +44,9 @@ public class CloseTableRequestTest {
         for (Version version : List.of(Version.V_6_3_7, Version.V_6_4_2, Version.CURRENT)) {
             RelationName relation = new RelationName("doc", "tbl");
             int tableOid = 1234;
-            CloseTableRequest request = new CloseTableRequest(relation, tableOid, List.of());
+            var ref = new SimpleReference(
+                relation, ColumnIdent.of("x"), RowGranularity.DOC, DataTypes.INTEGER, 1, null);
+            AlterColumnDefaultRequest request = new AlterColumnDefaultRequest(relation, tableOid, ref, null);
 
             var out = new BytesStreamOutput();
             out.setVersion(version);
@@ -82,7 +54,7 @@ public class CloseTableRequestTest {
 
             var in = out.bytes().streamInput();
             in.setVersion(version);
-            CloseTableRequest streamed = new CloseTableRequest(in);
+            AlterColumnDefaultRequest streamed = new AlterColumnDefaultRequest(in);
 
             assertThat(streamed.tableOid()).isEqualTo(tableOid);
         }
@@ -90,7 +62,9 @@ public class CloseTableRequestTest {
         // streaming to nodes with unsupported versions
         for (Version version : List.of(Version.V_6_3_6, Version.V_6_4_0, Version.V_6_4_1)) {
             RelationName relation = new RelationName("doc", "tbl");
-            CloseTableRequest request = new CloseTableRequest(relation, 1234, List.of());
+            var ref = new SimpleReference(
+                relation, ColumnIdent.of("x"), RowGranularity.DOC, DataTypes.INTEGER, 1, null);
+            AlterColumnDefaultRequest request = new AlterColumnDefaultRequest(relation, 1234, ref, null);
 
             var out = new BytesStreamOutput();
             out.setVersion(version);
@@ -98,7 +72,7 @@ public class CloseTableRequestTest {
 
             var in = out.bytes().streamInput();
             in.setVersion(version);
-            CloseTableRequest streamed = new CloseTableRequest(in);
+            AlterColumnDefaultRequest streamed = new AlterColumnDefaultRequest(in);
 
             assertThat(streamed.tableOid()).isEqualTo(OID_UNASSIGNED);
         }

--- a/server/src/test/java/io/crate/execution/ddl/tables/AlterColumnDefaultTaskTest.java
+++ b/server/src/test/java/io/crate/execution/ddl/tables/AlterColumnDefaultTaskTest.java
@@ -23,6 +23,7 @@ package io.crate.execution.ddl.tables;
 
 import static io.crate.testing.Asserts.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
 
 import org.elasticsearch.cluster.ClusterState;
 import org.junit.Test;
@@ -52,7 +53,7 @@ public class AlterColumnDefaultTaskTest extends CrateDummyClusterServiceUnitTest
         var task = buildAlterColumnDefaultTask(e, tbl.ident());
         Reference ref = tbl.getReference(ColumnIdent.of("x"));
         Symbol newDefault = Literal.of(42);
-        var request = new AlterColumnDefaultRequest(tbl.ident(), ref, newDefault);
+        var request = new AlterColumnDefaultRequest(tbl.ident(), OID_UNASSIGNED, ref, newDefault);
         ClusterState newState = task.execute(clusterService.state(), request);
         DocTableInfo newTable = new DocTableInfoFactory(e.nodeCtx).create(tbl.ident(), newState.metadata());
         Reference updatedRef = newTable.getReference(ColumnIdent.of("x"));
@@ -68,7 +69,7 @@ public class AlterColumnDefaultTaskTest extends CrateDummyClusterServiceUnitTest
         Reference ref = tbl.getReference(ColumnIdent.of("x"));
         assertThat(ref.defaultExpression()).isEqualTo(Literal.of(1));
         Symbol newDefault = Literal.of(99);
-        var request = new AlterColumnDefaultRequest(tbl.ident(), ref, newDefault);
+        var request = new AlterColumnDefaultRequest(tbl.ident(), OID_UNASSIGNED, ref, newDefault);
         ClusterState newState = task.execute(clusterService.state(), request);
         DocTableInfo newTable = new DocTableInfoFactory(e.nodeCtx).create(tbl.ident(), newState.metadata());
         Reference updatedRef = newTable.getReference(ColumnIdent.of("x"));
@@ -83,7 +84,7 @@ public class AlterColumnDefaultTaskTest extends CrateDummyClusterServiceUnitTest
         var task = buildAlterColumnDefaultTask(e, tbl.ident());
         Reference ref = tbl.getReference(ColumnIdent.of("x"));
         assertThat(ref.defaultExpression()).isNotNull();
-        var request = new AlterColumnDefaultRequest(tbl.ident(), ref, null);
+        var request = new AlterColumnDefaultRequest(tbl.ident(), OID_UNASSIGNED, ref, null);
         ClusterState newState = task.execute(clusterService.state(), request);
         DocTableInfo newTable = new DocTableInfoFactory(e.nodeCtx).create(tbl.ident(), newState.metadata());
         Reference updatedRef = newTable.getReference(ColumnIdent.of("x"));
@@ -97,7 +98,7 @@ public class AlterColumnDefaultTaskTest extends CrateDummyClusterServiceUnitTest
         DocTableInfo tbl = e.resolveTableInfo("tbl");
         var task = buildAlterColumnDefaultTask(e, tbl.ident());
         Reference ref = tbl.getReference(ColumnIdent.of("x"));
-        var request = new AlterColumnDefaultRequest(tbl.ident(), ref, null);
+        var request = new AlterColumnDefaultRequest(tbl.ident(), OID_UNASSIGNED, ref, null);
         ClusterState newState = task.execute(clusterService.state(), request);
         // No-op: cluster state should be the same object
         assertThat(newState).isSameAs(clusterService.state());
@@ -111,7 +112,7 @@ public class AlterColumnDefaultTaskTest extends CrateDummyClusterServiceUnitTest
         var task = buildAlterColumnDefaultTask(e, tbl.ident());
         Reference ref = tbl.getReference(ColumnIdent.of("o", "a"));
         Symbol newDefault = Literal.of(10);
-        var request = new AlterColumnDefaultRequest(tbl.ident(), ref, newDefault);
+        var request = new AlterColumnDefaultRequest(tbl.ident(), OID_UNASSIGNED, ref, newDefault);
         ClusterState newState = task.execute(clusterService.state(), request);
         DocTableInfo newTable = new DocTableInfoFactory(e.nodeCtx).create(tbl.ident(), newState.metadata());
         Reference updatedRef = newTable.getReference(ColumnIdent.of("o", "a"));
@@ -129,7 +130,7 @@ public class AlterColumnDefaultTaskTest extends CrateDummyClusterServiceUnitTest
         var task = buildAlterColumnDefaultTask(e, tbl.ident());
         Reference ref = tbl.getReference(ColumnIdent.of("x"));
         Symbol newDefault = Literal.of(77);
-        var request = new AlterColumnDefaultRequest(tbl.ident(), ref, newDefault);
+        var request = new AlterColumnDefaultRequest(tbl.ident(), OID_UNASSIGNED, ref, newDefault);
         ClusterState newState = task.execute(clusterService.state(), request);
         DocTableInfo newTable = new DocTableInfoFactory(e.nodeCtx).create(tbl.ident(), newState.metadata());
         Reference updatedRef = newTable.getReference(ColumnIdent.of("x"));

--- a/server/src/test/java/io/crate/execution/ddl/tables/DropColumnRequestTest.java
+++ b/server/src/test/java/io/crate/execution/ddl/tables/DropColumnRequestTest.java
@@ -30,43 +30,14 @@ import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.junit.Test;
 
+import io.crate.analyze.DropColumn;
+import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.RelationName;
+import io.crate.metadata.RowGranularity;
+import io.crate.metadata.SimpleReference;
+import io.crate.types.DataTypes;
 
-public class CloseTableRequestTest {
-
-    @Test
-    public void test_bwc_streaming() throws Exception {
-        RelationName relation = new RelationName("foo", "bar");
-        List<CloseTableRequest> requests = List.of(
-            new CloseTableRequest(relation, OID_UNASSIGNED, List.of("1")),
-            new CloseTableRequest(relation, OID_UNASSIGNED, List.of())
-        );
-
-        for (var request : requests) {
-            {
-                BytesStreamOutput out = new BytesStreamOutput();
-                request.writeTo(out);
-
-                try (var in = out.bytes().streamInput()) {
-                    CloseTableRequest deserializedRequest = new CloseTableRequest(in);
-                    assertThat(deserializedRequest.table()).isEqualTo(relation);
-                    assertThat(deserializedRequest.partitionValues()).isEqualTo(request.partitionValues());
-                }
-            }
-            {
-                BytesStreamOutput out = new BytesStreamOutput();
-                out.setVersion(Version.V_5_9_0);
-                request.writeTo(out);
-
-                try (var in = out.bytes().streamInput()) {
-                    in.setVersion(Version.V_5_9_0);
-                    CloseTableRequest deserializedRequest = new CloseTableRequest(in);
-                    assertThat(deserializedRequest.table()).isEqualTo(relation);
-                    assertThat(deserializedRequest.partitionValues()).isEqualTo(request.partitionValues());
-                }
-            }
-        }
-    }
+public class DropColumnRequestTest {
 
     @Test
     public void test_streaming_table_oids() throws Exception {
@@ -74,7 +45,10 @@ public class CloseTableRequestTest {
         for (Version version : List.of(Version.V_6_3_7, Version.V_6_4_2, Version.CURRENT)) {
             RelationName relation = new RelationName("doc", "tbl");
             int tableOid = 1234;
-            CloseTableRequest request = new CloseTableRequest(relation, tableOid, List.of());
+            var ref = new SimpleReference(
+                relation, ColumnIdent.of("x"), RowGranularity.DOC, DataTypes.INTEGER, 1, null);
+            DropColumnRequest request = new DropColumnRequest(
+                relation, tableOid, List.of(new DropColumn(ref, false)));
 
             var out = new BytesStreamOutput();
             out.setVersion(version);
@@ -82,7 +56,7 @@ public class CloseTableRequestTest {
 
             var in = out.bytes().streamInput();
             in.setVersion(version);
-            CloseTableRequest streamed = new CloseTableRequest(in);
+            DropColumnRequest streamed = new DropColumnRequest(in);
 
             assertThat(streamed.tableOid()).isEqualTo(tableOid);
         }
@@ -90,7 +64,10 @@ public class CloseTableRequestTest {
         // streaming to nodes with unsupported versions
         for (Version version : List.of(Version.V_6_3_6, Version.V_6_4_0, Version.V_6_4_1)) {
             RelationName relation = new RelationName("doc", "tbl");
-            CloseTableRequest request = new CloseTableRequest(relation, 1234, List.of());
+            var ref = new SimpleReference(
+                relation, ColumnIdent.of("x"), RowGranularity.DOC, DataTypes.INTEGER, 1, null);
+            DropColumnRequest request = new DropColumnRequest(
+                relation, 1234, List.of(new DropColumn(ref, false)));
 
             var out = new BytesStreamOutput();
             out.setVersion(version);
@@ -98,7 +75,7 @@ public class CloseTableRequestTest {
 
             var in = out.bytes().streamInput();
             in.setVersion(version);
-            CloseTableRequest streamed = new CloseTableRequest(in);
+            DropColumnRequest streamed = new DropColumnRequest(in);
 
             assertThat(streamed.tableOid()).isEqualTo(OID_UNASSIGNED);
         }

--- a/server/src/test/java/io/crate/execution/ddl/tables/DropColumnTaskTest.java
+++ b/server/src/test/java/io/crate/execution/ddl/tables/DropColumnTaskTest.java
@@ -25,6 +25,7 @@ import static io.crate.testing.Asserts.assertThat;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
 
 import java.util.List;
 import java.util.Map;
@@ -61,7 +62,7 @@ public class DropColumnTaskTest extends CrateDummyClusterServiceUnitTest {
         ClusterState initialState = clusterService.state();
         var dropColumnTask = buildDropColumnTask(e, tbl.ident());
         Reference colToDrop = tbl.getReference(ColumnIdent.of("y"));
-        var request = new DropColumnRequest(tbl.ident(), List.of(new DropColumn(colToDrop, false)));
+        var request = new DropColumnRequest(tbl.ident(), OID_UNASSIGNED, List.of(new DropColumn(colToDrop, false)));
         ClusterState newState = dropColumnTask.execute(initialState, request);
 
         assertThat(newState.version())
@@ -95,7 +96,7 @@ public class DropColumnTaskTest extends CrateDummyClusterServiceUnitTest {
         ClusterState initialState = clusterService.state();
         var dropColumnTask = buildDropColumnTask(e, tbl.ident());
         Reference colToDrop = tbl.getReference(ColumnIdent.of("y"));
-        var request = new DropColumnRequest(tbl.ident(), List.of(new DropColumn(colToDrop, false)));
+        var request = new DropColumnRequest(tbl.ident(), OID_UNASSIGNED, List.of(new DropColumn(colToDrop, false)));
         ClusterState newState = dropColumnTask.execute(initialState, request);
 
         assertThat(newState.version())
@@ -128,7 +129,7 @@ public class DropColumnTaskTest extends CrateDummyClusterServiceUnitTest {
         DocTableInfo tbl = e.resolveTableInfo("tbl");
         var dropColumnTask = buildDropColumnTask(e, tbl.ident());
         Reference colToDrop = tbl.getReference(ColumnIdent.of("o", "oo"));
-        var request = new DropColumnRequest(tbl.ident(), List.of(new DropColumn(colToDrop, false)));
+        var request = new DropColumnRequest(tbl.ident(), OID_UNASSIGNED, List.of(new DropColumn(colToDrop, false)));
         ClusterState newState = dropColumnTask.execute(clusterService.state(), request);
         DocTableInfo newTable = new DocTableInfoFactory(e.nodeCtx).create(tbl.ident(), newState.metadata());
 
@@ -153,7 +154,7 @@ public class DropColumnTaskTest extends CrateDummyClusterServiceUnitTest {
         // parent specified first then its child
         Reference colToDrop1 = tbl.getReference(ColumnIdent.of("o", "o2"));
         Reference colToDrop2 = tbl.getReference(ColumnIdent.of("o", List.of("o2", "c")));
-        var request = new DropColumnRequest(tbl.ident(), List.of(
+        var request = new DropColumnRequest(tbl.ident(), OID_UNASSIGNED, List.of(
             new DropColumn(colToDrop1, false),
             new DropColumn(colToDrop2, false)));
         ClusterState newState = dropColumnTask.execute(clusterService.state(), request);
@@ -178,7 +179,7 @@ public class DropColumnTaskTest extends CrateDummyClusterServiceUnitTest {
             333, // irrelevant
             null
         );
-        var request = new DropColumnRequest(tbl.ident(), List.of(new DropColumn(colToDrop, true)));
+        var request = new DropColumnRequest(tbl.ident(), OID_UNASSIGNED, List.of(new DropColumn(colToDrop, true)));
         ClusterState newState = dropColumnTask.execute(state, request);
         assertThat(newState).isSameAs(state);
     }
@@ -197,7 +198,7 @@ public class DropColumnTaskTest extends CrateDummyClusterServiceUnitTest {
             333, // irrelevant
             null
         );
-        var request = new DropColumnRequest(tbl.ident(), List.of(new DropColumn(colToDrop, false)));
+        var request = new DropColumnRequest(tbl.ident(), OID_UNASSIGNED, List.of(new DropColumn(colToDrop, false)));
         ClusterState newState = dropColumnTask.execute(clusterService.state(), request);
         DocTableInfo newTable = new DocTableInfoFactory(e.nodeCtx).create(tbl.ident(), newState.metadata());
 
@@ -215,7 +216,7 @@ public class DropColumnTaskTest extends CrateDummyClusterServiceUnitTest {
         var dropColumnTask = buildDropColumnTask(e, tbl.ident());
         Reference ref = tbl.getReference(ColumnIdent.of("y"));
 
-        DropColumnRequest request = new DropColumnRequest(tbl.ident(), List.of(new DropColumn(ref, true)));
+        DropColumnRequest request = new DropColumnRequest(tbl.ident(), OID_UNASSIGNED, List.of(new DropColumn(ref, true)));
         assertThatThrownBy(() -> dropColumnTask.execute(state, request))
             .isExactlyInstanceOf(UnsupportedOperationException.class)
             .hasMessage(
@@ -237,7 +238,7 @@ public class DropColumnTaskTest extends CrateDummyClusterServiceUnitTest {
             333, // irrelevant
             null
         );
-        var request = new DropColumnRequest(tbl.ident(), List.of(new DropColumn(colToDrop, false)));
+        var request = new DropColumnRequest(tbl.ident(), OID_UNASSIGNED, List.of(new DropColumn(colToDrop, false)));
         ClusterState newState = dropColumnTask.execute(clusterService.state(), request);
         DocTableInfo newTable = new DocTableInfoFactory(e.nodeCtx).create(tbl.ident(), newState.metadata());
 
@@ -259,7 +260,7 @@ public class DropColumnTaskTest extends CrateDummyClusterServiceUnitTest {
             333, // irrelevant
             null
         );
-        var request = new DropColumnRequest(tbl.ident(), List.of(new DropColumn(colToDrop, false)));
+        var request = new DropColumnRequest(tbl.ident(), OID_UNASSIGNED, List.of(new DropColumn(colToDrop, false)));
         ClusterState newState = dropColumnTask.execute(clusterService.state(), request);
         DocTableInfo newTable = new DocTableInfoFactory(e.nodeCtx).create(tbl.ident(), newState.metadata());
 
@@ -287,7 +288,7 @@ public class DropColumnTaskTest extends CrateDummyClusterServiceUnitTest {
             333, // irrelevant
             null
         );
-        var request = new DropColumnRequest(tbl.ident(), List.of(new DropColumn(colToDrop, false)));
+        var request = new DropColumnRequest(tbl.ident(), OID_UNASSIGNED, List.of(new DropColumn(colToDrop, false)));
         ClusterState newState = dropColumnTask.execute(clusterService.state(), request);
         DocTableInfo newTable = new DocTableInfoFactory(e.nodeCtx).create(tbl.ident(), newState.metadata());
 
@@ -311,7 +312,7 @@ public class DropColumnTaskTest extends CrateDummyClusterServiceUnitTest {
             333, // irrelevant
             null
         );
-        var request = new DropColumnRequest(tbl.ident(), List.of(new DropColumn(colToDrop, false)));
+        var request = new DropColumnRequest(tbl.ident(), OID_UNASSIGNED, List.of(new DropColumn(colToDrop, false)));
         ClusterState newState = dropColumnTask.execute(clusterService.state(), request);
         DocTableInfo newTable = new DocTableInfoFactory(e.nodeCtx).create(tbl.ident(), newState.metadata());
 

--- a/server/src/test/java/io/crate/execution/ddl/tables/DropConstraintRequestTest.java
+++ b/server/src/test/java/io/crate/execution/ddl/tables/DropConstraintRequestTest.java
@@ -32,41 +32,7 @@ import org.junit.Test;
 
 import io.crate.metadata.RelationName;
 
-public class CloseTableRequestTest {
-
-    @Test
-    public void test_bwc_streaming() throws Exception {
-        RelationName relation = new RelationName("foo", "bar");
-        List<CloseTableRequest> requests = List.of(
-            new CloseTableRequest(relation, OID_UNASSIGNED, List.of("1")),
-            new CloseTableRequest(relation, OID_UNASSIGNED, List.of())
-        );
-
-        for (var request : requests) {
-            {
-                BytesStreamOutput out = new BytesStreamOutput();
-                request.writeTo(out);
-
-                try (var in = out.bytes().streamInput()) {
-                    CloseTableRequest deserializedRequest = new CloseTableRequest(in);
-                    assertThat(deserializedRequest.table()).isEqualTo(relation);
-                    assertThat(deserializedRequest.partitionValues()).isEqualTo(request.partitionValues());
-                }
-            }
-            {
-                BytesStreamOutput out = new BytesStreamOutput();
-                out.setVersion(Version.V_5_9_0);
-                request.writeTo(out);
-
-                try (var in = out.bytes().streamInput()) {
-                    in.setVersion(Version.V_5_9_0);
-                    CloseTableRequest deserializedRequest = new CloseTableRequest(in);
-                    assertThat(deserializedRequest.table()).isEqualTo(relation);
-                    assertThat(deserializedRequest.partitionValues()).isEqualTo(request.partitionValues());
-                }
-            }
-        }
-    }
+public class DropConstraintRequestTest {
 
     @Test
     public void test_streaming_table_oids() throws Exception {
@@ -74,7 +40,7 @@ public class CloseTableRequestTest {
         for (Version version : List.of(Version.V_6_3_7, Version.V_6_4_2, Version.CURRENT)) {
             RelationName relation = new RelationName("doc", "tbl");
             int tableOid = 1234;
-            CloseTableRequest request = new CloseTableRequest(relation, tableOid, List.of());
+            DropConstraintRequest request = new DropConstraintRequest(relation, tableOid, "check_x");
 
             var out = new BytesStreamOutput();
             out.setVersion(version);
@@ -82,7 +48,7 @@ public class CloseTableRequestTest {
 
             var in = out.bytes().streamInput();
             in.setVersion(version);
-            CloseTableRequest streamed = new CloseTableRequest(in);
+            DropConstraintRequest streamed = new DropConstraintRequest(in);
 
             assertThat(streamed.tableOid()).isEqualTo(tableOid);
         }
@@ -90,7 +56,7 @@ public class CloseTableRequestTest {
         // streaming to nodes with unsupported versions
         for (Version version : List.of(Version.V_6_3_6, Version.V_6_4_0, Version.V_6_4_1)) {
             RelationName relation = new RelationName("doc", "tbl");
-            CloseTableRequest request = new CloseTableRequest(relation, 1234, List.of());
+            DropConstraintRequest request = new DropConstraintRequest(relation, 1234, "check_x");
 
             var out = new BytesStreamOutput();
             out.setVersion(version);
@@ -98,7 +64,7 @@ public class CloseTableRequestTest {
 
             var in = out.bytes().streamInput();
             in.setVersion(version);
-            CloseTableRequest streamed = new CloseTableRequest(in);
+            DropConstraintRequest streamed = new DropConstraintRequest(in);
 
             assertThat(streamed.tableOid()).isEqualTo(OID_UNASSIGNED);
         }

--- a/server/src/test/java/io/crate/execution/ddl/tables/DropPartitionsRequestTest.java
+++ b/server/src/test/java/io/crate/execution/ddl/tables/DropPartitionsRequestTest.java
@@ -22,10 +22,12 @@
 package io.crate.execution.ddl.tables;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
 
 import java.util.Arrays;
 import java.util.List;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.junit.Test;
 
@@ -41,7 +43,7 @@ public class DropPartitionsRequestTest {
             new PartitionName(relationName, List.of("1", "2")),
             new PartitionName(relationName, Arrays.asList("1", null))
         );
-        var req = new DropPartitionsRequest(relationName, partitions);
+        var req = new DropPartitionsRequest(relationName, OID_UNASSIGNED, partitions);
         try (var out = new BytesStreamOutput()) {
             req.writeTo(out);
             try (var in = out.bytes().streamInput()) {
@@ -51,5 +53,48 @@ public class DropPartitionsRequestTest {
             }
         }
     }
-}
 
+    @Test
+    public void test_streaming_table_oids() throws Exception {
+        // streaming to nodes with supported versions
+        for (Version version : List.of(Version.V_6_3_7, Version.V_6_4_2, Version.CURRENT)) {
+            RelationName relation = new RelationName("doc", "tbl");
+            int tableOid = 1234;
+            DropPartitionsRequest request = new DropPartitionsRequest(
+                relation,
+                tableOid,
+                List.of(new PartitionName(relation, List.of("1")))
+            );
+
+            var out = new BytesStreamOutput();
+            out.setVersion(version);
+            request.writeTo(out);
+
+            var in = out.bytes().streamInput();
+            in.setVersion(version);
+            DropPartitionsRequest streamed = new DropPartitionsRequest(in);
+
+            assertThat(streamed.tableOid()).isEqualTo(tableOid);
+        }
+
+        // streaming to nodes with unsupported versions
+        for (Version version : List.of(Version.V_6_3_6, Version.V_6_4_0, Version.V_6_4_1)) {
+            RelationName relation = new RelationName("doc", "tbl");
+            DropPartitionsRequest request = new DropPartitionsRequest(
+                relation,
+                1234,
+                List.of(new PartitionName(relation, List.of("1")))
+            );
+
+            var out = new BytesStreamOutput();
+            out.setVersion(version);
+            request.writeTo(out);
+
+            var in = out.bytes().streamInput();
+            in.setVersion(version);
+            DropPartitionsRequest streamed = new DropPartitionsRequest(in);
+
+            assertThat(streamed.tableOid()).isEqualTo(OID_UNASSIGNED);
+        }
+    }
+}

--- a/server/src/test/java/io/crate/execution/ddl/tables/DropTableRequestTest.java
+++ b/server/src/test/java/io/crate/execution/ddl/tables/DropTableRequestTest.java
@@ -32,41 +32,7 @@ import org.junit.Test;
 
 import io.crate.metadata.RelationName;
 
-public class CloseTableRequestTest {
-
-    @Test
-    public void test_bwc_streaming() throws Exception {
-        RelationName relation = new RelationName("foo", "bar");
-        List<CloseTableRequest> requests = List.of(
-            new CloseTableRequest(relation, OID_UNASSIGNED, List.of("1")),
-            new CloseTableRequest(relation, OID_UNASSIGNED, List.of())
-        );
-
-        for (var request : requests) {
-            {
-                BytesStreamOutput out = new BytesStreamOutput();
-                request.writeTo(out);
-
-                try (var in = out.bytes().streamInput()) {
-                    CloseTableRequest deserializedRequest = new CloseTableRequest(in);
-                    assertThat(deserializedRequest.table()).isEqualTo(relation);
-                    assertThat(deserializedRequest.partitionValues()).isEqualTo(request.partitionValues());
-                }
-            }
-            {
-                BytesStreamOutput out = new BytesStreamOutput();
-                out.setVersion(Version.V_5_9_0);
-                request.writeTo(out);
-
-                try (var in = out.bytes().streamInput()) {
-                    in.setVersion(Version.V_5_9_0);
-                    CloseTableRequest deserializedRequest = new CloseTableRequest(in);
-                    assertThat(deserializedRequest.table()).isEqualTo(relation);
-                    assertThat(deserializedRequest.partitionValues()).isEqualTo(request.partitionValues());
-                }
-            }
-        }
-    }
+public class DropTableRequestTest {
 
     @Test
     public void test_streaming_table_oids() throws Exception {
@@ -74,7 +40,7 @@ public class CloseTableRequestTest {
         for (Version version : List.of(Version.V_6_3_7, Version.V_6_4_2, Version.CURRENT)) {
             RelationName relation = new RelationName("doc", "tbl");
             int tableOid = 1234;
-            CloseTableRequest request = new CloseTableRequest(relation, tableOid, List.of());
+            DropTableRequest request = new DropTableRequest(relation, tableOid);
 
             var out = new BytesStreamOutput();
             out.setVersion(version);
@@ -82,7 +48,7 @@ public class CloseTableRequestTest {
 
             var in = out.bytes().streamInput();
             in.setVersion(version);
-            CloseTableRequest streamed = new CloseTableRequest(in);
+            DropTableRequest streamed = new DropTableRequest(in);
 
             assertThat(streamed.tableOid()).isEqualTo(tableOid);
         }
@@ -90,7 +56,7 @@ public class CloseTableRequestTest {
         // streaming to nodes with unsupported versions
         for (Version version : List.of(Version.V_6_3_6, Version.V_6_4_0, Version.V_6_4_1)) {
             RelationName relation = new RelationName("doc", "tbl");
-            CloseTableRequest request = new CloseTableRequest(relation, 1234, List.of());
+            DropTableRequest request = new DropTableRequest(relation, 1234);
 
             var out = new BytesStreamOutput();
             out.setVersion(version);
@@ -98,7 +64,7 @@ public class CloseTableRequestTest {
 
             var in = out.bytes().streamInput();
             in.setVersion(version);
-            CloseTableRequest streamed = new CloseTableRequest(in);
+            DropTableRequest streamed = new DropTableRequest(in);
 
             assertThat(streamed.tableOid()).isEqualTo(OID_UNASSIGNED);
         }

--- a/server/src/test/java/io/crate/execution/ddl/tables/OpenTableRequestTest.java
+++ b/server/src/test/java/io/crate/execution/ddl/tables/OpenTableRequestTest.java
@@ -22,6 +22,7 @@
 package io.crate.execution.ddl.tables;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
 
 import java.util.List;
 
@@ -37,8 +38,8 @@ public class OpenTableRequestTest {
     public void test_bwc_streaming() throws Exception {
         RelationName relation = new RelationName("foo", "bar");
         List<OpenTableRequest> requests = List.of(
-            new OpenTableRequest(relation, List.of("1")),
-            new OpenTableRequest(relation, List.of())
+            new OpenTableRequest(relation, OID_UNASSIGNED, List.of("1")),
+            new OpenTableRequest(relation, OID_UNASSIGNED, List.of())
         );
 
         for (var request : requests) {
@@ -66,5 +67,40 @@ public class OpenTableRequestTest {
             }
         }
     }
-}
 
+    @Test
+    public void test_streaming_table_oids() throws Exception {
+        // streaming to nodes with supported versions
+        for (Version version : List.of(Version.V_6_3_7, Version.V_6_4_2, Version.CURRENT)) {
+            RelationName relation = new RelationName("doc", "tbl");
+            int tableOid = 1234;
+            OpenTableRequest request = new OpenTableRequest(relation, tableOid, List.of());
+
+            var out = new BytesStreamOutput();
+            out.setVersion(version);
+            request.writeTo(out);
+
+            var in = out.bytes().streamInput();
+            in.setVersion(version);
+            OpenTableRequest streamed = new OpenTableRequest(in);
+
+            assertThat(streamed.tableOid()).isEqualTo(tableOid);
+        }
+
+        // streaming to nodes with unsupported versions
+        for (Version version : List.of(Version.V_6_3_6, Version.V_6_4_0, Version.V_6_4_1)) {
+            RelationName relation = new RelationName("doc", "tbl");
+            OpenTableRequest request = new OpenTableRequest(relation, 1234, List.of());
+
+            var out = new BytesStreamOutput();
+            out.setVersion(version);
+            request.writeTo(out);
+
+            var in = out.bytes().streamInput();
+            in.setVersion(version);
+            OpenTableRequest streamed = new OpenTableRequest(in);
+
+            assertThat(streamed.tableOid()).isEqualTo(OID_UNASSIGNED);
+        }
+    }
+}

--- a/server/src/test/java/io/crate/execution/ddl/tables/RenameColumnRequestTest.java
+++ b/server/src/test/java/io/crate/execution/ddl/tables/RenameColumnRequestTest.java
@@ -30,43 +30,13 @@ import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.junit.Test;
 
+import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.RelationName;
+import io.crate.metadata.RowGranularity;
+import io.crate.metadata.SimpleReference;
+import io.crate.types.DataTypes;
 
-public class CloseTableRequestTest {
-
-    @Test
-    public void test_bwc_streaming() throws Exception {
-        RelationName relation = new RelationName("foo", "bar");
-        List<CloseTableRequest> requests = List.of(
-            new CloseTableRequest(relation, OID_UNASSIGNED, List.of("1")),
-            new CloseTableRequest(relation, OID_UNASSIGNED, List.of())
-        );
-
-        for (var request : requests) {
-            {
-                BytesStreamOutput out = new BytesStreamOutput();
-                request.writeTo(out);
-
-                try (var in = out.bytes().streamInput()) {
-                    CloseTableRequest deserializedRequest = new CloseTableRequest(in);
-                    assertThat(deserializedRequest.table()).isEqualTo(relation);
-                    assertThat(deserializedRequest.partitionValues()).isEqualTo(request.partitionValues());
-                }
-            }
-            {
-                BytesStreamOutput out = new BytesStreamOutput();
-                out.setVersion(Version.V_5_9_0);
-                request.writeTo(out);
-
-                try (var in = out.bytes().streamInput()) {
-                    in.setVersion(Version.V_5_9_0);
-                    CloseTableRequest deserializedRequest = new CloseTableRequest(in);
-                    assertThat(deserializedRequest.table()).isEqualTo(relation);
-                    assertThat(deserializedRequest.partitionValues()).isEqualTo(request.partitionValues());
-                }
-            }
-        }
-    }
+public class RenameColumnRequestTest {
 
     @Test
     public void test_streaming_table_oids() throws Exception {
@@ -74,7 +44,10 @@ public class CloseTableRequestTest {
         for (Version version : List.of(Version.V_6_3_7, Version.V_6_4_2, Version.CURRENT)) {
             RelationName relation = new RelationName("doc", "tbl");
             int tableOid = 1234;
-            CloseTableRequest request = new CloseTableRequest(relation, tableOid, List.of());
+            var ref = new SimpleReference(
+                relation, ColumnIdent.of("x"), RowGranularity.DOC, DataTypes.INTEGER, 1, null);
+            RenameColumnRequest request = new RenameColumnRequest(
+                relation, tableOid, ref, ColumnIdent.of("y"));
 
             var out = new BytesStreamOutput();
             out.setVersion(version);
@@ -82,7 +55,7 @@ public class CloseTableRequestTest {
 
             var in = out.bytes().streamInput();
             in.setVersion(version);
-            CloseTableRequest streamed = new CloseTableRequest(in);
+            RenameColumnRequest streamed = new RenameColumnRequest(in);
 
             assertThat(streamed.tableOid()).isEqualTo(tableOid);
         }
@@ -90,7 +63,10 @@ public class CloseTableRequestTest {
         // streaming to nodes with unsupported versions
         for (Version version : List.of(Version.V_6_3_6, Version.V_6_4_0, Version.V_6_4_1)) {
             RelationName relation = new RelationName("doc", "tbl");
-            CloseTableRequest request = new CloseTableRequest(relation, 1234, List.of());
+            var ref = new SimpleReference(
+                relation, ColumnIdent.of("x"), RowGranularity.DOC, DataTypes.INTEGER, 1, null);
+            RenameColumnRequest request = new RenameColumnRequest(
+                relation, 1234, ref, ColumnIdent.of("y"));
 
             var out = new BytesStreamOutput();
             out.setVersion(version);
@@ -98,7 +74,7 @@ public class CloseTableRequestTest {
 
             var in = out.bytes().streamInput();
             in.setVersion(version);
-            CloseTableRequest streamed = new CloseTableRequest(in);
+            RenameColumnRequest streamed = new RenameColumnRequest(in);
 
             assertThat(streamed.tableOid()).isEqualTo(OID_UNASSIGNED);
         }

--- a/server/src/test/java/io/crate/execution/ddl/tables/RenameColumnTaskTest.java
+++ b/server/src/test/java/io/crate/execution/ddl/tables/RenameColumnTaskTest.java
@@ -24,6 +24,7 @@ package io.crate.execution.ddl.tables;
 import static io.crate.testing.Asserts.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
 
 import java.util.List;
 
@@ -59,7 +60,7 @@ public class RenameColumnTaskTest extends CrateDummyClusterServiceUnitTest {
         var renameColumnTask = buildRenameColumnTask(e, tbl.ident());
         Reference refToRename = tbl.getReference(ColumnIdent.of("x"));
         var newName = ColumnIdent.of("y");
-        var request = new RenameColumnRequest(tbl.ident(), refToRename, newName);
+        var request = new RenameColumnRequest(tbl.ident(), OID_UNASSIGNED, refToRename, newName);
         ClusterState newState = renameColumnTask.execute(clusterService.state(), request);
         DocTableInfo newTable = new DocTableInfoFactory(e.nodeCtx).create(tbl.ident(), newState.metadata());
         assertThat(newTable.getReference(refToRename.column())).isNull();
@@ -78,7 +79,7 @@ public class RenameColumnTaskTest extends CrateDummyClusterServiceUnitTest {
         var renameColumnTask = buildRenameColumnTask(e, tbl.ident());
         Reference refToRename1 = tbl.getReference(ColumnIdent.of("o"));
         var newName1 = ColumnIdent.of("p");
-        var request = new RenameColumnRequest(tbl.ident(), refToRename1, newName1);
+        var request = new RenameColumnRequest(tbl.ident(), OID_UNASSIGNED, refToRename1, newName1);
         ClusterState newState = renameColumnTask.execute(clusterService.state(), request);
         tbl = new DocTableInfoFactory(e.nodeCtx).create(tbl.ident(), newState.metadata());
         assertThat(tbl.getReference(refToRename1.column())).isNull();
@@ -86,7 +87,7 @@ public class RenameColumnTaskTest extends CrateDummyClusterServiceUnitTest {
 
         Reference refToRename2 = tbl.getReference(ColumnIdent.of("p", List.of("o2")));
         var newName2 = ColumnIdent.of("p", List.of("p2"));
-        request = new RenameColumnRequest(tbl.ident(), refToRename2, newName2);
+        request = new RenameColumnRequest(tbl.ident(), OID_UNASSIGNED, refToRename2, newName2);
         newState = renameColumnTask.execute(newState, request);
         tbl = new DocTableInfoFactory(e.nodeCtx).create(tbl.ident(), newState.metadata());
         assertThat(tbl.getReference(refToRename2.column())).isNull();
@@ -94,7 +95,7 @@ public class RenameColumnTaskTest extends CrateDummyClusterServiceUnitTest {
 
         Reference refToRename3 = tbl.getReference(ColumnIdent.of("p", List.of("p2", "x")));
         var newName3 = ColumnIdent.of("p", List.of("p2", "y"));
-        request = new RenameColumnRequest(tbl.ident(), refToRename3, newName3);
+        request = new RenameColumnRequest(tbl.ident(), OID_UNASSIGNED, refToRename3, newName3);
         newState = renameColumnTask.execute(newState, request);
         tbl = new DocTableInfoFactory(e.nodeCtx).create(tbl.ident(), newState.metadata());
         assertThat(tbl.getReference(refToRename3.column())).isNull();
@@ -113,7 +114,7 @@ public class RenameColumnTaskTest extends CrateDummyClusterServiceUnitTest {
         var renameColumnTask = buildRenameColumnTask(e, tbl.ident());
         Reference refToRename = tbl.getReference(ColumnIdent.of("x"));
         var newName = ColumnIdent.of("y");
-        var request = new RenameColumnRequest(tbl.ident(), refToRename, newName);
+        var request = new RenameColumnRequest(tbl.ident(), OID_UNASSIGNED, refToRename, newName);
         ClusterState newState = renameColumnTask.execute(clusterService.state(), request);
         DocTableInfo newTable = new DocTableInfoFactory(e.nodeCtx).create(tbl.ident(), newState.metadata());
         assertThat(newTable.getReference(refToRename.column())).isNull();
@@ -127,7 +128,7 @@ public class RenameColumnTaskTest extends CrateDummyClusterServiceUnitTest {
         newName = ColumnIdent.of("p");
         var oldNameOfChild = ColumnIdent.of("o", List.of("o2", "x"));
         var newNameOfChild = ColumnIdent.of("p", List.of("o2", "x"));
-        request = new RenameColumnRequest(tbl.ident(), refToRename, newName);
+        request = new RenameColumnRequest(tbl.ident(), OID_UNASSIGNED, refToRename, newName);
         newState = renameColumnTask.execute(newState, request);
         newTable = new DocTableInfoFactory(e.nodeCtx).create(tbl.ident(), newState.metadata());
         assertThat(newTable.getReference(oldNameOfChild)).isNull();
@@ -145,7 +146,7 @@ public class RenameColumnTaskTest extends CrateDummyClusterServiceUnitTest {
         var renameColumnTask = buildRenameColumnTask(e, tbl.ident());
         Reference refToRename = tbl.getReference(ColumnIdent.of("o", List.of("o2")));
         var newName = ColumnIdent.of("o", List.of("p2"));
-        var request = new RenameColumnRequest(tbl.ident(), refToRename, newName);
+        var request = new RenameColumnRequest(tbl.ident(), OID_UNASSIGNED, refToRename, newName);
         ClusterState newState = renameColumnTask.execute(clusterService.state(), request);
         DocTableInfo newTable = new DocTableInfoFactory(e.nodeCtx).create(tbl.ident(), newState.metadata());
         var oldPkCol = ColumnIdent.of("o", List.of("o2", "o3", "x"));
@@ -166,13 +167,13 @@ public class RenameColumnTaskTest extends CrateDummyClusterServiceUnitTest {
         var renameColumnTask = buildRenameColumnTask(e, tbl.ident());
         Reference refToRename = tbl.getReference(ColumnIdent.of("o", List.of("a")));
         var newName = ColumnIdent.of("o", List.of("b"));
-        var request = new RenameColumnRequest(tbl.ident(), refToRename, newName);
+        var request = new RenameColumnRequest(tbl.ident(), OID_UNASSIGNED, refToRename, newName);
         ClusterState newState = renameColumnTask.execute(clusterService.state(), request);
         tbl = new DocTableInfoFactory(e.nodeCtx).create(tbl.ident(), newState.metadata());
 
         refToRename = tbl.getReference(ColumnIdent.of("o"));
         newName = ColumnIdent.of("p");
-        request = new RenameColumnRequest(tbl.ident(), refToRename, newName);
+        request = new RenameColumnRequest(tbl.ident(), OID_UNASSIGNED, refToRename, newName);
         newState = renameColumnTask.execute(newState, request);
         tbl = new DocTableInfoFactory(e.nodeCtx).create(tbl.ident(), newState.metadata());
 
@@ -191,7 +192,7 @@ public class RenameColumnTaskTest extends CrateDummyClusterServiceUnitTest {
         var renameColumnTask = buildRenameColumnTask(e, tbl.ident());
         Reference refToRename = tbl.getReference(ColumnIdent.of("o"));
         var newName = ColumnIdent.of("o2");
-        var request = new RenameColumnRequest(tbl.ident(), refToRename, newName);
+        var request = new RenameColumnRequest(tbl.ident(), OID_UNASSIGNED, refToRename, newName);
         ClusterState newState = renameColumnTask.execute(clusterService.state(), request);
         DocTableInfo newTable = new DocTableInfoFactory(e.nodeCtx).create(tbl.ident(), newState.metadata());
         assertThat(newTable.generatedColumns()).hasSize(1);
@@ -207,7 +208,7 @@ public class RenameColumnTaskTest extends CrateDummyClusterServiceUnitTest {
         var renameColumnTask = buildRenameColumnTask(e, tbl.ident());
         Reference refToRename = tbl.getReference(ColumnIdent.of("a"));
         var newName = ColumnIdent.of("b");
-        var request = new RenameColumnRequest(tbl.ident(), refToRename, newName);
+        var request = new RenameColumnRequest(tbl.ident(), OID_UNASSIGNED, refToRename, newName);
         assertThatThrownBy(() -> renameColumnTask.execute(clusterService.state(), request))
             .isExactlyInstanceOf(IllegalArgumentException.class)
             .hasMessage("Cannot rename column to a name that is in use");
@@ -234,7 +235,7 @@ public class RenameColumnTaskTest extends CrateDummyClusterServiceUnitTest {
             null
         );
         var newName = ColumnIdent.of("b");
-        var request = new RenameColumnRequest(tbl.ident(), refToRename, newName);
+        var request = new RenameColumnRequest(tbl.ident(), OID_UNASSIGNED, refToRename, newName);
         assertThatThrownBy(() -> renameColumnTask.execute(clusterService.state(), request))
             .isExactlyInstanceOf(ColumnUnknownException.class)
             .hasMessage("Column a unknown");
@@ -248,7 +249,7 @@ public class RenameColumnTaskTest extends CrateDummyClusterServiceUnitTest {
         var renameColumnTask = buildRenameColumnTask(e, tbl.ident());
         Reference refToRename = tbl.getReference(ColumnIdent.of("x"));
         var newName = ColumnIdent.of("y");
-        var request = new RenameColumnRequest(tbl.ident(), refToRename, newName);
+        var request = new RenameColumnRequest(tbl.ident(), OID_UNASSIGNED, refToRename, newName);
         ClusterState newState = renameColumnTask.execute(clusterService.state(), request);
         DocTableInfo newTable = new DocTableInfoFactory(e.nodeCtx).create(tbl.ident(), newState.metadata());
         assertThat(newTable.clusteredBy()).isEqualTo(newName);
@@ -262,13 +263,13 @@ public class RenameColumnTaskTest extends CrateDummyClusterServiceUnitTest {
         var renameColumnTask = buildRenameColumnTask(e, tbl.ident());
         Reference refToRename = tbl.getReference(ColumnIdent.of("x"));
         var newName = ColumnIdent.of("x2");
-        var request = new RenameColumnRequest(tbl.ident(), refToRename, newName);
+        var request = new RenameColumnRequest(tbl.ident(), OID_UNASSIGNED, refToRename, newName);
         ClusterState newState = renameColumnTask.execute(clusterService.state(), request);
         tbl = new DocTableInfoFactory(e.nodeCtx).create(tbl.ident(), newState.metadata());
 
         refToRename = tbl.indexColumn(ColumnIdent.of("i"));
         newName = ColumnIdent.of("i2");
-        request = new RenameColumnRequest(tbl.ident(), refToRename, newName);
+        request = new RenameColumnRequest(tbl.ident(), OID_UNASSIGNED, refToRename, newName);
         newState = renameColumnTask.execute(newState, request);
         tbl = new DocTableInfoFactory(e.nodeCtx).create(tbl.ident(), newState.metadata());
 

--- a/server/src/test/java/io/crate/execution/ddl/tables/RenameTableRequestTest.java
+++ b/server/src/test/java/io/crate/execution/ddl/tables/RenameTableRequestTest.java
@@ -32,49 +32,16 @@ import org.junit.Test;
 
 import io.crate.metadata.RelationName;
 
-public class CloseTableRequestTest {
-
-    @Test
-    public void test_bwc_streaming() throws Exception {
-        RelationName relation = new RelationName("foo", "bar");
-        List<CloseTableRequest> requests = List.of(
-            new CloseTableRequest(relation, OID_UNASSIGNED, List.of("1")),
-            new CloseTableRequest(relation, OID_UNASSIGNED, List.of())
-        );
-
-        for (var request : requests) {
-            {
-                BytesStreamOutput out = new BytesStreamOutput();
-                request.writeTo(out);
-
-                try (var in = out.bytes().streamInput()) {
-                    CloseTableRequest deserializedRequest = new CloseTableRequest(in);
-                    assertThat(deserializedRequest.table()).isEqualTo(relation);
-                    assertThat(deserializedRequest.partitionValues()).isEqualTo(request.partitionValues());
-                }
-            }
-            {
-                BytesStreamOutput out = new BytesStreamOutput();
-                out.setVersion(Version.V_5_9_0);
-                request.writeTo(out);
-
-                try (var in = out.bytes().streamInput()) {
-                    in.setVersion(Version.V_5_9_0);
-                    CloseTableRequest deserializedRequest = new CloseTableRequest(in);
-                    assertThat(deserializedRequest.table()).isEqualTo(relation);
-                    assertThat(deserializedRequest.partitionValues()).isEqualTo(request.partitionValues());
-                }
-            }
-        }
-    }
+public class RenameTableRequestTest {
 
     @Test
     public void test_streaming_table_oids() throws Exception {
         // streaming to nodes with supported versions
         for (Version version : List.of(Version.V_6_3_7, Version.V_6_4_2, Version.CURRENT)) {
-            RelationName relation = new RelationName("doc", "tbl");
-            int tableOid = 1234;
-            CloseTableRequest request = new CloseTableRequest(relation, tableOid, List.of());
+            RelationName source = new RelationName("doc", "source");
+            RelationName target = new RelationName("doc", "target");
+            int sourceOid = 1234;
+            RenameTableRequest request = new RenameTableRequest(source, sourceOid, target, false);
 
             var out = new BytesStreamOutput();
             out.setVersion(version);
@@ -82,15 +49,16 @@ public class CloseTableRequestTest {
 
             var in = out.bytes().streamInput();
             in.setVersion(version);
-            CloseTableRequest streamed = new CloseTableRequest(in);
+            RenameTableRequest streamed = new RenameTableRequest(in);
 
-            assertThat(streamed.tableOid()).isEqualTo(tableOid);
+            assertThat(streamed.sourceOid()).isEqualTo(sourceOid);
         }
 
         // streaming to nodes with unsupported versions
         for (Version version : List.of(Version.V_6_3_6, Version.V_6_4_0, Version.V_6_4_1)) {
-            RelationName relation = new RelationName("doc", "tbl");
-            CloseTableRequest request = new CloseTableRequest(relation, 1234, List.of());
+            RelationName source = new RelationName("doc", "source");
+            RelationName target = new RelationName("doc", "target");
+            RenameTableRequest request = new RenameTableRequest(source, 1234, target, false);
 
             var out = new BytesStreamOutput();
             out.setVersion(version);
@@ -98,9 +66,9 @@ public class CloseTableRequestTest {
 
             var in = out.bytes().streamInput();
             in.setVersion(version);
-            CloseTableRequest streamed = new CloseTableRequest(in);
+            RenameTableRequest streamed = new RenameTableRequest(in);
 
-            assertThat(streamed.tableOid()).isEqualTo(OID_UNASSIGNED);
+            assertThat(streamed.sourceOid()).isEqualTo(OID_UNASSIGNED);
         }
     }
 }

--- a/server/src/test/java/io/crate/execution/dml/IndexerTest.java
+++ b/server/src/test/java/io/crate/execution/dml/IndexerTest.java
@@ -125,6 +125,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
             e.nodeCtx, table.ident(), e.fulltextAnalyzerResolver(), TransportAddColumn.ADD_COLUMN_OPERATOR);
         AddColumnRequest request = new AddColumnRequest(
                 table.ident(),
+                OID_UNASSIGNED,
                 newColumns,
                 Map.of(),
                 new IntArrayList(0)

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/shrink/ResizeRequestTest.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/shrink/ResizeRequestTest.java
@@ -22,9 +22,11 @@
 package org.elasticsearch.action.admin.indices.shrink;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
 
 import java.util.List;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.junit.Test;
 
@@ -37,8 +39,8 @@ public class ResizeRequestTest {
     public void test_streaming() throws Exception {
         RelationName table = new RelationName("foo", "bar");
         List<ResizeRequest> requests = List.of(
-            new ResizeRequest(table, List.of(), 4),
-            new ResizeRequest(table, List.of("2", "3"), 10)
+            new ResizeRequest(table, OID_UNASSIGNED, List.of(), 4),
+            new ResizeRequest(table, OID_UNASSIGNED, List.of("2", "3"), 10)
         );
         for (var originalReq : requests) {
             try (var out = new BytesStreamOutput()) {
@@ -52,6 +54,42 @@ public class ResizeRequestTest {
                     assertThat(request.ackTimeout()).isEqualTo(TimeValue.timeValueSeconds(60));
                 }
             }
+        }
+    }
+
+    @Test
+    public void test_streaming_table_oids() throws Exception {
+        // streaming to nodes with supported versions
+        for (Version version : List.of(Version.V_6_3_7, Version.V_6_4_2, Version.CURRENT)) {
+            RelationName relation = new RelationName("doc", "tbl");
+            int tableOid = 1234;
+            ResizeRequest request = new ResizeRequest(relation, tableOid, List.of(), 4);
+
+            var out = new BytesStreamOutput();
+            out.setVersion(version);
+            request.writeTo(out);
+
+            var in = out.bytes().streamInput();
+            in.setVersion(version);
+            ResizeRequest streamed = new ResizeRequest(in);
+
+            assertThat(streamed.tableOid()).isEqualTo(tableOid);
+        }
+
+        // streaming to nodes with unsupported versions
+        for (Version version : List.of(Version.V_6_3_6, Version.V_6_4_0, Version.V_6_4_1)) {
+            RelationName relation = new RelationName("doc", "tbl");
+            ResizeRequest request = new ResizeRequest(relation, 1234, List.of(), 4);
+
+            var out = new BytesStreamOutput();
+            out.setVersion(version);
+            request.writeTo(out);
+
+            var in = out.bytes().streamInput();
+            in.setVersion(version);
+            ResizeRequest streamed = new ResizeRequest(in);
+
+            assertThat(streamed.tableOid()).isEqualTo(OID_UNASSIGNED);
         }
     }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexServiceTest.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexServiceTest.java
@@ -21,6 +21,7 @@ package org.elasticsearch.cluster.metadata;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
 
 import java.util.Collections;
 import java.util.List;
@@ -114,7 +115,7 @@ public class MetadataCreateIndexServiceTest extends CrateDummyClusterServiceUnit
         int newNumShards = 1;
         var resizeIndexTask = new MetadataCreateIndexService.ResizeIndexTask(
             Mockito.mock(AllocationService.class),
-            new ResizeRequest(tbl, List.of(), newNumShards),
+            new ResizeRequest(tbl, OID_UNASSIGNED, List.of(), newNumShards),
             indexUUID,
             UUIDs.randomBase64UUID(),
             Mockito.mock(IndicesService.class),

--- a/server/src/testFixtures/java/org/elasticsearch/test/TestCluster.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/TestCluster.java
@@ -24,6 +24,7 @@ import static io.crate.lucene.CrateLuceneTestCase.rarely;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.elasticsearch.cluster.coordination.ClusterBootstrapService.INITIAL_MASTER_NODES_SETTING;
+import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
 import static org.elasticsearch.discovery.DiscoveryModule.DISCOVERY_TYPE_SETTING;
 import static org.elasticsearch.discovery.DiscoveryModule.ZEN2_DISCOVERY_TYPE;
 import static org.elasticsearch.test.ESTestCase.assertBusy;
@@ -391,7 +392,7 @@ public final class TestCluster implements Closeable {
             for (var relation : infoSchema.relations()) {
                 if (relation.relationType() == RelationType.BASE_TABLE && relation instanceof SystemTable<?> == false) {
                     relationNames.add(relation.ident());
-                    futures.add(client().execute(TransportDropTable.ACTION, new DropTableRequest(relation.ident())));
+                    futures.add(client().execute(TransportDropTable.ACTION, new DropTableRequest(relation.ident(), OID_UNASSIGNED)));
                 }
             }
             CompletableFuture<List<AcknowledgedResponse>> allResponses = CompletableFutures.allAsList(futures);


### PR DESCRIPTION
The RelationNames that are not used to re-resolve existing tables are excluded.

## Summary of the changes / Why this improves CrateDB

Concurrent `SWAP TABLE` can interfere with queries that re-resolve tables by name during execution. https://github.com/crate/crate/pull/19744 fixed this issue for INSERT only.

Instead of investigating this per query type, we can address it by reviewing table lookups by name. The candidates include:

- Schemas.getTableInfo
- Metadata.getRelation
- Metadata.getIndex
- Metadata.getIndices

https://github.com/crate/crate/pull/19795 handled `Schemas.getTableInfo`. This PR includes table OIDs in TransportRequests such that callers of `Metadata.getRelation` can utilize them.

## Checklist

 - [ ] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes.
       If you're an external contributor you can give yourself attribution and include your name and Github handle.
       e.g.:
       ```
       `John Doe <https://github.com/John_Doe>`_ added support for ...
       ```
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
