### PR TITLE
Fix QuerySplitter dropping aliased bare boolean filters

### DIFF
--- a/docs/appendices/release-notes/6.3.7.rst
+++ b/docs/appendices/release-notes/6.3.7.rst
@@ -91,3 +91,6 @@ Fixes
   :ref:`creating an S3 repository <sql-create-repo-s3>` on Linux ARM64. Special
   thanks to `Robert Palmer <https://github.com/robd003>`_ for fixing the issue
   on the upstream project.
+
+- Fixed an optimizer bug that could drop filters on aliased bare boolean
+  columns in join queries.

--- a/docs/appendices/release-notes/6.4.2.rst
+++ b/docs/appendices/release-notes/6.4.2.rst
@@ -91,3 +91,6 @@ Fixes
   :ref:`creating an S3 repository <sql-create-repo-s3>` on Linux ARM64. Special
   thanks to `Robert Palmer <https://github.com/robd003>`_ for fixing the issue
   on the upstream project.
+
+- Fixed an optimizer bug that could drop filters on aliased bare boolean
+  columns in join queries.

--- a/server/src/main/java/io/crate/analyze/relations/QuerySplitter.java
+++ b/server/src/main/java/io/crate/analyze/relations/QuerySplitter.java
@@ -29,6 +29,7 @@ import java.util.Set;
 
 import io.crate.analyze.RelationNames;
 import io.crate.expression.operator.AndOperator;
+import io.crate.expression.symbol.AliasSymbol;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.MatchPredicate;
@@ -144,6 +145,13 @@ public class QuerySplitter {
                 }
             }
             ctx.parts.merge(relationNames, matchPredicate, AndOperator::of);
+            return null;
+        }
+
+        @Override
+        public Void visitAlias(AliasSymbol aliasSymbol, Context ctx) {
+            Set<RelationName> qualifiedNames = RelationNames.getShallow(aliasSymbol);
+            ctx.parts.merge(qualifiedNames, aliasSymbol, AndOperator::of);
             return null;
         }
     }

--- a/server/src/test/java/io/crate/analyze/relations/QuerySplitterTest.java
+++ b/server/src/test/java/io/crate/analyze/relations/QuerySplitterTest.java
@@ -32,6 +32,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import io.crate.expression.operator.AndOperator;
+import io.crate.expression.symbol.AliasSymbol;
 import io.crate.expression.symbol.ScopedSymbol;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.ColumnIdent;
