### PR TITLE
Use table OIDs to isolate ALTER COLUMN DEFAULT from concurrent SWAP TABLE

### DIFF
--- a/docs/appendices/release-notes/6.5.0.rst
+++ b/docs/appendices/release-notes/6.5.0.rst
@@ -142,10 +142,11 @@ Performance and Resilience Improvements
 - Improved :ref:`DELETE <sql_reference_delete>`,
   :ref:`DROP TABLE <drop-table>`,
   :ref:`DROP COLUMN <sql-alter-table-drop-column>`,
-  :ref:`ADD COLUMN <sql-alter-table-add-column>` and
-  :ref:`RENAME COLUMN <sql-alter-table-rename-column>` such that concurrent
-  :ref:`SWAP TABLE <alter_cluster_swap_table>` cannot affect a ``DELETE``
-  already in progress.
+  :ref:`ADD COLUMN <sql-alter-table-add-column>`,
+  :ref:`RENAME COLUMN <sql-alter-table-rename-column>` and
+  :ref:`SET/DROP DEFAULT <SQL-alter-table-alter-column-default>`
+  such that concurrent :ref:`SWAP TABLE <alter_cluster_swap_table>`
+  cannot affect aforementioned queries already in progress.
 
 Administration and Operations
 -----------------------------

--- a/docs/appendices/release-notes/6.5.0.rst
+++ b/docs/appendices/release-notes/6.5.0.rst
@@ -143,8 +143,9 @@ Performance and Resilience Improvements
   :ref:`DROP TABLE <drop-table>`,
   :ref:`DROP COLUMN <sql-alter-table-drop-column>`,
   :ref:`ADD COLUMN <sql-alter-table-add-column>`,
-  :ref:`RENAME COLUMN <sql-alter-table-rename-column>` and
-  :ref:`SET/DROP DEFAULT <SQL-alter-table-alter-column-default>`
+  :ref:`RENAME COLUMN <sql-alter-table-rename-column>`,
+  :ref:`SET/DROP DEFAULT <SQL-alter-table-alter-column-default>` and
+  :ref:`DROP CONSTRAINT <sql-alter-drop-constraint>`
   such that concurrent :ref:`SWAP TABLE <alter_cluster_swap_table>`
   cannot affect aforementioned queries already in progress.
 

--- a/server/src/main/java/io/crate/analyze/AlterTableAlterColumnDefaultAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/AlterTableAlterColumnDefaultAnalyzer.java
@@ -118,6 +118,11 @@ public class AlterTableAlterColumnDefaultAnalyzer {
             EnsureNoMatchPredicate.ensureNoMatchPredicate(newDefault, "Cannot use MATCH in DEFAULT expression");
         }
 
-        return new AnalyzedAlterTableAlterColumnDefault(tableInfo.ident(), ref, newDefault);
+        return new AnalyzedAlterTableAlterColumnDefault(
+            tableInfo.ident(),
+            tableInfo.oid(),
+            ref,
+            newDefault
+        );
     }
 }

