### PR TITLE
Improve memory accounting for aggregations

### DIFF
--- a/docs/appendices/release-notes/6.4.3.rst
+++ b/docs/appendices/release-notes/6.4.3.rst
@@ -46,4 +46,5 @@ series.
 Fixes
 =====
 
-None
+- Fixed an issue that could lead to an ``OutOfMemoryError`` when running a
+  query with aggregations under memory pressure.

--- a/libs/shared/pom.xml
+++ b/libs/shared/pom.xml
@@ -72,5 +72,11 @@
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.lucene</groupId>
+            <artifactId>lucene-core</artifactId>
+            <version>10.5.0</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/libs/shared/src/main/java/io/crate/common/MutableDouble.java
+++ b/libs/shared/src/main/java/io/crate/common/MutableDouble.java
@@ -21,8 +21,11 @@
 
 package io.crate.common;
 
+import org.apache.lucene.util.RamUsageEstimator;
+
 public final class MutableDouble {
 
+    public static long SHALLOW_SIZE = RamUsageEstimator.shallowSizeOfInstance(MutableDouble.class);
     private double value;
     private boolean hasValue = false;
 

--- a/libs/shared/src/main/java/io/crate/common/MutableFloat.java
+++ b/libs/shared/src/main/java/io/crate/common/MutableFloat.java
@@ -21,8 +21,11 @@
 
 package io.crate.common;
 
+import org.apache.lucene.util.RamUsageEstimator;
+
 public final class MutableFloat {
 
+    public static long SHALLOW_SIZE = RamUsageEstimator.shallowSizeOfInstance(MutableFloat.class);
     private float value;
     private boolean hasValue = false;
 

--- a/libs/shared/src/main/java/io/crate/common/MutableLong.java
+++ b/libs/shared/src/main/java/io/crate/common/MutableLong.java
@@ -24,8 +24,11 @@ package io.crate.common;
 
 import java.util.Objects;
 
+import org.apache.lucene.util.RamUsageEstimator;
+
 public final class MutableLong {
 
+    public static long SHALLOW_SIZE = RamUsageEstimator.shallowSizeOfInstance(MutableLong.class);
     private long value;
     private boolean hasValue = false;
 

--- a/libs/shared/src/main/java/io/crate/common/MutableObject.java
+++ b/libs/shared/src/main/java/io/crate/common/MutableObject.java
@@ -21,9 +21,12 @@
 
 package io.crate.common;
 
+import org.apache.lucene.util.RamUsageEstimator;
 import org.jspecify.annotations.Nullable;
 
 public final class MutableObject {
+
+    public static long SHALLOW_SIZE = RamUsageEstimator.shallowSizeOfInstance(MutableObject.class);
 
     private Object value;
     private boolean hasValue = false;

--- a/server/src/main/java/io/crate/execution/engine/aggregation/GroupByMaps.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/GroupByMaps.java
@@ -24,11 +24,11 @@ package io.crate.execution.engine.aggregation;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 
 import org.apache.lucene.util.RamUsageEstimator;
 
+import io.crate.common.TriConsumer;
 import io.crate.data.breaker.RamAccounting;
 import io.crate.types.ByteType;
 import io.crate.types.DataType;
@@ -43,17 +43,33 @@ import io.netty.util.collection.ShortObjectHashMap;
 
 public final class GroupByMaps {
 
-    public static <K> BiConsumer<K, Object[]> accountForNewEntry(RamAccounting ramAccounting, DataType<K> type) {
-        return (key, states) -> {
+    public static <K, V> TriConsumer<ResizeAwareMap<K, V>, K, Object[]> accountForNewEntry(RamAccounting ramAccounting, DataType<K> type) {
+        long singleItemBytes = singleItemBytes(type);
+        return (map, key, states) -> {
             ramAccounting.addBytes(RamUsageEstimator.alignObjectSize(type.valueBytes(key) + 36));
             ramAccounting.addBytes(RamUsageEstimator.shallowSizeOf(states));
+            ramAccounting.addBytes(singleItemBytes * map.expectedCapacityIncrease());
+        };
+    }
+
+    /**
+     * Netty maps keep a primitive key array alongside the  Object[] array.
+     */
+    private static long singleItemBytes(DataType<?> type) {
+        return switch (type.id()) {
+            case ByteType.ID -> Byte.BYTES + RamUsageEstimator.NUM_BYTES_OBJECT_REF;
+            case ShortType.ID -> Short.BYTES + RamUsageEstimator.NUM_BYTES_OBJECT_REF;
+            case IntegerType.ID -> Integer.BYTES + RamUsageEstimator.NUM_BYTES_OBJECT_REF;
+            case LongType.ID, TimestampType.ID_WITH_TZ, TimestampType.ID_WITHOUT_TZ ->
+                Long.BYTES + RamUsageEstimator.NUM_BYTES_OBJECT_REF;
+            default -> RamUsageEstimator.NUM_BYTES_OBJECT_REF;
         };
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})
-    public static <K> BiConsumer<K, Object[]> accountForNewEntry(RamAccounting ramAccounting,
+    public static <K, V> TriConsumer<ResizeAwareMap<K, V>, K, Object[]> accountForNewEntry(RamAccounting ramAccounting,
                                                                  List<? extends DataType> types) {
-        return (key, states) -> {
+        return (map, key, states) -> {
             assert key instanceof List : "keys must be a list if there are multiple key types";
             long size = 0;
             for (int i = 0; i < types.size(); i++) {
@@ -63,18 +79,54 @@ public final class GroupByMaps {
             }
             ramAccounting.addBytes(RamUsageEstimator.alignObjectSize(size + 36));
             ramAccounting.addBytes(RamUsageEstimator.shallowSizeOf(states));
+            ramAccounting.addBytes((long) RamUsageEstimator.NUM_BYTES_OBJECT_REF * map.expectedCapacityIncrease());
         };
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})
-    public static <K, V> Supplier<Map<K, V>> mapForType(DataType<K> type) {
+    public static <K, V> Supplier<ResizeAwareMap<K, V>> mapForType(DataType<K> type) {
         return switch (type.id()) {
-            case ByteType.ID -> () -> (Map) new PrimitiveMapWithNulls<>(new ByteObjectHashMap<>());
-            case ShortType.ID -> () -> (Map) new PrimitiveMapWithNulls<>(new ShortObjectHashMap<>());
-            case IntegerType.ID -> () -> (Map) new PrimitiveMapWithNulls<>(new IntObjectHashMap<>());
+            case ByteType.ID -> () -> (ResizeAwareMap<K, V>) new ResizeAwareMap<>(
+                new PrimitiveMapWithNulls<>(new ByteObjectHashMap<>()),
+                ByteObjectHashMap.DEFAULT_CAPACITY,
+                ByteObjectHashMap.DEFAULT_LOAD_FACTOR,
+                true
+            );
+
+            case ShortType.ID -> () -> (ResizeAwareMap<K, V>) new ResizeAwareMap<>(
+                new PrimitiveMapWithNulls<>(new ShortObjectHashMap<>()),
+                ShortObjectHashMap.DEFAULT_CAPACITY,
+                ShortObjectHashMap.DEFAULT_LOAD_FACTOR,
+                true
+            );
+
+            case IntegerType.ID -> () -> (ResizeAwareMap<K, V>) new ResizeAwareMap<>(
+                new PrimitiveMapWithNulls<>(new IntObjectHashMap<>()),
+                IntObjectHashMap.DEFAULT_CAPACITY,
+                IntObjectHashMap.DEFAULT_LOAD_FACTOR,
+                true
+            );
+
             case LongType.ID, TimestampType.ID_WITH_TZ, TimestampType.ID_WITHOUT_TZ ->
-                () -> (Map) new PrimitiveMapWithNulls<>(new LongObjectHashMap<>());
-            default -> HashMap::new;
+                () -> (ResizeAwareMap<K, V>) new ResizeAwareMap<>(
+                    new PrimitiveMapWithNulls<>(new LongObjectHashMap<>()),
+                    LongObjectHashMap.DEFAULT_CAPACITY,
+                    LongObjectHashMap.DEFAULT_LOAD_FACTOR,
+                    true
+                );
+
+            default -> () -> wrapperForJDKMap(new HashMap<>());
         };
     }
+
+    public static <K, V> ResizeAwareMap<K, V> wrapperForJDKMap(Map<K, V> map) {
+        return new ResizeAwareMap<>(
+            map,
+            LongObjectHashMap.DEFAULT_CAPACITY,
+            LongObjectHashMap.DEFAULT_LOAD_FACTOR,
+            false
+        );
+    }
+
+
 }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/GroupByMaps.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/GroupByMaps.java
@@ -43,22 +43,26 @@ import io.netty.util.collection.ShortObjectHashMap;
 
 public final class GroupByMaps {
 
-    public static <K, V> BiConsumer<Map<K, V>, K> accountForNewEntry(RamAccounting ramAccounting, DataType<K> type) {
-        return (_, k) -> ramAccounting.addBytes(RamUsageEstimator.alignObjectSize(type.valueBytes(k) + 36));
+    public static <K> BiConsumer<K, Object[]> accountForNewEntry(RamAccounting ramAccounting, DataType<K> type) {
+        return (key, states) -> {
+            ramAccounting.addBytes(RamUsageEstimator.alignObjectSize(type.valueBytes(key) + 36));
+            ramAccounting.addBytes(RamUsageEstimator.shallowSizeOf(states));
+        };
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})
-    public static <K, V> BiConsumer<Map<K, V>, K> accountForNewEntry(RamAccounting ramAccounting,
-                                                                     List<? extends DataType> types) {
-        return (_, k) -> {
-            assert k instanceof List : "keys must be a list if there are multiple key types";
+    public static <K> BiConsumer<K, Object[]> accountForNewEntry(RamAccounting ramAccounting,
+                                                                 List<? extends DataType> types) {
+        return (key, states) -> {
+            assert key instanceof List : "keys must be a list if there are multiple key types";
             long size = 0;
             for (int i = 0; i < types.size(); i++) {
                 DataType dataType = types.get(i);
-                Object value = ((List) k).get(i);
+                Object value = ((List) key).get(i);
                 size += dataType.valueBytes(value);
             }
             ramAccounting.addBytes(RamUsageEstimator.alignObjectSize(size + 36));
+            ramAccounting.addBytes(RamUsageEstimator.shallowSizeOf(states));
         };
     }
 

--- a/server/src/main/java/io/crate/execution/engine/aggregation/GroupingCollector.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/GroupingCollector.java
@@ -36,6 +36,7 @@ import java.util.stream.Collector;
 
 import org.elasticsearch.Version;
 
+import io.crate.common.TriConsumer;
 import io.crate.common.annotations.VisibleForTesting;
 import io.crate.data.Input;
 import io.crate.data.Row;
@@ -64,7 +65,7 @@ public class GroupingCollector<K> implements Collector<Row, Map<K, Object[]>, It
     private final MemoryManager memoryManager;
     private final BiConsumer<K, Object[]> applyKeyToCells;
     private final int numKeyColumns;
-    private final BiConsumer<K, Object[]> accountForNewEntry;
+    private final TriConsumer<ResizeAwareMap<K, Object[]>, K, Object[]> accountForNewEntry;
     private final Function<Row, K> keyExtractor;
     private final BiConsumer<Map<K, Object[]>, Row> accumulator;
     private final Supplier<Map<K, Object[]>> supplier;
@@ -120,7 +121,7 @@ public class GroupingCollector<K> implements Collector<Row, Map<K, Object[]>, It
             keyInputs.size(),
             GroupByMaps.accountForNewEntry(ramAccountingContext, keyTypes),
             row -> evalKeyInputs(keyInputs),
-            HashMap::new
+            () -> GroupByMaps.wrapperForJDKMap(new HashMap<>())
         );
     }
 
@@ -148,7 +149,7 @@ public class GroupingCollector<K> implements Collector<Row, Map<K, Object[]>, It
                               Version minNodeVersion,
                               BiConsumer<K, Object[]> applyKeyToCells,
                               int numKeyColumns,
-                              BiConsumer<K, Object[]> accountForNewEntry,
+                              TriConsumer<ResizeAwareMap<K, Object[]>, K, Object[]> accountForNewEntry,
                               Function<Row, K> keyExtractor,
                               Supplier<Map<K, Object[]>> supplier) {
         this.expressions = expressions;
@@ -206,7 +207,7 @@ public class GroupingCollector<K> implements Collector<Row, Map<K, Object[]>, It
             for (int i = 0; i < aggregations.length; i++) {
                 states[i] = inputs[i][0].value();
             }
-            addWithAccounting(statesByKey, key, states);
+            addWithAccounting((ResizeAwareMap<K, Object[]>) statesByKey, key, states);
         } else {
             for (int i = 0; i < aggregations.length; i++) {
                 states[i] = aggregations[i].reduce(ramAccounting, states[i], inputs[i][0].value());
@@ -214,8 +215,8 @@ public class GroupingCollector<K> implements Collector<Row, Map<K, Object[]>, It
         }
     }
 
-    private void addWithAccounting(Map<K, Object[]> statesByKey, K key, Object[] states) {
-        accountForNewEntry.accept(key, states);
+    private void addWithAccounting(ResizeAwareMap<K, Object[]> statesByKey, K key, Object[] states) {
+        accountForNewEntry.accept(statesByKey, key, states);
         statesByKey.put(key, states);
     }
 
@@ -226,7 +227,7 @@ public class GroupingCollector<K> implements Collector<Row, Map<K, Object[]>, It
         K key = keyExtractor.apply(row);
         Object[] states = statesByKey.get(key);
         if (states == null) {
-            addNewEntry(statesByKey, key);
+            addNewEntry((ResizeAwareMap<K, Object[]>) statesByKey, key);
         } else {
             for (int i = 0; i < aggregations.length; i++) {
                 if (InputCondition.matches(filters[i])) {
@@ -238,7 +239,7 @@ public class GroupingCollector<K> implements Collector<Row, Map<K, Object[]>, It
     }
 
     @VisibleForTesting
-    void addNewEntry(Map<K, Object[]> statesByKey, K key) {
+    void addNewEntry(ResizeAwareMap<K, Object[]> statesByKey, K key) {
         Object[] states;
         states = new Object[aggregations.length];
         for (int i = 0; i < aggregations.length; i++) {

--- a/server/src/main/java/io/crate/execution/engine/aggregation/GroupingCollector.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/GroupingCollector.java
@@ -36,6 +36,7 @@ import java.util.stream.Collector;
 
 import org.elasticsearch.Version;
 
+import io.crate.common.annotations.VisibleForTesting;
 import io.crate.data.Input;
 import io.crate.data.Row;
 import io.crate.data.RowN;
@@ -63,7 +64,7 @@ public class GroupingCollector<K> implements Collector<Row, Map<K, Object[]>, It
     private final MemoryManager memoryManager;
     private final BiConsumer<K, Object[]> applyKeyToCells;
     private final int numKeyColumns;
-    private final BiConsumer<Map<K, Object[]>, K> accountForNewEntry;
+    private final BiConsumer<K, Object[]> accountForNewEntry;
     private final Function<Row, K> keyExtractor;
     private final BiConsumer<Map<K, Object[]>, Row> accumulator;
     private final Supplier<Map<K, Object[]>> supplier;
@@ -147,7 +148,7 @@ public class GroupingCollector<K> implements Collector<Row, Map<K, Object[]>, It
                               Version minNodeVersion,
                               BiConsumer<K, Object[]> applyKeyToCells,
                               int numKeyColumns,
-                              BiConsumer<Map<K, Object[]>, K> accountForNewEntry,
+                              BiConsumer<K, Object[]> accountForNewEntry,
                               Function<Row, K> keyExtractor,
                               Supplier<Map<K, Object[]>> supplier) {
         this.expressions = expressions;
@@ -193,7 +194,8 @@ public class GroupingCollector<K> implements Collector<Row, Map<K, Object[]>, It
         return Collections.emptySet();
     }
 
-    private void reduce(Map<K, Object[]> statesByKey, Row row) {
+    @VisibleForTesting
+    public void reduce(Map<K, Object[]> statesByKey, Row row) {
         for (CollectExpression<Row, ?> expression : expressions) {
             expression.setNextRow(row);
         }
@@ -213,7 +215,7 @@ public class GroupingCollector<K> implements Collector<Row, Map<K, Object[]>, It
     }
 
     private void addWithAccounting(Map<K, Object[]> statesByKey, K key, Object[] states) {
-        accountForNewEntry.accept(statesByKey, key);
+        accountForNewEntry.accept(key, states);
         statesByKey.put(key, states);
     }
 
@@ -235,7 +237,8 @@ public class GroupingCollector<K> implements Collector<Row, Map<K, Object[]>, It
         }
     }
 
-    private void addNewEntry(Map<K, Object[]> statesByKey, K key) {
+    @VisibleForTesting
+    void addNewEntry(Map<K, Object[]> statesByKey, K key) {
         Object[] states;
         states = new Object[aggregations.length];
         for (int i = 0; i < aggregations.length; i++) {

--- a/server/src/main/java/io/crate/execution/engine/aggregation/ResizeAwareMap.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/ResizeAwareMap.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.execution.engine.aggregation;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Wrapper for maps containing large number of elements.
+ *
+ * Resize of such map can create significant number of (retained) elements,
+ * memory accounting must utilize expectedCapacityIncrease to account for that.
+ */
+public class ResizeAwareMap<K, V> implements Map<K, V> {
+
+    // Copy of java.util.HashMap.MAXIMUM_CAPACITY
+    private static final int MAXIMUM_CAPACITY = 1 << 30;
+
+    private final Map<K, V> delegate;
+    private final float loadFactor;
+    private final boolean openAddressing;
+
+    private int currentCapacity;
+
+    public ResizeAwareMap(Map<K, V> delegate,
+                          int initialCapacity,
+                          float loadFactor,
+                          boolean openAddressing) {
+        this.delegate = delegate;
+        this.currentCapacity = tableSizeFor(initialCapacity);
+        this.loadFactor = loadFactor;
+        this.openAddressing = openAddressing;
+    }
+
+    @Override
+    public int size() {
+        return delegate.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return delegate.isEmpty();
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+        return delegate.containsKey(key);
+    }
+
+    @Override
+    public boolean containsValue(Object value) {
+        return delegate.containsValue(value);
+    }
+
+    @Override
+    public V get(Object key) {
+        return delegate.get(key);
+    }
+
+    @Override
+    public V put(K key, V value) {
+        growIfNeeded(1);
+        V result = delegate.put(key, value);
+        return result;
+    }
+
+    @Override
+    public V remove(Object key) {
+        return delegate.remove(key);
+    }
+
+    @Override
+    public void putAll(Map<? extends K, ? extends V> m) {
+        growIfNeeded(m.size());
+        delegate.putAll(m);
+    }
+
+    @Override
+    public void clear() {
+        delegate.clear();
+    }
+
+    @Override
+    public Set<K> keySet() {
+        return delegate.keySet();
+    }
+
+    @Override
+    public Collection<V> values() {
+        return delegate.values();
+    }
+
+    @Override
+    public Set<Entry<K, V>> entrySet() {
+        return delegate.entrySet();
+    }
+
+    /**
+     * @return internal capacity increase after the next put() or putAll().
+     * can only return 2 values:
+     * <ol>
+     *   <li> 0 (No resize would happen)</li>
+     *   <li> currentCapacity * 2 (Resize would happen. Both JDK and Netty Maps double their sizes)</li>
+     * </ol>
+     * <br>
+     */
+    public int expectedCapacityIncrease(int newItems) {
+        int capacity = currentCapacity;
+        while (capacity < MAXIMUM_CAPACITY && delegate.size() + newItems > resizeThreshold(capacity)) {
+            capacity = capacity << 1;
+        }
+        return capacity - currentCapacity;
+    }
+
+    public int currentCapacity() {
+        return currentCapacity;
+    }
+
+    /**
+     * Mirrors what delegate map is doing to keep track of the current capacity.
+     * Both JDK and Netty maps grow in power of 2.
+     * JDK map has an explicit limit.
+     * Netty map's growSize() doesn't check 1<<30 and rehash with negative capacity throws.
+     */
+    private void growIfNeeded(int newItems) {
+        while (currentCapacity < MAXIMUM_CAPACITY && delegate.size() + newItems > resizeThreshold(currentCapacity)) {
+            currentCapacity <<= 1;
+        }
+    }
+
+    private int resizeThreshold(int capacity) {
+        int threshold = (int) (capacity * loadFactor);
+        // Netty maps need 1 slot to be free, hence resize happens earlier.
+        // See calcMaxSize() in Netty maps.
+        return openAddressing ? Math.min(capacity - 1, threshold) : threshold;
+    }
+
+    /**
+     * Copied from java.util.HashMap#tableSizeFor
+     */
+    private static int tableSizeFor(int cap) {
+        int n = -1 >>> Integer.numberOfLeadingZeros(cap - 1);
+        return (n < 0) ? 1 : (n >= MAXIMUM_CAPACITY) ? MAXIMUM_CAPACITY : n + 1;
+    }
+}

--- a/server/src/main/java/io/crate/execution/engine/aggregation/ResizeAwareMap.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/ResizeAwareMap.java
@@ -79,8 +79,8 @@ public class ResizeAwareMap<K, V> implements Map<K, V> {
 
     @Override
     public V put(K key, V value) {
-        growIfNeeded(1);
         V result = delegate.put(key, value);
+        growIfNeeded();
         return result;
     }
 
@@ -91,8 +91,7 @@ public class ResizeAwareMap<K, V> implements Map<K, V> {
 
     @Override
     public void putAll(Map<? extends K, ? extends V> m) {
-        growIfNeeded(m.size());
-        delegate.putAll(m);
+        throw new UnsupportedOperationException("putAll is not supported on ResizeAwareMap");
     }
 
     @Override
@@ -116,17 +115,12 @@ public class ResizeAwareMap<K, V> implements Map<K, V> {
     }
 
     /**
-     * @return internal capacity increase after the next put() or putAll().
-     * can only return 2 values:
-     * <ol>
-     *   <li> 0 (No resize would happen)</li>
-     *   <li> currentCapacity * 2 (Resize would happen. Both JDK and Netty Maps double their sizes)</li>
-     * </ol>
-     * <br>
+     * @return internal capacity increase
+     * after the next put() which will add a new unique key.
      */
-    public int expectedCapacityIncrease(int newItems) {
+    public int expectedCapacityIncrease() {
         int capacity = currentCapacity;
-        while (capacity < MAXIMUM_CAPACITY && delegate.size() + newItems > resizeThreshold(capacity)) {
+        while (capacity < MAXIMUM_CAPACITY && delegate.size() + 1 > resizeThreshold(capacity)) {
             capacity = capacity << 1;
         }
         return capacity - currentCapacity;
@@ -142,8 +136,10 @@ public class ResizeAwareMap<K, V> implements Map<K, V> {
      * JDK map has an explicit limit.
      * Netty map's growSize() doesn't check 1<<30 and rehash with negative capacity throws.
      */
-    private void growIfNeeded(int newItems) {
-        while (currentCapacity < MAXIMUM_CAPACITY && delegate.size() + newItems > resizeThreshold(currentCapacity)) {
+    private void growIfNeeded() {
+        // This method is always called **after** put(),
+        // so delegate.size() already accounts for potential duplicate key(s).
+        while (currentCapacity < MAXIMUM_CAPACITY && delegate.size() > resizeThreshold(currentCapacity)) {
             currentCapacity <<= 1;
         }
     }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/ArbitraryAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/ArbitraryAggregation.java
@@ -264,6 +264,7 @@ public class ArbitraryAggregation extends AggregationFunction<Object, Object> {
 
         @Override
         public MutableObject initialState(RamAccounting ramAccounting, MemoryManager memoryManager, Version minNodeVersion) {
+            ramAccounting.addBytes(MutableObject.SHALLOW_SIZE);
             return new MutableObject();
         }
 
@@ -298,6 +299,7 @@ public class ArbitraryAggregation extends AggregationFunction<Object, Object> {
 
         @Override
         public MutableObject initialState(RamAccounting ramAccounting, MemoryManager memoryManager, Version minNodeVersion) {
+            ramAccounting.addBytes(MutableObject.SHALLOW_SIZE);
             return new MutableObject();
         }
 
@@ -342,6 +344,7 @@ public class ArbitraryAggregation extends AggregationFunction<Object, Object> {
 
         @Override
         public MutableObject initialState(RamAccounting ramAccounting, MemoryManager memoryManager, Version minNodeVersion) {
+            ramAccounting.addBytes(MutableObject.SHALLOW_SIZE);
             return new MutableObject();
         }
 

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/CountAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/CountAggregation.java
@@ -131,7 +131,7 @@ public class CountAggregation extends AggregationFunction<MutableLong, Long> {
     public MutableLong newState(RamAccounting ramAccounting,
                                 Version minNodeInCluster,
                                 MemoryManager memoryManager) {
-        ramAccounting.addBytes(LongStateType.INSTANCE.fixedSize());
+        ramAccounting.addBytes(MutableLong.SHALLOW_SIZE);
         return new MutableLong(0L);
     }
 
@@ -265,7 +265,7 @@ public class CountAggregation extends AggregationFunction<MutableLong, Long> {
                 new SortedNumericDocValueAggregator<>(
                     ref.storageIdent(),
                     (ramAccounting, _, _) -> {
-                        ramAccounting.addBytes(LongStateType.INSTANCE.fixedSize());
+                        ramAccounting.addBytes(MutableLong.SHALLOW_SIZE);
                         return new MutableLong(0L);
                     },
                     (_, _, state) -> state.add(1L)
@@ -273,7 +273,7 @@ public class CountAggregation extends AggregationFunction<MutableLong, Long> {
             case IpType.ID, StringType.ID, BitStringType.ID -> new BinaryDocValueAggregator<>(
                 ref.storageIdent(),
                 (ramAccounting, _, _) -> {
-                    ramAccounting.addBytes(LongStateType.INSTANCE.fixedSize());
+                    ramAccounting.addBytes(MutableLong.SHALLOW_SIZE);
                     return new MutableLong(0L);
                 },
                 (_, _, state) -> state.add(1L)

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/MaximumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/MaximumAggregation.java
@@ -102,7 +102,7 @@ public abstract class MaximumAggregation extends AggregationFunction<Object, Obj
 
         @Override
         public MutableLong initialState(RamAccounting ramAccounting, MemoryManager memoryManager, Version minNodeVersion) {
-            ramAccounting.addBytes(DataTypes.LONG.fixedSize());
+            ramAccounting.addBytes(MutableLong.SHALLOW_SIZE);
             return new MutableLong(Long.MIN_VALUE);
         }
 
@@ -144,7 +144,7 @@ public abstract class MaximumAggregation extends AggregationFunction<Object, Obj
 
         @Override
         public MutableDouble initialState(RamAccounting ramAccounting, MemoryManager memoryManager, Version minNodeVersion) {
-            ramAccounting.addBytes(DataTypes.DOUBLE.fixedSize());
+            ramAccounting.addBytes(MutableDouble.SHALLOW_SIZE);
             return new MutableDouble(- Double.MAX_VALUE);
         }
 
@@ -186,7 +186,7 @@ public abstract class MaximumAggregation extends AggregationFunction<Object, Obj
 
         @Override
         public MutableFloat initialState(RamAccounting ramAccounting, MemoryManager memoryManager, Version minNodeVersion) {
-            ramAccounting.addBytes(DataTypes.FLOAT.fixedSize());
+            ramAccounting.addBytes(MutableFloat.SHALLOW_SIZE);
             return new MutableFloat(- Float.MAX_VALUE);
         }
 

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/MinimumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/MinimumAggregation.java
@@ -101,7 +101,7 @@ public abstract class MinimumAggregation extends AggregationFunction<Object, Obj
 
         @Override
         public MutableLong initialState(RamAccounting ramAccounting, MemoryManager memoryManager, Version minNodeVersion) {
-            ramAccounting.addBytes(DataTypes.LONG.fixedSize());
+            ramAccounting.addBytes(MutableLong.SHALLOW_SIZE);
             return new MutableLong(Long.MAX_VALUE);
         }
 
@@ -143,7 +143,7 @@ public abstract class MinimumAggregation extends AggregationFunction<Object, Obj
 
         @Override
         public MutableDouble initialState(RamAccounting ramAccounting, MemoryManager memoryManager, Version minNodeVersion) {
-            ramAccounting.addBytes(DataTypes.DOUBLE.fixedSize());
+            ramAccounting.addBytes(MutableDouble.SHALLOW_SIZE);
             return new MutableDouble(Double.MAX_VALUE);
         }
 
@@ -184,7 +184,7 @@ public abstract class MinimumAggregation extends AggregationFunction<Object, Obj
 
         @Override
         public MutableFloat initialState(RamAccounting ramAccounting, MemoryManager memoryManager, Version minNodeVersion) {
-            ramAccounting.addBytes(DataTypes.FLOAT.fixedSize());
+            ramAccounting.addBytes(MutableFloat.SHALLOW_SIZE);
             return new MutableFloat(Float.MAX_VALUE);
         }
 

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/SumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/SumAggregation.java
@@ -259,7 +259,7 @@ public class SumAggregation<T extends Number> extends AggregationFunction<T, T> 
 
         @Override
         public MutableLong initialState(RamAccounting ramAccounting, MemoryManager memoryManager, Version minNodeVersion) {
-            ramAccounting.addBytes(DataTypes.LONG.fixedSize());
+            ramAccounting.addBytes(MutableLong.SHALLOW_SIZE);
             return new MutableLong(0L);
         }
 
@@ -294,7 +294,7 @@ public class SumAggregation<T extends Number> extends AggregationFunction<T, T> 
 
         @Override
         public MutableDouble initialState(RamAccounting ramAccounting, MemoryManager memoryManager, Version minNodeVersion) {
-            ramAccounting.addBytes(DataTypes.DOUBLE.fixedSize());
+            ramAccounting.addBytes(MutableDouble.SHALLOW_SIZE);
             return new MutableDouble(.0d);
         }
 
@@ -333,7 +333,7 @@ public class SumAggregation<T extends Number> extends AggregationFunction<T, T> 
 
         @Override
         public MutableFloat initialState(RamAccounting ramAccounting, MemoryManager memoryManager, Version minNodeVersion) {
-            ramAccounting.addBytes(DataTypes.FLOAT.fixedSize());
+            ramAccounting.addBytes(MutableFloat.SHALLOW_SIZE);
             return new MutableFloat(.0f);
         }
 

--- a/server/src/main/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIterator.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIterator.java
@@ -261,7 +261,7 @@ final class DocValuesGroupByOptimizedIterator {
                                                   RamAccounting ramAccounting,
                                                   MemoryManager memoryManager,
                                                   Version minNodeVersion,
-                                                  BiConsumer<Map<K, Object[]>, K> accountForNewKeyEntry,
+                                                  BiConsumer<K, Object[]> accountForNewKeyEntry,
                                                   Function<List<? extends LuceneCollectorExpression<?>>, K> keyExtractor,
                                                   BiConsumer<K, Object[]> applyKeyToCells,
                                                   Query query,
@@ -326,7 +326,7 @@ final class DocValuesGroupByOptimizedIterator {
             List<DocValueAggregator> aggregators,
             IndexSearcher indexSearcher,
             List<? extends LuceneCollectorExpression<?>> keyExpressions,
-            BiConsumer<Map<K, Object[]>, K> accountForNewKeyEntry,
+            BiConsumer<K, Object[]> accountForNewKeyEntry,
             Function<List<? extends LuceneCollectorExpression<?>>, K> keyExtractor,
             RamAccounting ramAccounting,
             MemoryManager memoryManager,
@@ -380,7 +380,7 @@ final class DocValuesGroupByOptimizedIterator {
                             state = aggregator.apply(ramAccounting, doc, state);
                             states[i] = state;
                         }
-                        accountForNewKeyEntry.accept(statesByKey, key);
+                        accountForNewKeyEntry.accept(key, states);
                         statesByKey.put(key, states);
                     } else {
                         for (int i = 0; i < aggregators.size(); i++) {

--- a/server/src/main/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIterator.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIterator.java
@@ -47,6 +47,7 @@ import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.ShardId;
 import org.jspecify.annotations.Nullable;
 
+import io.crate.common.TriConsumer;
 import io.crate.common.annotations.VisibleForTesting;
 import io.crate.common.collections.Lists;
 import io.crate.common.concurrent.Killable;
@@ -60,6 +61,7 @@ import io.crate.execution.dsl.projection.GroupProjection;
 import io.crate.execution.dsl.projection.Projection;
 import io.crate.execution.engine.aggregation.DocValueAggregator;
 import io.crate.execution.engine.aggregation.GroupByMaps;
+import io.crate.execution.engine.aggregation.ResizeAwareMap;
 import io.crate.execution.engine.fetch.ReaderContext;
 import io.crate.execution.jobs.SharedShardContext;
 import io.crate.expression.InputFactory;
@@ -261,7 +263,7 @@ final class DocValuesGroupByOptimizedIterator {
                                                   RamAccounting ramAccounting,
                                                   MemoryManager memoryManager,
                                                   Version minNodeVersion,
-                                                  BiConsumer<K, Object[]> accountForNewKeyEntry,
+                                                  TriConsumer<ResizeAwareMap<K, Object[]>, K, Object[]> accountForNewKeyEntry,
                                                   Function<List<? extends LuceneCollectorExpression<?>>, K> keyExtractor,
                                                   BiConsumer<K, Object[]> applyKeyToCells,
                                                   Query query,
@@ -326,7 +328,7 @@ final class DocValuesGroupByOptimizedIterator {
             List<DocValueAggregator> aggregators,
             IndexSearcher indexSearcher,
             List<? extends LuceneCollectorExpression<?>> keyExpressions,
-            BiConsumer<K, Object[]> accountForNewKeyEntry,
+            TriConsumer<ResizeAwareMap<K, Object[]>, K, Object[]> accountForNewKeyEntry,
             Function<List<? extends LuceneCollectorExpression<?>>, K> keyExtractor,
             RamAccounting ramAccounting,
             MemoryManager memoryManager,
@@ -335,7 +337,7 @@ final class DocValuesGroupByOptimizedIterator {
             Killable.Token killToken
         ) throws IOException {
 
-            HashMap<K, Object[]> statesByKey = new HashMap<>();
+            ResizeAwareMap<K, Object[]> statesByKey = GroupByMaps.wrapperForJDKMap(new HashMap<>());
             Weight weight = indexSearcher.createWeight(
                 indexSearcher.rewrite(query),
                 ScoreMode.COMPLETE_NO_SCORES,
@@ -380,7 +382,7 @@ final class DocValuesGroupByOptimizedIterator {
                             state = aggregator.apply(ramAccounting, doc, state);
                             states[i] = state;
                         }
-                        accountForNewKeyEntry.accept(key, states);
+                        accountForNewKeyEntry.accept(statesByKey, key, states);
                         statesByKey.put(key, states);
                     } else {
                         for (int i = 0; i < aggregators.size(); i++) {

--- a/server/src/test/java/io/crate/execution/engine/aggregation/GroupingCollectorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/GroupingCollectorTest.java
@@ -26,7 +26,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import org.elasticsearch.Version;
@@ -81,7 +80,7 @@ public class GroupingCollectorTest {
             DataTypes.LONG
         );
 
-        Map<Object, Object[]> statesByKey = new HashMap<>();
+        ResizeAwareMap<Object, Object[]> statesByKey = GroupByMaps.wrapperForJDKMap(new HashMap<>());
         collector.addNewEntry(statesByKey, 1L);
 
         assertThat(ramAccounting.totalBytes()).isEqualTo(112L);
@@ -118,7 +117,7 @@ public class GroupingCollectorTest {
             DataTypes.LONG
         );
 
-        Map<Object, Object[]> statesByKey = new HashMap<>();
+        ResizeAwareMap<Object, Object[]> statesByKey = GroupByMaps.wrapperForJDKMap(new HashMap<>());
         collector.reduce(statesByKey, new Row1(1L));
 
         assertThat(ramAccounting.totalBytes()).isEqualTo(88L);

--- a/server/src/test/java/io/crate/execution/engine/aggregation/GroupingCollectorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/GroupingCollectorTest.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.execution.engine.aggregation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.common.settings.Settings;
+import org.junit.Test;
+
+import io.crate.data.Input;
+import io.crate.data.Row1;
+import io.crate.execution.engine.aggregation.impl.MinimumAggregation;
+import io.crate.execution.engine.collect.CollectExpression;
+import io.crate.execution.engine.collect.RowCollectExpression;
+import io.crate.expression.symbol.AggregateMode;
+import io.crate.expression.symbol.Literal;
+import io.crate.metadata.FunctionType;
+import io.crate.metadata.Functions;
+import io.crate.metadata.Scalar;
+import io.crate.metadata.functions.Signature;
+import io.crate.metadata.settings.session.SessionSettingRegistry;
+import io.crate.testing.PlainRamAccounting;
+import io.crate.types.DataTypes;
+
+public class GroupingCollectorTest {
+
+    @Test
+    public void test_addNewEntry_accounts_for_shallow_size_of_states_array() {
+        RowCollectExpression keyInput = new RowCollectExpression(0);
+        List<Input<?>> keyInputs = Collections.singletonList(keyInput);
+        CollectExpression[] collectExpressions = new CollectExpression[]{keyInput};
+
+        Functions functions = Functions.load(Settings.EMPTY, new SessionSettingRegistry(Set.of()));
+        MinimumAggregation min = (MinimumAggregation) functions.getQualified(
+            Signature.builder(MinimumAggregation.NAME, FunctionType.AGGREGATE)
+                .argumentTypes(DataTypes.LONG.getTypeSignature())
+                .returnType(DataTypes.LONG.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC)
+                .build(),
+            List.of(DataTypes.LONG),
+            DataTypes.LONG
+        );
+
+        PlainRamAccounting ramAccounting = new PlainRamAccounting(-1);;
+        var collector = GroupingCollector.singleKey(
+            collectExpressions,
+            AggregateMode.ITER_FINAL,
+            new AggregationFunction[] { min },
+            new Input[][] { new Input[] { keyInput }},
+            new Input[] { Literal.BOOLEAN_TRUE },
+            ramAccounting,
+            null, // memoryManager is unused
+            Version.CURRENT,
+            keyInputs.get(0),
+            DataTypes.LONG
+        );
+
+        Map<Object, Object[]> statesByKey = new HashMap<>();
+        collector.addNewEntry(statesByKey, 1L);
+
+        assertThat(ramAccounting.totalBytes()).isEqualTo(112L);
+    }
+
+    @Test
+    public void test_reduce_accounts_for_shallow_size_of_states_array() {
+        RowCollectExpression keyInput = new RowCollectExpression(0);
+        List<Input<?>> keyInputs = Collections.singletonList(keyInput);
+        CollectExpression[] collectExpressions = new CollectExpression[]{keyInput};
+
+        Functions functions = Functions.load(Settings.EMPTY, new SessionSettingRegistry(Set.of()));
+        MinimumAggregation min = (MinimumAggregation) functions.getQualified(
+            Signature.builder(MinimumAggregation.NAME, FunctionType.AGGREGATE)
+                .argumentTypes(DataTypes.LONG.getTypeSignature())
+                .returnType(DataTypes.LONG.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC)
+                .build(),
+            List.of(DataTypes.LONG),
+            DataTypes.LONG
+        );
+
+        PlainRamAccounting ramAccounting = new PlainRamAccounting(-1);;
+        var collector = GroupingCollector.singleKey(
+            collectExpressions,
+            AggregateMode.ITER_FINAL,
+            new AggregationFunction[] { min },
+            new Input[][] { new Input[] { keyInput }},
+            new Input[] { Literal.BOOLEAN_TRUE },
+            ramAccounting,
+            null, // memoryManager is unused
+            Version.CURRENT,
+            keyInputs.get(0),
+            DataTypes.LONG
+        );
+
+        Map<Object, Object[]> statesByKey = new HashMap<>();
+        collector.reduce(statesByKey, new Row1(1L));
+
+        assertThat(ramAccounting.totalBytes()).isEqualTo(88L);
+    }
+
+
+
+}

--- a/server/src/test/java/io/crate/execution/engine/aggregation/ResizeAwareMapTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/ResizeAwareMapTest.java
@@ -41,10 +41,10 @@ public class ResizeAwareMapTest {
         ResizeAwareMap<Integer, Integer> map = new ResizeAwareMap<>(delegate, capacity, loadFactor, false);
 
         for (int i = 0; i < threshold; i++) {
-            assertThat(map.expectedCapacityIncrease(1)).isEqualTo(0);
+            assertThat(map.expectedCapacityIncrease()).isEqualTo(0);
             map.put(i, i);
         }
-        assertThat(map.expectedCapacityIncrease(1)).isEqualTo(capacity);
+        assertThat(map.expectedCapacityIncrease()).isEqualTo(capacity);
     }
 
     @Test
@@ -53,33 +53,10 @@ public class ResizeAwareMapTest {
         ResizeAwareMap<Integer, Integer> map = new ResizeAwareMap<>(delegate, 5, 0.75f, false);
         // 5 is rounded up to 8, hence threshold is 8*0.75 = 6
         for (int i = 0; i < 6; i++) {
-            assertThat(map.expectedCapacityIncrease(1)).isEqualTo(0);
+            assertThat(map.expectedCapacityIncrease()).isEqualTo(0);
             map.put(i, i);
         }
-        assertThat(map.expectedCapacityIncrease(1)).isEqualTo(8);
-    }
-
-    @Test
-    public void test_putAll_tracks_growth() {
-        Map<Integer, Integer> delegate = new HashMap<>();
-        float loadFactor = 0.75f;
-        ResizeAwareMap<Integer, Integer> map = new ResizeAwareMap<>(delegate, 4, loadFactor, false);
-
-        Map<Integer, Integer> bulk = new HashMap<>();
-        bulk.put(1, 1);
-        bulk.put(2, 2);
-        bulk.put(3, 3);
-        bulk.put(4, 4);
-        map.putAll(bulk);
-
-        int expectedNewCapacity = 8;
-        assertThat(map.currentCapacity()).isEqualTo(expectedNewCapacity);
-        int threshold = (int) (expectedNewCapacity * loadFactor);
-        for (int i = 0; i < threshold; i++) {
-            assertThat(map.expectedCapacityIncrease(1)).isEqualTo(0);
-            map.put(i, i);
-        }
-        assertThat(map.expectedCapacityIncrease(1)).isEqualTo(expectedNewCapacity);
+        assertThat(map.expectedCapacityIncrease()).isEqualTo(8);
     }
 
     @Test
@@ -91,9 +68,9 @@ public class ResizeAwareMapTest {
         ResizeAwareMap<Integer, Integer> map = new ResizeAwareMap<>(delegate, capacity, loadFactor, false);
 
         for (int i = 0; i < threshold + 1; i++) {
-            map.expectedCapacityIncrease(1);
+            map.expectedCapacityIncrease();
         }
-        // We did threshold + 1 calls, but actual capacity didn't cahnge without put calls.
+        // We did threshold + 1 calls, but actual capacity didn't change without put calls.
         assertThat(map.currentCapacity()).isEqualTo(capacity);
     }
 
@@ -105,6 +82,28 @@ public class ResizeAwareMapTest {
         when(delegate.size()).thenReturn(Integer.MAX_VALUE - 1);
 
         ResizeAwareMap<Integer, Integer> map = new ResizeAwareMap<>(delegate, maximumCapacity, 0.75f, false);
-        assertThat(map.expectedCapacityIncrease(1)).isEqualTo(0);
+        assertThat(map.expectedCapacityIncrease()).isEqualTo(0);
+    }
+
+    @Test
+    public void test_put_with_duplicate_key_does_no_resize() {
+        Map<Integer, Integer> delegate = new HashMap<>();
+        int capacity = 4;
+        float loadFactor = 0.75f;
+        int threshold = (int) (capacity * loadFactor);
+        ResizeAwareMap<Integer, Integer> map = new ResizeAwareMap<>(delegate, capacity, loadFactor, false);
+
+        // Bringing to the point where it's about to resize.
+        for (int i = 0; i < threshold; i++) {
+            map.put(i, i);
+        }
+        assertThat(map.size()).isEqualTo(threshold);
+        assertThat(map.currentCapacity()).isEqualTo(capacity);
+
+        // Next put() calls with duplicate keys won't trigger resize.
+        for (int i = 0; i < 3; i++) {
+            map.put(i, i);
+            assertThat(map.currentCapacity()).isEqualTo(capacity);
+        }
     }
 }

--- a/server/src/test/java/io/crate/execution/engine/aggregation/ResizeAwareMapTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/ResizeAwareMapTest.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.execution.engine.aggregation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+public class ResizeAwareMapTest {
+
+    @Test
+    public void test_put_initial_capacity_power_of_two() {
+        Map<Integer, Integer> delegate = new HashMap<>();
+        int capacity = 4;
+        float loadFactor = 0.75f;
+        int threshold = (int) (capacity * loadFactor);
+        ResizeAwareMap<Integer, Integer> map = new ResizeAwareMap<>(delegate, capacity, loadFactor, false);
+
+        for (int i = 0; i < threshold; i++) {
+            assertThat(map.expectedCapacityIncrease(1)).isEqualTo(0);
+            map.put(i, i);
+        }
+        assertThat(map.expectedCapacityIncrease(1)).isEqualTo(capacity);
+    }
+
+    @Test
+    public void test_put_initial_capacity_is_rounded_up_to_the_next_power_of_two() {
+        Map<Integer, Integer> delegate = new HashMap<>();
+        ResizeAwareMap<Integer, Integer> map = new ResizeAwareMap<>(delegate, 5, 0.75f, false);
+        // 5 is rounded up to 8, hence threshold is 8*0.75 = 6
+        for (int i = 0; i < 6; i++) {
+            assertThat(map.expectedCapacityIncrease(1)).isEqualTo(0);
+            map.put(i, i);
+        }
+        assertThat(map.expectedCapacityIncrease(1)).isEqualTo(8);
+    }
+
+    @Test
+    public void test_putAll_tracks_growth() {
+        Map<Integer, Integer> delegate = new HashMap<>();
+        float loadFactor = 0.75f;
+        ResizeAwareMap<Integer, Integer> map = new ResizeAwareMap<>(delegate, 4, loadFactor, false);
+
+        Map<Integer, Integer> bulk = new HashMap<>();
+        bulk.put(1, 1);
+        bulk.put(2, 2);
+        bulk.put(3, 3);
+        bulk.put(4, 4);
+        map.putAll(bulk);
+
+        int expectedNewCapacity = 8;
+        assertThat(map.currentCapacity()).isEqualTo(expectedNewCapacity);
+        int threshold = (int) (expectedNewCapacity * loadFactor);
+        for (int i = 0; i < threshold; i++) {
+            assertThat(map.expectedCapacityIncrease(1)).isEqualTo(0);
+            map.put(i, i);
+        }
+        assertThat(map.expectedCapacityIncrease(1)).isEqualTo(expectedNewCapacity);
+    }
+
+    @Test
+    public void test_expectedCapacityIncrease_does_not_mutate_state() {
+        Map<Integer, Integer> delegate = new HashMap<>();
+        int capacity = 4;
+        float loadFactor = 0.75f;
+        int threshold = (int) (capacity * loadFactor);
+        ResizeAwareMap<Integer, Integer> map = new ResizeAwareMap<>(delegate, capacity, loadFactor, false);
+
+        for (int i = 0; i < threshold + 1; i++) {
+            map.expectedCapacityIncrease(1);
+        }
+        // We did threshold + 1 calls, but actual capacity didn't cahnge without put calls.
+        assertThat(map.currentCapacity()).isEqualTo(capacity);
+    }
+
+    @Test
+    public void test_capacity_growth_stops_at_maximum_capacity() {
+        int maximumCapacity = 1 << 30;
+        @SuppressWarnings("unchecked")
+        Map<Integer, Integer> delegate = mock(Map.class);
+        when(delegate.size()).thenReturn(Integer.MAX_VALUE - 1);
+
+        ResizeAwareMap<Integer, Integer> map = new ResizeAwareMap<>(delegate, maximumCapacity, 0.75f, false);
+        assertThat(map.expectedCapacityIncrease(1)).isEqualTo(0);
+    }
+}

--- a/server/src/test/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIteratorTest.java
@@ -368,7 +368,7 @@ public class DocValuesGroupByOptimizedIteratorTest extends CrateDummyClusterServ
             null,
             null,
             null,
-            (states, key) -> {
+            (_, states, key) -> {
             },
             (expressions) -> expressions.get(0).value(),
             (key, cells) -> cells[0] = key,

--- a/server/src/test/java/io/crate/integrationtests/GroupByAggregateBreakerTest.java
+++ b/server/src/test/java/io/crate/integrationtests/GroupByAggregateBreakerTest.java
@@ -46,6 +46,6 @@ public class GroupByAggregateBreakerTest extends IntegTestCase {
         Asserts.assertSQLError(() -> execute("select region, count(*) from sys.summits group by 1"))
             .hasPGError(INTERNAL_ERROR)
             .hasHTTPError(INTERNAL_SERVER_ERROR, 5000)
-            .hasMessageContaining("Allocating 112b for 'collect: 0' failed, breaker would use 280b in total. Limit is 256b. Either increase memory and limit, change the query or reduce concurrent query load");
+            .hasMessageContaining("Allocating 112b for 'collect: 0' failed, breaker would use 304b in total. Limit is 256b. Either increase memory and limit, change the query or reduce concurrent query load");
     }
 }


### PR DESCRIPTION
In case of big number of aggregations in a query that happens to return many groups, shallow size can contribute a lot.

And underaccounting becomes even more significant
if query with many aggregations is in a CTE that is referenced many times in another query, for example

SELECT ... from CTE
UNION ALL
SELECT ... from CTE

Relates to https://github.com/crate/support/issues/911
I checked locally - without the fix I get OOM, and get CBE with it.
