### PR TITLE
Require superuser to COPY TO local file system

### DIFF
--- a/server/src/main/java/io/crate/planner/statement/CopyToPlan.java
+++ b/server/src/main/java/io/crate/planner/statement/CopyToPlan.java
@@ -47,6 +47,7 @@ import io.crate.analyze.relations.DocTableRelation;
 import io.crate.common.collections.Lists;
 import io.crate.data.Row;
 import io.crate.data.RowConsumer;
+import io.crate.exceptions.UnauthorizedException;
 import io.crate.exceptions.UnsupportedFeatureException;
 import io.crate.execution.dsl.phases.NodeOperationTree;
 import io.crate.execution.dsl.projection.MergeCountProjection;
@@ -251,6 +252,9 @@ public final class CopyToPlan implements Plan {
         WhereClause whereClause = new WhereClause(copyTo.whereClause(), partitions, Collections.emptySet());
         String uri = DataTypes.STRING.sanitizeValue(eval.apply(copyTo.uri()));
         if (uri.startsWith("/") || uri.startsWith("file:")) {
+            if (txnCtx.sessionSettings().authenticatedUser().isSuperUser() == false) {
+                throw new UnauthorizedException("Only a superuser can write to the local file system");
+            }
             // Settings of other schemes are validated later in plugins
             // as only plugins are aware of scheme specific properties.
             properties.ensureContainsOnly(CopyStatementSettings.COMMON_COPY_TO_SETTINGS);

--- a/server/src/test/java/io/crate/integrationtests/CopyIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/CopyIntegrationTest.java
@@ -1188,7 +1188,7 @@ public class CopyIntegrationTest extends SQLHttpIntegrationTest {
 
     @UseRandomizedSchema(random = false)
     @Test
-    public void test_copy_from_local_file_is_only_allowed_for_superusers() {
+    public void test_copy_from_or_to_local_file_is_only_allowed_for_superusers() {
         execute("CREATE TABLE quotes (id INT PRIMARY KEY, " +
             "quote STRING INDEX USING FULLTEXT) WITH (number_of_replicas = 0)");
         execute("CREATE USER test_user");
@@ -1202,6 +1202,11 @@ public class CopyIntegrationTest extends SQLHttpIntegrationTest {
             assertThatThrownBy(() -> execute("COPY quotes FROM ?", new Object[]{copyFilePath + "test_copy_from.json"}, session))
                 .isExactlyInstanceOf(UnauthorizedException.class)
                 .hasMessage("Only a superuser can read from the local file system");
+
+            String uriTemplate = Paths.get(folder.getRoot().toURI()).toUri().toString();
+            assertThatThrownBy(() -> execute("COPY quotes TO DIRECTORY ?", new Object[]{uriTemplate}, session))
+                .isExactlyInstanceOf(UnauthorizedException.class)
+                .hasMessage("Only a superuser can write to the local file system");
         }
     }
 


### PR DESCRIPTION
COPY FROM already restricts reading local files to superusers, but COPY TO had no equivalent check, so any user could write arbitrary files on the server filesystem. This requires superuser for COPY TO a local path, mirroring the COPY FROM check.