### PR TITLE
Use Welford's algorithm for stddev/variance aggregations

### DIFF
--- a/benchmarks/src/main/java/io/crate/execution/engine/aggregation/AggregateCollectorBenchmark.java
+++ b/benchmarks/src/main/java/io/crate/execution/engine/aggregation/AggregateCollectorBenchmark.java
@@ -53,6 +53,7 @@ import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.metadata.settings.session.SessionSettingRegistry;
+import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 
 
@@ -85,6 +86,7 @@ public class AggregateCollectorBenchmark {
             RamAccounting.NO_ACCOUNTING,
             memoryManager,
             Version.CURRENT,
+            new DataType[] { sumAggregation.partialType() },
             AggregateMode.ITER_FINAL,
             new AggregationFunction[] { sumAggregation },
             new Input[][] { {inExpr0 } },

--- a/benchmarks/src/main/java/io/crate/execution/engine/aggregation/GroupingLongCollectorBenchmark.java
+++ b/benchmarks/src/main/java/io/crate/execution/engine/aggregation/GroupingLongCollectorBenchmark.java
@@ -76,6 +76,7 @@ import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.metadata.settings.session.SessionSettingRegistry;
+import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import io.netty.util.collection.LongObjectHashMap;
 
@@ -143,6 +144,7 @@ public class GroupingLongCollectorBenchmark {
             RamAccounting.NO_ACCOUNTING,
             memoryManager,
             Version.CURRENT,
+            new DataType[] { sumAgg.partialType() },
             keyInputs.getFirst(),
             DataTypes.LONG
         );

--- a/benchmarks/src/main/java/io/crate/execution/engine/aggregation/GroupingStringCollectorBenchmark.java
+++ b/benchmarks/src/main/java/io/crate/execution/engine/aggregation/GroupingStringCollectorBenchmark.java
@@ -59,6 +59,7 @@ import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.metadata.settings.session.SessionSettingRegistry;
+import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 
 @BenchmarkMode(Mode.AverageTime)
@@ -112,6 +113,7 @@ public class GroupingStringCollectorBenchmark {
             RamAccounting.NO_ACCOUNTING,
             memoryManager,
             Version.CURRENT,
+            new DataType[] { minAgg.partialType() },
             keyInputs.get(0),
             DataTypes.STRING
         );

--- a/benchmarks/src/main/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregationBenchmark.java
+++ b/benchmarks/src/main/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregationBenchmark.java
@@ -61,6 +61,7 @@ import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.metadata.settings.session.SessionSettingRegistry;
+import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 
 @BenchmarkMode(Mode.AverageTime)
@@ -102,6 +103,7 @@ public class HyperLogLogDistinctAggregationBenchmark {
             RamAccounting.NO_ACCOUNTING,
             onHeapMemoryManager,
             Version.CURRENT,
+            new DataType[] { hllAggregation.partialType() },
             AggregateMode.ITER_FINAL,
             new AggregationFunction[] { hllAggregation },
             new Input[][] { { inExpr0 } },
@@ -112,6 +114,7 @@ public class HyperLogLogDistinctAggregationBenchmark {
             RamAccounting.NO_ACCOUNTING,
             offHeapMemoryManager,
             Version.CURRENT,
+            new DataType[] { hllAggregation.partialType() },
             AggregateMode.ITER_FINAL,
             new AggregationFunction[] { hllAggregation },
             new Input[][] { { inExpr0 } },

--- a/benchmarks/src/main/java/io/crate/operation/aggregation/IntervalAggregationBenchmark.java
+++ b/benchmarks/src/main/java/io/crate/operation/aggregation/IntervalAggregationBenchmark.java
@@ -61,6 +61,7 @@ import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.metadata.settings.session.SessionSettingRegistry;
+import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 
 @BenchmarkMode(Mode.AverageTime)
@@ -118,6 +119,7 @@ public class IntervalAggregationBenchmark {
             RamAccounting.NO_ACCOUNTING,
             onHeapMemoryManager,
             Version.CURRENT,
+            new DataType[] { intervalSumAggregation.partialType() },
             AggregateMode.ITER_FINAL,
             new AggregationFunction[] { intervalSumAggregation },
             new Input[][] { { inExpr0 } },
@@ -128,6 +130,7 @@ public class IntervalAggregationBenchmark {
             RamAccounting.NO_ACCOUNTING,
             onHeapMemoryManager,
             Version.CURRENT,
+            new DataType[] { intervalAvgAggregation.partialType() },
             AggregateMode.ITER_FINAL,
             new AggregationFunction[] { intervalAvgAggregation },
             new Input[][] { { inExpr0 } },

--- a/docs/appendices/release-notes/6.5.0.rst
+++ b/docs/appendices/release-notes/6.5.0.rst
@@ -136,7 +136,13 @@ Data Types
 Scalar and Aggregation Functions
 --------------------------------
 
-None
+- The :ref:`stddev_pop() <aggregation-stddev-pop>`, :ref:`stddev_samp()
+  <aggregation-stddev-samp>`, :ref:`stddev() <aggregation-stddev>` and
+  :ref:`variance() <aggregation-variance>` aggregations now use a numerically
+  stable algorithm, improving precision for large-magnitude inputs. The change
+  is transparent for rolling upgrades: while any node is still on an older
+  version the previous algorithm is used, and the new one takes over once all
+  nodes are on 6.5.0.
 
 Performance and Resilience Improvements
 ---------------------------------------

--- a/server/src/main/java/io/crate/execution/dsl/projection/builder/ProjectionBuilder.java
+++ b/server/src/main/java/io/crate/execution/dsl/projection/builder/ProjectionBuilder.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.UnaryOperator;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.settings.Settings;
 import org.jspecify.annotations.Nullable;
 
@@ -64,13 +65,15 @@ public class ProjectionBuilder {
                                                        Collection<Function> aggregates,
                                                        UnaryOperator<Symbol> subQueryAndParamBinder,
                                                        AggregateMode mode,
-                                                       RowGranularity granularity) {
+                                                       RowGranularity granularity,
+                                                       Version minNodeInCluster) {
         InputColumns.SourceSymbols sourceSymbols = new InputColumns.SourceSymbols(inputs);
         ArrayList<Aggregation> aggregations = getAggregations(
             aggregates,
             mode,
             sourceSymbols,
-            subQueryAndParamBinder
+            subQueryAndParamBinder,
+            minNodeInCluster
         );
         return new AggregationProjection(aggregations, granularity, mode);
     }
@@ -81,14 +84,16 @@ public class ProjectionBuilder {
         Collection<Function> values,
         UnaryOperator<Symbol> subQueryAndParamBinder,
         AggregateMode mode,
-        RowGranularity requiredGranularity) {
+        RowGranularity requiredGranularity,
+        Version minNodeInCluster) {
 
         InputColumns.SourceSymbols sourceSymbols = new InputColumns.SourceSymbols(inputs);
         ArrayList<Aggregation> aggregations = getAggregations(
             values,
             mode,
             sourceSymbols,
-            subQueryAndParamBinder
+            subQueryAndParamBinder,
+            minNodeInCluster
         );
         return new GroupProjection(
             Lists.map(InputColumns.create(keys, sourceSymbols), subQueryAndParamBinder),
@@ -101,7 +106,8 @@ public class ProjectionBuilder {
     private ArrayList<Aggregation> getAggregations(Collection<Function> functions,
                                                    AggregateMode mode,
                                                    InputColumns.SourceSymbols sourceSymbols,
-                                                   UnaryOperator<Symbol> subQueryAndParamBinder) {
+                                                   UnaryOperator<Symbol> subQueryAndParamBinder,
+                                                   Version minNodeInCluster) {
         ArrayList<Aggregation> aggregations = new ArrayList<>(functions.size());
         for (Function function : functions) {
             assert function.signature().getType() == FunctionType.AGGREGATE :
@@ -128,7 +134,8 @@ public class ProjectionBuilder {
 
                 case PARTIAL_FINAL:
                     InputColumn partialInput = sourceSymbols.getICForSource(function);
-                    aggregationInputs = List.of(new InputColumn(partialInput.index(), aggregationFunction.partialType()));
+                    aggregationInputs = List.of(
+                        new InputColumn(partialInput.index(), aggregationFunction.partialType(minNodeInCluster)));
                     filterInput = Literal.BOOLEAN_TRUE;
                     break;
 
@@ -136,7 +143,7 @@ public class ProjectionBuilder {
                     throw new AssertionError("Invalid mode: " + mode.name());
             }
 
-            var valueType = mode.returnType(aggregationFunction);
+            var valueType = mode.returnType(aggregationFunction, minNodeInCluster);
             Aggregation aggregation = new Aggregation(
                 aggregationFunction.signature(),
                 aggregationFunction.boundSignature().returnType(),

--- a/server/src/main/java/io/crate/execution/engine/aggregation/AggregateCollector.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/AggregateCollector.java
@@ -40,6 +40,7 @@ import io.crate.execution.engine.collect.CollectExpression;
 import io.crate.expression.InputCondition;
 import io.crate.expression.symbol.AggregateMode;
 import io.crate.memory.MemoryManager;
+import io.crate.types.DataType;
 
 /**
  * Collector implementation which uses {@link AggregationFunction}s to aggregate the rows it will receive.
@@ -56,11 +57,13 @@ public class AggregateCollector implements Collector<Row, Object[], Iterable<Row
     private final BiConsumer<Object[], Row> accumulator;
     private final Function<Object[], Iterable<Row>> finisher;
     private final Version minNodeVersion;
+    private final DataType<?>[] partialTypes;
 
     public AggregateCollector(List<? extends CollectExpression<Row, ?>> expressions,
                               RamAccounting ramAccounting,
                               MemoryManager memoryManager,
                               Version minNodeVersion,
+                              DataType<?>[] partialTypes,
                               AggregateMode mode,
                               AggregationFunction<?, ?>[] aggregations,
                               Input<?>[][] inputs,
@@ -69,6 +72,7 @@ public class AggregateCollector implements Collector<Row, Object[], Iterable<Row
         this.ramAccounting = ramAccounting;
         this.memoryManager = memoryManager;
         this.minNodeVersion = minNodeVersion;
+        this.partialTypes = partialTypes;
         this.aggregations = aggregations;
         this.filters = filters;
         this.inputs = inputs;
@@ -123,7 +127,7 @@ public class AggregateCollector implements Collector<Row, Object[], Iterable<Row
     private Object[] prepareState() {
         Object[] states = new Object[aggregations.length];
         for (int i = 0; i < aggregations.length; i++) {
-            states[i] = aggregations[i].newState(ramAccounting, minNodeVersion, memoryManager);
+            states[i] = aggregations[i].newState(ramAccounting, partialTypes[i], minNodeVersion, memoryManager);
         }
         return states;
     }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/AggregationContext.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/AggregationContext.java
@@ -24,23 +24,37 @@ package io.crate.execution.engine.aggregation;
 import java.util.List;
 
 import io.crate.data.Input;
+import io.crate.types.DataType;
 
 public final class AggregationContext {
 
     private final AggregationFunction impl;
     private final Input<Boolean> filter;
     private final Input<?>[] inputs;
+    private final DataType<?> partialType;
 
     public AggregationContext(AggregationFunction aggregationFunction,
                               Input<Boolean> filter,
-                              List<Input<?>> inputs) {
+                              List<Input<?>> inputs,
+                              DataType<?> partialType) {
         this.impl = aggregationFunction;
         this.filter = filter;
         this.inputs = inputs.toArray(new Input[0]);
+        this.partialType = partialType;
     }
 
     public AggregationFunction function() {
         return impl;
+    }
+
+    /**
+     * The partial-state type the plan chose for this aggregation (the type used to stream the partial
+     * state cluster-wide). Passed into {@link AggregationFunction#newState(io.crate.data.breaker.RamAccounting,
+     * DataType, org.elasticsearch.Version, io.crate.memory.MemoryManager)} so the accumulator layout follows
+     * the wire format rather than being re-derived from a local version.
+     */
+    public DataType<?> partialType() {
+        return partialType;
     }
 
     public Input<?>[] inputs() {

--- a/server/src/main/java/io/crate/execution/engine/aggregation/AggregationFunction.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/AggregationFunction.java
@@ -69,6 +69,25 @@ public abstract class AggregationFunction<TPartial, TFinal> implements FunctionI
                                       MemoryManager memoryManager);
 
     /**
+     * Variant of {@link #newState(RamAccounting, Version, MemoryManager)} that also receives the
+     * partial-state type the plan already picked for this aggregation. Aggregations whose
+     * partial-state layout changed between versions override this to build the state that matches
+     * {@code partialType} exactly, so the accumulator can never disagree with the streamed wire
+     * format (which is derived from the same {@link #partialType(Version)} at plan time). The
+     * default ignores {@code partialType} and delegates to the version-based variant.
+     *
+     * @param partialType the partial-state type chosen by the plan (the same type used to stream the
+     *                     partial state cluster-wide)
+     */
+    @Nullable
+    public TPartial newState(RamAccounting ramAccounting,
+                             DataType<?> partialType,
+                             Version minNodeInCluster,
+                             MemoryManager memoryManager) {
+        return newState(ramAccounting, minNodeInCluster, memoryManager);
+    }
+
+    /**
      * the "aggregate" function.
      *
      * @param ramAccounting used to account for additional memory usage if the state grows in size
@@ -100,6 +119,19 @@ public abstract class AggregationFunction<TPartial, TFinal> implements FunctionI
     public abstract TFinal terminatePartial(RamAccounting ramAccounting, TPartial state);
 
     public abstract DataType<?> partialType();
+
+    /**
+     * Version-aware variant of {@link #partialType()} used at plan time to pick the wire format of
+     * the streamed partial state. The default ignores the version and delegates to {@link
+     * #partialType()}. Aggregations whose partial-state layout changed between versions override
+     * this to return a backwards-compatible type while the cluster still contains older nodes, so
+     * that the choice stays consistent with {@link #newState(RamAccounting, Version, MemoryManager)}.
+     *
+     * @param minNodeInCluster the version of the oldest node in the cluster
+     */
+    public DataType<?> partialType(Version minNodeInCluster) {
+        return partialType();
+    }
 
     /**
      * Executing aggregations as window functions might require different runtime implementations in order to still be
@@ -145,6 +177,24 @@ public abstract class AggregationFunction<TPartial, TFinal> implements FunctionI
                                                        Version shardCreatedVersion,
                                                        List<Literal<?>> optionalParams) {
         return null;
+    }
+
+    /**
+     * Variant of {@link #getDocValueAggregator(LuceneReferenceResolver, List, DocTableInfo, Version, List)}
+     * that also receives the partial-state type the plan picked. Aggregations whose partial-state layout
+     * changed between versions override this so the doc-value produced partial matches the streamed wire
+     * format. The default ignores {@code partialStateType} and delegates.
+     *
+     * @param partialStateType the partial-state type chosen by the plan for this aggregation
+     */
+    @Nullable
+    public DocValueAggregator<?> getDocValueAggregator(LuceneReferenceResolver referenceResolver,
+                                                       List<Reference> aggregationReferences,
+                                                       DocTableInfo table,
+                                                       Version shardCreatedVersion,
+                                                       DataType<?> partialStateType,
+                                                       List<Literal<?>> optionalParams) {
+        return getDocValueAggregator(referenceResolver, aggregationReferences, table, shardCreatedVersion, optionalParams);
     }
 
 

--- a/server/src/main/java/io/crate/execution/engine/aggregation/AggregationPipe.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/AggregationPipe.java
@@ -34,6 +34,7 @@ import io.crate.data.breaker.RamAccounting;
 import io.crate.execution.engine.collect.CollectExpression;
 import io.crate.expression.symbol.AggregateMode;
 import io.crate.memory.MemoryManager;
+import io.crate.types.DataType;
 
 public class AggregationPipe implements Projector {
 
@@ -49,11 +50,13 @@ public class AggregationPipe implements Projector {
         AggregationFunction<?, ?>[] functions = new AggregationFunction[aggregations.length];
         Input<?>[][] inputs = new Input[aggregations.length][];
         Input[] filters = new Input[aggregations.length];
+        DataType<?>[] partialTypes = new DataType[aggregations.length];
         for (int i = 0; i < aggregations.length; i++) {
             AggregationContext aggregation = aggregations[i];
             functions[i] = aggregation.function();
             inputs[i] = aggregation.inputs();
             filters[i] = aggregation.filter();
+            partialTypes[i] = aggregation.partialType();
         }
 
         collector = new AggregateCollector(
@@ -61,6 +64,7 @@ public class AggregationPipe implements Projector {
             ramAccounting,
             memoryManager,
             minNodeVersion,
+            partialTypes,
             aggregateMode,
             functions,
             inputs,

--- a/server/src/main/java/io/crate/execution/engine/aggregation/GroupingCollector.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/GroupingCollector.java
@@ -70,6 +70,7 @@ public class GroupingCollector<K> implements Collector<Row, Map<K, Object[]>, It
     private final BiConsumer<Map<K, Object[]>, Row> accumulator;
     private final Supplier<Map<K, Object[]>> supplier;
     private final Version minNodeVersion;
+    private final DataType<?>[] partialTypes;
 
     static GroupingCollector<Object> singleKey(CollectExpression<Row, ?>[] expressions,
                                                AggregateMode mode,
@@ -79,6 +80,7 @@ public class GroupingCollector<K> implements Collector<Row, Map<K, Object[]>, It
                                                RamAccounting ramAccounting,
                                                MemoryManager memoryManager,
                                                Version minNodeVersion,
+                                               DataType<?>[] partialTypes,
                                                Input<?> keyInput,
                                                DataType keyType) {
         return new GroupingCollector<>(
@@ -90,6 +92,7 @@ public class GroupingCollector<K> implements Collector<Row, Map<K, Object[]>, It
             ramAccounting,
             memoryManager,
             minNodeVersion,
+            partialTypes,
             (key, cells) -> cells[0] = key,
             1,
             GroupByMaps.accountForNewEntry(ramAccounting, keyType),
@@ -106,6 +109,7 @@ public class GroupingCollector<K> implements Collector<Row, Map<K, Object[]>, It
                                                     RamAccounting ramAccountingContext,
                                                     MemoryManager memoryManager,
                                                     Version minNodeVersion,
+                                                    DataType<?>[] partialTypes,
                                                     List<Input<?>> keyInputs,
                                                     List<? extends DataType> keyTypes) {
         return new GroupingCollector<>(
@@ -117,6 +121,7 @@ public class GroupingCollector<K> implements Collector<Row, Map<K, Object[]>, It
             ramAccountingContext,
             memoryManager,
             minNodeVersion,
+            partialTypes,
             GroupingCollector::applyKeysToCells,
             keyInputs.size(),
             GroupByMaps.accountForNewEntry(ramAccountingContext, keyTypes),
@@ -147,6 +152,7 @@ public class GroupingCollector<K> implements Collector<Row, Map<K, Object[]>, It
                               RamAccounting ramAccounting,
                               MemoryManager memoryManager,
                               Version minNodeVersion,
+                              DataType<?>[] partialTypes,
                               BiConsumer<K, Object[]> applyKeyToCells,
                               int numKeyColumns,
                               TriConsumer<ResizeAwareMap<K, Object[]>, K, Object[]> accountForNewEntry,
@@ -166,6 +172,7 @@ public class GroupingCollector<K> implements Collector<Row, Map<K, Object[]>, It
         this.accumulator = mode == AggregateMode.PARTIAL_FINAL ? this::reduce : this::iter;
         this.supplier = supplier;
         this.minNodeVersion = minNodeVersion;
+        this.partialTypes = partialTypes;
     }
 
     @Override
@@ -245,7 +252,7 @@ public class GroupingCollector<K> implements Collector<Row, Map<K, Object[]>, It
         for (int i = 0; i < aggregations.length; i++) {
             AggregationFunction aggregation = aggregations[i];
 
-            var newState = aggregation.newState(ramAccounting, minNodeVersion, memoryManager);
+            var newState = aggregation.newState(ramAccounting, partialTypes[i], minNodeVersion, memoryManager);
             if (InputCondition.matches(filters[i])) {
                 //noinspection unchecked
                 states[i] = aggregation.iterate(ramAccounting, memoryManager, newState, inputs[i]);

--- a/server/src/main/java/io/crate/execution/engine/aggregation/GroupingProjector.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/GroupingProjector.java
@@ -38,6 +38,7 @@ import io.crate.execution.engine.collect.CollectExpression;
 import io.crate.expression.symbol.AggregateMode;
 import io.crate.expression.symbol.Symbol;
 import io.crate.memory.MemoryManager;
+import io.crate.types.DataType;
 
 public class GroupingProjector implements Projector {
 
@@ -58,11 +59,13 @@ public class GroupingProjector implements Projector {
         AggregationFunction<?, ?>[] functions = new AggregationFunction[aggregations.length];
         Input<?>[][] inputs = new Input[aggregations.length][];
         Input<Boolean>[] filters = new Input[aggregations.length];
+        DataType<?>[] partialTypes = new DataType[aggregations.length];
         for (int i = 0; i < aggregations.length; i++) {
             AggregationContext aggregation = aggregations[i];
             functions[i] = aggregation.function();
             inputs[i] = aggregation.inputs();
             filters[i] = aggregation.filter();
+            partialTypes[i] = aggregation.partialType();
         }
         if (keys.size() == 1) {
             Symbol key = keys.get(0);
@@ -75,6 +78,7 @@ public class GroupingProjector implements Projector {
                 ramAccounting,
                 memoryManager,
                 minNodeVersion,
+                partialTypes,
                 keyInputs.get(0),
                 key.valueType()
             );
@@ -88,6 +92,7 @@ public class GroupingProjector implements Projector {
                 ramAccounting,
                 memoryManager,
                 minNodeVersion,
+                partialTypes,
                 keyInputs,
                 typeView(keys)
             );

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/StandardDeviationAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/StandardDeviationAggregation.java
@@ -168,6 +168,7 @@ public abstract class StandardDeviationAggregation<V extends Variance> extends A
                                                        List<Reference> aggregationReferences,
                                                        DocTableInfo table,
                                                        Version shardCreatedVersion,
+                                                       DataType<?> partialStateType,
                                                        List<Literal<?>> optionalParams) {
         Reference reference = getAggReference(aggregationReferences);
         if (reference == null) {
@@ -179,7 +180,7 @@ public abstract class StandardDeviationAggregation<V extends Variance> extends A
                      reference.storageIdent(),
                      (ramAccounting, memoryManager, version) -> {
                          ramAccounting.addBytes(V.fixedSize());
-                         return newState(ramAccounting, version, memoryManager);
+                         return newState(ramAccounting, partialStateType, version, memoryManager);
                      },
                      (_, values, state) -> {
                          state.increment(values.nextValue());
@@ -190,7 +191,7 @@ public abstract class StandardDeviationAggregation<V extends Variance> extends A
                 reference.storageIdent(),
                 (ramAccounting, memoryManager, version) -> {
                     ramAccounting.addBytes(V.fixedSize());
-                    return newState(ramAccounting, version, memoryManager);
+                    return newState(ramAccounting, partialStateType, version, memoryManager);
                 },
                 (_, values, state) -> {
                     var value = NumericUtils.sortableIntToFloat((int) values.nextValue());
@@ -202,7 +203,7 @@ public abstract class StandardDeviationAggregation<V extends Variance> extends A
                 reference.storageIdent(),
                 (ramAccounting, memoryManager, version) -> {
                     ramAccounting.addBytes(V.fixedSize());
-                    return newState(ramAccounting, version, memoryManager);
+                    return newState(ramAccounting, partialStateType, version, memoryManager);
                 },
                 (_, values, state) -> {
                     var value = NumericUtils.sortableLongToDouble((values.nextValue()));

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/StandardDeviationPopAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/StandardDeviationPopAggregation.java
@@ -46,6 +46,7 @@ public class StandardDeviationPopAggregation extends StandardDeviationAggregatio
 
     static {
         DataTypes.register(StdDevPopStateType.ID, _ -> StdDevPopStateType.INSTANCE);
+        DataTypes.register(StdDevPopStateTypeWelford.ID, _ -> StdDevPopStateTypeWelford.INSTANCE);
     }
 
     private static final List<DataType<?>> SUPPORTED_TYPES = Lists.concat(
@@ -81,7 +82,28 @@ public class StandardDeviationPopAggregation extends StandardDeviationAggregatio
 
         @Override
         public StandardDeviationPop readValueFrom(StreamInput in) throws IOException {
-            return new StandardDeviationPop(in);
+            return new StandardDeviationPop(in, true);
+        }
+    }
+
+    public static class StdDevPopStateTypeWelford extends StdDevPopStateType {
+
+        public static final StdDevPopStateTypeWelford INSTANCE = new StdDevPopStateTypeWelford();
+        public static final int ID = 8196;
+
+        @Override
+        public int id() {
+            return ID;
+        }
+
+        @Override
+        public String getName() {
+            return "stddev_pop_state_welford";
+        }
+
+        @Override
+        public StandardDeviationPop readValueFrom(StreamInput in) throws IOException {
+            return new StandardDeviationPop(in, false);
         }
     }
 
@@ -91,7 +113,14 @@ public class StandardDeviationPopAggregation extends StandardDeviationAggregatio
 
     @Override
     public DataType<?> partialType() {
-        return new StdDevPopStateType();
+        return StdDevPopStateTypeWelford.INSTANCE;
+    }
+
+    @Override
+    public DataType<?> partialType(Version minNodeInCluster) {
+        return minNodeInCluster.before(Version.V_6_5_0)
+            ? StdDevPopStateType.INSTANCE
+            : StdDevPopStateTypeWelford.INSTANCE;
     }
 
     @Nullable
@@ -100,6 +129,19 @@ public class StandardDeviationPopAggregation extends StandardDeviationAggregatio
                                          Version minNodeInCluster,
                                          MemoryManager memoryManager) {
         ramAccounting.addBytes(StandardDeviationPop.fixedSize());
-        return new StandardDeviationPop();
+        // Local/window-only fallback; the streaming paths use the partialType-aware overload below.
+        return new StandardDeviationPop(minNodeInCluster.before(Version.V_6_5_0));
+    }
+
+    @Nullable
+    @Override
+    public StandardDeviationPop newState(RamAccounting ramAccounting,
+                                         DataType<?> partialType,
+                                         Version minNodeInCluster,
+                                         MemoryManager memoryManager) {
+        ramAccounting.addBytes(StandardDeviationPop.fixedSize());
+        // Follow the partial-state type the plan chose: StdDevPopStateType (id 8192) = legacy layout,
+        // StdDevPopStateTypeWelford (id 8196) = Welford layout. See #19885.
+        return new StandardDeviationPop(partialType.id() == StdDevPopStateType.ID);
     }
 }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/StandardDeviationSampAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/StandardDeviationSampAggregation.java
@@ -46,6 +46,7 @@ public class StandardDeviationSampAggregation extends StandardDeviationAggregati
 
     static {
         DataTypes.register(StdDevSampStateType.ID, _ -> StdDevSampStateType.INSTANCE);
+        DataTypes.register(StdDevSampStateTypeWelford.ID, _ -> StdDevSampStateTypeWelford.INSTANCE);
     }
 
     private static final List<DataType<?>> SUPPORTED_TYPES = Lists.concat(
@@ -83,7 +84,28 @@ public class StandardDeviationSampAggregation extends StandardDeviationAggregati
 
         @Override
         public StandardDeviationSamp readValueFrom(StreamInput in) throws IOException {
-            return new StandardDeviationSamp(in);
+            return new StandardDeviationSamp(in, true);
+        }
+    }
+
+    public static class StdDevSampStateTypeWelford extends StdDevSampStateType {
+
+        public static final StdDevSampStateTypeWelford INSTANCE = new StdDevSampStateTypeWelford();
+        public static final int ID = 8197;
+
+        @Override
+        public int id() {
+            return ID;
+        }
+
+        @Override
+        public String getName() {
+            return "stddev_sampl_state_welford";
+        }
+
+        @Override
+        public StandardDeviationSamp readValueFrom(StreamInput in) throws IOException {
+            return new StandardDeviationSamp(in, false);
         }
     }
 
@@ -93,7 +115,14 @@ public class StandardDeviationSampAggregation extends StandardDeviationAggregati
 
     @Override
     public DataType<?> partialType() {
-        return new StdDevSampStateType();
+        return StdDevSampStateTypeWelford.INSTANCE;
+    }
+
+    @Override
+    public DataType<?> partialType(Version minNodeInCluster) {
+        return minNodeInCluster.before(Version.V_6_5_0)
+            ? StdDevSampStateType.INSTANCE
+            : StdDevSampStateTypeWelford.INSTANCE;
     }
 
     @Nullable
@@ -102,6 +131,19 @@ public class StandardDeviationSampAggregation extends StandardDeviationAggregati
                                           Version minNodeInCluster,
                                           MemoryManager memoryManager) {
         ramAccounting.addBytes(StandardDeviationSamp.fixedSize());
-        return new StandardDeviationSamp();
+        // Local/window-only fallback; the streaming paths use the partialType-aware overload below.
+        return new StandardDeviationSamp(minNodeInCluster.before(Version.V_6_5_0));
+    }
+
+    @Nullable
+    @Override
+    public StandardDeviationSamp newState(RamAccounting ramAccounting,
+                                          DataType<?> partialType,
+                                          Version minNodeInCluster,
+                                          MemoryManager memoryManager) {
+        ramAccounting.addBytes(StandardDeviationSamp.fixedSize());
+        // Follow the partial-state type the plan chose: StdDevSampStateType (id 8193) = legacy layout,
+        // StdDevSampStateTypeWelford (id 8197) = Welford layout. See #19885.
+        return new StandardDeviationSamp(partialType.id() == StdDevSampStateType.ID);
     }
 }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/VarianceAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/VarianceAggregation.java
@@ -66,6 +66,7 @@ public class VarianceAggregation extends AggregationFunction<Variance, Double> {
 
     static {
         DataTypes.register(VarianceStateType.ID, _ -> VarianceStateType.INSTANCE);
+        DataTypes.register(VarianceStateTypeWelford.ID, _ -> VarianceStateTypeWelford.INSTANCE);
     }
 
     static final List<DataType<?>> SUPPORTED_TYPES = Lists.concat(
@@ -121,7 +122,7 @@ public class VarianceAggregation extends AggregationFunction<Variance, Double> {
 
         @Override
         public Variance readValueFrom(StreamInput in) throws IOException {
-            return new Variance(in);
+            return new Variance(in, true);
         }
 
         @Override
@@ -140,6 +141,31 @@ public class VarianceAggregation extends AggregationFunction<Variance, Double> {
         }
     }
 
+    /**
+     * State type for the Welford wire format (6.5+). Shares everything with the legacy
+     * {@link VarianceStateType} except the id/name and the {@code legacy} flag it reads states with.
+     */
+    public static class VarianceStateTypeWelford extends VarianceStateType {
+
+        public static final VarianceStateTypeWelford INSTANCE = new VarianceStateTypeWelford();
+        public static final int ID = 2049;
+
+        @Override
+        public int id() {
+            return ID;
+        }
+
+        @Override
+        public String getName() {
+            return "variance_state_welford";
+        }
+
+        @Override
+        public Variance readValueFrom(StreamInput in) throws IOException {
+            return new Variance(in, false);
+        }
+    }
+
     private final Signature signature;
     private final BoundSignature boundSignature;
 
@@ -154,7 +180,22 @@ public class VarianceAggregation extends AggregationFunction<Variance, Double> {
                              Version minNodeInCluster,
                              MemoryManager memoryManager) {
         ramAccounting.addBytes(VarianceStateType.INSTANCE.fixedSize());
-        return new Variance();
+        // Local/window-only fallback (state never streamed cross-node here); the streaming paths use
+        // the partialType-aware overload below. See #19760, #19885.
+        return new Variance(minNodeInCluster.before(Version.V_6_5_0));
+    }
+
+    @Nullable
+    @Override
+    public Variance newState(RamAccounting ramAccounting,
+                             DataType<?> partialType,
+                             Version minNodeInCluster,
+                             MemoryManager memoryManager) {
+        ramAccounting.addBytes(VarianceStateType.INSTANCE.fixedSize());
+        // Follow the partial-state type the plan already chose so the accumulator layout can never
+        // diverge from the streamed wire format: VarianceStateType (id 2048) = legacy naive layout,
+        // VarianceStateTypeWelford (id 2049) = Welford layout. See #19885.
+        return new Variance(partialType.id() == VarianceStateType.ID);
     }
 
     @Override
@@ -209,7 +250,14 @@ public class VarianceAggregation extends AggregationFunction<Variance, Double> {
 
     @Override
     public DataType<?> partialType() {
-        return VarianceStateType.INSTANCE;
+        return VarianceStateTypeWelford.INSTANCE;
+    }
+
+    @Override
+    public DataType<?> partialType(Version minNodeInCluster) {
+        return minNodeInCluster.before(Version.V_6_5_0)
+            ? VarianceStateType.INSTANCE
+            : VarianceStateTypeWelford.INSTANCE;
     }
 
     @Override
@@ -228,6 +276,7 @@ public class VarianceAggregation extends AggregationFunction<Variance, Double> {
                                                        List<Reference> aggregationReferences,
                                                        DocTableInfo table,
                                                        Version shardCreatedVersion,
+                                                       DataType<?> partialStateType,
                                                        List<Literal<?>> optionalParams) {
         Reference reference = getAggReference(aggregationReferences);
         if (reference == null) {
@@ -245,7 +294,7 @@ public class VarianceAggregation extends AggregationFunction<Variance, Double> {
                     reference.storageIdent(),
                     (ramAccounting, _, _) -> {
                         ramAccounting.addBytes(VarianceStateType.INSTANCE.fixedSize());
-                        return new Variance();
+                        return new Variance(partialStateType.id() == VarianceStateType.ID);
                     },
                     (_, values, state) -> state.increment(values.nextValue())
                 );
@@ -254,7 +303,7 @@ public class VarianceAggregation extends AggregationFunction<Variance, Double> {
                     reference.storageIdent(),
                     (ramAccounting, _, _) -> {
                         ramAccounting.addBytes(VarianceStateType.INSTANCE.fixedSize());
-                        return new Variance();
+                        return new Variance(partialStateType.id() == VarianceStateType.ID);
                     },
                     (_, values, state) -> {
                         var value = NumericUtils.sortableIntToFloat((int) values.nextValue());
@@ -266,7 +315,7 @@ public class VarianceAggregation extends AggregationFunction<Variance, Double> {
                     reference.storageIdent(),
                     (ramAccounting, _, _) -> {
                         ramAccounting.addBytes(VarianceStateType.INSTANCE.fixedSize());
-                        return new Variance();
+                        return new Variance(partialStateType.id() == VarianceStateType.ID);
                     },
                     (_, values, state) -> {
                         var value = NumericUtils.sortableLongToDouble((values.nextValue()));

--- a/server/src/main/java/io/crate/execution/engine/aggregation/statistics/StandardDeviationPop.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/statistics/StandardDeviationPop.java
@@ -31,8 +31,12 @@ public class StandardDeviationPop extends Variance {
     public StandardDeviationPop() {
     }
 
-    public StandardDeviationPop(StreamInput in) throws IOException {
-        super(in);
+    public StandardDeviationPop(boolean legacy) {
+        super(legacy);
+    }
+
+    public StandardDeviationPop(StreamInput in, boolean legacy) throws IOException {
+        super(in, legacy);
     }
 
     @Override

--- a/server/src/main/java/io/crate/execution/engine/aggregation/statistics/StandardDeviationSamp.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/statistics/StandardDeviationSamp.java
@@ -31,8 +31,12 @@ public class StandardDeviationSamp extends Variance {
     public StandardDeviationSamp() {
     }
 
-    public StandardDeviationSamp(StreamInput in) throws IOException {
-        super(in);
+    public StandardDeviationSamp(boolean legacy) {
+        super(legacy);
+    }
+
+    public StandardDeviationSamp(StreamInput in, boolean legacy) throws IOException {
+        super(in, legacy);
     }
 
     @Override

--- a/server/src/main/java/io/crate/execution/engine/aggregation/statistics/Variance.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/statistics/Variance.java
@@ -36,26 +36,50 @@ public class Variance implements Writeable, Comparable<Variance> {
         return FIXED_SIZE;
     }
 
-    private double sumOfSqrs;
-    private double sum;
+    /**
+     * The streamed partial state is always two IEEE-754 doubles plus a count, but the meaning of
+     * the two doubles depends on {@link #legacy}:
+     * <ul>
+     *   <li>legacy  (pre-6.5 wire format): {@code d1} = Σx² (sum of squares), {@code d2} = Σx (sum)</li>
+     *   <li>Welford (6.5+ wire format):    {@code d1} = running mean,         {@code d2} = M2 = Σ(x-mean)²</li>
+     * </ul>
+     * Welford's online algorithm never squares the raw values, so it avoids the catastrophic
+     * cancellation that produced a negative variance (and NULL standard deviations) for
+     * large-magnitude inputs. See #19760.
+     * <p>
+     * The naive layout is kept as a rolling-upgrade fallback: as long as any node in the cluster is
+     * older than 6.5.0 the partial state is streamed in the legacy layout so that pre-6.5 nodes
+     * (which only understand the naive layout) keep interoperating. The mode is chosen cluster-wide
+     * at plan time from the min node version and mirrored by {@code newState}, so both accumulators
+     * are never mixed within a single query. See #19885.
+     */
+    private final boolean legacy;
+    private double d1;
+    private double d2;
     private long count;
 
     public Variance() {
-        sumOfSqrs = 0.0;
-        sum = 0.0;
-        count = 0;
+        this(false);
     }
 
-    public Variance(StreamInput in) throws IOException {
-        sumOfSqrs = in.readDouble();
-        sum = in.readDouble();
-        count = in.readVLong();
+    public Variance(boolean legacy) {
+        this.legacy = legacy;
+        this.d1 = 0.0;
+        this.d2 = 0.0;
+        this.count = 0;
+    }
+
+    public Variance(StreamInput in, boolean legacy) throws IOException {
+        this.legacy = legacy;
+        this.d1 = in.readDouble();
+        this.d2 = in.readDouble();
+        this.count = in.readVLong();
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeDouble(sumOfSqrs);
-        out.writeDouble(sum);
+        out.writeDouble(d1);
+        out.writeDouble(d2);
         out.writeVLong(count);
     }
 
@@ -63,16 +87,40 @@ public class Variance implements Writeable, Comparable<Variance> {
         return count;
     }
 
+    public boolean isLegacy() {
+        return legacy;
+    }
+
     public Variance increment(double value) {
-        sumOfSqrs += (value * value);
-        sum += value;
-        count++;
+        if (legacy) {
+            d1 += value * value;
+            d2 += value;
+            count++;
+        } else {
+            count++;
+            double delta = value - d1;
+            d1 += delta / count;
+            d2 += delta * (value - d1);
+        }
         return this;
     }
 
     public void decrement(double value) {
-        sumOfSqrs -= (value * value);
-        sum -= value;
+        if (legacy) {
+            d1 -= value * value;
+            d2 -= value;
+            count--;
+            return;
+        }
+        if (count == 1) {
+            count = 0;
+            d1 = 0.0;
+            d2 = 0.0;
+            return;
+        }
+        double meanPrev = (count * d1 - value) / (count - 1);
+        d2 -= (value - d1) * (value - meanPrev);
+        d1 = meanPrev;
         count--;
     }
 
@@ -80,18 +128,43 @@ public class Variance implements Writeable, Comparable<Variance> {
         if (count == 0) {
             return Double.NaN;
         }
-        double variance = (sumOfSqrs - ((sum * sum) / count)) / count;
-        // The naive sum-of-squares formula can produce a small negative result for
-        // large-magnitude inputs with little spread (e.g. a constant DATE/TIMESTAMP) due to
-        // floating point cancellation. A variance is never negative, so clamp it; otherwise
-        // sqrt() in the stddev variants would yield NaN (returned to the user as NULL).
-        return variance < 0 ? 0 : variance;
+        if (legacy) {
+            // The naive sum-of-squares formula can produce a small negative result for
+            // large-magnitude inputs with little spread (e.g. a constant DATE/TIMESTAMP) due to
+            // floating point cancellation. A variance is never negative, so clamp it; otherwise
+            // sqrt() in the stddev variants would yield NaN (returned to the user as NULL).
+            double variance = (d1 - ((d2 * d2) / count)) / count;
+            return variance < 0 ? 0 : variance;
+        }
+        // d2 (M2) is non-negative by construction under forward accumulation; the clamp guards
+        // against tiny negative residues from decrement() in removable window frames.
+        return Math.max(d2, 0.0) / count;
     }
 
     public void merge(Variance other) {
-        sumOfSqrs += other.sumOfSqrs;
-        sum += other.sum;
-        count += other.count;
+        assert legacy == other.legacy
+            : "Cannot merge a legacy and a Welford variance state; the mode must be chosen "
+              + "consistently cluster-wide at plan time";
+        if (legacy) {
+            d1 += other.d1;
+            d2 += other.d2;
+            count += other.count;
+            return;
+        }
+        if (other.count == 0) {
+            return;
+        }
+        if (count == 0) {
+            d1 = other.d1;
+            d2 = other.d2;
+            count = other.count;
+            return;
+        }
+        long newCount = count + other.count;
+        double delta = other.d1 - d1;
+        d2 = d2 + other.d2 + delta * delta * count * other.count / newCount;
+        d1 = d1 + delta * other.count / newCount;
+        count = newCount;
     }
 
     @Override

--- a/server/src/main/java/io/crate/execution/engine/collect/DocValuesAggregates.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/DocValuesAggregates.java
@@ -178,6 +178,9 @@ public final class DocValuesAggregates {
                 aggregationReferences,
                 table,
                 shardVersionCreated,
+                // Doc-value aggregation runs shard-level (ITER_PARTIAL), so the aggregation's value
+                // type is the partial-state type the plan chose; newState follows it.
+                aggregation.valueType(),
                 literals
             );
             if (docValueAggregator == null) {

--- a/server/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
@@ -501,7 +501,8 @@ final class GroupByOptimizedIterator {
         docCtx.add(collectPhase.toCollect().stream()::iterator);
 
         InputFactory inputFactory = new InputFactory(nodeCtx);
-        InputFactory.Context<CollectExpression<Row, ?>> ctxForAggregations = inputFactory.ctxForAggregations(collectTask.txnCtx());
+        InputFactory.Context<CollectExpression<Row, ?>> ctxForAggregations =
+            inputFactory.ctxForAggregations(collectTask.txnCtx(), groupProjection.mode());
         ctxForAggregations.add(groupProjection.values());
         final List<CollectExpression<Row, ?>> aggExpressions = ctxForAggregations.expressions();
 
@@ -931,7 +932,7 @@ final class GroupByOptimizedIterator {
             AggregationContext aggregation = aggregations.get(i);
             AggregationFunction function = aggregation.function();
 
-            var newState = function.newState(ramAccounting, minNodeVersion, memoryManager);
+            var newState = function.newState(ramAccounting, aggregation.partialType(), minNodeVersion, memoryManager);
             if (InputCondition.matches(aggregation.filter())) {
                 states[i] = function.iterate(
                     ramAccounting,

--- a/server/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
+++ b/server/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
@@ -319,7 +319,8 @@ public class ProjectionToProjectorVisitor
 
     @Override
     public Projector visitGroupProjection(GroupProjection projection, Context context) {
-        InputFactory.Context<CollectExpression<Row, ?>> ctx = inputFactory.ctxForAggregations(context.txnCtx);
+        InputFactory.Context<CollectExpression<Row, ?>> ctx =
+            inputFactory.ctxForAggregations(context.txnCtx, projection.mode());
 
         ctx.add(projection.keys());
         ctx.add(projection.values());
@@ -344,7 +345,8 @@ public class ProjectionToProjectorVisitor
 
     @Override
     public Projector visitAggregationProjection(AggregationProjection projection, Context context) {
-        InputFactory.Context<CollectExpression<Row, ?>> ctx = inputFactory.ctxForAggregations(context.txnCtx);
+        InputFactory.Context<CollectExpression<Row, ?>> ctx =
+            inputFactory.ctxForAggregations(context.txnCtx, projection.mode());
         ctx.add(projection.aggregations());
         return new AggregationPipe(
             ctx.expressions(),

--- a/server/src/main/java/io/crate/expression/InputFactory.java
+++ b/server/src/main/java/io/crate/expression/InputFactory.java
@@ -38,6 +38,7 @@ import io.crate.execution.engine.collect.CollectExpression;
 import io.crate.execution.engine.collect.RowCollectExpression;
 import io.crate.expression.reference.GatheringRefResolver;
 import io.crate.expression.reference.ReferenceResolver;
+import io.crate.expression.symbol.AggregateMode;
 import io.crate.expression.symbol.Aggregation;
 import io.crate.expression.symbol.InputColumn;
 import io.crate.expression.symbol.Symbol;
@@ -47,6 +48,7 @@ import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
 import io.crate.metadata.Schemas;
 import io.crate.metadata.TransactionContext;
+import io.crate.types.DataType;
 
 /**
  * Factory which can be used to create {@link Input}s from symbols.
@@ -100,13 +102,13 @@ public class InputFactory {
         return context;
     }
 
-    public Context<CollectExpression<Row, ?>> ctxForAggregations(TransactionContext txnCtx) {
+    public Context<CollectExpression<Row, ?>> ctxForAggregations(TransactionContext txnCtx, AggregateMode mode) {
         List<CollectExpression<Row, ?>> expressions = new ArrayList<>();
         List<AggregationContext> aggregationContexts = new ArrayList<>();
         return new Context<>(
             expressions,
             aggregationContexts,
-            new AggregationVisitor(txnCtx, nodeCtx, expressions, aggregationContexts));
+            new AggregationVisitor(txnCtx, nodeCtx, expressions, aggregationContexts, mode));
     }
 
     public static class Context<T extends Input<?>> {
@@ -191,13 +193,16 @@ public class InputFactory {
     private static class AggregationVisitor extends InputColumnVisitor {
 
         private final List<AggregationContext> aggregationContexts;
+        private final AggregateMode mode;
 
         AggregationVisitor(TransactionContext txnCtx,
                            NodeContext nodeCtx,
                            List<CollectExpression<Row, ?>> expressions,
-                           List<AggregationContext> aggregationContexts) {
+                           List<AggregationContext> aggregationContexts,
+                           AggregateMode mode) {
             super(txnCtx, nodeCtx, expressions);
             this.aggregationContexts = aggregationContexts;
+            this.mode = mode;
         }
 
         @Override
@@ -211,7 +216,15 @@ public class InputFactory {
             for (Symbol aggInput : aggregation.inputs()) {
                 inputs.add(aggInput.accept(this, context));
             }
-            AggregationContext aggregationContext = new AggregationContext((AggregationFunction<?, ?>) impl, filter, inputs);
+            // The plan already picked the partial-state type for this aggregation. On a producing node
+            // (ITER_PARTIAL / ITER_FINAL) that is the aggregation output type; on a reducer (PARTIAL_FINAL)
+            // it is the (partial) input type. newState follows this so the accumulator layout can never
+            // diverge from the streamed wire format.
+            DataType<?> partialType = mode == AggregateMode.PARTIAL_FINAL && !aggregation.inputs().isEmpty()
+                ? aggregation.inputs().get(0).valueType()
+                : aggregation.valueType();
+            AggregationContext aggregationContext =
+                new AggregationContext((AggregationFunction<?, ?>) impl, filter, inputs, partialType);
             aggregationContexts.add(aggregationContext);
 
             // can't generate an input from an aggregation.

--- a/server/src/main/java/io/crate/expression/symbol/AggregateMode.java
+++ b/server/src/main/java/io/crate/expression/symbol/AggregateMode.java
@@ -24,6 +24,7 @@ package io.crate.expression.symbol;
 import java.io.IOException;
 import java.util.List;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
@@ -34,8 +35,10 @@ import io.crate.types.DataType;
 public enum AggregateMode {
     ITER_PARTIAL {
         @Override
-        public DataType<?> returnType(AggregationFunction<?, ?> function) {
-            return function.partialType();
+        public DataType<?> returnType(AggregationFunction<?, ?> function, Version minNodeInCluster) {
+            // ITER_PARTIAL emits the streamed partial state, so its type must match the wire format
+            // the rest of the cluster expects for the given min node version.
+            return function.partialType(minNodeInCluster);
         }
 
         @Override
@@ -48,7 +51,7 @@ public enum AggregateMode {
 
     private static final List<AggregateMode> VALUES = List.of(values());
 
-    public DataType<?> returnType(AggregationFunction<?, ?> function) {
+    public DataType<?> returnType(AggregationFunction<?, ?> function, Version minNodeInCluster) {
         return function.boundSignature().returnType();
     }
 

--- a/server/src/main/java/io/crate/planner/operators/GroupHashAggregate.java
+++ b/server/src/main/java/io/crate/planner/operators/GroupHashAggregate.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.SequencedCollection;
 import java.util.Set;
 
+import org.elasticsearch.Version;
 import org.jspecify.annotations.Nullable;
 
 import io.crate.analyze.OrderBy;
@@ -149,6 +150,9 @@ public class GroupHashAggregate extends ForwardingLogicalPlan {
             executionPlan = Merge.ensureOnHandler(executionPlan, plannerContext);
         }
         SubQueryAndParamBinder paramBinder = new SubQueryAndParamBinder(params, subQueryResults);
+        // Chosen once here so the streamed partial-state wire format stays consistent cluster-wide
+        // during a rolling upgrade (see AggregationFunction#partialType(Version)).
+        Version minNodeVersion = plannerContext.clusterState().nodes().getMinNodeVersion();
 
         DistinctRewriter.Result rewritten = DistinctRewriter.rewrite(
             aggregates,
@@ -166,7 +170,8 @@ public class GroupHashAggregate extends ForwardingLogicalPlan {
                 rewritten.aggregates(),
                 paramBinder,
                 AggregateMode.ITER_FINAL,
-                source.preferShardProjections() ? RowGranularity.SHARD : RowGranularity.CLUSTER
+                source.preferShardProjections() ? RowGranularity.SHARD : RowGranularity.CLUSTER,
+                minNodeVersion
             );
             executionPlan.addProjection(groupProjection, NO_LIMIT, 0, null);
             if (rewritten.evalProjection() != null) {
@@ -184,7 +189,8 @@ public class GroupHashAggregate extends ForwardingLogicalPlan {
                         rewritten.aggregates(),
                         paramBinder,
                         AggregateMode.ITER_PARTIAL,
-                        RowGranularity.SHARD
+                        RowGranularity.SHARD,
+                        minNodeVersion
                     )
                 );
                 executionPlan.addProjection(
@@ -194,7 +200,8 @@ public class GroupHashAggregate extends ForwardingLogicalPlan {
                         rewritten.aggregates(),
                         paramBinder,
                         AggregateMode.PARTIAL_FINAL,
-                        RowGranularity.NODE
+                        RowGranularity.NODE,
+                        minNodeVersion
                     ),
                     NO_LIMIT,
                     0,
@@ -212,7 +219,8 @@ public class GroupHashAggregate extends ForwardingLogicalPlan {
                         rewritten.aggregates(),
                         paramBinder,
                         AggregateMode.ITER_FINAL,
-                        RowGranularity.NODE
+                        RowGranularity.NODE,
+                        minNodeVersion
                     ),
                     NO_LIMIT,
                     0,
@@ -231,7 +239,8 @@ public class GroupHashAggregate extends ForwardingLogicalPlan {
             rewritten.aggregates(),
             paramBinder,
             AggregateMode.ITER_PARTIAL,
-            source.preferShardProjections() ? RowGranularity.SHARD : RowGranularity.NODE
+            source.preferShardProjections() ? RowGranularity.SHARD : RowGranularity.NODE,
+            minNodeVersion
         );
         executionPlan.addProjection(toPartial);
         executionPlan.setDistributionInfo(DistributionInfo.DEFAULT_MODULO);
@@ -242,7 +251,8 @@ public class GroupHashAggregate extends ForwardingLogicalPlan {
             rewritten.aggregates(),
             paramBinder,
             AggregateMode.PARTIAL_FINAL,
-            RowGranularity.CLUSTER
+            RowGranularity.CLUSTER,
+            minNodeVersion
         );
         return createMerge(
             plannerContext,

--- a/server/src/main/java/io/crate/planner/operators/HashAggregate.java
+++ b/server/src/main/java/io/crate/planner/operators/HashAggregate.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.SequencedCollection;
 import java.util.Set;
 
+import org.elasticsearch.Version;
 import org.jspecify.annotations.Nullable;
 
 import io.crate.analyze.OrderBy;
@@ -98,6 +99,9 @@ public class HashAggregate extends ForwardingLogicalPlan {
 
         AggregationOutputValidator.validateOutputs(aggregates);
         var paramBinder = new SubQueryAndParamBinder(params, subQueryResults);
+        // Chosen once here so the streamed partial-state wire format stays consistent cluster-wide
+        // during a rolling upgrade (see AggregationFunction#partialType(Version)).
+        Version minNodeVersion = plannerContext.clusterState().nodes().getMinNodeVersion();
 
         DistinctRewriter.Result rewritten = rewriteDistinct
             ? DistinctRewriter.rewrite(
@@ -120,7 +124,8 @@ public class HashAggregate extends ForwardingLogicalPlan {
                         rewritten.aggregates(),
                         paramBinder,
                         AggregateMode.ITER_PARTIAL,
-                        RowGranularity.SHARD
+                        RowGranularity.SHARD,
+                        minNodeVersion
                     )
                 );
                 executionPlan.addProjection(
@@ -129,7 +134,8 @@ public class HashAggregate extends ForwardingLogicalPlan {
                         rewritten.aggregates(),
                         paramBinder,
                         AggregateMode.PARTIAL_FINAL,
-                        RowGranularity.CLUSTER
+                        RowGranularity.CLUSTER,
+                        minNodeVersion
                     )
                 );
                 if (rewritten.evalProjection() != null) {
@@ -142,7 +148,8 @@ public class HashAggregate extends ForwardingLogicalPlan {
                 rewritten.aggregates(),
                 paramBinder,
                 AggregateMode.ITER_FINAL,
-                RowGranularity.CLUSTER
+                RowGranularity.CLUSTER,
+                minNodeVersion
             );
             executionPlan.addProjection(fullAggregation);
             if (rewritten.evalProjection() != null) {
@@ -155,7 +162,8 @@ public class HashAggregate extends ForwardingLogicalPlan {
             rewritten.aggregates(),
             paramBinder,
             AggregateMode.ITER_PARTIAL,
-            source.preferShardProjections() ? RowGranularity.SHARD : RowGranularity.NODE
+            source.preferShardProjections() ? RowGranularity.SHARD : RowGranularity.NODE,
+            minNodeVersion
         );
         executionPlan.addProjection(toPartial);
 
@@ -164,7 +172,8 @@ public class HashAggregate extends ForwardingLogicalPlan {
             rewritten.aggregates(),
             paramBinder,
             AggregateMode.PARTIAL_FINAL,
-            RowGranularity.CLUSTER
+            RowGranularity.CLUSTER,
+            minNodeVersion
         );
         ResultDescription resultDescription = executionPlan.resultDescription();
         return new Merge(

--- a/server/src/test/java/io/crate/execution/engine/aggregation/GroupingCollectorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/GroupingCollectorTest.java
@@ -45,6 +45,7 @@ import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.metadata.settings.session.SessionSettingRegistry;
 import io.crate.testing.PlainRamAccounting;
+import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 
 public class GroupingCollectorTest {
@@ -76,6 +77,7 @@ public class GroupingCollectorTest {
             ramAccounting,
             null, // memoryManager is unused
             Version.CURRENT,
+            new DataType[] { DataTypes.LONG },
             keyInputs.get(0),
             DataTypes.LONG
         );
@@ -113,6 +115,7 @@ public class GroupingCollectorTest {
             ramAccounting,
             null, // memoryManager is unused
             Version.CURRENT,
+            new DataType[] { DataTypes.LONG },
             keyInputs.get(0),
             DataTypes.LONG
         );

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/StdDevPopAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/StdDevPopAggregationTest.java
@@ -161,6 +161,35 @@ public class StdDevPopAggregationTest extends AggregationTestCase {
     }
 
     @Test
+    public void test_new_state_follows_the_plan_chosen_partial_type() throws Exception {
+        // The plan's chosen partial type - not a locally re-read node version - decides the state
+        // layout, so a producing node's accumulator can never diverge from the streamed wire format
+        // during a rolling upgrade. Pairing each partial type with the "wrong" version proves the
+        // partial type wins. See #19885.
+        var func = (io.crate.execution.engine.aggregation.AggregationFunction<?, ?>) nodeCtx.functions().get(
+            null,
+            StandardDeviationPopAggregation.NAME,
+            List.of(Literal.of(DataTypes.DOUBLE, null)),
+            SearchPath.pathWithPGCatalogAndDoc());
+        var legacy = (io.crate.execution.engine.aggregation.statistics.Variance) func.newState(
+            io.crate.data.breaker.RamAccounting.NO_ACCOUNTING,
+            StandardDeviationPopAggregation.StdDevPopStateType.INSTANCE,
+            org.elasticsearch.Version.CURRENT,
+            null);
+        assertThat(legacy.isLegacy()).isTrue();
+        var welford = (io.crate.execution.engine.aggregation.statistics.Variance) func.newState(
+            io.crate.data.breaker.RamAccounting.NO_ACCOUNTING,
+            StandardDeviationPopAggregation.StdDevPopStateTypeWelford.INSTANCE,
+            org.elasticsearch.Version.V_6_4_0,
+            null);
+        assertThat(welford.isLegacy()).isFalse();
+        assertThat(func.partialType(org.elasticsearch.Version.V_6_4_0).id())
+            .isEqualTo(StandardDeviationPopAggregation.StdDevPopStateType.ID);
+        assertThat(func.partialType(org.elasticsearch.Version.CURRENT).id())
+            .isEqualTo(StandardDeviationPopAggregation.StdDevPopStateTypeWelford.ID);
+    }
+
+    @Test
     public void testUnsupportedType() {
         assertThatThrownBy(() -> executeAggregation(DataTypes.GEO_POINT, new Object[][]{}))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/StdDevSampAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/StdDevSampAggregationTest.java
@@ -164,6 +164,35 @@ public class StdDevSampAggregationTest extends AggregationTestCase {
     }
 
     @Test
+    public void test_new_state_follows_the_plan_chosen_partial_type() throws Exception {
+        // The plan's chosen partial type - not a locally re-read node version - decides the state
+        // layout, so a producing node's accumulator can never diverge from the streamed wire format
+        // during a rolling upgrade. Pairing each partial type with the "wrong" version proves the
+        // partial type wins. See #19885.
+        var func = (io.crate.execution.engine.aggregation.AggregationFunction<?, ?>) nodeCtx.functions().get(
+            null,
+            StandardDeviationSampAggregation.NAMES.get(0),
+            List.of(Literal.of(DataTypes.DOUBLE, null)),
+            SearchPath.pathWithPGCatalogAndDoc());
+        var legacy = (io.crate.execution.engine.aggregation.statistics.Variance) func.newState(
+            io.crate.data.breaker.RamAccounting.NO_ACCOUNTING,
+            StandardDeviationSampAggregation.StdDevSampStateType.INSTANCE,
+            org.elasticsearch.Version.CURRENT,
+            null);
+        assertThat(legacy.isLegacy()).isTrue();
+        var welford = (io.crate.execution.engine.aggregation.statistics.Variance) func.newState(
+            io.crate.data.breaker.RamAccounting.NO_ACCOUNTING,
+            StandardDeviationSampAggregation.StdDevSampStateTypeWelford.INSTANCE,
+            org.elasticsearch.Version.V_6_4_0,
+            null);
+        assertThat(welford.isLegacy()).isFalse();
+        assertThat(func.partialType(org.elasticsearch.Version.V_6_4_0).id())
+            .isEqualTo(StandardDeviationSampAggregation.StdDevSampStateType.ID);
+        assertThat(func.partialType(org.elasticsearch.Version.CURRENT).id())
+            .isEqualTo(StandardDeviationSampAggregation.StdDevSampStateTypeWelford.ID);
+    }
+
+    @Test
     public void testUnsupportedType() {
         assertThatThrownBy(() -> executeAggregation(DataTypes.GEO_POINT, new Object[][]{}))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/VarianceAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/VarianceAggregationTest.java
@@ -132,6 +132,65 @@ public class VarianceAggregationTest extends AggregationTestCase {
     }
 
     @Test
+    public void test_large_magnitude_low_spread_is_precise() throws Exception {
+        // The naive sum-of-squares formula loses all precision at ~1e12 magnitude (ulp ~1e9 at
+        // ~1e24), so it cannot recover the small spread. Welford computes the exact population
+        // variance of {1, 2, 3} offset by 1e12, which is 2/3.
+        Object result = executeAggregation(DataTypes.DOUBLE, new Object[][]{
+            {1_000_000_000_001.0d}, {1_000_000_000_002.0d}, {1_000_000_000_003.0d}});
+        assertThat(result).isEqualTo(0.6666666666666666d);
+    }
+
+    @Test
+    public void test_new_state_follows_the_plan_chosen_partial_type() throws Exception {
+        // The plan's chosen partial type - not a locally re-read node version - decides the state
+        // layout, so a producing node's accumulator can never diverge from the streamed wire format
+        // during a rolling upgrade. Pairing each partial type with the "wrong" version proves the
+        // partial type wins. See #19885.
+        var func = (io.crate.execution.engine.aggregation.AggregationFunction<?, ?>) nodeCtx.functions().get(
+            null,
+            VarianceAggregation.NAME,
+            List.of(Literal.of(DataTypes.DOUBLE, null)),
+            SearchPath.pathWithPGCatalogAndDoc());
+        var legacy = (io.crate.execution.engine.aggregation.statistics.Variance) func.newState(
+            io.crate.data.breaker.RamAccounting.NO_ACCOUNTING,
+            VarianceAggregation.VarianceStateType.INSTANCE,
+            org.elasticsearch.Version.CURRENT,
+            null);
+        assertThat(legacy.isLegacy()).isTrue();
+        var welford = (io.crate.execution.engine.aggregation.statistics.Variance) func.newState(
+            io.crate.data.breaker.RamAccounting.NO_ACCOUNTING,
+            VarianceAggregation.VarianceStateTypeWelford.INSTANCE,
+            org.elasticsearch.Version.V_6_4_0,
+            null);
+        assertThat(welford.isLegacy()).isFalse();
+        // partialType(version) still drives the plan-time wire-format choice.
+        assertThat(func.partialType(org.elasticsearch.Version.V_6_4_0).id())
+            .isEqualTo(VarianceAggregation.VarianceStateType.ID);
+        assertThat(func.partialType(org.elasticsearch.Version.CURRENT).id())
+            .isEqualTo(VarianceAggregation.VarianceStateTypeWelford.ID);
+    }
+
+    @Test
+    public void test_legacy_naive_accumulator_is_numerically_correct() {
+        // A mixed (< 6.5) cluster runs entirely on the naive layout, so it must stay correct on its
+        // own. Population variance of {7, 3} is 4.0.
+        var legacy = new io.crate.execution.engine.aggregation.statistics.Variance(true);
+        legacy.increment(7.0d);
+        legacy.increment(3.0d);
+        assertThat(legacy.isLegacy()).isTrue();
+        assertThat(legacy.result()).isEqualTo(4.0d);
+
+        // Merging two legacy partials equals a single legacy accumulation.
+        var a = new io.crate.execution.engine.aggregation.statistics.Variance(true);
+        a.increment(7.0d);
+        var b = new io.crate.execution.engine.aggregation.statistics.Variance(true);
+        b.increment(3.0d);
+        a.merge(b);
+        assertThat(a.result()).isEqualTo(4.0d);
+    }
+
+    @Test
     public void testUnsupportedType() throws Exception {
         assertThatThrownBy(() -> executeAggregation(DataTypes.GEO_POINT, new Object[][] {}))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)

--- a/server/src/test/java/io/crate/execution/engine/aggregation/statistics/VarianceStreamingTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/statistics/VarianceStreamingTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.execution.engine.aggregation.statistics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.junit.Test;
+
+import io.crate.Streamer;
+import io.crate.execution.engine.aggregation.impl.VarianceAggregation.VarianceStateType;
+import io.crate.execution.engine.aggregation.impl.VarianceAggregation.VarianceStateTypeWelford;
+
+public class VarianceStreamingTest {
+
+    @Test
+    public void test_welford_state_round_trips_through_streamer() throws Exception {
+        Variance original = new Variance(false);
+        original.increment(1_000_000_000_001.0d);
+        original.increment(1_000_000_000_002.0d);
+        original.increment(1_000_000_000_003.0d);
+
+        Variance restored = roundTrip(VarianceStateTypeWelford.INSTANCE.streamer(), original);
+
+        assertThat(restored.isLegacy()).isFalse();
+        assertThat(restored.result()).isEqualTo(original.result());
+    }
+
+    @Test
+    public void test_legacy_state_round_trips_through_streamer() throws Exception {
+        Variance original = new Variance(true);
+        original.increment(10.7d);
+        original.increment(42.9d);
+        original.increment(0.3d);
+
+        Variance restored = roundTrip(VarianceStateType.INSTANCE.streamer(), original);
+
+        assertThat(restored.isLegacy()).isTrue();
+        assertThat(restored.result()).isEqualTo(original.result());
+    }
+
+    private static Variance roundTrip(Streamer<Variance> streamer, Variance original) throws Exception {
+        BytesStreamOutput out = new BytesStreamOutput();
+        streamer.writeValueTo(out, original);
+        StreamInput in = out.bytes().streamInput();
+        return streamer.readValueFrom(in);
+    }
+}

--- a/server/src/test/java/io/crate/execution/engine/collect/GroupByOptimizedIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/GroupByOptimizedIteratorTest.java
@@ -121,7 +121,7 @@ public class GroupByOptimizedIteratorTest extends CrateDummyClusterServiceUnitTe
             Collections.emptyList(),
             CountAggregation.COUNT_STAR_SIGNATURE.getReturnType().createType()
         );
-        aggregationContexts = List.of(new AggregationContext(aggregation, () -> true, List.of()));
+        aggregationContexts = List.of(new AggregationContext(aggregation, () -> true, List.of(), aggregation.partialType()));
     }
 
     private BatchIterator<Row> createBatchIterator(Runnable onNextReader) {

--- a/server/src/test/java/io/crate/execution/engine/window/AggregationWindowFunctionsTest.java
+++ b/server/src/test/java/io/crate/execution/engine/window/AggregationWindowFunctionsTest.java
@@ -189,7 +189,9 @@ public class AggregationWindowFunctionsTest extends AbstractWindowFunctionTest {
 
     @Test
     public void testVarianceOverUnboundedFollowingFrames() throws Throwable {
-        Object[] expected = new Object[]{0.22222222222222202, 0.0, 0.0, 0.6666666666666666, 0.25, 0.0, null};
+        // First element is the correctly-rounded double of 2/9; the numerically stable accumulator
+        // (#19760) rounds it more accurately than the previous 0.22222222222222202.
+        Object[] expected = new Object[]{0.2222222222222222, 0.0, 0.0, 0.6666666666666666, 0.25, 0.0, null};
         assertEvaluate(
             "variance(x) OVER(" +
             "   PARTITION BY x>2 ORDER BY x RANGE BETWEEN CURRENT ROW and UNBOUNDED FOLLOWING" +
@@ -201,7 +203,9 @@ public class AggregationWindowFunctionsTest extends AbstractWindowFunctionTest {
 
     @Test
     public void testStdDevPopOverUnboundedFollowingFrames() throws Throwable {
-        Object[] expected = new Object[]{0.47140452079103146, 0.0, 0.0, 0.816496580927726, 0.5, 0.0, null};
+        // First element is rounded more accurately by the numerically stable accumulator
+        // (#19760) than the previous 0.47140452079103146.
+        Object[] expected = new Object[]{0.4714045207910317, 0.0, 0.0, 0.816496580927726, 0.5, 0.0, null};
         assertEvaluate(
             "stddev_pop(x) OVER(" +
             "   PARTITION BY x>2 ORDER BY x RANGE BETWEEN CURRENT ROW and UNBOUNDED FOLLOWING" +

--- a/server/src/test/java/io/crate/expression/InputFactoryTest.java
+++ b/server/src/test/java/io/crate/expression/InputFactoryTest.java
@@ -39,8 +39,10 @@ import io.crate.data.Input;
 import io.crate.data.Row;
 import io.crate.data.RowN;
 import io.crate.execution.engine.aggregation.AggregationContext;
+import io.crate.execution.engine.aggregation.impl.VarianceAggregation;
 import io.crate.execution.engine.collect.CollectExpression;
 import io.crate.expression.scalar.arithmetic.ArithmeticFunctions;
+import io.crate.expression.symbol.AggregateMode;
 import io.crate.expression.symbol.Aggregation;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.InputColumn;
@@ -87,6 +89,36 @@ public class InputFactoryTest extends CrateDummyClusterServiceUnitTest {
     }
 
     @Test
+    public void test_aggregation_context_partial_type_follows_mode() throws Exception {
+        // The partial-state type stored on AggregationContext must be the one the plan chose, so
+        // newState can follow it instead of re-deriving from a local node version. Its location is
+        // mode-dependent, and getting it wrong for the reducer silently reintroduces the rolling-upgrade
+        // divergence this fix closes (see #19885), so assert both modes explicitly.
+        Function varianceX = (Function) expressions.asSymbol("variance(x)");
+
+        // Reducer (PARTIAL_FINAL): reads the partial state as its INPUT and outputs the final double,
+        // so the partial-state type must come from the input column, not the (double) value type.
+        var reduceAgg = new Aggregation(
+            varianceX.signature(),
+            DataTypes.DOUBLE,
+            List.of(new InputColumn(0, VarianceAggregation.VarianceStateType.INSTANCE)));
+        var reduceCtx = factory.ctxForAggregations(txnCtx, AggregateMode.PARTIAL_FINAL);
+        reduceCtx.add(List.of(reduceAgg));
+        assertThat(reduceCtx.aggregations().get(0).partialType())
+            .isEqualTo(VarianceAggregation.VarianceStateType.INSTANCE);
+
+        // Producer (ITER_PARTIAL): the partial-state type is the aggregation's own value type.
+        var iterAgg = new Aggregation(
+            varianceX.signature(),
+            VarianceAggregation.VarianceStateTypeWelford.INSTANCE,
+            List.of(new InputColumn(0, DataTypes.DOUBLE)));
+        var iterCtx = factory.ctxForAggregations(txnCtx, AggregateMode.ITER_PARTIAL);
+        iterCtx.add(List.of(iterAgg));
+        assertThat(iterCtx.aggregations().get(0).partialType())
+            .isEqualTo(VarianceAggregation.VarianceStateTypeWelford.INSTANCE);
+    }
+
+    @Test
     public void testAggregationSymbolsInputReuse() throws Exception {
         Function countX = (Function) expressions.asSymbol("count(x)");
         Function avgX = (Function) expressions.asSymbol("avg(x)");
@@ -100,7 +132,7 @@ public class InputFactoryTest extends CrateDummyClusterServiceUnitTest {
                             List.of(new InputColumn(0)))
         );
 
-        InputFactory.Context<CollectExpression<Row, ?>> ctx = factory.ctxForAggregations(txnCtx);
+        InputFactory.Context<CollectExpression<Row, ?>> ctx = factory.ctxForAggregations(txnCtx, AggregateMode.ITER_FINAL);
         ctx.add(aggregations);
         List<AggregationContext> aggregationContexts = ctx.aggregations();
 
@@ -117,7 +149,7 @@ public class InputFactoryTest extends CrateDummyClusterServiceUnitTest {
         // keys: [ in(0), in(1) + 10 ]
         List<Symbol> keys = Arrays.asList(new InputColumn(0, DataTypes.LONG), add);
 
-        InputFactory.Context<CollectExpression<Row, ?>> ctx = factory.ctxForAggregations(txnCtx);
+        InputFactory.Context<CollectExpression<Row, ?>> ctx = factory.ctxForAggregations(txnCtx, AggregateMode.ITER_FINAL);
         ctx.add(keys);
         ArrayList<CollectExpression<Row, ?>> expressions = new ArrayList<>(ctx.expressions());
         assertThat(expressions).hasSize(2);
@@ -155,7 +187,7 @@ public class InputFactoryTest extends CrateDummyClusterServiceUnitTest {
             List.of(new InputColumn(0))
         ));
 
-        InputFactory.Context<CollectExpression<Row, ?>> ctx = factory.ctxForAggregations(txnCtx);
+        InputFactory.Context<CollectExpression<Row, ?>> ctx = factory.ctxForAggregations(txnCtx, AggregateMode.ITER_FINAL);
         ctx.add(keys);
 
         // inputs: [ x, add ]

--- a/server/src/testFixtures/java/io/crate/operation/aggregation/AggregationTestCase.java
+++ b/server/src/testFixtures/java/io/crate/operation/aggregation/AggregationTestCase.java
@@ -248,13 +248,27 @@ public abstract class AggregationTestCase extends ESTestCase {
                 var resultWithDocValues = assertAndGetMergedIterAndPartial(
                     aggregationFunction, terminatePartialAggFunction, partialResultWithDocValues.get(0).get(0));
 
-                assertThat(resultWithoutDocValues).isEqualTo(resultWithDocValues);
+                // Welford's parallel merge is order-sensitive in the last ULP: the iterate and
+                // doc-value paths accumulate values in different orders, so their floating-point
+                // stddev/variance results can differ by an ULP. Tolerate a tiny difference - relative
+                // for large magnitudes, with a small absolute floor so a near-zero expected value does
+                // not degenerate to exact-match - while still catching real regressions; other result
+                // types must match exactly. See #19760, #19885.
+                if (resultWithoutDocValues instanceof Double d1 && resultWithDocValues instanceof Double d2) {
+                    double tolerance = Math.max(1e-9, Math.abs(d2) * 1e-11);
+                    assertThat(Math.abs(d1 - d2))
+                        .as("iterate vs doc-value result within Welford last-ULP tolerance")
+                        .isLessThanOrEqualTo(tolerance);
+                } else {
+                    assertThat(resultWithoutDocValues).isEqualTo(resultWithDocValues);
+                }
             } else {
                 var docValueAggregator = aggregationFunction.getDocValueAggregator(
                     refResolver,
                     targetColumns,
                     mock(DocTableInfo.class),
                     Version.CURRENT,
+                    aggregationFunction.partialType(),
                     List.of()
                 );
                 if (docValueAggregator != null) {
@@ -624,6 +638,7 @@ public abstract class AggregationTestCase extends ESTestCase {
             toReference(argumentTypes),
             mock(DocTableInfo.class),
             Version.CURRENT,
+            aggregationFunction.partialType(),
             List.of()
         );
     }


### PR DESCRIPTION
## Summary

Replaces the naive sum-of-squares accumulator shared by `stddev_pop`, `stddev_samp`, `stddev` and `variance` with **Welford's online algorithm**, for 6.5.0. This is the numerically stable follow-up to the clamp that shipped in 6.3.7 / 6.4.2 (#19760). The change is **transparent for rolling upgrades**.

## Problem

`Variance` accumulated with `(sum(x^2) - sum(x)^2/n) / n`. For large-magnitude inputs (a `DATE`/`TIMESTAMP` is stored as epoch millis, ~1.78e12, so `x^2` ~3.2e24 exceeds a double's exact range), `sum(x^2)` and `sum(x)^2/n` round differently and their subtraction (catastrophic cancellation) produced a **negative** variance. `sqrt(negative)` is `NaN`, returned to the user as `NULL`:

```sql
SELECT STDDEV_POP(DATE '2026-07-08') FROM (VALUES (1),(2),(3),(4),(5)) AS t(x);  -- was NULL, expected 0.0
```

6.3.7 / 6.4.2 clamped the result (`variance < 0 ? 0 : variance`), which fixes the `NULL`/negative symptom but not the underlying precision loss. This PR fixes the precision at the source.

## Change

`Variance` now tracks `(count, mean, m2)` and updates via Welford's online algorithm — the same approach used by PostgreSQL (Youngs-Cramer), MySQL (Knuth/Welford) and DuckDB. It never squares the raw values, so:

- The reported case returns exactly `0.0` at any magnitude (`m2` stays exactly `0` for identical inputs).
- Precision is exact even for spread-out large-magnitude data, e.g. `variance(1e12+1, 1e12+2, 1e12+3)` now returns `2/3` instead of `0`.
- `merge` uses the Chan et al. parallel formula (matches `float8_combine` in PostgreSQL).
- `decrement` (removable window frames) uses the reverse-Welford update, clamped at `>= 0`.

### Windowing / `decrement`

PostgreSQL provides no float inverse for variance (it recomputes window frames) because float subtraction is unstable. CrateDB keeps its incremental `decrement` (behavior-preserving), guarded by `max(m2, 0)`. The drift is negligible except for moving-window variance over large-magnitude, near-constant columns, and never returns `NULL`/negative. This choice was confirmed on the issue (Plan A).

### Rolling upgrade (transparent)

Welford changes the streamed partial-state layout from `(sumOfSqrs, sum, count)` to `(mean, m2, count)`. `StreamBucket` has no per-value version negotiation, so a mixed-version cluster must agree on one format. Rather than failing queries during the upgrade, the aggregations keep a **dual-mode partial state**:

- While **any** node is still `< 6.5`, the partial is streamed in the **legacy naive layout** — byte-identical to the pre-6.5 format — so pre-6.5 nodes keep interoperating.
- Once **all** nodes are `>= 6.5.0`, the **Welford layout** takes over.

The format is chosen **once, cluster-wide, at plan time** — `partialType(minNodeVersion)` from the coordinator's cluster state. The key correctness property: **`newState` follows that already-chosen partial type** (threaded from the plan through `AggregationContext` to the collectors and the doc-values path) rather than each node re-deriving the format from its own local min node version. During a rolling upgrade a participating node's local cluster state can momentarily disagree with the coordinator's plan-time view; if the produced accumulator layout and the streamed wire format came from those two different reads, the reducer would **silently** mis-decode the partial (both layouts are byte-identical). Deriving both from the single plan-time decision makes that impossible by construction. (This supersedes the earlier error-gate approach — see the thread.)

## Performance

Benchmarked earlier on the issue with crate-benchmarks: ~2–5% on `uservisits` (a numerically stable one-pass algorithm does one division per row). Considered acceptable for 6.5.0; the cheap clamp remains on the 6.3/6.4 lines.

## Testing

This change threads through shared aggregation plumbing, so it is tested across every layer — unit, distributed, the full CI suite, and a live end-to-end run on a built node.

- **Bug fix / precision:** `variance(1e12+1, 1e12+2, 1e12+3) == 2/3` (fails on the naive accumulator, passes on Welford); constant / large-magnitude inputs to all four functions return `0.0`, not `NULL` (#19760).
- **Rolling-upgrade invariant:** `newState` follows the plan's chosen partial **type**, not a locally re-read version — `newState(legacyType, CURRENT)` builds a legacy accumulator and `newState(WelfordType, 6.4.0)` a Welford one (the type wins over the version, for all three functions). `InputFactory` derives the type **mode-correctly** (reducer → input column, producer → output type). Legacy layout is byte-identical to the pre-6.5 wire format.
- **Streaming:** `VarianceStreamingTest` round-trips both the legacy and Welford wire formats.
- **No regression across aggregations:** the full `*AggregationTest` set — **224 tests, 0 failures** (every aggregation type), run 3× with different random seeds.
- **Distributed:** `GroupByAggregateTest` stddev/variance ITs (partial → stream → reduce) — 4/4.
- **Window:** `AggregationWindowFunctionsTest` — 43 tests.
- **Full CI suite** on the pushed commit: `BUILD SUCCESS` — **11760 tests run, 0 failed**.
- **Live end-to-end:** a single-node CrateDB built from this branch — **25/25 SQL value-checks pass** across in-memory, doc-values, distributed GROUP BY, window, numeric, and NULL paths.

The two detailed reports below capture the full test matrix and the live-server SQL run.

<details>
<summary><b>📋 Report 1 — Testing summary (unit → distributed → full CI → live end-to-end)</b></summary>

# Evidence 2 — Testing summary for the Welford stddev/variance change (#19885)

Scope of the change: `variance`, `stddev`, `stddev_pop`, `stddev_samp` — their partial state moves to
Welford's algorithm, with a dual-mode rolling-upgrade fallback where `newState` follows the plan's
chosen partial type. Because that threads through shared aggregation plumbing (`AggregationContext`,
the collectors, doc-values, planner), testing deliberately spans **unit → distributed → full-suite →
live end-to-end**.

## 1. Unit tests — correctness of the four functions
- `VarianceAggregationTest`, `StdDevPopAggregationTest`, `StdDevSampAggregationTest` — per-function
  results for `double`, `real`, `integer`, `bigint`, `smallint`, `byte`, `timestamptz`, `numeric`.
- `test_repeated_large_values_return_zero` — the #19760 repro (constant large input → `0.0`).
- `test_large_magnitude_low_spread_is_precise` — `variance(1e12+1,+2,+3) == 2/3` (fails on the naive
  accumulator, passes on Welford) — the precision guard.
- `numeric` (BigDecimal) exactness asserted against fixed expected strings.

## 2. Unit tests — the rolling-upgrade correctness invariant (the heart of this PR)
- `test_new_state_follows_the_plan_chosen_partial_type` (all three functions): pairs each partial
  type with the **"wrong" version** to prove the plan's partial **type wins over the node version** —
  i.e. a producing node's accumulator can never diverge from the streamed wire format.
- `InputFactoryTest#test_aggregation_context_partial_type_follows_mode`: proves the partial type is
  derived **mode-correctly** — from the *input* column on a reducer (`PARTIAL_FINAL`) and the *output*
  type on a producer (`ITER_PARTIAL`). A regression here would silently reintroduce the divergence;
  the test is a bidirectional guard.
- `test_legacy_naive_accumulator_is_numerically_correct`: the legacy naive layout (used while any
  node is `< 6.5`) still computes the right variance and merges correctly.

## 3. Unit tests — wire format
- `VarianceStreamingTest`: round-trips **both** the legacy and the Welford partial-state layouts
  through their streamers, asserting the `legacy` flag and the result are preserved.
- Legacy layout independently verified **byte-identical** to the pre-6.5 (6.4) wire format, so a 6.5
  node can stream to a 6.4 node during a rolling upgrade.

## 4. Regression across *all* aggregation types (shared-plumbing safety)
- Ran the **entire `*AggregationTest` set — 224 tests, 0 failures** (sum, avg, min, max, count, topk,
  percentile, collect_set, geometric_mean, arbitrary, cmp_by, numeric-stddev, …). Confirms the
  `newState`/`AggregationContext`/collector changes did not regress any other aggregation.
- Aggregation suite run **3× with different random seeds** — no flakiness.

## 5. Distributed integration tests (partial → stream → reduce)
- `GroupByAggregateTest` stddev/variance methods (`groupByAggregateStdDevPopByte`,
  `groupByAggregateVarianceByte`, `groupByAggregateStdDevPopDouble`, `groupByStatsAggregatesGlobal`)
  — **4/4 pass**, exercising the real cross-node partial-aggregation path.

## 6. Window functions
- `AggregationWindowFunctionsTest` — **43 tests pass** (after rebase on current master, which added
  window tests), including `variance`/`stddev_pop` over cumulative and removable frames.

## 7. Full CI suite on the exact pushed commit
- GitHub Actions "Test CrateDB SQL on ubuntu-latest" on `db153fc1e7`:
  **`BUILD SUCCESS` — 11760 tests run, 104 skipped, 0 failed.**
- `compile`, `checkstyle`, `forbiddenApis`, `Analyze`, `Vale`, `doctests` all green.
- (The one red check is the fork-PR "Publish Test Report" step — a GitHub token permission artifact,
  not a test failure; `mvn test` itself is `BUILD SUCCESS`.)

## 8. Live end-to-end on a running node (see Evidence 1)
- Fresh single-node CrateDB built from this branch; **25/25 SQL value-checks pass** plus GROUP BY,
  doc-values, window, numeric, and NULL cases verified by inspection — covering in-memory,
  doc-values, distributed, and window execution paths against the mathematically-correct answers.

## 9. Test-harness robustness note
- Welford's parallel merge is order-sensitive in the last ULP, so the iterate-vs-doc-value cross-check
  in `AggregationTestCase` now tolerates a last-ULP difference (`|d1-d2| ≤ max(1e-9, |d2|·1e-11)`) —
  tight enough that any real wrong-format decode (NaN / order-of-magnitude error) is still caught.

---

### Bottom line
Every layer is covered: the four functions' correctness, the rolling-upgrade "state-follows-type"
invariant (the risky part), the wire format for both layouts, zero regression across all 224
aggregation unit tests, the distributed reduce path, window frames, the full 11760-test CI suite, and
a live end-to-end run. The reported bug is fixed at the source and precision is improved, with no
observed regression anywhere.

</details>

<details>
<summary><b>🧪 Report 2 — Live-server SQL regression run (queries + results)</b></summary>

# Evidence 1 — Local end-to-end SQL testing (live CrateDB node)

**What:** every aggregation whose partial state changed to Welford's algorithm on this PR —
`variance`, `stddev` (= `stddev_samp`), `stddev_pop`, `stddev_samp` — exercised against a **running
single-node CrateDB** built from this branch, via the HTTP `/_sql` endpoint.

**How it was produced**
- Branch `welford-variance-19760` @ `db153fc1e7` (rebased on current `master`).
- Built a fresh binary distribution (`./mvnw -pl app -am -DskipTests package`), started a real node
  (`bin/crate -Cdiscovery.type=single-node`), and ran SQL over `POST /_sql`.
- The node genuinely runs the new code — proven by `variance(1e12+1, 1e12+2, 1e12+3) = 0.666…` (2/3),
  a value the old naive `Σx²`-based accumulator **cannot** produce (it returns `0`).

**Result: 25 / 25 automated value-checks PASS, 0 FAIL**, plus the `numeric` BigDecimal path and the
full GROUP BY / window breakdowns verified by inspection. Every path the new state touches is covered:
in-memory `VALUES`, doc-values table scan, distributed GROUP BY (partial→reduce), window frames
(incl. removable), all input types, and NULL edge cases.

---

## A. The reported bug (#19760): constant / large-magnitude input must be `0.0`, not `NULL`

| # | Query | Result | Expected | |
|---|-------|--------|----------|---|
| A1 | `stddev_pop(x)` over 5× `DATE '2026-07-08'` | `0.0` | `0.0` | ✅ |
| A2 | `variance(x)` over 5× `1783468800000` (bigint) | `0.0` | `0.0` | ✅ |
| A3 | `stddev_samp(x)` over 5× `1783468800000` | `0.0` | `0.0` | ✅ |
| A4 | `stddev(x)` over 5× `1783468800000` | `0.0` | `0.0` | ✅ |
| A5 | `stddev_pop(x)` over 3× `'2026-07-08'::timestamptz` | `0.0` | `0.0` | ✅ |

The exact repro from the issue:
```sql
SELECT stddev_pop(x) FROM (VALUES (DATE '2026-07-08'),(DATE '2026-07-08'),
       (DATE '2026-07-08'),(DATE '2026-07-08'),(DATE '2026-07-08')) AS t(x);
-- => 0.0   (was NULL before the 6.3.7/6.4.2 clamp; now exact at the source)
```

## B. Precision — large magnitude, small spread (naive formula loses this entirely)

| # | Query | Result | Expected | |
|---|-------|--------|----------|---|
| B1 | `variance(1e12+1, 1e12+2, 1e12+3)` | `0.6666666666666666` | `2/3` | ✅ |
| B2 | `stddev_pop` of the same | `0.816496580927726` | `√(2/3)` | ✅ |

> The naive accumulator returns `0` here (all precision lost at ~1e24); Welford recovers the exact 2/3.

## C. Known-correct values (must match hand / PostgreSQL computation — regression guard)

| # | Query | Result | Expected | |
|---|-------|--------|----------|---|
| C1 | `variance{7,3}` | `4.0` | `4.0` | ✅ |
| C2 | `stddev_pop{7,3}` | `2.0` | `2.0` | ✅ |
| C3 | `stddev_pop{2,4,4,4,5,5,7,9}` (textbook) | `2.0` | `2.0` | ✅ |
| C4 | `stddev_samp{2,4,4,4,5,5,7,9}` | `2.138089935299395` | `√(32/7)` | ✅ |
| C5 | `stddev_samp{10.7,42.9,0.3}` (double) | `22.210207863352682` | `22.210207863352682` | ✅ |

## D. All input types give identical results for the same data `{7,3}` → `stddev_pop = 2.0`

`integer` ✅ · `bigint` ✅ · `real` ✅ · `double` ✅ · `smallint` ✅ (all `2.0`)

## E. NULL handling / edge cases

| # | Query | Result | Expected | |
|---|-------|--------|----------|---|
| E1 | single value → `stddev_pop` | `0.0` | `0.0` | ✅ |
| E2 | single value → `stddev_samp` | `null` | `NULL` (needs ≥2) | ✅ |
| E3 | all-NULL → `variance` | `null` | `NULL` | ✅ |
| E4 | NULLs ignored → `variance{7,3,NULL}` | `4.0` | `4.0` | ✅ |

## F. `numeric` (BigDecimal) path — exact, and untouched by this PR

The `numeric` stddev aggregations use the separate `NumericStandardDeviation*` classes (**not** the
Welford double classes this PR changes). They return exact arbitrary-precision results, matching the
existing unit-test expectations:

```sql
-- table: regn(x numeric(6,2)) with rows 10.7, 42.9, 0.3
SELECT stddev(x)      FROM regn;  -- 22.21020786335268257417589186151252
SELECT stddev_samp(x) FROM regn;  -- 22.21020786335268257417589186151252
SELECT stddev_pop(x)  FROM regn;  -- 18.13455878212156068287097312248802
```
All ✅ exact. `variance(numeric)` is **not a registered function** in CrateDB (only `stddev` has a
BigDecimal variant) — this is pre-existing master behavior, unrelated to this PR.

## G. GROUP BY over a real table (doc-values + distributed partial → reduce)

Table `reg(grp, xi bigint, xd double)` with three groups — `const` (identical large values),
`small` `{7,3}`, `spread` `{1e12+1,+2,+3}`:

```sql
SELECT grp, variance(xd) AS var, stddev_pop(xd) AS sdp, stddev_samp(xd) AS sds, count(*) AS n
FROM reg GROUP BY grp ORDER BY grp;
```
| grp | variance | stddev_pop | stddev_samp | n |
|-----|----------|------------|-------------|---|
| const  | `0.0` | `0.0` | `0.0` | 3 |
| small  | `4.0` | `2.0` | `2.8284271247461903` | 2 |
| spread | `0.6666666666666666` | `0.816496580927726` | `1.0` | 3 |

All correct — including the bug case (`const → 0`) and the precision case (`spread`) surviving the
**distributed partial→reduce** path, and the doc-values scan (`variance(xi) WHERE grp='small' = 4.0`). ✅

## H. Window functions (incl. removable-frame path)

```sql
SELECT x, variance(x) OVER (ORDER BY x ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
FROM (VALUES (1),(2),(3),(4)) AS t(x);
-- (1→0.0) (2→0.25) (3→0.6666666666666666) (4→1.25)   ✅

SELECT x, stddev_pop(x) OVER (ORDER BY x ROWS BETWEEN 1 PRECEDING AND CURRENT ROW)
FROM (VALUES (1),(2),(3),(4)) AS t(x);
-- (1→0.0) (2→0.5) (3→0.5) (4→0.5)   ✅ (exercises removeFromAggregatedState)
```

## I. Consistency: doc-values (table) result == literal (`VALUES`) result

`variance(xi) WHERE grp='small'` (table/doc-values) = `4.0` = the literal-path `variance{7,3}`. ✅

---

### Conclusion
On a live node built from this branch: the reported bug is fixed at the source (constant/large inputs
→ exactly `0.0`), precision is materially improved (`2/3` vs `0`), and **every** other case — all four
functions, all input types, GROUP BY, doc-values, window frames, NULLs, and the untouched numeric
path — matches the mathematically-correct expected values. **No regression observed.**

</details>

## Notes / non-goals

- The `numeric` (BigDecimal) variance path is exact and untouched.
- The rolling upgrade is transparent (queries keep working throughout), so this is no longer a breaking change — moved out of Breaking Changes in the release notes.
- The distributed (partial → stream → reduce) path is exercised by the existing `GroupByAggregateTest` ITs; the doc-values path by the reproduction / optimized-iterator tests.

Refs #19760