--- a/server/src/main/java/io/crate/analyze/AnalyzedAlterTableAlterColumnDefault.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedAlterTableAlterColumnDefault.java
@@ -30,6 +30,7 @@ import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
 
 public record AnalyzedAlterTableAlterColumnDefault(RelationName table,
+                                                   int tableOid,
                                                    Reference ref,
                                                    @Nullable Symbol newDefault) implements DDLStatement {
 

--- a/server/src/main/java/io/crate/execution/ddl/tables/AlterColumnDefaultRequest.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/AlterColumnDefaultRequest.java
@@ -21,8 +21,11 @@
 
 package io.crate.execution.ddl.tables;
 
+import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
+
 import java.io.IOException;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -35,12 +38,17 @@ import io.crate.metadata.RelationName;
 public class AlterColumnDefaultRequest extends AcknowledgedRequest<AlterColumnDefaultRequest> {
 
     private final RelationName relationName;
+    private final int tableOid;
     private final Reference ref;
     @Nullable
     private final Symbol newDefault;
 
-    public AlterColumnDefaultRequest(RelationName relationName, Reference ref, @Nullable Symbol newDefault) {
+    public AlterColumnDefaultRequest(RelationName relationName,
+                                     int tableOid,
+                                     Reference ref,
+                                     @Nullable Symbol newDefault) {
         this.relationName = relationName;
+        this.tableOid = tableOid;
         this.ref = ref;
         this.newDefault = newDefault;
     }
@@ -48,6 +56,11 @@ public class AlterColumnDefaultRequest extends AcknowledgedRequest<AlterColumnDe
     public AlterColumnDefaultRequest(StreamInput in) throws IOException {
         super(in);
         this.relationName = new RelationName(in);
+        if (in.getVersion().onOrAfter(Version.V_6_5_0)) {
+            this.tableOid = in.readVInt();
+        } else {
+            this.tableOid = OID_UNASSIGNED;
+        }
         this.ref = Reference.fromStream(in);
         this.newDefault = Symbol.nullableFromStream(in);
     }
@@ -56,12 +69,19 @@ public class AlterColumnDefaultRequest extends AcknowledgedRequest<AlterColumnDe
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         relationName.writeTo(out);
+        if (out.getVersion().onOrAfter(Version.V_6_5_0)) {
+            out.writeVInt(tableOid);
+        }
         Reference.toStream(out, ref);
         Symbol.nullableToStream(newDefault, out);
     }
 
     public RelationName relationName() {
         return relationName;
+    }
+
+    public int tableOid() {
+        return tableOid;
     }
 
     public Reference ref() {

--- a/server/src/main/java/io/crate/execution/ddl/tables/DropConstraintRequest.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/DropConstraintRequest.java
@@ -21,8 +21,11 @@
 
 package io.crate.execution.ddl.tables;
 
+import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
+
 import java.io.IOException;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -32,23 +35,35 @@ import io.crate.metadata.RelationName;
 public class DropConstraintRequest extends AcknowledgedRequest<DropConstraintRequest> {
 
     private final RelationName relationName;
+    private final int tableOid;
     private final String constraintName;
 
     public DropConstraintRequest(RelationName relationName,
+                                 int tableOid,
                                  String constraintName) {
         this.relationName = relationName;
+        this.tableOid = tableOid;
         this.constraintName = constraintName;
     }
 
     public DropConstraintRequest(StreamInput in) throws IOException {
         super(in);
         relationName = new RelationName(in);
+        if (in.getVersion().onOrAfter(Version.V_6_5_0)) {
+            tableOid = in.readVInt();
+        } else {
+            tableOid = OID_UNASSIGNED;
+        }
         constraintName = in.readString();
     }
 
 
     public RelationName relationName() {
         return relationName;
+    }
+
+    public int tableOid() {
+        return tableOid;
     }
 
     public String constraintName() {
@@ -59,6 +74,9 @@ public class DropConstraintRequest extends AcknowledgedRequest<DropConstraintReq
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         relationName.writeTo(out);
+        if (out.getVersion().onOrAfter(Version.V_6_5_0)) {
+            out.writeVInt(tableOid);
+        }
         out.writeString(constraintName);
     }
 }

--- a/server/src/main/java/io/crate/execution/ddl/tables/TransportAlterColumnDefault.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/TransportAlterColumnDefault.java
@@ -27,7 +27,6 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
-import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -75,7 +74,13 @@ public class TransportAlterColumnDefault extends AbstractDDLTransportAction<Alte
 
     @Override
     public ClusterStateTaskExecutor<AlterColumnDefaultRequest> clusterStateTaskExecutor(AlterColumnDefaultRequest request) {
-        return new AlterTableTask<>(nodeContext, request.relationName(), Metadata.OID_UNASSIGNED, null, ALTER_COLUMN_DEFAULT_OPERATOR);
+        return new AlterTableTask<>(
+            nodeContext,
+            request.relationName(),
+            request.tableOid(),
+            null,
+            ALTER_COLUMN_DEFAULT_OPERATOR
+        );
     }
 
     @Override

--- a/server/src/main/java/io/crate/execution/ddl/tables/TransportDropConstraint.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/TransportDropConstraint.java
@@ -27,7 +27,6 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
-import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -72,7 +71,13 @@ public class TransportDropConstraint extends AbstractDDLTransportAction<DropCons
 
     @Override
     public ClusterStateTaskExecutor<DropConstraintRequest> clusterStateTaskExecutor(DropConstraintRequest request) {
-        return new AlterTableTask<>(nodeContext, request.relationName(), Metadata.OID_UNASSIGNED, null, DROP_CONSTRAINT_OPERATOR);
+        return new AlterTableTask<>(
+            nodeContext,
+            request.relationName(),
+            request.tableOid(),
+            null,
+            DROP_CONSTRAINT_OPERATOR
+        );
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/node/ddl/AlterTableAlterColumnDefaultPlan.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/AlterTableAlterColumnDefaultPlan.java
@@ -52,7 +52,12 @@ public class AlterTableAlterColumnDefaultPlan implements Plan {
                               RowConsumer consumer,
                               Row params,
                               SubQueryResults subQueryResults) throws Exception {
-        var request = new AlterColumnDefaultRequest(analyzed.table(), analyzed.ref(), analyzed.newDefault());
+        var request = new AlterColumnDefaultRequest(
+            analyzed.table(),
+            analyzed.tableOid(),
+            analyzed.ref(),
+            analyzed.newDefault()
+        );
         dependencies.client()
             .execute(TransportAlterColumnDefault.ACTION, request)
             .whenComplete(new OneRowActionListener<>(consumer, r -> r.isAcknowledged() ? new Row1(-1L) : new Row1(0L)));

--- a/server/src/main/java/io/crate/planner/node/ddl/AlterTableDropCheckConstraintPlan.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/AlterTableDropCheckConstraintPlan.java
@@ -55,6 +55,7 @@ public class AlterTableDropCheckConstraintPlan implements Plan {
                               SubQueryResults subQueryResults) {
         var request = new DropConstraintRequest(
             dropCheckConstraint.tableInfo().ident(),
+            dropCheckConstraint.tableInfo().oid(),
             dropCheckConstraint.name()
         );
 

--- a/server/src/test/java/io/crate/execution/ddl/tables/AlterColumnDefaultRequestTest.java
+++ b/server/src/test/java/io/crate/execution/ddl/tables/AlterColumnDefaultRequestTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.execution.ddl.tables;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.junit.Test;
+
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.RelationName;
+import io.crate.metadata.RowGranularity;
+import io.crate.metadata.SimpleReference;
+import io.crate.types.DataTypes;
+
+public class AlterColumnDefaultRequestTest {
+
+    @Test
+    public void test_streaming_table_oids() throws Exception {
+        // streaming to nodes with supported versions
+        RelationName relation = new RelationName("doc", "tbl");
+        int tableOid = 1234;
+        var ref = new SimpleReference(
+            relation, ColumnIdent.of("x"), RowGranularity.DOC, DataTypes.INTEGER, 1, null);
+        AlterColumnDefaultRequest request = new AlterColumnDefaultRequest(
+            relation, tableOid, ref, null);
+
+        var out = new BytesStreamOutput();
+        out.setVersion(Version.V_6_5_0);
+        request.writeTo(out);
+
+        var in = out.bytes().streamInput();
+        in.setVersion(Version.V_6_5_0);
+        AlterColumnDefaultRequest streamed = new AlterColumnDefaultRequest(in);
+
+        assertThat(streamed.tableOid()).isEqualTo(tableOid);
+
+        // streaming to nodes with unsupported versions
+        relation = new RelationName("doc", "tbl");
+        ref = new SimpleReference(
+            relation, ColumnIdent.of("x"), RowGranularity.DOC, DataTypes.INTEGER, 1, null);
+        request = new AlterColumnDefaultRequest(
+            relation, 1234, ref, null);
+
+        out = new BytesStreamOutput();
+        out.setVersion(Version.V_6_4_0);
+        request.writeTo(out);
+
+        in = out.bytes().streamInput();
+        in.setVersion(Version.V_6_4_0);
+        streamed = new AlterColumnDefaultRequest(in);
+
+        assertThat(streamed.tableOid()).isEqualTo(OID_UNASSIGNED);
+    }
+}

--- a/server/src/test/java/io/crate/execution/ddl/tables/AlterColumnDefaultTaskTest.java
+++ b/server/src/test/java/io/crate/execution/ddl/tables/AlterColumnDefaultTaskTest.java
@@ -53,7 +53,7 @@ public class AlterColumnDefaultTaskTest extends CrateDummyClusterServiceUnitTest
         var task = buildAlterColumnDefaultTask(e, tbl.ident());
         Reference ref = tbl.getReference(ColumnIdent.of("x"));
         Symbol newDefault = Literal.of(42);
-        var request = new AlterColumnDefaultRequest(tbl.ident(), ref, newDefault);
+        var request = new AlterColumnDefaultRequest(tbl.ident(), Metadata.OID_UNASSIGNED, ref, newDefault);
         ClusterState newState = task.execute(clusterService.state(), request);
         DocTableInfo newTable = new DocTableInfoFactory(e.nodeCtx).create(tbl.ident(), newState.metadata());
         Reference updatedRef = newTable.getReference(ColumnIdent.of("x"));
@@ -69,7 +69,7 @@ public class AlterColumnDefaultTaskTest extends CrateDummyClusterServiceUnitTest
         Reference ref = tbl.getReference(ColumnIdent.of("x"));
         assertThat(ref.defaultExpression()).isEqualTo(Literal.of(1));
         Symbol newDefault = Literal.of(99);
-        var request = new AlterColumnDefaultRequest(tbl.ident(), ref, newDefault);
+        var request = new AlterColumnDefaultRequest(tbl.ident(), Metadata.OID_UNASSIGNED, ref, newDefault);
         ClusterState newState = task.execute(clusterService.state(), request);
         DocTableInfo newTable = new DocTableInfoFactory(e.nodeCtx).create(tbl.ident(), newState.metadata());
         Reference updatedRef = newTable.getReference(ColumnIdent.of("x"));
@@ -84,7 +84,7 @@ public class AlterColumnDefaultTaskTest extends CrateDummyClusterServiceUnitTest
         var task = buildAlterColumnDefaultTask(e, tbl.ident());
         Reference ref = tbl.getReference(ColumnIdent.of("x"));
         assertThat(ref.defaultExpression()).isNotNull();
-        var request = new AlterColumnDefaultRequest(tbl.ident(), ref, null);
+        var request = new AlterColumnDefaultRequest(tbl.ident(), Metadata.OID_UNASSIGNED, ref, null);
         ClusterState newState = task.execute(clusterService.state(), request);
         DocTableInfo newTable = new DocTableInfoFactory(e.nodeCtx).create(tbl.ident(), newState.metadata());
         Reference updatedRef = newTable.getReference(ColumnIdent.of("x"));
@@ -98,7 +98,7 @@ public class AlterColumnDefaultTaskTest extends CrateDummyClusterServiceUnitTest
         DocTableInfo tbl = e.resolveTableInfo("tbl");
         var task = buildAlterColumnDefaultTask(e, tbl.ident());
         Reference ref = tbl.getReference(ColumnIdent.of("x"));
-        var request = new AlterColumnDefaultRequest(tbl.ident(), ref, null);
+        var request = new AlterColumnDefaultRequest(tbl.ident(), Metadata.OID_UNASSIGNED, ref, null);
         ClusterState newState = task.execute(clusterService.state(), request);
         // No-op: cluster state should be the same object
         assertThat(newState).isSameAs(clusterService.state());
@@ -112,7 +112,7 @@ public class AlterColumnDefaultTaskTest extends CrateDummyClusterServiceUnitTest
         var task = buildAlterColumnDefaultTask(e, tbl.ident());
         Reference ref = tbl.getReference(ColumnIdent.of("o", "a"));
         Symbol newDefault = Literal.of(10);
-        var request = new AlterColumnDefaultRequest(tbl.ident(), ref, newDefault);
+        var request = new AlterColumnDefaultRequest(tbl.ident(), Metadata.OID_UNASSIGNED, ref, newDefault);
         ClusterState newState = task.execute(clusterService.state(), request);
         DocTableInfo newTable = new DocTableInfoFactory(e.nodeCtx).create(tbl.ident(), newState.metadata());
         Reference updatedRef = newTable.getReference(ColumnIdent.of("o", "a"));
@@ -130,7 +130,7 @@ public class AlterColumnDefaultTaskTest extends CrateDummyClusterServiceUnitTest
         var task = buildAlterColumnDefaultTask(e, tbl.ident());
         Reference ref = tbl.getReference(ColumnIdent.of("x"));
         Symbol newDefault = Literal.of(77);
-        var request = new AlterColumnDefaultRequest(tbl.ident(), ref, newDefault);
+        var request = new AlterColumnDefaultRequest(tbl.ident(), Metadata.OID_UNASSIGNED, ref, newDefault);
         ClusterState newState = task.execute(clusterService.state(), request);
         DocTableInfo newTable = new DocTableInfoFactory(e.nodeCtx).create(tbl.ident(), newState.metadata());
         Reference updatedRef = newTable.getReference(ColumnIdent.of("x"));

--- a/server/src/test/java/io/crate/execution/ddl/tables/DropConstraintRequestTest.java
+++ b/server/src/test/java/io/crate/execution/ddl/tables/DropConstraintRequestTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.execution.ddl.tables;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.junit.Test;
+
+import io.crate.metadata.RelationName;
+
+public class DropConstraintRequestTest {
+
+    @Test
+    public void test_streaming_table_oids() throws Exception {
+        // streaming to nodes with supported versions
+        RelationName relation = new RelationName("doc", "tbl");
+        int tableOid = 1234;
+        DropConstraintRequest request = new DropConstraintRequest(relation, tableOid, "check_x");
+
+        var out = new BytesStreamOutput();
+        out.setVersion(Version.V_6_5_0);
+        request.writeTo(out);
+
+        var in = out.bytes().streamInput();
+        in.setVersion(Version.V_6_5_0);
+        DropConstraintRequest streamed = new DropConstraintRequest(in);
+
+        assertThat(streamed.tableOid()).isEqualTo(tableOid);
+
+        // streaming to nodes with unsupported versions
+        relation = new RelationName("doc", "tbl");
+        request = new DropConstraintRequest(relation, 1234, "check_x");
+
+        out = new BytesStreamOutput();
+        out.setVersion(Version.V_6_4_0);
+        request.writeTo(out);
+
+        in = out.bytes().streamInput();
+        in.setVersion(Version.V_6_4_0);
+        streamed = new DropConstraintRequest(in);
+
+        assertThat(streamed.tableOid()).isEqualTo(OID_UNASSIGNED);
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Relates to https://github.com/crate/crate/pull/19883.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes.
       If you're an external contributor you can give yourself attribution and include your name and Github handle.
       e.g.:
       ```
       `John Doe <https://github.com/John_Doe>`_ added support for ...
       ```
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
