### PR TITLE
Fix NPE when processing single bucket is rejected by the SEARCH thread pool

### DIFF
--- a/server/src/main/java/io/crate/execution/IncrementalPageBucketReceiver.java
+++ b/server/src/main/java/io/crate/execution/IncrementalPageBucketReceiver.java
@@ -114,7 +114,7 @@ public class IncrementalPageBucketReceiver<T> implements PageBucketReceiver {
             }
         }
         if (isLast) {
-            if (remainingUpstreams.decrementAndGet() == 0) {
+            if (remainingUpstreams.decrementAndGet() == 0 && currentlyAccumulating != null) {
                 currentlyAccumulating.whenComplete((r, t) -> consumeRows());
             }
         }

--- a/server/src/main/java/io/crate/execution/engine/InterceptingRowConsumer.java
+++ b/server/src/main/java/io/crate/execution/engine/InterceptingRowConsumer.java
@@ -62,10 +62,10 @@ class InterceptingRowConsumer implements RowConsumer {
     public void accept(BatchIterator<Row> iterator, @Nullable Throwable failure) {
         consumer.accept(iterator, failure);
         initTracker.future.whenComplete((_, err) -> {
-            Throwable t = SQLExceptions.unwrap(failure == null ? err : failure);
-            if (t == null) {
+            if (err == null && failure == null) {
                 return;
             }
+            Throwable t = SQLExceptions.unwrap(failure == null ? err : failure);
             if (iterator != null) {
                 iterator.kill(t);
             }

--- a/server/src/test/java/io/crate/execution/IncrementalPageBucketReceiverTest.java
+++ b/server/src/test/java/io/crate/execution/IncrementalPageBucketReceiverTest.java
@@ -30,6 +30,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 import java.util.function.BinaryOperator;
@@ -173,6 +175,32 @@ public class IncrementalPageBucketReceiverTest {
             distributedResultResponse -> distributedResultResponse.needMore() == false,
             Duration.ofSeconds(1)
         );
+    }
+
+    @Test
+    public void test_no_npe_when_first_accumulating_on_last_bucket_throws() {
+        TestingRowConsumer batchConsumer = new TestingRowConsumer();
+        Collector<Row, ?, Iterable<Row>> collector = Collectors.collectingAndThen(Collectors.toList(), l -> l);
+
+        var pageBucketReceiver = new IncrementalPageBucketReceiver<>(
+            collector,
+            batchConsumer,
+            (_) -> {
+                // Imitate SEARCH pool exhaustion
+                throw new RejectedExecutionException();
+            },
+            new Streamer[1],
+            1
+        );
+
+        final CompletableFuture<DistributedResultResponse> result = new CompletableFuture<>();
+        PageResultListener listener = needMore -> result.complete(new DistributedResultResponse(needMore));
+        pageBucketReceiver.setBucket(0, Bucket.EMPTY, true, listener);
+        assertThat(pageBucketReceiver.completionFuture())
+            .failsWithin(1, TimeUnit.MILLISECONDS)
+            .withThrowableOfType(ExecutionException.class)
+            .havingCause()
+            .isExactlyInstanceOf(RejectedExecutionException.class);
     }
 
     @Test


### PR DESCRIPTION
Relates to https://github.com/crate/support/issues/909

Seeing `CompletionException` with message NPE in the JFR-s. 
Not sure if I interpreted it correctly, but `setBucket` caught my attention anyway

<img width="858" height="822" alt="Screenshot 2026-08-03 at 16 04 52 2" src="https://github.com/user-attachments/assets/0461fbf7-77ad-4c6c-a351-cb843536d753" />


