### PR TITLE
Optimize `select numeric_column from table group by numeric_column` through a loose index scan

### DIFF
--- a/docs/appendices/release-notes/6.5.0.rst
+++ b/docs/appendices/release-notes/6.5.0.rst
@@ -183,6 +183,11 @@ Performance and Resilience Improvements
   Lucene's term dictionary. Such queries now take 41% less time to complete in
   our benchmark for high-cardinality columns.
 
+- Improved the performance of ``GROUP BY`` queries where the grouping key is a
+  numeric column by taking advantage of Lucene's BKD trees. The speed up depends
+  on a number of factors, such as a column's cardinality ratio, but can range
+  from 20% up to two orders of magnitude.
+
 Administration and Operations
 -----------------------------
 

--- a/server/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
@@ -34,6 +34,7 @@ import java.util.function.LongFunction;
 import java.util.function.Supplier;
 
 import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.PostingsEnum;
@@ -214,6 +215,100 @@ final class GroupByOptimizedIterator {
             .iterator();
     }
 
+    /// Returns a batchIterator that reads the BKD points index instead of scanning documents, for:
+    ///
+    ///     `SELECT numKey FROM t GROUP BY numKey`
+    ///
+    /// Only works for a keys-only GROUP BY on a single numeric column and without a WHERE clause.
+    /// Returns null for other queries.
+    @Nullable
+    static BatchIterator<Row> tryUseLooseIndexScan(IndexShard indexShard,
+                                                   RoutedCollectPhase collectPhase,
+                                                   CollectTask collectTask) {
+        GroupProjection groupProjection = singleKeyGroupProjection(collectPhase.projections());
+        if (groupProjection == null) {
+            return null;
+        }
+        if (!groupProjection.values().isEmpty()) {
+            // There are three cases:
+            //   1. count(*),                            e.g. SELECT x, count(*) FROM tbl GROUP BY x
+            //   2. aggregates over the key column,       e.g. SELECT x, avg(x) FROM tbl GROUP BY x
+            //   3. aggregates over a different column,   e.g. SELECT x, avg(y) FROM tbl GROUP BY x
+            //
+            // (1) and (2) can be implemented with just the PointTree, but currently aren't.
+            //
+            // (3) requires doc values, and they cannot be driven from PointValues, because
+            // PointValues is ordered by value: advanceExact requires a doc id >= the current one
+            // (see DocValuesIterator), while a value-ordered traversal hands out doc ids in
+            // arbitrary order.
+            return null;
+        }
+        if (!collectPhase.where().equals(Literal.BOOLEAN_TRUE)) {
+            // In theory a WHERE clause that uses only this key column could be pushed down to the
+            // PointTree, but that's currently not implemented.
+            // Any other WHERE clause, using other columns, cannot work at all.
+            return null;
+        }
+
+        Reference docKeyRef = getKeyRef(collectPhase.toCollect(), groupProjection.keys().getFirst());
+        if (docKeyRef == null) {
+            return null; // group by on a non-reference
+        }
+        final Reference keyRef = DocReferences.docRefToRegularRef(docKeyRef);
+        if (!LooseIndexScan.supportsType(keyRef.valueType())) {
+            return null; // not a type that CrateDB indexes as a single point dimension
+        }
+        if (keyRef.indexType() == IndexType.NONE) {
+            return null; // INDEX OFF, no points written
+        }
+
+        int bytesPerValue = pointWidth(
+            () -> indexShard.acquireSearcher("loose-index-scan:" + formatSource(collectPhase)), keyRef.storageIdent());
+        if (bytesPerValue < 0) {
+            return null;
+        }
+
+        ShardId shardId = indexShard.shardId();
+        SharedShardContext sharedShardContext = collectTask.sharedShardContexts().getOrCreateContext(shardId);
+        var searcherRef = sharedShardContext.acquireSearcher("loose-index-scan:" + formatSource(collectPhase));
+        collectTask.addSearcher(sharedShardContext.readerId(), searcherRef);
+
+        return LooseIndexScan.iterator(
+            searcherRef.item(),
+            keyRef,
+            bytesPerValue,
+            collectTask.getRamAccounting(),
+            collectTask.killToken()
+        );
+    }
+
+    /**
+     * The point width of `fieldName`, or -1 if the loose index scan cannot be used because the
+     * column has no points at all, or is indexed with more than one dimension.
+     */
+    static int pointWidth(Supplier<Engine.Searcher> acquireSearcher, String fieldName) {
+        // Acquires a separate searcher for the same reason as hasHighCardinalityRatio: going through
+        // sharedShardContexts() and then bailing out causes issues in the fallback logic later on.
+        try (var searcher = acquireSearcher.get()) {
+            // Enough to inspect only the first segment that contains the field since Lucene makes sure all segments
+            // use the same dimension.
+            // A segment can lack the field entirely if the column was added after it was written, or if every
+            // doc in it has a NULL value.
+            for (LeafReaderContext leaf : searcher.getIndexReader().leaves()) {
+                FieldInfo fieldInfo = leaf.reader().getFieldInfos().fieldInfo(fieldName);
+                if (fieldInfo == null) {
+                    continue;
+                }
+                assert fieldInfo.getPointIndexDimensionCount() > 0
+                    : "pointWidth() called on a field that has no points (not indexed)";
+                return fieldInfo.getPointIndexDimensionCount() == 1
+                    ? fieldInfo.getPointNumBytes()
+                    : -1;
+            }
+            return -1;
+        }
+    }
+
     private static Iterable<Row> countsToRows(Map<String, Long> countsByKey, AggregateMode mode) {
         final Object[] cells = new Object[2];
         final Row row = new RowN(cells);
@@ -298,7 +393,7 @@ final class GroupByOptimizedIterator {
         return countsByKey;
     }
 
-    private static int countNullValues(Reference keyRef, IndexSearcher searcher) throws IOException {
+    public static int countNullValues(Reference keyRef, IndexSearcher searcher) throws IOException {
         String keyStorageIdent = keyRef.storageIdent();
         Query existsQuery = keyRef.hasDocValues() || keyRef.indexType() == IndexType.FULLTEXT
             ? new FieldExistsQuery(keyStorageIdent)
@@ -862,7 +957,12 @@ final class GroupByOptimizedIterator {
         return null;
     }
 
-    private static GroupProjection getSingleStringKeyGroupProjection(Collection<? extends Projection> projections) {
+    /**
+     * The single shard level GroupProjection with exactly one grouping key of any type, or null if
+     * the projections don't have that shape.
+     */
+    @Nullable
+    private static GroupProjection singleKeyGroupProjection(Collection<? extends Projection> projections) {
         GroupProjection groupProjection = null;
         int shardProjections = 0;
         for (var projection : projections) {
@@ -873,10 +973,17 @@ final class GroupByOptimizedIterator {
                 }
             }
         }
-        if (shardProjections != 1 || groupProjection == null) {
+        if (shardProjections != 1 || groupProjection == null || groupProjection.keys().size() != 1) {
             return null;
         }
-        if (groupProjection.keys().size() != 1 || groupProjection.keys().get(0).valueType().id() != DataTypes.STRING.id()) {
+        return groupProjection;
+    }
+
+    @Nullable
+    private static GroupProjection getSingleStringKeyGroupProjection(Collection<? extends Projection> projections) {
+        GroupProjection groupProjection = singleKeyGroupProjection(projections);
+        if (groupProjection == null
+            || groupProjection.keys().getFirst().valueType().id() != DataTypes.STRING.id()) {
             return null;
         }
         return groupProjection;

--- a/server/src/main/java/io/crate/execution/engine/collect/LooseIndexScan.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/LooseIndexScan.java
@@ -1,0 +1,559 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.execution.engine.collect;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.PriorityQueue;
+import java.util.Set;
+
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.PointValues;
+import org.apache.lucene.index.PointValues.IntersectVisitor;
+import org.apache.lucene.index.PointValues.PointTree;
+import org.apache.lucene.index.PointValues.Relation;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.util.ArrayUtil;
+import org.apache.lucene.util.ArrayUtil.ByteArrayComparator;
+import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.apache.lucene.util.bkd.BKDConfig;
+import org.jspecify.annotations.Nullable;
+
+import io.crate.common.concurrent.Killable.Token;
+import io.crate.data.BatchIterator;
+import io.crate.data.InMemoryBatchIterator;
+import io.crate.data.Row;
+import io.crate.data.RowN;
+import io.crate.data.SentinelRow;
+import io.crate.data.breaker.RamAccounting;
+import io.crate.metadata.IndexType;
+import io.crate.metadata.Reference;
+import io.crate.types.ByteType;
+import io.crate.types.DataType;
+import io.crate.types.DateType;
+import io.crate.types.DoubleType;
+import io.crate.types.FloatType;
+import io.crate.types.IntegerType;
+import io.crate.types.LongType;
+import io.crate.types.ShortType;
+import io.crate.types.StorageSupport;
+import io.crate.types.TimestampType;
+
+/**
+ * Loose index scan (a.k.a. skip scan) over the BKD points index of a single numeric column. This can be used to serve
+ * a keys-only GROUP BY without reading documents.
+ * <p>
+ * A BKD tree with one dimension (which is what is used for numeric columns) has all the values in leaf blocks sorted.
+ * With that, a left-to-right traversal yields every point in ascending value order.
+ * <p>
+ * Deduplication is then a comparison against the previously emitted value. The key optimization is when finding a node
+ * for which {@code min == max}. This means that the whole subtree holds a single distinct value. That is the "loose"
+ * part.
+ * <p>
+ * Applicability is decided by {@link GroupByOptimizedIterator#tryUseLooseIndexScan}.
+ */
+final class LooseIndexScan {
+
+    /// Types CrateDB indexes as a single point dimension, and whose [StorageSupport#decode(byte[])]
+    /// can turn a packed point back into a value.
+    ///
+    /// `ip` and NUMERIC(19..38) are 1-dimension points too, but are left out for now: they need more
+    /// complex logic for comparison and decoding. `boolean` and `text` write no points at all.
+    private static final Set<Integer> SUPPORTED_TYPE_IDS = Set.of(
+        ByteType.ID,
+        ShortType.ID,
+        IntegerType.ID,
+        LongType.ID,
+        FloatType.ID,
+        DoubleType.ID,
+        DateType.ID,
+        TimestampType.ID_WITH_TZ,
+        TimestampType.ID_WITHOUT_TZ
+    );
+
+    static boolean supportsType(DataType<?> type) {
+        return SUPPORTED_TYPE_IDS.contains(type.id());
+    }
+
+    private LooseIndexScan() {
+    }
+
+    /**
+     * Distinct values of `keyRef`, read from the points index.
+     */
+    static BatchIterator<Row> iterator(IndexSearcher searcher,
+                                       Reference keyRef,
+                                       int bytesPerValue,
+                                       RamAccounting ramAccounting,
+                                       Token killToken) {
+        return InMemoryBatchIterator.of(
+            rows(searcher, keyRef, bytesPerValue, ramAccounting, killToken),
+            SentinelRow.SENTINEL,
+            // distinct values loaded lazily from each segment
+            true
+        );
+    }
+
+    // The distinct values as single cell rows, produced lazily.
+    private static Iterable<Row> rows(IndexSearcher searcher,
+                                      Reference keyRef,
+                                      int bytesPerValue,
+                                      RamAccounting ramAccounting,
+                                      Token killToken) {
+        // moveToStart() re-invokes this Iterable. Without closing the previous pass first, each
+        // rewind would account the same memory again.
+        ShardDistinctValues[] previous = new ShardDistinctValues[1];
+        return () -> {
+            try {
+                if (previous[0] != null) {
+                    previous[0].close();
+                    previous[0] = null;
+                }
+
+                boolean returnNull = keyRef.isNullable()
+                    && GroupByOptimizedIterator.countNullValues(keyRef, searcher) > 0;
+
+                ShardDistinctValues distinctValues = new ShardDistinctValues(
+                    keyRef,
+                    returnNull,
+                    bytesPerValue,
+                    createSegmentCursors(
+                        searcher, keyRef, bytesPerValue, ramAccounting, killToken
+                    ),
+                    ramAccounting
+                );
+                previous[0] = distinctValues;
+                return distinctValues;
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        };
+    }
+
+    /**
+     * An iterator over distinct values in a shard. The values are returned NULL first and then in ascending order.
+     * <p>
+     * {@code ShardDistinctValues} reads distinct values from individual segments. The values returned from each segment
+     * are already sorted, so {@code ShardDistinctValues} needs a heap of size {@code number_of_segments}.
+     * <p>
+     * Lucene's MergedIterator does the same thing, but it caches each sub-iterator's last value in its heap,
+     * so sub-iterators may not reuse the returned object. That's not true for our segment cursors.
+     */
+    static final class ShardDistinctValues implements Iterator<Row> {
+
+        private final PriorityQueue<SegmentCursor> queue;
+        private final ByteArrayComparator cmp;
+        private final int bytesPerValue;
+        private final StorageSupport<?> storageSupport;
+        private final Object[] cells = new Object[1];
+        private final Row row = new RowN(cells);
+        private final RamAccounting ramAccounting;
+        private final long accountedBytes;
+
+        private byte[] current;
+        /// A value sits in `current`, not yet handed out by `next()`.
+        private boolean nextAvailable;
+        /// No point is written for NULL, so the tree cannot report it. It is emitted first.
+        private boolean returnNull;
+
+        ShardDistinctValues(Reference keyRef,
+                            boolean returnNull,
+                            int bytesPerValue,
+                            List<SegmentCursor> cursors,
+                            RamAccounting ramAccounting) throws IOException {
+            this.bytesPerValue = bytesPerValue;
+            this.cmp = ArrayUtil.getUnsignedComparator(bytesPerValue);
+
+            this.storageSupport = keyRef.valueType().storageSupportSafe();
+            assert supportsType(keyRef.valueType())
+                : "ShardDistinctValues can only be used with types that decode points";
+
+            this.ramAccounting = ramAccounting;
+            // bytesPerValue for the `current` field
+            this.accountedBytes = bytesPerValue + (long) cursors.size() * RamUsageEstimator.NUM_BYTES_OBJECT_REF;
+            ramAccounting.addBytes(accountedBytes);
+            this.returnNull = returnNull;
+            this.queue = new PriorityQueue<>(
+                Math.max(1, cursors.size()),
+                (a, b) -> cmp.compare(a.value(), 0, b.value(), 0)
+            );
+            // Only cursors that actually hold values can get into the queue (the comparator requires a value).
+            for (var c : cursors) {
+                if (c.next()) {
+                    queue.add(c);
+                }
+            }
+        }
+
+        /**
+         * Releases the bytes accounted for this instance, and closes every cursor still in the queue.
+         * A cursor that had already exhausted itself was closed by {@link #advance()} already.
+         */
+        void close() {
+            ramAccounting.addBytes(-accountedBytes);
+            while (!queue.isEmpty()) {
+                queue.poll().close();
+            }
+        }
+
+        @Override
+        public boolean hasNext() {
+            if (returnNull || nextAvailable) {
+                return true;
+            }
+
+            try {
+                nextAvailable = advance();
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+
+            return nextAvailable;
+        }
+
+        @Override
+        public Row next() {
+            if (!hasNext()) {
+                throw new NoSuchElementException("All distinct values have been consumed");
+            }
+            if (returnNull) {
+                returnNull = false;
+                cells[0] = null;
+            } else {
+                nextAvailable = false;
+                cells[0] = storageSupport.decode(current);
+            }
+            return row;
+        }
+
+        // Advances `current` to the next distinct value. Returns false once every segment is exhausted.
+        private boolean advance() throws IOException {
+            while (!queue.isEmpty()) {
+                SegmentCursor cursor = queue.poll();
+                // NB: value() returns the cursor's own array, and the cursor may overwrite it.
+                boolean found = current == null || cmp.compare(cursor.value(), 0, current, 0) != 0;
+                if (found) {
+                    if (current == null) {
+                        current = new byte[bytesPerValue];
+                    }
+                    System.arraycopy(cursor.value(), 0, current, 0, bytesPerValue);
+                }
+
+                if (cursor.next()) {
+                    queue.add(cursor);
+                } else {
+                    // Exhausted, so we can close it/release used memory right away.
+                    cursor.close();
+                }
+
+                if (!found) {
+                    continue; // the same value, from another segment
+                }
+                return true;
+            }
+            return false;
+        }
+    }
+
+    // One cursor per segment that has points for `keyRef`.
+    private static List<SegmentCursor> createSegmentCursors(IndexSearcher searcher,
+                                                            Reference keyRef,
+                                                            int bytesPerValue,
+                                                            RamAccounting ramAccounting,
+                                                            Token killToken) throws IOException {
+        assert keyRef.indexType() != IndexType.NONE
+            : "SegmentCursors can be created only for indexed columns";
+
+        String field = keyRef.storageIdent();
+        List<SegmentCursor> cursors = new ArrayList<>(searcher.getLeafContexts().size());
+        for (var leaf : searcher.getLeafContexts()) {
+            LeafReader reader = leaf.reader();
+            PointValues values = reader.getPointValues(field);
+            if (values == null || values.size() == 0) {
+                // The column was added after this segment was written, or every doc in it has a
+                // NULL value, so no points were written for it here.
+                continue;
+            }
+            cursors.add(new SegmentCursor(values, reader.getLiveDocs(), bytesPerValue, ramAccounting, killToken));
+        }
+        return cursors;
+    }
+
+    /**
+     * A cursor for distinct values in a segment. Values are ordered in ascending order.
+     * <p>
+     * This is done by traversing a {@link PointTree}, depth first, left to right.
+     * At each node:
+     * <p>(1) if {@code min == max}, the whole subtree contains identical values, we just take {@code min} and skip the
+     * subtree;
+     * <p>(2) otherwise descend into subtree
+     * <p>(3) if at a leaf, copy the leaf block's points.
+     */
+    static final class SegmentCursor {
+
+        private final PointTree tree;
+        @Nullable
+        private final Bits liveDocs;
+        // Number of bytes needed to store a value.
+        private final int bytesPerValue;
+        private final ByteArrayComparator cmp;
+        private final RamAccounting ramAccounting;
+        private final Token killToken;
+
+        /// The value most recently returned by `next()`.
+        private byte @Nullable [] current;
+
+        // The distinct values of one leaf block.
+        private byte[] buffer;
+        // Number of packed values in buffer.
+        private int numValues;
+        private int nextValueIndex;
+        private boolean treeFullyVisited;
+        // Running total of bytes accounted via `ramAccounting`, including buffer growth.
+        private long accountedBytes;
+
+        private final CopyLeafValuesVisitor copyLeafValuesVisitor = new CopyLeafValuesVisitor();
+        private final LiveDocVisitor liveDocVisitor = new LiveDocVisitor();
+
+        SegmentCursor(PointValues values,
+                      @Nullable Bits liveDocs,
+                      int bytesPerValue,
+                      RamAccounting ramAccounting,
+                      Token killToken) throws IOException {
+            this.tree = values.getPointTree();
+            this.liveDocs = liveDocs;
+            this.bytesPerValue = bytesPerValue;
+            this.cmp = ArrayUtil.getUnsignedComparator(bytesPerValue);
+            this.ramAccounting = ramAccounting;
+            this.killToken = killToken;
+            // Buffer's max size:
+            //
+            // The buffer is always filled with either 1 value (in internal nodes) or with all the values from a leaf.
+            // All the leaves (except for maybe the right-most) have the same size.
+            // This size is never exceeded because, as soon as the buffer is filled with at least one value,
+            // it's not filled again, until all the values have been returned from the cursor.
+            // This implies that the buffer's max size is the size of the first leaf,
+            // which is likely BKDConfig.DEFAULT_MAX_POINTS_IN_LEAF_NODE.
+            // With 4-8 bytes per point, this is currently 2-4kb.
+            //
+            // Buffer's growth:
+            //
+            // Given the above, it's expected to grow once, at most, which is
+            // from the initial size to the number of points in the first leaf.
+            //
+            // With all the above, 2-4kb is a relatively small value for which there will be no buffer growth
+            // in most cases, so we choose that.
+            this.buffer = new byte[bytesPerValue * BKDConfig.DEFAULT_MAX_POINTS_IN_LEAF_NODE];
+            // bytesPerValue for the `current` field, which is allocated on the first next()
+            this.accountedBytes = buffer.length + bytesPerValue;
+            ramAccounting.addBytes(accountedBytes);
+        }
+
+        // Appends a value unless it's not already in the buffer.
+        private void append(byte[] packed) {
+            // Values arrive ascending, so a duplicate can only equal the value appended just before it,
+            // or - when the buffer has been drained - the last one returned.
+            if (numValues > 0) {
+                if (cmp.compare(packed, 0, buffer, (numValues - 1) * bytesPerValue) == 0) {
+                    return;
+                }
+            } else if (current != null && cmp.compare(packed, 0, current, 0) == 0) {
+                return;
+            }
+            maybeGrowBuffer(1);
+            System.arraycopy(packed, 0, buffer, numValues * bytesPerValue, bytesPerValue);
+            numValues++;
+        }
+
+        private void maybeGrowBuffer(int numNewValue) {
+            int required = (numValues + numNewValue) * bytesPerValue;
+            if (buffer.length < required) {
+                int before = buffer.length;
+                buffer = ArrayUtil.growExact(buffer, required);
+                long grown = buffer.length - before;
+                accountedBytes += grown;
+                ramAccounting.addBytes(grown);
+            }
+        }
+
+        /**
+         * Releases the bytes this cursor accounted for via {@code ramAccounting}, including any
+         * buffer growth since construction.
+         */
+        void close() {
+            ramAccounting.addBytes(-accountedBytes);
+            accountedBytes = 0;
+        }
+
+        // Advances to the next distinct value. Returns false once the segment is exhausted.
+        public boolean next() throws IOException {
+            while (nextValueIndex == numValues) {
+                if (treeFullyVisited) {
+                    return false;
+                }
+                fill();
+            }
+            if (current == null) {
+                current = new byte[bytesPerValue];
+            }
+            System.arraycopy(buffer, nextValueIndex * bytesPerValue, current, 0, bytesPerValue);
+            nextValueIndex++;
+            return true;
+        }
+
+        /**
+         * The current value, valid only after {@link #next()} returned true.
+         * The array is the cursor's own and is overwritten by the next call. Copy it if it has to outlive that.
+         */
+        public byte[] value() {
+            return current;
+        }
+
+        // Walks the tree until the buffer holds something, or the tree runs out.
+        private void fill() throws IOException {
+            nextValueIndex = 0;
+            numValues = 0;
+            while (numValues == 0 && !treeFullyVisited) {
+                killToken.raiseIfKilled();
+                if (cmp.compare(tree.getMinPackedValue(), 0, tree.getMaxPackedValue(), 0) == 0) {
+                    // The whole subtree holds a single value.
+                    // getMinPackedValue() returns the array the cursor mutates while navigating, but
+                    // passing it straight in is safe: append() copies it out immediately, and step(),
+                    // which overwrites it, only runs afterwards.
+                    // Points of deleted documents linger until segments merge, so the value is only a
+                    // candidate until a live document is found for it.
+                    if (liveDocs == null || hasLiveDoc()) {
+                        append(tree.getMinPackedValue());
+                    }
+                    step();
+                } else if (!tree.moveToChild()) {
+                    // No child, so this is a leaf: buffer its points.
+                    // The number of points in a leaf is an int
+                    // (see: org.apache.lucene.util.bkd.BKDConfig.maxPointsInLeafNode),
+                    // so it's safe to cast to `int` here.
+                    maybeGrowBuffer((int) tree.size());
+                    tree.visitDocValues(copyLeafValuesVisitor);
+                    step();
+                }
+                // else: moveToChild() descended, the loop inspects the child next
+            }
+        }
+
+        // Moves to the next node in depth-first order, after the current subtree.
+        private void step() throws IOException {
+            while (!tree.moveToSibling()) {
+                if (!tree.moveToParent()) {
+                    treeFullyVisited = true;
+                    return;
+                }
+            }
+        }
+
+        /**
+         * True if any document below the current node is live. Visits doc ids only, so no point values
+         * are decoded, and stops at the first live one.
+         * <p>
+         * The probe runs on a clone rooted at the current node, never on {@code tree} itself. The reason is:
+         * IntersectVisitor cannot signal "stop", so leaving early means we need to throw an exception.
+         * The exception is not handled in the {@code BKDReader} that implements the {@code PointTree}, so the
+         * tree may be left in an inconsistent state.
+         */
+        private boolean hasLiveDoc() throws IOException {
+            liveDocVisitor.found = false;
+            PointTree probe = tree.clone();
+            try {
+                probe.visitDocIDs(liveDocVisitor);
+            } catch (StopVisiting stop) {
+                // a live document was found, nothing left to check
+            }
+            return liveDocVisitor.found;
+        }
+
+        private final class LiveDocVisitor implements IntersectVisitor {
+
+            boolean found;
+
+            @Override
+            public void visit(int docID) {
+                assert liveDocs != null : "Only used when the segment has deletes";
+                if (liveDocs.get(docID)) {
+                    found = true;
+                    throw StopVisiting.INSTANCE;
+                }
+            }
+
+            @Override
+            public void visit(int docID, byte[] packedValue) {
+                visit(docID);
+            }
+
+            @Override
+            public Relation compare(byte[] minPackedValue, byte[] maxPackedValue) {
+                return Relation.CELL_CROSSES_QUERY;
+            }
+        }
+
+        /**
+         * Copies a leaf block's values. Ascending order comes from Lucene, per the contract of
+         * {@link IntersectVisitor#visit(int, byte[])}: "In the 1D case, values are visited in
+         * increasing order, and in the case of ties, in increasing docID order."
+         */
+        private final class CopyLeafValuesVisitor implements IntersectVisitor {
+
+            @Override
+            public void visit(int docID) {
+                throw new IllegalStateException("compare() never reports CELL_INSIDE_QUERY");
+            }
+
+            @Override
+            public void visit(int docID, byte[] packedValue) {
+                if (liveDocs == null || liveDocs.get(docID)) {
+                    append(packedValue);
+                }
+            }
+
+            @Override
+            public Relation compare(byte[] minPackedValue, byte[] maxPackedValue) {
+                // CELL_CROSSES_QUERY forces a visit per point, which is what we need: the values.
+                return Relation.CELL_CROSSES_QUERY;
+            }
+        }
+    }
+
+    /**
+     * Used to leave an {@link IntersectVisitor} early.
+     * It carries no stack trace and no suppression, so throwing it costs nothing.
+     */
+    private static final class StopVisiting extends RuntimeException {
+
+        static final StopVisiting INSTANCE = new StopVisiting();
+
+        private StopVisiting() {
+            super(null, null, false, false);
+        }
+    }
+}

--- a/server/src/main/java/io/crate/execution/engine/collect/LuceneShardCollectorProvider.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/LuceneShardCollectorProvider.java
@@ -173,6 +173,14 @@ public class LuceneShardCollectorProvider extends ShardCollectorProvider {
         if (it != null) {
             return it;
         }
+        it = GroupByOptimizedIterator.tryUseLooseIndexScan(
+            indexShard,
+            normalizedPhase,
+            collectTask
+        );
+        if (it != null) {
+            return it;
+        }
         it = GroupByOptimizedIterator.tryOptimizeSingleStringKey(
             nodeCtx.functions(),
             referenceResolver,

--- a/server/src/main/java/io/crate/types/ByteType.java
+++ b/server/src/main/java/io/crate/types/ByteType.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.function.Function;
 
+import org.apache.lucene.util.NumericUtils;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
@@ -58,6 +59,13 @@ public class ByteType extends DataType<Byte> implements Streamer<Byte>, FixedWid
         public Byte decode(int input) {
             return (byte) input;
         }
+
+        // byte is indexed by IntIndexer, so its points are 4 bytes wide.
+        @Override
+        public Byte decode(byte[] packedPoint) {
+            return (byte) NumericUtils.sortableBytesToInt(packedPoint, 0);
+        }
+
     };
 
     private ByteType() {

--- a/server/src/main/java/io/crate/types/DateType.java
+++ b/server/src/main/java/io/crate/types/DateType.java
@@ -31,6 +31,7 @@ import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.util.function.Function;
 
+import org.apache.lucene.util.NumericUtils;
 import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -63,6 +64,12 @@ public class DateType extends DataType<Long>
                                                Function<ColumnIdent, Reference> getRef) {
             return new LongIndexer(ref);
         }
+
+        @Override
+        public Long decode(byte[] packedPoint) {
+            return NumericUtils.sortableBytesToLong(packedPoint, 0);
+        }
+
     };
 
     @Override

--- a/server/src/main/java/io/crate/types/DoubleType.java
+++ b/server/src/main/java/io/crate/types/DoubleType.java
@@ -118,6 +118,12 @@ public class DoubleType extends DataType<Double> implements FixedWidthType, Stre
                                                  Function<ColumnIdent, Reference> getRef) {
             return new DoubleIndexer(ref);
         }
+
+        @Override
+        public Double decode(byte[] packedPoint) {
+            return NumericUtils.sortableLongToDouble(NumericUtils.sortableBytesToLong(packedPoint, 0));
+        }
+
     };
 
     private static final BigDecimal DOUBLE_MAX = BigDecimal.valueOf(Double.MAX_VALUE);

--- a/server/src/main/java/io/crate/types/FloatType.java
+++ b/server/src/main/java/io/crate/types/FloatType.java
@@ -118,6 +118,12 @@ public class FloatType extends DataType<Float> implements Streamer<Float>, Fixed
                                                 Function<ColumnIdent, Reference> getRef) {
             return new FloatIndexer(ref);
         }
+
+        @Override
+        public Float decode(byte[] packedPoint) {
+            return NumericUtils.sortableIntToFloat(NumericUtils.sortableBytesToInt(packedPoint, 0));
+        }
+
     };
 
     private static final BigDecimal MAX = BigDecimal.valueOf(Float.MAX_VALUE);

--- a/server/src/main/java/io/crate/types/IntegerType.java
+++ b/server/src/main/java/io/crate/types/IntegerType.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.function.Function;
 
+import org.apache.lucene.util.NumericUtils;
 import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -57,6 +58,12 @@ public class IntegerType extends DataType<Integer> implements Streamer<Integer>,
         public Integer decode(int input) {
             return input;
         }
+
+        @Override
+        public Integer decode(byte[] packedPoint) {
+            return NumericUtils.sortableBytesToInt(packedPoint, 0);
+        }
+
     };
 
     private IntegerType() {

--- a/server/src/main/java/io/crate/types/LongType.java
+++ b/server/src/main/java/io/crate/types/LongType.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.function.Function;
 
+import org.apache.lucene.util.NumericUtils;
 import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -61,6 +62,12 @@ public class LongType extends DataType<Long> implements FixedWidthType, Streamer
         public Long decode(long input) {
             return input;
         }
+
+        @Override
+        public Long decode(byte[] packedPoint) {
+            return NumericUtils.sortableBytesToLong(packedPoint, 0);
+        }
+
     };
 
     @Override

--- a/server/src/main/java/io/crate/types/ShortType.java
+++ b/server/src/main/java/io/crate/types/ShortType.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.function.Function;
 
+import org.apache.lucene.util.NumericUtils;
 import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -57,6 +58,13 @@ public class ShortType extends DataType<Short> implements Streamer<Short>, Fixed
         public Short decode(int input) {
             return (short) input;
         }
+
+        // smallint is indexed by IntIndexer, so its points are 4 bytes wide.
+        @Override
+        public Short decode(byte[] packedPoint) {
+            return (short) NumericUtils.sortableBytesToInt(packedPoint, 0);
+        }
+
     };
 
     private ShortType() {

--- a/server/src/main/java/io/crate/types/StorageSupport.java
+++ b/server/src/main/java/io/crate/types/StorageSupport.java
@@ -89,6 +89,13 @@ public abstract class StorageSupport<T> {
     }
 
     /**
+     * Decode a value from the packed bytes of a point in the BKD index.
+     */
+    public T decode(byte[] packedPoint) {
+        throw new UnsupportedOperationException("decodeFromPackedPoint not supported");
+    }
+
+    /**
      * @return {@code true} if values should always be loaded from stored fields
      */
     public boolean retrieveFromStoredFields() {

--- a/server/src/main/java/io/crate/types/TimestampType.java
+++ b/server/src/main/java/io/crate/types/TimestampType.java
@@ -38,6 +38,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.function.Function;
 
+import org.apache.lucene.util.NumericUtils;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
@@ -85,6 +86,12 @@ public final class TimestampType extends DataType<Long>
                                                Function<ColumnIdent, Reference> getRef) {
             return new LongIndexer(ref);
         }
+
+        @Override
+        public Long decode(byte[] packedPoint) {
+            return NumericUtils.sortableBytesToLong(packedPoint, 0);
+        }
+
     };
 
     private final int id;

--- a/server/src/test/java/io/crate/integrationtests/GroupByAggregateTest.java
+++ b/server/src/test/java/io/crate/integrationtests/GroupByAggregateTest.java
@@ -29,9 +29,11 @@ import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.TreeSet;
 import java.util.stream.Stream;
 
 import org.assertj.core.data.Percentage;
@@ -55,6 +57,8 @@ import io.crate.testing.SQLResponse;
 import io.crate.testing.UseJdbc;
 import io.crate.testing.UseRandomizedOptimizerRules;
 import io.crate.testing.UseRandomizedSchema;
+import io.crate.types.DataType;
+import io.crate.types.DataTypes;
 
 @IntegTestCase.ClusterScope(numDataNodes = 2, numClientNodes = 0, supportsDedicatedMasters = false)
 public class GroupByAggregateTest extends IntegTestCase {
@@ -132,6 +136,83 @@ public class GroupByAggregateTest extends IntegTestCase {
 
         execute("select count(*), name from t group by name, x limit 2");
         assertThat(response).hasRowCount(2L);
+    }
+
+    @Test
+    // JDBC disabled to have simpler assertions for the timestamp and date columns.
+    // They are inserted as long values, but retrieved as strings via JDBC.
+    // Timestamps and dates are tested thoroughly in other tests.
+    @UseJdbc(value = 0)
+    public void test_group_by_for_types_with_loose_index_scan() throws Exception {
+        record TestCase(DataType<?> dataType, List<Object> values) { }
+
+        // LongIndexer rejects Long.MIN_VALUE/MAX_VALUE outright (reserved sentinels),
+        // so we use the closest extreme values.
+        List<TestCase> testCases = List.of(
+            new TestCase(DataTypes.BYTE, List.of(Byte.MIN_VALUE, Byte.MIN_VALUE, Byte.MAX_VALUE, -1)),
+            new TestCase(DataTypes.SHORT, List.of(Short.MIN_VALUE, Short.MIN_VALUE, Short.MAX_VALUE, -1)),
+            new TestCase(DataTypes.INTEGER, List.of(Integer.MIN_VALUE, Integer.MIN_VALUE, Integer.MAX_VALUE, -1)),
+            new TestCase(
+                DataTypes.LONG,
+                List.of(Long.MIN_VALUE + 1, Long.MIN_VALUE + 1, Long.MAX_VALUE - 1, -1)
+            ),
+            new TestCase(DataTypes.FLOAT, List.of(-Float.MAX_VALUE, -Float.MAX_VALUE, Float.MAX_VALUE, -1.23f)),
+            new TestCase(DataTypes.DOUBLE, List.of(-Double.MAX_VALUE, -Double.MAX_VALUE, Double.MAX_VALUE, -1.23d)),
+            new TestCase(DataTypes.DATE, List.of(Long.MIN_VALUE, Long.MIN_VALUE, Long.MAX_VALUE, 0L)),
+            new TestCase(
+                DataTypes.TIMESTAMPZ,
+                List.of(Long.MIN_VALUE + 1, Long.MIN_VALUE + 1, Long.MAX_VALUE - 1, -1)
+            ),
+            new TestCase(
+                DataTypes.TIMESTAMP,
+                List.of(Long.MIN_VALUE + 1, Long.MIN_VALUE + 1, Long.MAX_VALUE - 1, -1)
+            )
+        );
+
+        for (TestCase tc : testCases) {
+            for (boolean indexing : List.of(true, false)) {
+                assertGroupByMinAndMaxValues(tc.dataType(), indexing, tc.values());
+            }
+        }
+    }
+
+    /// Asserts that `GROUP BY` returns correct results when `values` are
+    /// inserted into a column of type `dataType`. Indexing can be enabled
+    /// or disabled with `indexing`.
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private void assertGroupByMinAndMaxValues(DataType<?> dataType,
+                                              boolean indexing,
+                                              List<Object> values) {
+        String columnType = dataType.getName();
+        String columnDefinition = indexing ? columnType : columnType + " index off";
+        execute("create table t (v " + columnDefinition + ")");
+
+        // A row with a NULL value is added on top of `values` to check it's grouped separately
+        // and sorted last, regardless of type.
+        Object[][] rows = new Object[values.size() + 1][];
+        for (int i = 0; i < values.size(); i++) {
+            rows[i] = new Object[] { values.get(i) };
+        }
+        rows[values.size()] = new Object[] { null };
+        execute("insert into t (v) values (?)", rows);
+        execute("refresh table t");
+
+        // De-duplicate
+        TreeSet<Object> distinctValues = new TreeSet<>((a, b) -> ((DataType) dataType).compare(a, b));
+        for (Object value : values) {
+            distinctValues.add(dataType.implicitCast(value));
+        }
+        List<String> expected = new ArrayList<>();
+        for (Object value : distinctValues) {
+            expected.add(String.valueOf(value));
+        }
+        expected.add("NULL");
+
+        execute("select v from t group by v order by v nulls last");
+        assertThat(response)
+            .as("column definition: " + columnDefinition)
+            .hasRows(expected.toArray(new String[0]));
+        execute("drop table t");
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Relates to: #13818 and #19715.

This PR optimizes `select numeric_column from table group by numeric_column`.  Once #19715 is merged, it will make queries like `select count(distinct numeric_column) from table` faster.

The basic idea is a loose scan over Lucene's BKD tree/index holding values of a numeric field. 

The BKD tree for numeric value has points that are 1-dimensional. This has a nice effect that all the values in the tree's leaves are sorted. The non-leaf nodes have a `min` and `max` marker, that contain the minimum and maximum value for the whole sub-tree. If `min == max`, we can skip scanning the sub-tree, and just take that value.

### Benchmarking

I've been testing this code through the rewrite branch (count -> group by), with and without these changes. This was to guarantee all the changes together give us a better result for #13818. 

V1 = https://github.com/crate/crate/pull/19715
V2 = V1 + this PR

#### `select count(distinct "duration") from uservisits`

`uservisits` has 7.7M rows.

`duration` is an integer column, and has a very low cardinality, just 10 distinct values.

```
Q:     select count(distinct "duration") from uservisits

C: 3
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |      316.736 ±   73.986 |    183.435 |    283.269 |    394.237 |    475.840 |
|   V2    |        9.433 ±    9.820 |      2.290 |      4.254 |     15.487 |     55.008 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               - 188.43%                           - 194.08%   
There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 188.43%
The test has statistical significance
```

#### `select count(distinct "adRevenue") from uservisits`

`adRevenue` is a float column and has a cardinality of around 80%.

```
# Results (server side duration in ms)
V1: 6.5.0-e12fdcecb42d9268adc598bcfc1e445b2ce8e617
V2: 6.5.0-07c953be777dabb51214963e92871c2c13f1c0b6

Q:     select count(distinct "adRevenue") from uservisits

C: 1
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |     3975.409 ±  654.541 |   2862.586 |   3929.230 |   4454.960 |   5438.730 |
|   V2    |     3243.746 ±  381.671 |   2593.601 |   3177.353 |   3529.777 |   4261.901 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -  20.27%                           -  21.16%   
There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 20.27%
The test has statistical significance
```

#### `select count(distinct UserId) from hits`

`hits` contains 10M rows from ClickBench's `hits` table, the cardinality ration for UserId is ~15%. The table has 105 columns.

```
# Results (server side duration in ms)
V1: 6.5.0-e12fdcecb42d9268adc598bcfc1e445b2ce8e617
V2: 6.5.0-07c953be777dabb51214963e92871c2c13f1c0b6

Q:     SELECT COUNT(DISTINCT UserID)
    FROM hits

C: 5
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |     3747.217 ±  763.313 |   1768.524 |   3649.210 |   4266.992 |   6445.164 |
|   V2    |     2513.626 ±  353.524 |   1835.570 |   2482.055 |   2732.909 |   3573.416 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -  39.41%                           -  38.07%   
There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 39.41%
The test has statistical significance


System/JVM Metrics (durations in ms, byte-values in MB)
    |    YOUNG GC            |       OLD GC           |      HEAP         |     ALLOC     
    |  cnt      avg      max |  cnt      avg      max |  initial     used |     rate      total
 V1 |  104   439.26   459.53 |    9  6690.50  8815.84 |    17180    11127 |   618.31      93653
 V2 |   32   430.88   254.18 |    8   581.14   622.47 |    17180     1633 |   398.28      40392
  ```

**Note**: I set up this particular benchmark a bit differently from other benchmarks. Benchmarks usually use `COPY FROM` to import the data from a CSV/TSV file. For the `hits` table that was very slow, so what I did was to reuse the `data` directory. I started CrateDB, loaded 10M rows into `hits`, and used that data directory in benchmarks.

This benchmark, when run the usual way (recreating the table and re-inserting data each time), returned different results. I believe the reason is the significant load from re-inserting data and running queries immediately after that. Currently, I'm not aware of any reason why this kind of loading data would affect the benchmark.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes.
       If you're an external contributor you can give yourself attribution and include your name and Github handle.
       e.g.:
       ```
       `John Doe <https://github.com/John_Doe>`_ added support for ...
       ```
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes
