### PR TITLE
Change insert-from-values bulk error reporting to fail individual items

### DIFF
--- a/docs/appendices/release-notes/6.4.3.rst
+++ b/docs/appendices/release-notes/6.4.3.rst
@@ -43,6 +43,41 @@ Version 6.4.3 - Unreleased
 See the :ref:`version_6.4.0` release notes for a full list of changes in the 6.4
 series.
 
+Breaking Changes
+================
+
+- Changed the error response for ``INSERT INTO .. VALUES`` bulk operations for
+  errors like unavailable shards. In 5.10 the reporting was unintentionally
+  changed to report the error on top-level instead of per bulk item. This
+  restores the 5.9 behavior and reports the error per bulk item again. This
+  allows to distinguish successful inserts if only a subset of shards wasn't
+  available. For example if using the HTTP interface, the response could look
+  like this:
+
+  ::
+
+    HTTP/1.1 200 OK
+    {
+        "cols": [],
+        "duration": 60112.33,
+        "results": [
+            {
+                "rowcount": 1
+            },
+            {
+                "rowcount": 1
+            },
+            {
+                "error": {
+                    "code": 5002,
+                    "message": "UnavailableShardsException[[doc.tbl][1] primary shard is not active Timeout: [1m], request: [ShardRequest{, shardId=[tbl/tAwjETKASaGfQJRrnn1M4g][1], timeout=1m}]]"
+                },
+                "rowcount": -2
+            }
+        ]
+    }
+
+
 Fixes
 =====
 

--- a/server/src/main/java/io/crate/execution/dml/ShardResponse.java
+++ b/server/src/main/java/io/crate/execution/dml/ShardResponse.java
@@ -39,6 +39,7 @@ import org.jspecify.annotations.Nullable;
 
 import com.carrotsearch.hppc.IntArrayList;
 import com.carrotsearch.hppc.IntObjectHashMap;
+import com.carrotsearch.hppc.IntObjectMap;
 
 import io.crate.Streamer;
 import io.crate.execution.dml.upsert.ShardUpsertRequest;
@@ -323,6 +324,10 @@ public class ShardResponse extends ReplicationResponse implements WriteResponse 
             return failures.get(location);
         }
 
+        public IntObjectMap<Throwable> failures() {
+            return failures;
+        }
+
         public List<Object[]> resultRows() {
             return resultRows;
         }
@@ -331,9 +336,11 @@ public class ShardResponse extends ReplicationResponse implements WriteResponse 
             return successfulWrites.cardinality();
         }
 
-        public void markAsFailed(List<ShardUpsertRequest.Item> items) {
+        public void markAsFailed(List<ShardUpsertRequest.Item> items, Throwable failure) {
             for (ShardUpsertRequest.Item item : items) {
-                failureLocations.set(item.location());
+                int location = item.location();
+                failureLocations.set(location);
+                failures.put(location, failure);
             }
         }
     }

--- a/server/src/main/java/io/crate/planner/operators/InsertFromValues.java
+++ b/server/src/main/java/io/crate/planner/operators/InsertFromValues.java
@@ -36,7 +36,6 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -64,11 +63,14 @@ import org.elasticsearch.index.shard.ShardNotFoundException;
 import org.jspecify.annotations.Nullable;
 
 import com.carrotsearch.hppc.IntArrayList;
+import com.carrotsearch.hppc.IntObjectMap;
 
 import io.crate.analyze.OrderBy;
 import io.crate.analyze.SymbolEvaluator;
 import io.crate.analyze.relations.TableFunctionRelation;
 import io.crate.common.concurrent.ConcurrencyLimit;
+import io.crate.common.exceptions.Exceptions;
+import io.crate.data.BatchIterator;
 import io.crate.data.CollectionBucket;
 import io.crate.data.InMemoryBatchIterator;
 import io.crate.data.Input;
