### PR TITLE
Reject stale SWAP TABLE requests using table OIDs

### DIFF
--- a/docs/appendices/release-notes/6.5.0.rst
+++ b/docs/appendices/release-notes/6.5.0.rst
@@ -153,6 +153,10 @@ Performance and Resilience Improvements
   source relation name points to a different table while the statement is being
   executed.
 
+- Improved :ref:`SWAP TABLE <alter_cluster_swap_table>` to fail if the source or
+  target relation name points to a different table while the statement is being
+  executed.
+
 Administration and Operations
 -----------------------------
 

--- a/server/src/main/java/io/crate/execution/ddl/RelationNameSwap.java
+++ b/server/src/main/java/io/crate/execution/ddl/RelationNameSwap.java
@@ -21,39 +21,66 @@
 
 package io.crate.execution.ddl;
 
-import io.crate.metadata.RelationName;
+import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
+
+import java.io.IOException;
+
+import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 
-import java.io.IOException;
+import io.crate.metadata.RelationName;
 
 public final class RelationNameSwap implements Writeable {
 
     private final RelationName source;
+    private final int sourceOid;
     private final RelationName target;
+    private final int targetOid;
 
-    public RelationNameSwap(RelationName source, RelationName target) {
+    public RelationNameSwap(RelationName source, int sourceOid, RelationName target, int targetOid) {
         this.source = source;
+        this.sourceOid = sourceOid;
         this.target = target;
+        this.targetOid = targetOid;
     }
 
     public RelationNameSwap(StreamInput in) throws IOException {
         this.source = new RelationName(in);
         this.target = new RelationName(in);
+        if (in.getVersion().onOrAfter(Version.V_6_5_0)) {
+            this.sourceOid = in.readVInt();
+            this.targetOid = in.readVInt();
+        } else {
+            this.sourceOid = OID_UNASSIGNED;
+            this.targetOid = OID_UNASSIGNED;
+        }
     }
 
     public RelationName source() {
         return source;
     }
 
+    public int sourceOid() {
+        return sourceOid;
+    }
+
     public RelationName target() {
         return target;
+    }
+
+    public int targetOid() {
+        return targetOid;
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         source.writeTo(out);
         target.writeTo(out);
+        if (out.getVersion().onOrAfter(Version.V_6_5_0)) {
+            out.writeVInt(sourceOid);
+            out.writeVInt(targetOid);
+        }
     }
 }

--- a/server/src/main/java/io/crate/execution/ddl/SwapRelationsOperation.java
+++ b/server/src/main/java/io/crate/execution/ddl/SwapRelationsOperation.java
@@ -21,8 +21,11 @@
 
 package io.crate.execution.ddl;
 
+import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
+
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.function.Consumer;
 
@@ -37,6 +40,7 @@ import org.elasticsearch.cluster.routing.allocation.AllocationService;
 import org.elasticsearch.index.Index;
 
 import io.crate.common.collections.Lists;
+import io.crate.exceptions.RelationUnknown;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.cluster.DDLClusterStateService;
@@ -129,6 +133,8 @@ public class SwapRelationsOperation {
 
             RelationMetadata.Table sourceRelation = metadata.getRelation(source);
             RelationMetadata.Table targetRelation = metadata.getRelation(target);
+            validateRelation(source, nameSwap.sourceOid(), sourceRelation);
+            validateRelation(target, nameSwap.targetOid(), targetRelation);
             updatedMetadata
                 .dropRelation(source)
                 .dropRelation(target)
@@ -208,6 +214,24 @@ public class SwapRelationsOperation {
             updatedState = ddlClusterStateService.onSwapRelations(updatedState, swapAction.source(), swapAction.target());
         }
         return updatedState;
+    }
+
+    private static void validateRelation(RelationName relationName,
+                                         int relationOid,
+                                         RelationMetadata.Table relationMetadata) {
+        if (relationOid == OID_UNASSIGNED) {
+            return;
+        }
+        if (relationMetadata == null) {
+            throw new RelationUnknown(relationName);
+        }
+        if (relationMetadata.oid() != relationOid) {
+            throw new IllegalStateException(String.format(
+                Locale.ENGLISH,
+                "Relation '%s' changed while SWAP TABLE was being executed",
+                relationName
+            ));
+        }
     }
 
     private void removeOccurrences(ClusterState state,

--- a/server/src/main/java/io/crate/planner/SwapTablePlan.java
+++ b/server/src/main/java/io/crate/planner/SwapTablePlan.java
@@ -72,7 +72,12 @@ public class SwapTablePlan implements Plan {
 
         RelationName source = swapTable.source().ident();
         SwapRelationsRequest request = new SwapRelationsRequest(
-            Collections.singletonList(new RelationNameSwap(source, swapTable.target().ident())),
+            Collections.singletonList(new RelationNameSwap(
+                source,
+                swapTable.source().oid(),
+                swapTable.target().ident(),
+                swapTable.target().oid()
+            )),
             dropSource ? Collections.singletonList(source) : emptyList()
         );
         OneRowActionListener<AcknowledgedResponse> listener = new OneRowActionListener<>(

--- a/server/src/test/java/io/crate/execution/ddl/RelationNameSwapTest.java
+++ b/server/src/test/java/io/crate/execution/ddl/RelationNameSwapTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.execution.ddl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.junit.Test;
+
+import io.crate.metadata.RelationName;
+
+public class RelationNameSwapTest {
+
+    @Test
+    public void test_streaming_table_oids() throws Exception {
+        // streaming to nodes with supported versions
+        RelationName source = new RelationName("doc", "source");
+        RelationName target = new RelationName("doc", "target");
+        int sourceOid = 1234;
+        int targetOid = 5678;
+        RelationNameSwap swap = new RelationNameSwap(source, sourceOid, target, targetOid);
+
+        var out = new BytesStreamOutput();
+        out.setVersion(Version.V_6_5_0);
+        swap.writeTo(out);
+
+        var in = out.bytes().streamInput();
+        in.setVersion(Version.V_6_5_0);
+        RelationNameSwap streamed = new RelationNameSwap(in);
+
+        assertThat(streamed.sourceOid()).isEqualTo(sourceOid);
+        assertThat(streamed.targetOid()).isEqualTo(targetOid);
+
+        // streaming to nodes with unsupported versions
+        swap = new RelationNameSwap(source, sourceOid, target, targetOid);
+
+        out = new BytesStreamOutput();
+        out.setVersion(Version.V_6_4_0);
+        swap.writeTo(out);
+
+        in = out.bytes().streamInput();
+        in.setVersion(Version.V_6_4_0);
+        streamed = new RelationNameSwap(in);
+
+        assertThat(streamed.sourceOid()).isEqualTo(OID_UNASSIGNED);
+        assertThat(streamed.targetOid()).isEqualTo(OID_UNASSIGNED);
+    }
+}

--- a/server/src/test/java/io/crate/execution/ddl/SwapRelationsOperationTest.java
+++ b/server/src/test/java/io/crate/execution/ddl/SwapRelationsOperationTest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.execution.ddl;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import io.crate.metadata.RelationName;
+import io.crate.metadata.doc.DocTableInfo;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.SQLExecutor;
+
+public class SwapRelationsOperationTest extends CrateDummyClusterServiceUnitTest {
+
+    @Test
+    public void test_rejects_swap_if_source_name_resolves_to_different_table_oid() throws Exception {
+        var e = SQLExecutor.of(clusterService)
+            .addTable("create table a (x int)")
+            .addTable("create table b (x int)");
+        DocTableInfo b = e.resolveTableInfo("b");
+
+        var operation = new SwapRelationsOperation(null, null);
+        var request = new SwapRelationsRequest(
+            List.of(new RelationNameSwap(
+                new RelationName("doc", "a"),
+                b.oid(),
+                new RelationName("doc", "b"),
+                b.oid()
+            )),
+            List.of()
+        );
+
+        assertThatThrownBy(() -> operation.execute(clusterService.state(), request))
+            .isExactlyInstanceOf(IllegalStateException.class)
+            .hasMessage("Relation 'doc.a' changed while SWAP TABLE was being executed");
+    }
+
+    @Test
+    public void test_rejects_swap_if_target_name_resolves_to_different_table_oid() throws Exception {
+        var e = SQLExecutor.of(clusterService)
+            .addTable("create table a (x int)")
+            .addTable("create table b (x int)");
+        DocTableInfo a = e.resolveTableInfo("a");
+
+        var operation = new SwapRelationsOperation(null, null);
+        var request = new SwapRelationsRequest(
+            List.of(new RelationNameSwap(
+                new RelationName("doc", "a"),
+                a.oid(),
+                new RelationName("doc", "b"),
+                a.oid()
+            )),
+            List.of()
+        );
+
+        assertThatThrownBy(() -> operation.execute(clusterService.state(), request))
+            .isExactlyInstanceOf(IllegalStateException.class)
+            .hasMessage("Relation 'doc.b' changed while SWAP TABLE was being executed");
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Relates to https://github.com/crate/crate/pull/19912.

Name-changing queries like `SWAP TABLE` operate on the tables referenced by the relation names at the time of analysis. If one of these relation names points to a different table during execution, the original intent of the query can no longer be fulfilled, so the query must be rejected.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes.
       If you're an external contributor you can give yourself attribution and include your name and Github handle.
       e.g.:
       ```
       `John Doe <https://github.com/John_Doe>`_ added support for ...
       ```
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
