### PR TITLE
Fix NPE in RANGE, FOLLOWING window frame aggregation (backport #19892)

### DIFF
--- a/docs/appendices/release-notes/6.3.8.rst
+++ b/docs/appendices/release-notes/6.3.8.rst
@@ -46,4 +46,6 @@ series.
 Fixes
 =====
 
-None
+- Fixed a ``NullPointerException`` that could happen if using an aggregation
+  function as window function with ``RANGE..FOLLOWING`` on a column containing
+  ``NULL`` values.

--- a/server/src/main/java/io/crate/execution/engine/window/WindowProjector.java
+++ b/server/src/main/java/io/crate/execution/engine/window/WindowProjector.java
@@ -255,7 +255,8 @@ public class WindowProjector {
             // probe value to null so it doesn't impact ordering (ie. all values will be consistently GT or LT
             // `null`)
             if (offsetColumnPosition != -1) {
-                x[offsetColumnPosition] = applyOffsetOnOrderingValue.apply(currentRow[offsetColumnPosition], finalOffsetValue);
+                Object curValue = currentRow[offsetColumnPosition];
+                x[offsetColumnPosition] = curValue == null ? null : applyOffsetOnOrderingValue.apply(curValue, finalOffsetValue);
             }
             return x;
         };

--- a/server/src/test/java/io/crate/execution/engine/window/AggregationWindowFunctionsTest.java
+++ b/server/src/test/java/io/crate/execution/engine/window/AggregationWindowFunctionsTest.java
@@ -284,6 +284,18 @@ public class AggregationWindowFunctionsTest extends AbstractWindowFunctionTest {
     }
 
     @Test
+    public void test_agg_over_range_following_with_null_values() throws Throwable {
+        Object[] expected = new Object[]{ 3L, 3L, 3L, 2L, 2L, 1L, 0L};
+        assertEvaluate("count(x) OVER (" +
+             "ORDER BY x RANGE BETWEEN CURRENT ROW AND 1 FOLLOWING)",
+            expected,
+            List.of(ColumnIdent.of("x")),
+            INPUT_ROWS
+        );
+    }
+
+
+    @Test
     public void test_agg_over_range_following() throws Throwable {
         Object[] expected = new Object[]{
             11.5,


### PR DESCRIPTION

## Summary of the changes / Why this improves CrateDB

Fixes https://github.com/crate/crate/issues/19890

Currently, when a table has a null value and an aggregation is run over it with an "over range following" window function, a null pointer exception is raised.

The cause is because as the code iterates through the rows, when a row with a null value is encountered, the code tries to add/subtract (via the offsetApplicationFunction) an integer to the null value. When UNBOUNDED,
this code path is not hit, so we did not see the issue before.

(cherry picked from commit edc4308c18f4964fa02f65f875326202a5e59fec)

 \# Conflicts:
 \#	docs/appendices/release-notes/6.3.8.rst


## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes.
       If you're an external contributor you can give yourself attribution and include your name and Github handle.
       e.g.:
       ```
       `John Doe <https://github.com/John_Doe>`_ added support for ...
       ```
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
