### PR TITLE
Fix incorrect results of RANGE offset window frames when using DESC ORDER BY

### DIFF
--- a/docs/appendices/release-notes/6.4.3.rst
+++ b/docs/appendices/release-notes/6.4.3.rst
@@ -80,3 +80,6 @@ Fixes
 
 - Fixed an issue that could lead to a memory leak if nodes within the
   cluster were temporarily not reachable.
+
+- Fixed incorrect results in window function when using
+  ``RANGE <offset> FOLLOWING/PRECEDING`` with ``ORDER BY <column> DESC``.

--- a/server/src/main/java/io/crate/execution/engine/window/WindowProjector.java
+++ b/server/src/main/java/io/crate/execution/engine/window/WindowProjector.java
@@ -181,8 +181,10 @@ public class WindowProjector {
         Object[] endProbeValues = new Object[numCellsInSourceRow];
         BiFunction<Object[], Object[], Object[]> updateProbeValues;
         if (offsetValue != null && framingMode == WindowFrame.Mode.RANGE) {
-            updateProbeValues = createUpdateProbeValueFunction(
-                windowDefinition, ArithmeticOperatorsFactory::getAddFunction, offsetValue, offsetType);
+            BiFunction<DataType<?>, DataType<?>, BiFunction> offsetFn = windowDefinition.orderBy().reverseFlags()[0]
+                ? ArithmeticOperatorsFactory::getSubtractFunction
+                : ArithmeticOperatorsFactory::getAddFunction;
+            updateProbeValues = createUpdateProbeValueFunction(windowDefinition, offsetFn, offsetValue, offsetType);
         } else {
             updateProbeValues = (currentRow, x) -> x;
         }
@@ -211,8 +213,10 @@ public class WindowProjector {
         Object[] startProbeValues = new Object[numCellsInSourceRow];
         BiFunction<Object[], Object[], Object[]> updateStartProbeValue;
         if (offsetValue != null && framingMode == WindowFrame.Mode.RANGE) {
-            updateStartProbeValue = createUpdateProbeValueFunction(
-                windowDefinition, ArithmeticOperatorsFactory::getSubtractFunction, offsetValue, offsetType);
+            BiFunction<DataType<?>, DataType<?>, BiFunction> offsetFn = windowDefinition.orderBy().reverseFlags()[0]
+                ? ArithmeticOperatorsFactory::getAddFunction
+                : ArithmeticOperatorsFactory::getSubtractFunction;
+            updateStartProbeValue = createUpdateProbeValueFunction(windowDefinition, offsetFn, offsetValue, offsetType);
         } else {
             updateStartProbeValue = (currentRow, x) -> x;
         }

--- a/server/src/test/java/io/crate/execution/engine/window/AggregationWindowFunctionsTest.java
+++ b/server/src/test/java/io/crate/execution/engine/window/AggregationWindowFunctionsTest.java
@@ -332,7 +332,7 @@ public class AggregationWindowFunctionsTest extends AbstractWindowFunctionTest {
     }
 
     @Test
-    public void test_agg_over_range_following_with_null_values() throws Throwable {
+    public void test_agg_over_range_asc_following_with_null_values() throws Throwable {
         Object[] expected = new Object[]{ 3L, 3L, 3L, 2L, 2L, 1L, 0L};
         assertEvaluate("count(x) OVER (" +
              "ORDER BY x RANGE BETWEEN CURRENT ROW AND 1 FOLLOWING)",
@@ -342,6 +342,38 @@ public class AggregationWindowFunctionsTest extends AbstractWindowFunctionTest {
         );
     }
 
+    @Test
+    public void test_agg_over_range_desc_following_with_null_values() throws Throwable {
+        Object[] expected = new Object[]{ 0L, 2L, 2L, 3L, 3L, 3L, 1L};
+        assertEvaluate("count(x) OVER (" +
+             "ORDER BY x DESC RANGE BETWEEN CURRENT ROW AND 1 FOLLOWING)",
+            expected,
+            List.of(ColumnIdent.of("x")),
+            INPUT_ROWS
+        );
+    }
+
+    @Test
+    public void test_agg_over_range_asc_preceding_with_null_values() throws Throwable {
+        Object[] expected = new Object[]{ 1L, 3L, 3L, 3L, 2L, 2L, 0L};
+        assertEvaluate("count(x) OVER (" +
+             "ORDER BY x RANGE BETWEEN 1 PRECEDING AND CURRENT ROW)",
+            expected,
+            List.of(ColumnIdent.of("x")),
+            INPUT_ROWS
+        );
+    }
+
+    @Test
+    public void test_agg_over_range_desc_preceding_with_null_values() throws Throwable {
+        Object[] expected = new Object[]{ 0L, 1L, 2L, 2L, 3L, 3L, 3L};
+        assertEvaluate("count(x) OVER (" +
+             "ORDER BY x DESC RANGE BETWEEN 1 PRECEDING AND CURRENT ROW)",
+            expected,
+            List.of(ColumnIdent.of("x")),
+            INPUT_ROWS
+        );
+    }
 
     @Test
     public void test_agg_over_range_following() throws Throwable {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Fixes https://github.com/crate/crate/issues/19872

RANGE <offset> FOLLOWING/PRECEDING window frames locate their boundary via a probe value where probe value = (current row's value +/- offset) and the rows are sorted by ORDER BY. This probe value is compared to each candidate row's value in order to know if the candidate row falls into the frame or not.

For example, `RANGE BETWEEN CURRENT ROW AND 1 FOLLOWING` builds a probe value to look for the next value 1 greater than the current row (when ORDER BY <column> ASC) or next value 1 less than the current row (when ORDER BY <column> DESC). This translates to probe value = (current row's value + offset) in the ASC case and probe value = (current row's value - offset) in the DESC case.

The probe construction previously only accounted for ASC ordering. If current row value = 5 and order by is DESC, but the offset is added during probe construction, we look in the wrong direction for a row with value = 6 instead of value = 4.

Similar logic for the `PRECEDING` case. There, we move the start frame boundary instead of the end frame boundary.

This commit applies the offset with add or subtract when calculating the probe value depending on the ORDER BY in the start and end probe construction in order to handle both `FOLLOWING` and `PRECEDING` when used with ORDER BY <column> DESC.



## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes.
       If you're an external contributor you can give yourself attribution and include your name and Github handle.
       e.g.:
       ```
       `John Doe <https://github.com/John_Doe>`_ added support for ...
       ```
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
