### PR TITLE
Use table OIDs to isolate DROP TABLE from concurrent SWAP TABLE

### DIFF
--- a/docs/appendices/release-notes/6.5.0.rst
+++ b/docs/appendices/release-notes/6.5.0.rst
@@ -139,7 +139,8 @@ Performance and Resilience Improvements
   performance by caching analyzed ``ViewInfo`` instances, reducing repeated
   analysis of view definitions when accessing ``information_schema`` views.
 
-- Improved :ref:`DELETE <sql_reference_delete>` such that concurrent
+- Improved :ref:`DELETE <sql_reference_delete>` and
+  :ref:`DROP TABLE <drop-table>` such that concurrent
   :ref:`SWAP TABLE <alter_cluster_swap_table>` cannot affect a ``DELETE``
   already in progress.
 

--- a/server/src/main/java/io/crate/analyze/AnalyzedDropTable.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedDropTable.java
@@ -31,10 +31,12 @@ public final class AnalyzedDropTable<T extends TableInfo> implements DDLStatemen
 
     private final boolean dropIfExists;
     private final RelationName tableName;
+    private final int tableOid;
 
-    AnalyzedDropTable(boolean dropIfExists, RelationName tableName) {
+    AnalyzedDropTable(boolean dropIfExists, RelationName tableName, int tableOid) {
         this.dropIfExists = dropIfExists;
         this.tableName = tableName;
+        this.tableOid = tableOid;
     }
 
 
@@ -44,6 +46,10 @@ public final class AnalyzedDropTable<T extends TableInfo> implements DDLStatemen
 
     public RelationName tableName() {
         return tableName;
+    }
+
+    public int tableOid() {
+        return tableOid;
     }
 
     @Override

--- a/server/src/main/java/io/crate/analyze/DropTableAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/DropTableAnalyzer.java
@@ -21,6 +21,8 @@
 
 package io.crate.analyze;
 
+import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
+
 import java.util.List;
 
 import org.apache.logging.log4j.LogManager;
@@ -73,6 +75,7 @@ class DropTableAnalyzer {
                                                                boolean dropIfExists,
                                                                CoordinatorSessionSettings sessionSettings) {
         RelationName tableName;
+        int tableOid = OID_UNASSIGNED;
         try {
             TableInfo tableInfo = schemas.findRelation(
                 name,
@@ -81,6 +84,7 @@ class DropTableAnalyzer {
                 sessionSettings.searchPath()
             );
             tableName = tableInfo.ident();
+            tableOid = tableInfo.oid();
         } catch (SchemaUnknownException | RelationUnknown e) {
             tableName = RelationName.of(name, sessionSettings.searchPath().currentSchema());
             var metadata = clusterService.state().metadata();
@@ -101,6 +105,6 @@ class DropTableAnalyzer {
                 t
             );
         }
-        return new AnalyzedDropTable<>(dropIfExists, tableName);
+        return new AnalyzedDropTable<>(dropIfExists, tableName, tableOid);
     }
 }

--- a/server/src/main/java/io/crate/execution/ddl/tables/DropTableRequest.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/DropTableRequest.java
@@ -21,6 +21,8 @@
 
 package io.crate.execution.ddl.tables;
 
+import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
+
 import java.io.IOException;
 
 import org.elasticsearch.Version;
@@ -33,18 +35,29 @@ import io.crate.metadata.RelationName;
 public class DropTableRequest extends AcknowledgedRequest<DropTableRequest> {
 
     private final RelationName relationName;
+    private final int tableOid;
 
-    public DropTableRequest(RelationName relationName) {
+    public DropTableRequest(RelationName relationName, int tableOid) {
         this.relationName = relationName;
+        this.tableOid = tableOid;
     }
 
     public RelationName tableIdent() {
         return relationName;
     }
 
+    public int tableOid() {
+        return tableOid;
+    }
+
     public DropTableRequest(StreamInput in) throws IOException {
         super(in);
         relationName = new RelationName(in);
+        if (in.getVersion().onOrAfter(Version.V_6_5_0)) {
+            tableOid = in.readVInt();
+        } else {
+            tableOid = OID_UNASSIGNED;
+        }
         if (in.getVersion().before(Version.V_5_8_0)) {
             in.readBoolean(); // isPartitioned
         }
@@ -54,6 +67,9 @@ public class DropTableRequest extends AcknowledgedRequest<DropTableRequest> {
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         relationName.writeTo(out);
+        if (out.getVersion().onOrAfter(Version.V_6_5_0)) {
+            out.writeVInt(tableOid);
+        }
         if (out.getVersion().before(Version.V_5_8_0)) {
             // sets isPartitioned to true,
             // which if wrong shouldn't cause much harm, as it will only result in a

--- a/server/src/main/java/io/crate/metadata/cluster/DropTableClusterStateTaskExecutor.java
+++ b/server/src/main/java/io/crate/metadata/cluster/DropTableClusterStateTaskExecutor.java
@@ -21,9 +21,10 @@
 
 package io.crate.metadata.cluster;
 
+import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
+
 import java.util.Collection;
 import java.util.List;
-
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
@@ -47,20 +48,40 @@ public class DropTableClusterStateTaskExecutor extends DDLClusterStateTaskExecut
 
     @Override
     protected ClusterState execute(ClusterState currentState, DropTableRequest request) throws Exception {
+        Metadata.Builder newMetadata;
+        Collection<Index> indices;
+        int tableOid = request.tableOid();
         RelationName relationName = request.tableIdent();
-        Metadata currentMetadata = currentState.metadata();
 
-        if (!currentMetadata.contains(relationName)) {
-            throw new RelationUnknown(relationName);
+        if (tableOid == OID_UNASSIGNED) {
+            Metadata currentMetadata = currentState.metadata();
+            if (!currentMetadata.contains(relationName)) {
+                throw new RelationUnknown(relationName);
+            }
+
+            indices = currentMetadata.getIndices(
+                relationName,
+                List.of(),
+                false,
+                IndexMetadata::getIndex
+            );
+            newMetadata = Metadata.builder(currentMetadata)
+                .dropRelation(relationName);
+        } else {
+            Metadata currentMetadata = currentState.metadata();
+
+            indices = currentMetadata.getIndices(
+                tableOid,
+                List.of(),
+                false,
+                IndexMetadata::getIndex
+            );
+            newMetadata = Metadata.builder(currentMetadata)
+                .dropRelation(tableOid);
+
+            // relationName may be different from request.tableIdent if swap/rename applied along the way
+            relationName = currentMetadata.getRelationName(tableOid);
         }
-        Collection<Index> indices = currentMetadata.getIndices(
-            relationName,
-            List.of(),
-            false,
-            IndexMetadata::getIndex
-        );
-        Metadata.Builder newMetadata = Metadata.builder(currentMetadata)
-            .dropRelation(relationName);
 
         currentState = ClusterState.builder(currentState)
             .metadata(newMetadata)

--- a/server/src/main/java/io/crate/planner/node/ddl/DropTablePlan.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/DropTablePlan.java
@@ -71,7 +71,7 @@ public class DropTablePlan implements Plan {
                               RowConsumer consumer,
                               Row params,
                               SubQueryResults subQueryResults) {
-        var request = new DropTableRequest(dropTable.tableName());
+        var request = new DropTableRequest(dropTable.tableName(), dropTable.tableOid());
         dependencies.client().execute(TransportDropTable.ACTION, request).whenComplete((response, err) -> {
             if (err == null) {
                 if (!response.isAcknowledged() && LOGGER.isWarnEnabled()) {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -997,6 +997,17 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata> {
             return this;
         }
 
+        public Builder dropRelation(int tableOID) {
+            RelationName relationName = null;
+            for (RelationMetadata relationMetadata : relations()) {
+                if (relationMetadata.oid() == tableOID) {
+                    relationName = relationMetadata.name();
+                    break;
+                }
+            }
+            return relationName == null ? this : dropRelation(relationName);
+        }
+
         @Nullable
         public <T extends RelationMetadata> T getRelation(RelationName relation) {
             return Metadata.getRelation(relation, schemas::get);

--- a/server/src/test/java/io/crate/execution/ddl/tables/DropTableRequestTest.java
+++ b/server/src/test/java/io/crate/execution/ddl/tables/DropTableRequestTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.execution.ddl.tables;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.junit.Test;
+
+import io.crate.metadata.RelationName;
+
+public class DropTableRequestTest {
+
+    @Test
+    public void test_streaming_table_oids() throws Exception {
+        // streaming to nodes with supported versions
+        RelationName relation = new RelationName("doc", "tbl");
+        int tableOid = 1234;
+        DropTableRequest request = new DropTableRequest(relation, tableOid);
+
+        var out = new BytesStreamOutput();
+        out.setVersion(Version.V_6_5_0);
+        request.writeTo(out);
+
+        var in = out.bytes().streamInput();
+        in.setVersion(Version.V_6_5_0);
+        DropTableRequest streamed = new DropTableRequest(in);
+
+        assertThat(streamed.tableOid()).isEqualTo(tableOid);
+
+        // streaming to nodes with unsupported versions
+        relation = new RelationName("doc", "tbl");
+        request = new DropTableRequest(relation, 1234);
+
+        out = new BytesStreamOutput();
+        out.setVersion(Version.V_6_4_0);
+        request.writeTo(out);
+
+        in = out.bytes().streamInput();
+        in.setVersion(Version.V_6_4_0);
+        streamed = new DropTableRequest(in);
+
+        assertThat(streamed.tableOid()).isEqualTo(OID_UNASSIGNED);
+    }
+}

--- a/server/src/test/java/io/crate/integrationtests/PartitionedTableConcurrentIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/PartitionedTableConcurrentIntegrationTest.java
@@ -55,6 +55,8 @@ import org.elasticsearch.test.IntegTestCase;
 import org.junit.After;
 import org.junit.Test;
 
+import com.carrotsearch.randomizedtesting.annotations.Repeat;
+
 import io.crate.common.unit.TimeValue;
 import io.crate.data.Bucket;
 import io.crate.data.CollectionBucket;
@@ -659,5 +661,65 @@ public class PartitionedTableConcurrentIntegrationTest extends IntegTestCase {
             return;
         }
         fail("The test failed to complete a successful interleaving of swap with delete");
+    }
+
+    @Repeat(iterations = 30)
+    @Test
+    public void test_concurrent_table_swaps_with_drop() throws Exception {
+        for (int retry = 0; retry < 10; retry++) {
+            execute("drop table if exists t1");
+            execute("drop table if exists t2");
+            execute("create table t1 (p int) partitioned by (p)");
+            execute("create table t2 (p int)");
+            execute("insert into t1 values (1), (2)");
+            execute("insert into t2 values (3), (4)");
+            execute("refresh table t1, t2");
+
+            final AtomicReference<Throwable> dropError = new AtomicReference<>();
+            final AtomicReference<Throwable> swapError = new AtomicReference<>();
+            final CyclicBarrier barrier = new CyclicBarrier(2);
+
+            Thread t1 = new Thread(() -> {
+                try {
+                    barrier.await();
+                    execute("drop table t2");
+                } catch (Throwable e) {
+                    dropError.set(e);
+                }
+            });
+
+            Thread t2 = new Thread(() -> {
+                try {
+                    barrier.await();
+                    execute("ALTER CLUSTER SWAP TABLE t1 TO t2");
+                } catch (Throwable e) {
+                    swapError.set(e);
+                }
+            });
+
+            t1.start();
+            t2.start();
+
+            t1.join();
+            t2.join();
+
+            // SWAP failed because the table was dropped too early
+            if (swapError.get() != null) {
+                System.out.println(swapError.get().getMessage());
+                continue;
+            }
+            assertThat(dropError.get()).isNull();
+
+            execute("select distinct table_name from sys.shards where schema_name = 'doc' and table_name = 't2'");
+            if (response.rowCount() > 0) {
+                // DROP TABLE was analyzed after SWAP TABLE and dropped the original t1.
+                continue;
+            }
+
+            execute("select * from t2 order by p");
+            assertThat(response).hasRows("1", "2");
+            return;
+        }
+        fail("The test failed to complete a successful interleaving of swap with drop");
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/PartitionedTableConcurrentIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/PartitionedTableConcurrentIntegrationTest.java
@@ -55,8 +55,6 @@ import org.elasticsearch.test.IntegTestCase;
 import org.junit.After;
 import org.junit.Test;
 
-import com.carrotsearch.randomizedtesting.annotations.Repeat;
-
 import io.crate.common.unit.TimeValue;
 import io.crate.data.Bucket;
 import io.crate.data.CollectionBucket;
@@ -661,65 +659,5 @@ public class PartitionedTableConcurrentIntegrationTest extends IntegTestCase {
             return;
         }
         fail("The test failed to complete a successful interleaving of swap with delete");
-    }
-
-    @Repeat(iterations = 30)
-    @Test
-    public void test_concurrent_table_swaps_with_drop() throws Exception {
-        for (int retry = 0; retry < 10; retry++) {
-            execute("drop table if exists t1");
-            execute("drop table if exists t2");
-            execute("create table t1 (p int) partitioned by (p)");
-            execute("create table t2 (p int)");
-            execute("insert into t1 values (1), (2)");
-            execute("insert into t2 values (3), (4)");
-            execute("refresh table t1, t2");
-
-            final AtomicReference<Throwable> dropError = new AtomicReference<>();
-            final AtomicReference<Throwable> swapError = new AtomicReference<>();
-            final CyclicBarrier barrier = new CyclicBarrier(2);
-
-            Thread t1 = new Thread(() -> {
-                try {
-                    barrier.await();
-                    execute("drop table t2");
-                } catch (Throwable e) {
-                    dropError.set(e);
-                }
-            });
-
-            Thread t2 = new Thread(() -> {
-                try {
-                    barrier.await();
-                    execute("ALTER CLUSTER SWAP TABLE t1 TO t2");
-                } catch (Throwable e) {
-                    swapError.set(e);
-                }
-            });
-
-            t1.start();
-            t2.start();
-
-            t1.join();
-            t2.join();
-
-            // SWAP failed because the table was dropped too early
-            if (swapError.get() != null) {
-                System.out.println(swapError.get().getMessage());
-                continue;
-            }
-            assertThat(dropError.get()).isNull();
-
-            execute("select distinct table_name from sys.shards where schema_name = 'doc' and table_name = 't2'");
-            if (response.rowCount() > 0) {
-                // DROP TABLE was analyzed after SWAP TABLE and dropped the original t1.
-                continue;
-            }
-
-            execute("select * from t2 order by p");
-            assertThat(response).hasRows("1", "2");
-            return;
-        }
-        fail("The test failed to complete a successful interleaving of swap with drop");
     }
 }

--- a/server/src/testFixtures/java/org/elasticsearch/test/TestCluster.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/TestCluster.java
@@ -391,7 +391,7 @@ public final class TestCluster implements Closeable {
             for (var relation : infoSchema.relations()) {
                 if (relation.relationType() == RelationType.BASE_TABLE && relation instanceof SystemTable<?> == false) {
                     relationNames.add(relation.ident());
-                    futures.add(client().execute(TransportDropTable.ACTION, new DropTableRequest(relation.ident())));
+                    futures.add(client().execute(TransportDropTable.ACTION, new DropTableRequest(relation.ident(), Metadata.OID_UNASSIGNED)));
                 }
             }
             CompletableFuture<List<AcknowledgedResponse>> allResponses = CompletableFutures.allAsList(futures);


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

DROP now uses table OIDs instead of relying on relation names captured during analysis which could be stale due to concurrent SWAP TABLE.

Relates: https://github.com/crate/crate/pull/19851.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes.
       If you're an external contributor you can give yourself attribution and include your name and Github handle.
       e.g.:
       ```
       `John Doe <https://github.com/John_Doe>`_ added support for ...
       ```
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
