### PR TITLE
Use table OIDs to isolate DELETE from concurrent SWAP TABLE

### DIFF
--- a/docs/appendices/release-notes/6.5.0.rst
+++ b/docs/appendices/release-notes/6.5.0.rst
@@ -139,6 +139,10 @@ Performance and Resilience Improvements
   performance by caching analyzed ``ViewInfo`` instances, reducing repeated
   analysis of view definitions when accessing ``information_schema`` views.
 
+- Improved :ref:`DELETE <sql_reference_delete>` such that concurrent
+  :ref:`SWAP TABLE <alter_cluster_swap_table>` cannot affect a ``DELETE``
+  already in progress.
+
 Administration and Operations
 -----------------------------
 

--- a/server/src/main/java/io/crate/execution/ddl/tables/DropPartitionsRequest.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/DropPartitionsRequest.java
@@ -21,10 +21,13 @@
 
 package io.crate.execution.ddl.tables;
 
+import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -35,15 +38,21 @@ import io.crate.metadata.RelationName;
 public class DropPartitionsRequest extends AcknowledgedRequest<DropPartitionsRequest> {
 
     private final RelationName relationName;
+    private final int tableOid;
     private final List<PartitionName> partitions;
 
-    public DropPartitionsRequest(RelationName relationName, List<PartitionName> partitions) {
+    public DropPartitionsRequest(RelationName relationName, int tableOid, List<PartitionName> partitions) {
         this.relationName = relationName;
+        this.tableOid = tableOid;
         this.partitions = partitions;
     }
 
     public RelationName relationName() {
         return relationName;
+    }
+
+    public int tableOid() {
+        return tableOid;
     }
 
     public List<PartitionName> partitions() {
@@ -53,6 +62,11 @@ public class DropPartitionsRequest extends AcknowledgedRequest<DropPartitionsReq
     public DropPartitionsRequest(StreamInput in) throws IOException {
         super(in);
         relationName = new RelationName(in);
+        if (in.getVersion().onOrAfter(Version.V_6_5_0)) {
+            tableOid = in.readVInt();
+        } else {
+            tableOid = OID_UNASSIGNED;
+        }
         int size = in.readVInt();
         partitions = new ArrayList<>(size);
         for (int i = 0; i < size; i++) {
@@ -69,6 +83,9 @@ public class DropPartitionsRequest extends AcknowledgedRequest<DropPartitionsReq
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         relationName.writeTo(out);
+        if (out.getVersion().onOrAfter(Version.V_6_5_0)) {
+            out.writeVInt(tableOid);
+        }
         out.writeVInt(partitions.size());
         for (PartitionName partition : partitions) {
             assert partition.relationName().equals(relationName)

--- a/server/src/main/java/io/crate/execution/ddl/tables/TransportDropPartitionsAction.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/TransportDropPartitionsAction.java
@@ -33,6 +33,7 @@ import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.metadata.MetadataDeleteIndexService;
 import org.elasticsearch.cluster.metadata.RelationMetadata;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -45,6 +46,7 @@ import org.elasticsearch.transport.TransportService;
 import io.crate.exceptions.RelationUnknown;
 import io.crate.execution.ddl.AbstractDDLTransportAction;
 import io.crate.metadata.PartitionName;
+import io.crate.metadata.RelationName;
 import io.crate.metadata.cluster.DDLClusterStateTaskExecutor;
 
 @Singleton
@@ -80,7 +82,13 @@ public class TransportDropPartitionsAction extends AbstractDDLTransportAction<Dr
         executor = new DDLClusterStateTaskExecutor<>() {
             @Override
             protected ClusterState execute(ClusterState currentState, DropPartitionsRequest request) {
-                RelationMetadata.Table table = currentState.metadata().getRelation(request.relationName());
+                int tableOid = request.tableOid();
+                RelationMetadata.Table table;
+                if (tableOid == Metadata.OID_UNASSIGNED) {
+                    table = currentState.metadata().getRelation(request.relationName());
+                } else {
+                    table = currentState.metadata().getRelation(tableOid);
+                }
                 if (table == null) {
                     throw new RelationUnknown(request.relationName());
                 }
@@ -98,22 +106,43 @@ public class TransportDropPartitionsAction extends AbstractDDLTransportAction<Dr
     private static <T> Collection<T> getIndices(ClusterState currentState,
                                                 DropPartitionsRequest request,
                                                 Function<IndexMetadata, T> mapFunction) {
+        RelationName relationName = request.relationName();
+        int tableOid = request.tableOid();
         Collection<T> indices;
         if (request.partitions().isEmpty()) {
-            indices = currentState.metadata().getIndices(
-                request.relationName(),
-                List.of(),
-                false,
-                mapFunction);
+            if (tableOid == Metadata.OID_UNASSIGNED) {
+                indices = currentState.metadata().getIndices(
+                    relationName,
+                    List.of(),
+                    false,
+                    mapFunction);
+            } else {
+                indices = currentState.metadata().getIndices(
+                    tableOid,
+                    List.of(),
+                    false,
+                    mapFunction);
+            }
         } else {
             indices = new HashSet<>();
-            for (PartitionName partition : request.partitions()) {
-                indices.addAll(currentState.metadata().getIndices(
-                    request.relationName(),
-                    partition.values(),
-                    false,
-                    mapFunction)
-                );
+            if (tableOid == Metadata.OID_UNASSIGNED) {
+                for (PartitionName partition : request.partitions()) {
+                    indices.addAll(currentState.metadata().getIndices(
+                        relationName,
+                        partition.values(),
+                        false,
+                        mapFunction)
+                    );
+                }
+            } else {
+                for (PartitionName partition : request.partitions()) {
+                    indices.addAll(currentState.metadata().getIndices(
+                        tableOid,
+                        partition.values(),
+                        false,
+                        mapFunction)
+                    );
+                }
             }
         }
         return indices;

--- a/server/src/main/java/io/crate/planner/node/ddl/DeleteAllPartitions.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/DeleteAllPartitions.java
@@ -38,9 +38,11 @@ import io.crate.planner.operators.SubQueryResults;
 public final class DeleteAllPartitions implements Plan {
 
     private final RelationName relationName;
+    private final int tableOid;
 
-    public DeleteAllPartitions(RelationName relationName) {
+    public DeleteAllPartitions(RelationName relationName, int tableOid) {
         this.relationName = relationName;
+        this.tableOid = tableOid;
     }
 
     @Override
@@ -57,7 +59,7 @@ public final class DeleteAllPartitions implements Plan {
         var listener = new OneRowActionListener<>(consumer, ignoredResponse -> Row1.ROW_COUNT_UNKNOWN);
         dependencies.client().execute(
             TransportDropPartitionsAction.ACTION,
-            new DropPartitionsRequest(relationName, List.of())
+            new DropPartitionsRequest(relationName, tableOid, List.of())
         ).whenComplete(listener);
     }
 }

--- a/server/src/main/java/io/crate/planner/node/ddl/DeletePartitions.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/DeletePartitions.java
@@ -49,10 +49,12 @@ import io.crate.types.DataTypes;
 public class DeletePartitions implements Plan {
 
     private final RelationName relationName;
+    private final int tableOid;
     private final List<List<Symbol>> partitions;
 
-    public DeletePartitions(RelationName relationName, List<List<Symbol>> partitions) {
+    public DeletePartitions(RelationName relationName, int tableOid, List<List<Symbol>> partitions) {
         this.relationName = relationName;
+        this.tableOid = tableOid;
         this.partitions = partitions;
     }
 
@@ -76,7 +78,7 @@ public class DeletePartitions implements Plan {
             relationName, plannerContext.transactionContext(), dependencies.nodeContext(), params, subQueryResults);
         dependencies.client().execute(
             TransportDropPartitionsAction.ACTION,
-            new DropPartitionsRequest(relationName, partitionNames)
+            new DropPartitionsRequest(relationName, tableOid, partitionNames)
         ).whenComplete(new OneRowActionListener<>(consumer, ignoredResponse -> Row1.ROW_COUNT_UNKNOWN));
     }
 

--- a/server/src/main/java/io/crate/planner/statement/DeletePlanner.java
+++ b/server/src/main/java/io/crate/planner/statement/DeletePlanner.java
@@ -96,7 +96,7 @@ public final class DeletePlanner {
             // deleting whole partitions is only valid if the query only contains filters based on partition-by cols
             var hasNonPartitionReferences = query.any(s -> s instanceof Reference && table.partitionedByColumns().contains(s) == false);
             if (hasNonPartitionReferences == false) {
-                return new DeletePartitions(table.ident(), detailedQuery.partitions());
+                return new DeletePartitions(table.ident(), table.oid(), detailedQuery.partitions());
             }
         }
 
@@ -104,7 +104,7 @@ public final class DeletePlanner {
             return new DeleteById(tableRel.tableInfo(), detailedQuery.docKeys().get());
         }
         if (table.isPartitioned() && query instanceof Input<?> input && DataTypes.BOOLEAN.sanitizeValue(input.value())) {
-            return new DeleteAllPartitions(table.ident());
+            return new DeleteAllPartitions(table.ident(), table.oid());
         }
 
         return new Delete(tableRel, detailedQuery);
@@ -148,7 +148,7 @@ public final class DeletePlanner {
                 }
                 dependencies.client().execute(
                     TransportDropPartitionsAction.ACTION,
-                    new DropPartitionsRequest(table.relationName(), partitionValues)
+                    new DropPartitionsRequest(table.relationName(), table.tableInfo().oid(), partitionValues)
                 ).whenComplete(new OneRowActionListener<>(consumer, _ -> Row1.ROW_COUNT_UNKNOWN));
                 return;
             }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -1733,6 +1733,34 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata> {
         return result;
     }
 
+    public <T> List<T> getIndices(RelationName relationName,
+                                  List<String> partitionValues,
+                                  boolean strict,
+                                  Function<IndexMetadata, T> as) {
+        RelationMetadata relation = getRelation(relationName);
+        if (relation == null) {
+            if (strict) {
+                throw new RelationUnknown(relationName);
+            }
+            return List.of();
+        }
+        return getIndices(relation, partitionValues, strict, as);
+    }
+
+    public <T> List<T> getIndices(int tableOid,
+                                  List<String> partitionValues,
+                                  boolean strict,
+                                  Function<IndexMetadata, T> as) {
+        RelationMetadata relation = getRelation(tableOid);
+        if (relation == null) {
+            if (strict) {
+                throw new RelationUnknown(String.format(Locale.ENGLISH, "Relation not found for oid=%s", tableOid));
+            }
+            return List.of();
+        }
+        return getIndices(relation, partitionValues, strict, as);
+    }
+
     /**
      * <p>
      * Resolve the indices for a relation and return their data either as
@@ -1745,22 +1773,15 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata> {
      *
      * @param partitionValues filter by a single partition. Use `List.of()` to include all partitions.
      **/
-    public <T> List<T> getIndices(RelationName relationName,
-                                  List<String> partitionValues,
-                                  boolean strict,
-                                  Function<IndexMetadata, T> as) {
-        RelationMetadata relation = getRelation(relationName);
-        switch (relation) {
-            case null -> {
-                if (strict) {
-                    throw new RelationUnknown(relationName);
-                }
-                return List.of();
-            }
+    private <T> List<T> getIndices(RelationMetadata relationMetadata,
+                                   List<String> partitionValues,
+                                   boolean strict,
+                                   Function<IndexMetadata, T> as) {
+        switch (relationMetadata) {
             case RelationMetadata.BlobTable blobTable -> {
                 IndexMetadata imd = index(blobTable.indexUUID());
                 if (imd == null) {
-                    throw new RelationUnknown(relationName);
+                    throw new RelationUnknown(blobTable.name());
                 }
                 T item = as.apply(imd);
                 if (item != null) {
@@ -1775,7 +1796,7 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata> {
                     IndexMetadata imd = index(indexUUID);
                     if (imd == null) {
                         if (strict) {
-                            throw new RelationUnknown(relationName);
+                            throw new RelationUnknown(table.name());
                         }
                         continue;
                     }
@@ -1799,7 +1820,7 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata> {
             }
         }
         // should be never reached
-        throw new UnsupportedOperationException("Unsupported relation type: " + relation.getClass().getName());
+        throw new UnsupportedOperationException("Unsupported relation type: " + relationMetadata.getClass().getName());
     }
 
     @Nullable

--- a/server/src/test/java/io/crate/execution/ddl/tables/DropPartitionsRequestTest.java
+++ b/server/src/test/java/io/crate/execution/ddl/tables/DropPartitionsRequestTest.java
@@ -22,6 +22,7 @@
 package io.crate.execution.ddl.tables;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
 
 import java.util.Arrays;
 import java.util.List;
@@ -41,7 +42,7 @@ public class DropPartitionsRequestTest {
             new PartitionName(relationName, List.of("1", "2")),
             new PartitionName(relationName, Arrays.asList("1", null))
         );
-        var req = new DropPartitionsRequest(relationName, partitions);
+        var req = new DropPartitionsRequest(relationName, OID_UNASSIGNED, partitions);
         try (var out = new BytesStreamOutput()) {
             req.writeTo(out);
             try (var in = out.bytes().streamInput()) {

--- a/server/src/test/java/io/crate/integrationtests/PartitionedTableConcurrentIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/PartitionedTableConcurrentIntegrationTest.java
@@ -24,6 +24,8 @@ package io.crate.integrationtests;
 import static com.carrotsearch.randomizedtesting.RandomizedTest.$;
 import static com.carrotsearch.randomizedtesting.RandomizedTest.randomAsciiLettersOfLength;
 import static org.assertj.core.api.Assertions.assertThat;
+import static io.crate.testing.Asserts.assertThat;
+import static org.assertj.core.api.Fail.fail;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -595,5 +597,67 @@ public class PartitionedTableConcurrentIntegrationTest extends IntegTestCase {
         assertThat(response.rows()[0][0]).isEqualTo(50L);
         execute("select count(*) from information_schema.table_partitions where table_name = 't2'");
         assertThat(response.rows()[0][0]).isEqualTo(50L);
+    }
+
+    @Test
+    public void test_concurrent_table_swaps_with_delete() throws Exception {
+        for (int retry = 0; retry < 10; retry++) {
+            execute("drop table if exists t1");
+            execute("drop table if exists t2");
+            execute("create table t1 (p int) partitioned by (p)");
+            execute("create table t2 (p int)");
+            execute("insert into t1 values (1), (2)");
+            execute("insert into t2 values (3), (4)");
+            execute("refresh table t1, t2");
+
+            final AtomicReference<Throwable> error = new AtomicReference<>();
+            final CyclicBarrier barrier = new CyclicBarrier(2);
+            boolean[] swapInterleaved = {false};
+
+            Thread t1 = new Thread(() -> {
+                try {
+                    barrier.await();
+                    execute("delete from t1 where p=1");
+                } catch (Throwable e) {
+                    error.set(e);
+                }
+            });
+
+            Thread t2 = new Thread(() -> {
+                try {
+                    barrier.await();
+                    execute("ALTER CLUSTER SWAP TABLE t1 TO t2");
+                    if (t1.isAlive()) {
+                        swapInterleaved[0] = true;
+                    }
+                } catch (Throwable e) {
+                    error.set(e);
+                }
+            });
+
+            t1.start();
+            t2.start();
+
+            t1.join();
+            t2.join();
+
+            assertThat(error.get()).isNull();
+
+            if (swapInterleaved[0] == false) {
+                continue;
+            }
+
+            execute("select * from t1 order by p");
+            assertThat(response).hasRows("3", "4");
+
+            execute("select * from t2 order by p");
+            // DELETE was executed on t2 not t1 such that `1` is not deleted.
+            if (response.rowCount() == 2 && response.rows()[0][0].equals(1) && response.rows()[1][0].equals(2)) {
+                continue;
+            }
+            assertThat(response).hasRows("2");
+            return;
+        }
+        fail("The test failed to complete a successful interleaving of swap with delete");
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Similar to https://github.com/crate/crate/pull/19744, this PR handles a concurrent SWAP with DELETE.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes.
       If you're an external contributor you can give yourself attribution and include your name and Github handle.
       e.g.:
       ```
       `John Doe <https://github.com/John_Doe>`_ added support for ...
       ```
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
