### PR TITLE
Bound pg-wire binary length before allocation

### DIFF
--- a/server/src/main/java/io/crate/protocols/postgres/types/BitType.java
+++ b/server/src/main/java/io/crate/protocols/postgres/types/BitType.java
@@ -90,6 +90,9 @@ public class BitType extends PGType<BitString> {
     public BitString readBinaryValue(ByteBuf buffer, int valueLength) {
         int bitLen = buffer.readInt();
         int byteLen = (bitLen + 7) / 8;
+        if (bitLen < 0 || byteLen < 0 || byteLen > buffer.readableBytes()) {
+            throw new IllegalArgumentException("Invalid bit length: " + bitLen);
+        }
         byte[] bytes = new byte[byteLen];
         buffer.readBytes(bytes);
         BitSet bitSet = new BitSet();

--- a/server/src/main/java/io/crate/protocols/postgres/types/PGArray.java
+++ b/server/src/main/java/io/crate/protocols/postgres/types/PGArray.java
@@ -162,6 +162,9 @@ public class PGArray extends PGType<List<Object>> {
     @Override
     public List<Object> readBinaryValue(ByteBuf buffer, int valueLength) {
         int dimensions = buffer.readInt();
+        if (dimensions < 0 || dimensions > buffer.readableBytes()) {
+            throw new IllegalArgumentException("Invalid number of dimensions: " + dimensions);
+        }
         buffer.readInt(); // flags bit 0: 0=no-nulls, 1=has-nulls
         buffer.readInt(); // element oid
         if (dimensions == 0) {

--- a/server/src/main/java/io/crate/protocols/postgres/types/PGFloatVectorType.java
+++ b/server/src/main/java/io/crate/protocols/postgres/types/PGFloatVectorType.java
@@ -92,6 +92,9 @@ public class PGFloatVectorType extends PGType<float[]> {
         buffer.readInt(); // element oid
         int dimension = buffer.readInt();
         buffer.readInt();  // lowerBound ignored
+        if (dimension < 0 || dimension > buffer.readableBytes()) {
+            throw new IllegalArgumentException("Invalid vector dimension: " + dimension);
+        }
         return readArrayAsBinary(buffer, dimension);
     }
 


### PR DESCRIPTION
Several pg-wire binary decoders read a length or dimension from the wire and allocate before checking it against the readable bytes, so a small crafted message can request a huge allocation. This bounds the declared lengths before allocating.