@@ -149,5 +150,27 @@ public class QuerySplitterTest extends CrateDummyClusterServiceUnitTest {
 
         Symbol query = AndOperator.join(List.of(bool_a, bool_b, scopedSymbol, matchPredicate));
         assertThat(QuerySplitter.split(query)).containsExactlyEntriesOf(Map.of(Set.of(tr1), query));
+    }
+
+    // tracks a bug: https://github.com/crate/crate/issues/19837
+    @Test
+    public void test_split_preserves_aliased_boolean_predicate() {
+        Symbol cFlag = new SimpleReference(
+            tr1,
+            ColumnIdent.of("c_flag"),
+            RowGranularity.DOC,
+            DataTypes.BOOLEAN,
+            0,
+            null
+        );
+        Symbol alias = new AliasSymbol("c_flag", cFlag);
+        Symbol rightQuery = asSymbol("t2.b = 1");
+        Symbol query = AndOperator.of(alias, rightQuery);
+
+        Map<Set<RelationName>, Symbol> split = QuerySplitter.split(query);
+
+        assertThat(split).hasSize(2);
+        assertThat(split.get(Set.of(tr1))).isEqualTo(alias);
+        assertThat(split.get(Set.of(tr2))).isEqualTo(rightQuery);
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes https://github.com/crate/crate/issues/19837.

Below is the `explain verbose` output of the provided join query:
```
cr> explain verbose SELECT c_flag FROM (SELECT l.c_flag AS c_flag FROM lft l JOIN rgt r ON l.u = r.u WHERE r.f = 1) x WHERE c_flag;
+--------------------------------------+----------------------------------------------------------------------+
| STEP                                 | QUERY PLAN                                                           |
+--------------------------------------+----------------------------------------------------------------------+
| Initial logical plan                 | Filter[c_flag] (rows=0)                                              |
|                                      |   └ Rename[c_flag] AS x (rows=0)                                     |
|                                      |     └ Eval[c_flag AS c_flag] (rows=0)                                |
|                                      |       └ Filter[(f = 1::bigint)] (rows=0)                             |
|                                      |         └ Join[INNER | (u = u)] (rows=unknown)                       |
|                                      |           ├ Rename[c_flag, u] AS l (rows=unknown)                    |
|                                      |           │  └ Collect[doc.lft | [c_flag, u] | true] (rows=unknown)  |
|                                      |           └ Rename[u, f] AS r (rows=unknown)                         |
|                                      |             └ Collect[doc.rgt | [u, f] | true] (rows=unknown)        |
| optimizer_move_filter_beneath_rename | Rename[c_flag] AS x (rows=0)                                         |
|                                      |   └ Filter[c_flag AS c_flag] (rows=0)                                |
|                                      |     └ Eval[c_flag AS c_flag] (rows=0)                                |
|                                      |       └ Filter[(f = 1::bigint)] (rows=0)                             |
|                                      |         └ Join[INNER | (u = u)] (rows=unknown)                       |
|                                      |           ├ Rename[c_flag, u] AS l (rows=unknown)                    |
|                                      |           │  └ Collect[doc.lft | [c_flag, u] | true] (rows=unknown)  |
|                                      |           └ Rename[u, f] AS r (rows=unknown)                         |
|                                      |             └ Collect[doc.rgt | [u, f] | true] (rows=unknown)        |
| optimizer_move_filter_beneath_eval   | Rename[c_flag] AS x (rows=0)                                         |
|                                      |   └ Eval[c_flag AS c_flag] (rows=0)                                  |
|                                      |     └ Filter[c_flag AS c_flag] (rows=0)                              |
|                                      |       └ Filter[(f = 1::bigint)] (rows=0)                             |
|                                      |         └ Join[INNER | (u = u)] (rows=unknown)                       |
|                                      |           ├ Rename[c_flag, u] AS l (rows=unknown)                    |
|                                      |           │  └ Collect[doc.lft | [c_flag, u] | true] (rows=unknown)  |
|                                      |           └ Rename[u, f] AS r (rows=unknown)                         |
|                                      |             └ Collect[doc.rgt | [u, f] | true] (rows=unknown)        |
| optimizer_merge_filters              | Rename[c_flag] AS x (rows=0)                                         |
|                                      |   └ Eval[c_flag AS c_flag] (rows=0)                                  |
|                                      |     └ Filter[(c_flag AS c_flag AND (f = 1::bigint))] (rows=0)        |
|                                      |       └ Join[INNER | (u = u)] (rows=unknown)                         |
|                                      |         ├ Rename[c_flag, u] AS l (rows=unknown)                      |
|                                      |         │  └ Collect[doc.lft | [c_flag, u] | true] (rows=unknown)    |
|                                      |         └ Rename[u, f] AS r (rows=unknown)                           |
|                                      |           └ Collect[doc.rgt | [u, f] | true] (rows=unknown)          |
| optimizer_move_filter_beneath_join   | Rename[c_flag] AS x (rows=unknown)                                   |
|                                      |   └ Eval[c_flag AS c_flag] (rows=unknown)                            |
|                                      |     └ Join[INNER | (u = u)] (rows=unknown)                           |
|                                      |       ├ Rename[c_flag, u] AS l (rows=unknown)                        |
|                                      |       │  └ Collect[doc.lft | [c_flag, u] | true] (rows=unknown)      |
|                                      |       └ Filter[(f = 1::bigint)] (rows=0)                             |
|                                      |         └ Rename[u, f] AS r (rows=unknown)                           |
|                                      |           └ Collect[doc.rgt | [u, f] | true] (rows=unknown)          |
| optimizer_rewrite_join_plan          | Rename[c_flag] AS x (rows=unknown)                                   |
|                                      |   └ Eval[c_flag AS c_flag] (rows=unknown)                            |
|                                      |     └ HashJoin[INNER | (u = u)] (rows=unknown)                       |
|                                      |       ├ Rename[c_flag, u] AS l (rows=unknown)                        |
|                                      |       │  └ Collect[doc.lft | [c_flag, u] | true] (rows=unknown)      |
|                                      |       └ Filter[(f = 1::bigint)] (rows=0)                             |
|                                      |         └ Rename[u, f] AS r (rows=unknown)                           |
|                                      |           └ Collect[doc.rgt | [u, f] | true] (rows=unknown)          |
| optimizer_move_filter_beneath_rename | Rename[c_flag] AS x (rows=unknown)                                   |
|                                      |   └ Eval[c_flag AS c_flag] (rows=unknown)                            |
|                                      |     └ HashJoin[INNER | (u = u)] (rows=unknown)                       |
|                                      |       ├ Rename[c_flag, u] AS l (rows=unknown)                        |
|                                      |       │  └ Collect[doc.lft | [c_flag, u] | true] (rows=unknown)      |
|                                      |       └ Rename[u, f] AS r (rows=0)                                   |
|                                      |         └ Filter[(f = 1::bigint)] (rows=0)                           |
|                                      |           └ Collect[doc.rgt | [u, f] | true] (rows=unknown)          |
| optimizer_merge_filter_and_collect   | Rename[c_flag] AS x (rows=unknown)                                   |
|                                      |   └ Eval[c_flag AS c_flag] (rows=unknown)                            |
|                                      |     └ HashJoin[INNER | (u = u)] (rows=unknown)                       |
|                                      |       ├ Rename[c_flag, u] AS l (rows=unknown)                        |
|                                      |       │  └ Collect[doc.lft | [c_flag, u] | true] (rows=unknown)      |
|                                      |       └ Rename[u, f] AS r (rows=unknown)                             |
|                                      |         └ Collect[doc.rgt | [u, f] | (f = 1::bigint)] (rows=unknown) |
| Final logical plan                   | Rename[c_flag] AS x (rows=unknown)                                   |
|                                      |   └ Eval[c_flag AS c_flag] (rows=unknown)                            |
|                                      |     └ HashJoin[INNER | (u = u)] (rows=unknown)                       |
|                                      |       ├ Rename[c_flag, u] AS l (rows=unknown)                        |
|                                      |       │  └ Collect[doc.lft | [c_flag, u] | true] (rows=unknown)      |
|                                      |       └ Rename[u] AS r (rows=unknown)                                |
|                                      |         └ Collect[doc.rgt | [u] | (f = 1::bigint)] (rows=unknown)    |
+--------------------------------------+----------------------------------------------------------------------+
EXPLAIN 9 rows in set (42.510 sec)
```

As shown, the aliased bare boolean filter was lost in `optimizer_move_filter_beneath_join`. The reason was `QuerySplitter` not properly handling aliased symbols.

Please see the commit for more details.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes.
       If you're an external contributor you can give yourself attribution and include your name and Github handle.
       e.g.:
       ```
       `John Doe <https://github.com/John_Doe>`_ added support for ...
       ```
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
