### PR TITLE
Reject stale RENAME TABLE requests using table OIDs

### DIFF
--- a/docs/appendices/release-notes/6.5.0.rst
+++ b/docs/appendices/release-notes/6.5.0.rst
@@ -147,6 +147,10 @@ Performance and Resilience Improvements
   :ref:`SWAP TABLE <alter_cluster_swap_table>` cannot affect a ``DELETE``
   already in progress.
 
+- Improved :ref:`RENAME TABLE <sql-alter-table-rename-to>` to fail if the
+  source relation name points to a different table while the statement is being
+  executed.
+
 Administration and Operations
 -----------------------------
 

--- a/server/src/main/java/io/crate/analyze/AlterTableAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/AlterTableAnalyzer.java
@@ -103,7 +103,7 @@ class AlterTableAnalyzer {
         RelationName targetName = new RelationName(sourceName.schema(), newIdentParts.get(0));
         targetName.ensureValidForRelationCreation();
         boolean isPartitioned = source instanceof DocTableInfo docTable && docTable.isPartitioned();
-        return new AnalyzedAlterTableRenameTable(sourceName, targetName, isPartitioned);
+        return new AnalyzedAlterTableRenameTable(sourceName, source.oid(), targetName, isPartitioned);
     }
 
     public AnalyzedAlterTableOpenClose analyze(AlterTableOpenClose<Expression> node,

--- a/server/src/main/java/io/crate/analyze/AnalyzedAlterTableRenameTable.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedAlterTableRenameTable.java
@@ -29,17 +29,23 @@ import io.crate.metadata.RelationName;
 public class AnalyzedAlterTableRenameTable implements DDLStatement {
 
     private final RelationName sourceName;
+    private final int sourceOid;
     private final RelationName targetName;
     private final boolean isPartitioned;
 
-    AnalyzedAlterTableRenameTable(RelationName sourceName, RelationName targetName, boolean isPartitioned) {
+    AnalyzedAlterTableRenameTable(RelationName sourceName, int sourceOid, RelationName targetName, boolean isPartitioned) {
         this.sourceName = sourceName;
+        this.sourceOid = sourceOid;
         this.targetName = targetName;
         this.isPartitioned = isPartitioned;
     }
 
     public RelationName sourceName() {
         return sourceName;
+    }
+
+    public int sourceOid() {
+        return sourceOid;
     }
 
     public RelationName targetName() {

--- a/server/src/main/java/io/crate/execution/ddl/tables/RenameTableRequest.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/RenameTableRequest.java
@@ -21,8 +21,11 @@
 
 package io.crate.execution.ddl.tables;
 
+import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
+
 import java.io.IOException;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -32,17 +35,23 @@ import io.crate.metadata.RelationName;
 public class RenameTableRequest extends AcknowledgedRequest<RenameTableRequest> {
 
     private final RelationName sourceName;
+    private final int sourceOid;
     private final RelationName targetName;
     private final boolean isPartitioned;
 
-    public RenameTableRequest(RelationName sourceName, RelationName targetName, boolean isPartitioned) {
+    public RenameTableRequest(RelationName sourceName, int sourceOid, RelationName targetName, boolean isPartitioned) {
         this.sourceName = sourceName;
+        this.sourceOid = sourceOid;
         this.targetName = targetName;
         this.isPartitioned = isPartitioned;
     }
 
     public RelationName sourceName() {
         return sourceName;
+    }
+
+    public int sourceOid() {
+        return sourceOid;
     }
 
     public RelationName targetName() {
@@ -56,6 +65,11 @@ public class RenameTableRequest extends AcknowledgedRequest<RenameTableRequest> 
     public RenameTableRequest(StreamInput in) throws IOException {
         super(in);
         sourceName = new RelationName(in);
+        if (in.getVersion().onOrAfter(Version.V_6_5_0)) {
+            sourceOid = in.readVInt();
+        } else {
+            sourceOid = OID_UNASSIGNED;
+        }
         targetName = new RelationName(in);
         isPartitioned = in.readBoolean();
     }
@@ -64,6 +78,9 @@ public class RenameTableRequest extends AcknowledgedRequest<RenameTableRequest> 
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         sourceName.writeTo(out);
+        if (out.getVersion().onOrAfter(Version.V_6_5_0)) {
+            out.writeVInt(sourceOid);
+        }
         targetName.writeTo(out);
         out.writeBoolean(isPartitioned);
     }

--- a/server/src/main/java/io/crate/metadata/cluster/RenameTableClusterStateExecutor.java
+++ b/server/src/main/java/io/crate/metadata/cluster/RenameTableClusterStateExecutor.java
@@ -21,6 +21,8 @@
 
 package io.crate.metadata.cluster;
 
+import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
+
 import java.util.List;
 import java.util.Locale;
 
@@ -63,6 +65,7 @@ public class RenameTableClusterStateExecutor {
         RelationMetadata relationMetadataSource = currentMetadata.getRelation(source);
         RelationMetadata relationMetadataTarget = currentMetadata.getRelation(target);
         boolean isView = relationMetadataSource instanceof RelationMetadata.View;
+        validateSourceRelation(source, request.sourceOid(), relationMetadataSource);
 
         if (relationMetadataTarget != null) {
             boolean viewExists = relationMetadataTarget instanceof RelationMetadata.View;
@@ -148,5 +151,23 @@ public class RenameTableClusterStateExecutor {
             ddlClusterStateService.onRenameTable(clusterStateAfterRename, source, target, request.isPartitioned()),
             "rename-table"
         );
+    }
+
+    private static void validateSourceRelation(RelationName source,
+                                               int sourceOid,
+                                               RelationMetadata relationMetadataSource) {
+        if (sourceOid == OID_UNASSIGNED) {
+            return;
+        }
+        if (relationMetadataSource == null) {
+            throw new RelationUnknown(source);
+        }
+        if (relationMetadataSource.oid() != sourceOid) {
+            throw new IllegalStateException(String.format(
+                Locale.ENGLISH,
+                "Relation '%s' changed while RENAME TABLE was being executed",
+                source
+            ));
+        }
     }
 }

--- a/server/src/main/java/io/crate/planner/node/ddl/AlterTableRenameTablePlan.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/AlterTableRenameTablePlan.java
@@ -54,6 +54,7 @@ public class AlterTableRenameTablePlan implements Plan {
                               Row params, SubQueryResults subQueryResults) throws Exception {
         var request = new RenameTableRequest(
             analyzedAlterTableRenameTable.sourceName(),
+            analyzedAlterTableRenameTable.sourceOid(),
             analyzedAlterTableRenameTable.targetName(),
             analyzedAlterTableRenameTable.isPartitioned());
         dependencies.client().execute(TransportRenameTable.ACTION, request)

--- a/server/src/test/java/io/crate/execution/ddl/tables/RenameTableRequestTest.java
+++ b/server/src/test/java/io/crate/execution/ddl/tables/RenameTableRequestTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.execution.ddl.tables;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.junit.Test;
+
+import io.crate.metadata.RelationName;
+
+public class RenameTableRequestTest {
+
+    @Test
+    public void test_streaming_table_oids() throws Exception {
+        // streaming to nodes with supported versions
+        RelationName source = new RelationName("doc", "source");
+        RelationName target = new RelationName("doc", "target");
+        int sourceOid = 1234;
+        RenameTableRequest request = new RenameTableRequest(source, sourceOid, target, false);
+
+        var out = new BytesStreamOutput();
+        out.setVersion(Version.V_6_5_0);
+        request.writeTo(out);
+
+        var in = out.bytes().streamInput();
+        in.setVersion(Version.V_6_5_0);
+        RenameTableRequest streamed = new RenameTableRequest(in);
+
+        assertThat(streamed.sourceOid()).isEqualTo(sourceOid);
+
+        // streaming to nodes with unsupported versions
+        request = new RenameTableRequest(source, sourceOid, target, false);
+
+        out = new BytesStreamOutput();
+        out.setVersion(Version.V_6_4_0);
+        request.writeTo(out);
+
+        in = out.bytes().streamInput();
+        in.setVersion(Version.V_6_4_0);
+        streamed = new RenameTableRequest(in);
+
+        assertThat(streamed.sourceOid()).isEqualTo(OID_UNASSIGNED);
+    }
+}

--- a/server/src/test/java/io/crate/metadata/cluster/RenameTableClusterStateExecutorTest.java
+++ b/server/src/test/java/io/crate/metadata/cluster/RenameTableClusterStateExecutorTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.metadata.cluster;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.Test;
+
+import io.crate.execution.ddl.tables.RenameTableRequest;
+import io.crate.metadata.RelationName;
+import io.crate.metadata.doc.DocTableInfo;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.SQLExecutor;
+
+public class RenameTableClusterStateExecutorTest extends CrateDummyClusterServiceUnitTest {
+
+    @Test
+    public void test_rejects_rename_if_source_name_resolves_to_different_table_oid() throws Exception {
+        var e = SQLExecutor.of(clusterService)
+            .addTable("create table a (x int)")
+            .addTable("create table b (x int)");
+        DocTableInfo b = e.resolveTableInfo("b");
+
+        var executor = new RenameTableClusterStateExecutor(null, null);
+        var request = new RenameTableRequest(
+            new RelationName("doc", "a"),
+            b.oid(),
+            new RelationName("doc", "target"),
+            false
+        );
+
+        assertThatThrownBy(() -> executor.execute(clusterService.state(), request))
+            .isExactlyInstanceOf(IllegalStateException.class)
+            .hasMessage("Relation 'doc.a' changed while RENAME TABLE was being executed");
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

A concurrent ``SWAP TABLE`` can be interleaved with ``RENAME TABLE``. For example::

    Initial metadata:
    table a (oid = 1)
    table b (oid = 2)

    RENAME a TO a2 is analyzed and resolves table a (oid = 1).

    SWAP a TO b completes after RENAME is analyzed but before it is executed.
    
    Metadata is updated to:
    table a (oid = 2)
    table b (oid = 1)

At execution time, ``RENAME TABLE`` would have three possible outcomes:

1. Rename the table currently referenced by ``a``::

       table a2 (oid = 2)
       table b  (oid = 1)

2. Rename the table resolved by the oid during analysis::

       table a  (oid = 2)
       table a2 (oid = 1)

3. Reject the stale request.

This PR chooses option 3 and rejects such scenarios because ``RENAME TABLE`` should rename the table that the source name referred to during analysis.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes.
       If you're an external contributor you can give yourself attribution and include your name and Github handle.
       e.g.:
       ```
       `John Doe <https://github.com/John_Doe>`_ added support for ...
       ```
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
