### PR TITLE
Fix ORDER BY on aliased view column over a join

### DIFF
--- a/docs/appendices/release-notes/6.3.7.rst
+++ b/docs/appendices/release-notes/6.3.7.rst
@@ -94,3 +94,8 @@ Fixes
 
 - Fixed an optimizer bug that could drop filters on aliased bare boolean
   columns in join queries.
+
+- Fixed an issue that caused a ``SELECT`` with ``LIMIT`` and ``ORDER BY`` on a
+  :ref:`view <ddl-views>` column that aliases a column of a joined relation to
+  contain duplicate entries of the column (plain & aliased) in the fetch list,
+  or fail with ```Must have an orderByPosition for each symbol``.

--- a/docs/appendices/release-notes/6.4.2.rst
+++ b/docs/appendices/release-notes/6.4.2.rst
@@ -94,3 +94,8 @@ Fixes
 
 - Fixed an optimizer bug that could drop filters on aliased bare boolean
   columns in join queries.
+
+- Fixed an issue that caused a ``SELECT`` with ``LIMIT`` and ``ORDER BY`` on a
+  :ref:`view <ddl-views>` column that aliases a column of a joined relation to
+  contain duplicate entries of the column (plain & aliased) in the fetch list,
+  or fail with ```Must have an orderByPosition for each symbol``.

--- a/server/src/main/java/io/crate/planner/PositionalOrderBy.java
+++ b/server/src/main/java/io/crate/planner/PositionalOrderBy.java
@@ -22,6 +22,7 @@
 package io.crate.planner;
 
 import io.crate.analyze.OrderBy;