@@ -298,16 +300,32 @@ public class InsertFromValues implements LogicalPlan {
                 dependencies.scheduler(),
                 tableInfo.isPartitioned());
         }).whenComplete((response, t) -> {
-            if (t == null) {
-                if (returnValues.isEmpty()) {
-                    consumer.accept(InMemoryBatchIterator.of(new Row1((long) response.numSuccessfulWrites()), SENTINEL),
-                                    null);
-                } else {
-                    consumer.accept(InMemoryBatchIterator.of(new CollectionBucket(response.resultRows()), SENTINEL, false), null);
-                }
-            } else {
+            if (t != null) {
                 consumer.accept(null, t);
+                return;
             }
+
+            IntObjectMap<Throwable> failures = response.failures();
+            if (!failures.isEmpty()) {
+                Throwable mergedFailure = null;
+                for (var cursor : failures.values()) {
+                    Throwable failure = SQLExceptions.unwrap(cursor.value);
+                    if (reportErrorAsRowCount(failure, tableInfo.isPartitioned(), rows.size())) {
+                        continue;
+                    }
+                    mergedFailure = Exceptions.useOrSuppress(mergedFailure, failure);
+                }
+                if (mergedFailure != null) {
+                    consumer.accept(null, mergedFailure);
+                    return;
+                }
+            }
+
+            BatchIterator<Row> batchIterator = returnValues.isEmpty()
+                ? InMemoryBatchIterator.of(new Row1((long) response.numSuccessfulWrites()), SENTINEL)
+                : InMemoryBatchIterator.of(new CollectionBucket(response.resultRows()), SENTINEL, false);
+
+            consumer.accept(batchIterator, null);
         });
     }
 