+import io.crate.expression.symbol.AliasSymbol;
 import io.crate.expression.symbol.Symbol;
 import io.crate.planner.consumer.OrderByPositionVisitor;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -83,8 +84,14 @@ public class PositionalOrderBy {
      *                                            b        a
      *     newOutputs:  [b, a]  -> orderByIndices 0 DESC , 1 ASC NULLS FIRST
      * </pre>
-     *
      * If the newOutputs don't contain a symbol that was used in the oldOutputs `null` is returned.
+     * <p>
+     * A symbol and the same symbol wrapped in an {@link AliasSymbol} are considered equivalent, as
+     * both positions carry the same value and therefore sort identically. This can happen when the
+     * two output lists (joins) are produced on different sides of a relation boundary, e.g.
+     * {@code ORDER BY bar} where one side outputs {@code foo AS bar} and the other the plain
+     * {@code foo}. This mirrors {@code InputColumns.SourceSymbols}, which registers an
+     * {@code AliasSymbol} and its wrapped symbol under the same index.
      */
     @Nullable
     public PositionalOrderBy tryMapToNewOutputs(List<Symbol> oldOutputs, List<Symbol> newOutputs) {
@@ -94,6 +101,9 @@ public class PositionalOrderBy {
             int idxInOldOutputs = indices[i];
             Symbol orderByExpr = oldOutputs.get(idxInOldOutputs);
             int idxInNewOutputs = newOutputs.indexOf(orderByExpr);
+            if (idxInNewOutputs < 0) {
+                idxInNewOutputs = indexOfIgnoringAlias(newOutputs, orderByExpr);
+            }
             if (idxInNewOutputs < 0) {
                 return null;
             } else {
@@ -105,6 +115,27 @@ public class PositionalOrderBy {
             Arrays.copyOf(reverseFlags, reverseFlags.length),
             Arrays.copyOf(nullsFirst, nullsFirst.length)
         );
+    }
+
+    /**
+     * Index of {@code symbol} in {@code outputs}, comparing symbols with any {@link AliasSymbol}
+     * wrapper stripped. Returns -1 if there is no match.
+     */
+    private static int indexOfIgnoringAlias(List<Symbol> outputs, Symbol symbol) {
+        Symbol unaliasedSymbol = unalias(symbol);
+        for (int i = 0; i < outputs.size(); i++) {
+            if (unalias(outputs.get(i)).equals(unaliasedSymbol)) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private static Symbol unalias(Symbol symbol) {
+        while (symbol instanceof AliasSymbol alias) {
+            symbol = alias.symbol();
+        }
+        return symbol;
     }
 
     @Nullable

--- a/server/src/main/java/io/crate/planner/consumer/OrderByPositionVisitor.java
+++ b/server/src/main/java/io/crate/planner/consumer/OrderByPositionVisitor.java
@@ -29,6 +29,7 @@ import org.jspecify.annotations.Nullable;
 
 import com.carrotsearch.hppc.IntArrayList;
 
+import io.crate.expression.symbol.AliasSymbol;
 import io.crate.expression.symbol.InputColumn;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolVisitor;
@@ -92,6 +93,19 @@ public class OrderByPositionVisitor extends SymbolVisitor<OrderByPositionVisitor
     public Void visitInputColumn(InputColumn inputColumn, Context context) {
         context.orderByPositions.add(inputColumn.index());
         return null;
+    }
+
+    @Override
+    public Void visitAlias(AliasSymbol aliasSymbol, Context context) {
+        int idx = context.sourceSymbols.indexOf(aliasSymbol);
+        if (idx >= 0) {
+            context.orderByPositions.add(idx);
+            return null;
+        }
+        // The outputs may contain the aliased symbol in its un-aliased form, e.g. if the
+        // alias comes from a sub-relation select item (`ORDER BY bar` -> `foo AS bar`)
+        // while the source outputs the plain `foo` column.
+        return aliasSymbol.symbol().accept(this, context);
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/Order.java
+++ b/server/src/main/java/io/crate/planner/operators/Order.java
@@ -21,8 +21,8 @@
 
 package io.crate.planner.operators;
 
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -40,6 +40,7 @@ import io.crate.data.Row;
 import io.crate.execution.dsl.projection.OrderedLimitAndOffsetProjection;
 import io.crate.execution.dsl.projection.builder.InputColumns;
 import io.crate.execution.dsl.projection.builder.ProjectionBuilder;
+import io.crate.expression.symbol.AliasSymbol;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.Symbols;
 import io.crate.planner.DependencyCarrier;
@@ -63,7 +64,24 @@ public class Order extends ForwardingLogicalPlan {
 
     public Order(LogicalPlan source, OrderBy orderBy) {
         super(source);
-        this.outputs = Lists.concatUnique(source.outputs(), orderBy.orderBySymbols());
+        List<Symbol> sourceOutputs = source.outputs();
+        List<Symbol> extraOrderBySymbols = new ArrayList<>();
+        for (Symbol orderBySymbol : orderBy.orderBySymbols()) {
+            // An order-by symbol that only aliases an existing source output (e.g. `ORDER BY bar`
+            // resolving to `foo AS bar` via a view/sub-relation select item, while the source
+            // already outputs the plain `foo`) shouldn't be an extra output; `InputColumns` resolves the
+            // alias to the source column when building the sort projection.
+            //
+            // Adding it would also make `rewriteToFetch` below treat it as a computed extra output
+            // and map it to a fetch stub, even though the value is already carried by the source.
+            if (!sourceOutputs.contains(orderBySymbol)
+                && !(orderBySymbol instanceof AliasSymbol alias && sourceOutputs.contains(alias.symbol()))) {
+                extraOrderBySymbols.add(orderBySymbol);
+            }
+        }
+        this.outputs = extraOrderBySymbols.isEmpty()
+            ? sourceOutputs
+            : Lists.concatUnique(sourceOutputs, extraOrderBySymbols);
         this.orderBy = orderBy;
     }
 
@@ -90,7 +108,8 @@ public class Order extends ForwardingLogicalPlan {
     @Nullable
     @Override
     public FetchRewrite rewriteToFetch(Collection<Symbol> usedColumns) {
-        HashSet<Symbol> allUsedColumns = new HashSet<>(usedColumns);
+        // Preserve the order
+        LinkedHashSet<Symbol> allUsedColumns = new LinkedHashSet<>(usedColumns);
         allUsedColumns.addAll(orderBy.orderBySymbols());
         FetchRewrite fetchRewrite = source.rewriteToFetch(allUsedColumns);
         if (fetchRewrite == null) {

--- a/server/src/test/java/io/crate/planner/SubQueryPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/SubQueryPlannerTest.java
@@ -28,7 +28,6 @@ import static io.crate.testing.Asserts.isFunction;
 import static io.crate.testing.Asserts.isLimitAndOffset;
 import static io.crate.testing.Asserts.isLiteral;
 import static io.crate.testing.Asserts.isReference;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 
@@ -96,8 +95,9 @@ public class SubQueryPlannerTest extends CrateDummyClusterServiceUnitTest {
             isLimitAndOffset(3, 0),
             exactlyInstanceOf(EvalProjection.class)
         );
-        assertSQL(projections.get(0).outputs(), "INPUT(0)");
-        assertSQL(projections.get(4).outputs(), "INPUT(1)");
+        for (int i = 0; i < projections.size(); i++) {
+            assertSQL(projections.get(i).outputs(), "INPUT(0)");
+        }
     }
 
     @Test

--- a/server/src/test/java/io/crate/planner/ViewPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/ViewPlannerTest.java
@@ -77,6 +77,7 @@ public class ViewPlannerTest extends CrateDummyClusterServiceUnitTest {
     /**
      * https://github.com/crate/crate/issues/17427
      */
+    @Test
     public void test_push_filter_beyond_view_with_aliased_column() throws Exception {
         var e = SQLExecutor.of(clusterService)
             .addTable("CREATE TABLE doc.t1 (field1 INT, arr ARRAY(OBJECT))")
@@ -90,6 +91,42 @@ public class ViewPlannerTest extends CrateDummyClusterServiceUnitTest {
             "  └ Eval[field1 AS tableid, unnest(arr)]",
             "    └ ProjectSet[unnest(arr), arr, field1 AS tableid]",
             "      └ Collect[doc.t1 | [arr, field1 AS tableid] | (field1 AS tableid = 1)]"
+        );
+    }
+
+    /**
+     * ORDER BY on a view column that only aliases an underlying column must not add an extra
+     * output to {@link io.crate.planner.operators.Order}.
+     * <p>
+     * Through a view, {@code ORDER BY bar} resolves to {@code AliasSymbol(foo, "bar")}, which
+     * is not {@code equals} to the plain {@code foo} a join already outputs. Appending it makes
+     * {@code Order.rewriteToFetch} treat it as a computed extra output and map it to a fetch stub.
+     */
+    @Test
+    public void test_order_by_aliased_view_column_does_not_add_extra_fetch_output() throws Exception {
+        var e = SQLExecutor.of(clusterService)
+            .addTable("CREATE TABLE doc.tbl1 (ts timestamp, id int, val double)")
+            .addTable("CREATE TABLE doc.tbl2 (id int, name string)")
+            .addView(new RelationName("doc", "v"),
+                """
+                SELECT y.name AS new_name, x.ts, x.val
+                FROM doc.tbl1 x
+                INNER JOIN doc.tbl2 y ON x.id = y.id
+                """);
+
+        var logicalPlan = e.logicalPlan("SELECT * FROM doc.v ORDER BY ts, new_name LIMIT 100");
+
+        assertThat(logicalPlan).hasOperators(
+            "Rename[new_name, ts, val] AS doc.v",
+            "  └ Eval[name AS new_name, ts, val]",
+            "    └ Fetch[ts, val, id, name, id]",
+            "      └ Limit[100::bigint;0]",
+            "        └ OrderBy[ts ASC name AS new_name ASC]",
+            "          └ HashJoin[INNER | (id = id)]",
+            "            ├ Rename[x._fetchid, ts, id] AS x",
+            "            │  └ Collect[doc.tbl1 | [_fetchid, ts, id] | true]",
+            "            └ Rename[name, id] AS y",
+            "              └ Collect[doc.tbl2 | [name, id] | true]"
         );
     }
 }


### PR DESCRIPTION
`ORDER BY <view column>` resolves to an `AliasSymbol` wrapping the underlying column, e.g. `foo AS bar`. When the source of the `Order` operator is a join that already outputs the plain `foo`, the alias is not `equals` to any source output. This had two consequences:

- `Order` appended the alias as an extra output. `rewriteToFetch` then treated it as a computed output and mapped it to a fetch stub, even though the value is already carried by the source.
- `OrderByPositionVisitor` and `PositionalOrderBy.tryMapToNewOutputs` found no position for the alias, so the statement failed with `Must have an orderByPosition for each symbol`.

Treat a symbol and the same symbol wrapped in an `AliasSymbol` as equivalent when resolving order-by positions, and don't add an order-by symbol to `Order.outputs` if the source already provides it unaliased. `InputColumns.SourceSymbols` already registers both forms under the same index, so the sort projection resolves the alias to the source column.