@@ -656,25 +674,10 @@ public class InsertFromValues implements LogicalPlan {
 
         CompletableFuture<ShardResponse.CompressedResult> result = new CompletableFuture<>();
         AtomicInteger numRequests = new AtomicInteger(shardUpsertRequests.size());
-        AtomicReference<Throwable> lastFailure = new AtomicReference<>(null);
 
         Consumer<ShardUpsertRequest> countdown = _ -> {
             if (numRequests.decrementAndGet() == 0) {
-                Throwable throwable = lastFailure.get();
-                if (throwable == null) {
-                    result.complete(compressedResult);
-                } else {
-                    throwable = SQLExceptions.unwrap(throwable);
-                    // we want to report duplicate key exceptions
-                    if (!SQLExceptions.isDocumentAlreadyExistsException(throwable) &&
-                            (partitionWasDeleted(throwable, isPartitioned)
-                                    || partitionClosed(throwable, isPartitioned)
-                                    || mixedArgumentTypesFailure(throwable))) {
-                        result.complete(compressedResult);
-                    } else {
-                        result.completeExceptionally(throwable);
-                    }
-                }
+                result.complete(compressedResult);
             }
         };
         for (ShardUpsertRequest request : shardUpsertRequests) {
@@ -685,10 +688,9 @@ public class InsertFromValues implements LogicalPlan {
                     .primaryShard()
                     .currentNodeId();
             } catch (IndexNotFoundException | ShardNotFoundException e) {
-                lastFailure.set(e);
                 if (!isPartitioned) {
                     synchronized (compressedResult) {
-                        compressedResult.markAsFailed(request.items());
+                        compressedResult.markAsFailed(request.items(), e);
                     }
                 }
                 countdown.accept(request);
@@ -700,15 +702,13 @@ public class InsertFromValues implements LogicalPlan {
             ActionListener<ShardResponse> listener = new ActionListener<>() {
                 @Override
                 public void onResponse(ShardResponse shardResponse) {
+                    nodeLimit.onSample(startTime);
                     Throwable throwable = shardResponse.failure();
-                    if (throwable == null) {
-                        nodeLimit.onSample(startTime);
-                        synchronized (compressedResult) {
-                            compressedResult.update(shardResponse);
+                    synchronized (compressedResult) {
+                        compressedResult.update(shardResponse);
+                        if (throwable != null) {
+                            compressedResult.markAsFailed(request.items(), SQLExceptions.unwrap(throwable));
                         }
-                    } else {
-                        nodeLimit.onSample(startTime);
-                        lastFailure.set(throwable);
                     }
                     countdown.accept(request);
                 }
@@ -717,12 +717,9 @@ public class InsertFromValues implements LogicalPlan {
                 public void onFailure(Exception e) {
                     nodeLimit.onSample(startTime);
                     Throwable t = SQLExceptions.unwrap(e);
-                    if (!partitionWasDeleted(t, isPartitioned)) {
-                        synchronized (compressedResult) {
-                            compressedResult.markAsFailed(request.items());
-                        }
+                    synchronized (compressedResult) {
+                        compressedResult.markAsFailed(request.items(), t);
                     }
-                    lastFailure.set(t);
                     countdown.accept(request);
                 }
             };
@@ -738,16 +735,36 @@ public class InsertFromValues implements LogicalPlan {
         return result;
     }
 
+
+    private static boolean reportErrorAsRowCount(Throwable t, boolean isPartitioned, int numValues) {
+        if (mixedArgumentTypesFailure(t)) {
+            return true;
+        }
+        if (isPartitioned) {
+            if (partitionWasDeleted(t)) {
+                return true;
+            }
+            if (partitionClosed(t)) {
+                return true;
+            }
+            return false;
+        }
+        if (numValues > 1) {
+            return true;
+        }
+        return false;
+    }
+
     private static boolean mixedArgumentTypesFailure(Throwable throwable) {
         return throwable instanceof ClassCastException;
     }
 
-    private static boolean partitionWasDeleted(Throwable throwable, boolean isPartitioned) {
-        return throwable instanceof IndexNotFoundException && isPartitioned;
+    private static boolean partitionWasDeleted(Throwable throwable) {
+        return throwable instanceof IndexNotFoundException;
     }
 
-    private static boolean partitionClosed(Throwable throwable, boolean isPartitioned) {
-        if (throwable instanceof ClusterBlockException blockException && isPartitioned) {
+    private static boolean partitionClosed(Throwable throwable) {
+        if (throwable instanceof ClusterBlockException blockException) {
             for (ClusterBlock clusterBlock : blockException.blocks()) {
                 if (clusterBlock.id() == INDEX_CLOSED_BLOCK.id()) {
                     return true;

--- a/server/src/test/java/io/crate/integrationtests/DisruptedRestSQLActionITest.java
+++ b/server/src/test/java/io/crate/integrationtests/DisruptedRestSQLActionITest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.integrationtests;
+
+import static io.crate.testing.Asserts.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.elasticsearch.node.Node;
+import org.elasticsearch.test.IntegTestCase;
+import org.elasticsearch.test.IntegTestCase.Slow;
+import org.junit.Test;
+
+@IntegTestCase.ClusterScope(scope = IntegTestCase.Scope.TEST, numDataNodes = 0, numClientNodes = 0)
+@Slow
+public class DisruptedRestSQLActionITest extends SQLHttpIntegrationTest {
+
+    private List<String> dataNodes;
+
+    @Override
+    protected String setupNodes() {
+        cluster().startMasterOnlyNode();
+        dataNodes = cluster().startDataOnlyNodes(2);
+        return dataNodes.get(1);
+    }
+
+    @Test
+    public void test_bulk_insert_from_values_reports_errors_per_item_on_unavailable_shard_failurs() throws Exception {
+        execute("CREATE TABLE doc.tbl (x INT) CLUSTERED INTO 4 SHARDS with (number_of_replicas = 0)");
+        ensureGreen();
+        ensureStableCluster(3);
+        execute("set global \"cluster.routing.allocation.enable\" = 'none'");
+        String dataNode = dataNodes.get(0);
+        cluster().stopRandomNode(settings -> Node.NODE_NAME_SETTING.get(settings).equals(dataNode));
+        assertBusy(() -> {
+            execute("select health from sys.health where table_name = 'tbl'");
+            assertThat(response).hasRows("RED");
+        });
+        // Sending a couple of values to ensure it hits a shard that was on the stopped node
+        var body = """
+            {
+              "stmt": "INSERT INTO doc.tbl (x) VALUES (?)",
+              "bulk_args": [[1], [2], [3], [4], [5], [6]]
+            }
+            """;
+        var response = post(body);
+        assertThat(response.body()).contains("UnavailableShardsException");
+        assertThat(response.body()).contains("\"rowcount\":-2");
+        assertThat(response.body()).contains("\"rowcount\":1");
+        assertThat(response.statusCode()).isEqualTo(200);
+    }
+}

--- a/server/src/test/java/io/crate/integrationtests/SQLHttpIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SQLHttpIntegrationTest.java
@@ -39,6 +39,8 @@ import java.security.SecureRandom;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.Locale;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
@@ -48,6 +50,7 @@ import javax.net.ssl.X509ExtendedTrustManager;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.http.HttpServerTransport;
 import org.elasticsearch.test.IntegTestCase;
+import org.elasticsearch.test.TestCluster;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.jspecify.annotations.Nullable;
 import org.junit.After;
@@ -131,14 +134,28 @@ public abstract class SQLHttpIntegrationTest extends IntegTestCase {
             .build();
     }
 
+    /// For sub-classes to override to initialize nodes
+    /// @return node to use as http endpoint
+    @Nullable
+    protected String setupNodes() {
+        return null;
+    }
+
     @Before
     public void setup() {
+        String httpEndpointNode = setupNodes();
+        TestCluster cluster = cluster();
+        ThreadPool threadPool = httpEndpointNode == null
+            ? cluster.getInstance(ThreadPool.class)
+            : cluster.getInstance(ThreadPool.class, httpEndpointNode);
         this.httpClient = HttpClient.newBuilder()
             .followRedirects(Redirect.NORMAL)
-            .executor(cluster().getInstance(ThreadPool.class).generic())
+            .executor(threadPool.generic())
             .sslContext(sslContext)
             .build();
-        HttpServerTransport httpServerTransport = cluster().getInstance(HttpServerTransport.class);
+        HttpServerTransport httpServerTransport = httpEndpointNode == null
+            ? cluster.getInstance(HttpServerTransport.class)
+            : cluster.getInstance(HttpServerTransport.class, httpEndpointNode);
         address = httpServerTransport.boundAddress().publishAddress().address();
         uri = URI.create(String.format(Locale.ENGLISH,
             "%s://%s:%s/_sql?error_trace",
@@ -166,15 +183,17 @@ public abstract class SQLHttpIntegrationTest extends IntegTestCase {
     }
 
     protected HttpResponse<String> post(String body, String[] ... headers) throws Exception {
-        Builder builder = HttpRequest.newBuilder(uri)
+        Builder requestBuilder = HttpRequest.newBuilder(uri)
             .header("Content-Type", "application/json");
         if (body != null) {
-            builder.POST(BodyPublishers.ofString(body));
+            requestBuilder.POST(BodyPublishers.ofString(body));
         }
         for (String[] header : headers) {
-            builder.headers(header[0], header[1]);
+            requestBuilder.headers(header[0], header[1]);
         }
-        return httpClient.send(builder.build(), BodyHandlers.ofString());
+        HttpRequest request = requestBuilder.build();
+        CompletableFuture<HttpResponse<String>> response = httpClient.sendAsync(request, BodyHandlers.ofString());
+        return response.get(120, TimeUnit.SECONDS);
     }
 
     protected URI upload(String table, String content) throws Exception {

--- a/server/src/testFixtures/java/org/elasticsearch/test/TestCluster.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/TestCluster.java
@@ -2043,8 +2043,11 @@ public final class TestCluster implements Closeable {
     public List<String> startDataOnlyNodes(int numNodes, Settings settings) {
         return startNodes(
             numNodes,
-            Settings.builder().put(settings).put(Node.NODE_MASTER_SETTING.getKey(), false)
-                .put(Node.NODE_DATA_SETTING.getKey(), true).build());
+            Settings.builder()
+                .put(settings)
+                .put(Node.NODE_MASTER_SETTING.getKey(), false)
+                .put(Node.NODE_DATA_SETTING.getKey(), true)
+                .build());
     }
 
     private int getMasterNodesCount() {


### PR DESCRIPTION
Closes https://github.com/crate/crate/issues/19857

https://github.com/crate/crate/pull/16799 unintentionally changed the
behavior for bulk inserts, changing the error reporting from:

    ❮ http localhost:4200/_sql stmt="insert into tbl (x) values (?)" bulk_args:='[[1], [2], [3]]'
    {
        "cols": [],
        "duration": 54.05847,
        "results": [
            {
                "rowcount": -2
            },
            {
                "rowcount": -2
            },
            {
                "rowcount": -2
            }
        ]
    }

To something like:

    ❮ http localhost:4200/_sql stmt="insert into tbl (x) values (?)" bulk_args:='[[1], [2], [3]]'
    HTTP/1.1 500 Internal Server Error
    {
        "error": {
            "code": 5002,
            "message": "UnavailableShardsException[[doc.tbl][1] primary shard is not active Timeout: [1m], request: [ShardRequest{, shardId=[tbl/CDmOrBPFQRy-oDhLNtpysg][1], timeout=1m}]]"
        }
    }

This restores the error reporting per bulk item, and includes the error
addition from the linked PR:

    ❮ http localhost:4200/_sql stmt="insert into tbl (x) values (?)" bulk_args:='[[1], [2], [3]]'
    HTTP/1.1 200 OK
    {
        "cols": [],
        "duration": 60112.33,
        "results": [
            {
                "rowcount": 1
            },
            {
                "rowcount": 1
            },
            {
                "error": {
                    "code": 5002,
                    "message": "UnavailableShardsException[[doc.tbl][1] primary shard is not active Timeout: [1m], request: [ShardRequest{, shardId=[tbl/tAwjETKASaGfQJRrnn1M4g][1], timeout=1m}]]"
                },
                "rowcount": -2
            }
        ]
    }
