### PR TITLE
Fix CREATE USER/ROLE to set session settings

### DIFF
--- a/docs/admin/user-management.rst
+++ b/docs/admin/user-management.rst
@@ -190,6 +190,17 @@ methods. You can specify the user's password in the ``WITH`` clause of the
     cr> CREATE USER user_b WITH (password = 'a_secret_password');
     CREATE OK, 1 row affected (... sec)
 
+The ``WITH`` clause also accepts modifiable :ref:`session settings
+<conf-session>`, which are applied to every new session opened by the user::
+
+    cr> CREATE USER user_e WITH (password = 'a_secret_password', search_path = 'myschema');
+    CREATE OK, 1 row affected (... sec)
+
+.. hide:
+
+    cr> DROP USER user_e;
+    DROP OK, 1 row affected (... sec)
+
 The username parameter of the statement follows the principles of an identifier
 which means that it must be double-quoted if it contains special characters
 (e.g. whitespace) or if the case needs to be maintained::

--- a/docs/appendices/release-notes/6.4.3.rst
+++ b/docs/appendices/release-notes/6.4.3.rst
@@ -101,3 +101,14 @@ Fixes
   A large positive ``precision`` had the same effect and now is capped to
   ``16383``, meaning, if the ``precision`` exceeds ``16383`` the function would
   yield results as if the precision was set to the maximum value of ``16383``.
+
+- Fixed an issue that caused :ref:`CREATE USER <ref-create-user>` to fail with
+  ``Setting '<name>' is not supported`` even when a valid
+  :ref:`session setting <conf-session>` was provided, e.g.::
+
+    CREATE USER john WITH (password = 'foo', enable_hashjoin = false);
+
+  Such :ref:`session settings <conf-session>` are now saved with the created
+  user. Like with :ref:`ALTER ROLE <ref-alter-role>`, they can only be set for
+  a user and not for a role.
+

--- a/docs/config/session.rst
+++ b/docs/config/session.rst
@@ -19,7 +19,9 @@ example:
   SET OK, 0 rows affected (... sec)
 
 Alternatively, session settings can be modified permanently from their default
-values for a user, with the use of :ref:`ALTER ROLE <ref-alter-role>`.
+values for a user, either when the user is created with :ref:`CREATE USER
+<create-user-session-settings>`, or later on with :ref:`ALTER ROLE
+<ref-alter-role>`.
 
 To retrieve the current value of a session setting, use :ref:`SHOW <ref-show>`
 e.g:
@@ -37,7 +39,8 @@ Besides using ``SHOW``, it is also possible to use the :ref:`current_setting
     :ref:`sys.sessions <sys-sessions>` table.
 
 .. NOTE::
-    Default values for session settings can set per role using :ref:`ALTER ROLE
+    Default values for session settings can set per user using :ref:`CREATE
+    USER <create-user-session-settings>` or :ref:`ALTER ROLE
     <ref-alter-role>`.
 
 Supported session settings

--- a/docs/sql/statements/alter-role.rst
+++ b/docs/sql/statements/alter-role.rst
@@ -95,6 +95,9 @@ are supported to alter an existing user account:
     Changes to session settings are only applied to new sessions opened by the
     user.
 
+    Session settings can also be set when the user is created, see
+    :ref:`CREATE USER <create-user-session-settings>`.
+
 
 ``RESET``
 ---------

--- a/docs/sql/statements/create-role.rst
+++ b/docs/sql/statements/create-role.rst
@@ -26,10 +26,11 @@ and those must be assigned afterwards, for details see the
 
     ``ROLE`` is essentially the same as ``USER`` with the difference that a
     ``ROLE`` **cannot** login to the database, and therefore **cannot** be
-    assigned a password, and can be :ref:`granted <granting_roles>` to another
-    ``USER`` or ``ROLE``. On the other hand, a ``USER`` **can** login to the
-    database and **can** also be assigned a password, but **cannot** be granted
-    to another ``USER`` or ``ROLE``.
+    assigned a password or :ref:`session settings <conf-session>`, and can be
+    :ref:`granted <granting_roles>` to another ``USER`` or ``ROLE``. On the
+    other hand, a ``USER`` **can** login to the database and **can** also be
+    assigned a password and session settings, but **cannot** be granted to
+    another ``USER`` or ``ROLE``.
 
 For usages of the ``CREATE ROLE`` statement see
 :ref:`administration_user_management`.

--- a/docs/sql/statements/create-user.rst
+++ b/docs/sql/statements/create-user.rst
@@ -103,5 +103,21 @@ The following ``user_parameter`` are supported to define a new user account:
 
 .. vale on
 
+.. _create-user-session-settings:
+
+:session settings:
+  Any of the modifiable :ref:`session settings <conf-session>`. The value set
+  is used when the user logs in to the database, instead of the default value,
+  thus, there is no need to use ``SET`` statements to modify a setting value
+  after the user is created. e.g.::
+
+     CREATE USER john WITH (password='foo', search_path='my_schema')
+
+.. NOTE::
+
+    Session settings can only be set for a user and not for a role and are
+    therefore not inherited by other users. They can be changed or reset after
+    a user is created with :ref:`ALTER ROLE <ref-alter-role>`.
+
 .. _iss: https://www.rfc-editor.org/rfc/rfc7519#section-4.1.1
 .. _aud: https://www.rfc-editor.org/rfc/rfc7519#section-4.1.3

--- a/server/src/main/java/io/crate/analyze/RoleAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/RoleAnalyzer.java
@@ -21,11 +21,7 @@
 
 package io.crate.analyze;
 
-import static io.crate.role.Role.Properties.JWT_KEY;
-import static io.crate.role.Role.Properties.PASSWORD_KEY;
-
 import java.util.Map;
-import java.util.Set;
 
 import io.crate.analyze.expressions.ExpressionAnalysisContext;
 import io.crate.analyze.expressions.ExpressionAnalyzer;
@@ -51,14 +47,15 @@ public class RoleAnalyzer {
     public AnalyzedCreateRole analyze(CreateRole node,
                                       ParamTypeHints paramTypeHints,
                                       CoordinatorTxnCtx txnContext) {
+        // Validation of properties takes place later on in CreateRolePlan (when calling Role.Properties.of())
         GenericProperties<Symbol> properties = mappedProperties(node.properties(), paramTypeHints, txnContext);
-        properties.ensureContainsOnly(Set.of(PASSWORD_KEY, JWT_KEY));
         return new AnalyzedCreateRole(node.name(), node.isUser(), properties);
     }
 
     public AnalyzedAlterRole analyze(AlterRoleSet<Expression> node,
                                      ParamTypeHints paramTypeHints,
                                      CoordinatorTxnCtx txnContext) {
+        // Validation of properties takes place later on in AlterRolePlan (when calling Role.Properties.of())
         GenericProperties<Symbol> properties = mappedProperties(node.properties(), paramTypeHints, txnContext);
         return new AnalyzedAlterRole(node.name(), properties, false);
     }

--- a/server/src/main/java/io/crate/planner/node/ddl/CreateRolePlan.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/CreateRolePlan.java
@@ -86,7 +86,8 @@ public class CreateRolePlan implements Plan {
                 createRole.roleName(),
                 createRole.isUser(),
                 roleProperties.password(),
-                roleProperties.jwtProperties())
+                roleProperties.jwtProperties(),
+                roleProperties.sessionSettings())
             .whenComplete(new OneRowActionListener<>(consumer, rCount -> new Row1(rCount == null ? -1 : rCount)));
     }
 }

--- a/server/src/main/java/io/crate/role/CreateRoleRequest.java
+++ b/server/src/main/java/io/crate/role/CreateRoleRequest.java
@@ -22,6 +22,7 @@
 package io.crate.role;
 
 import java.io.IOException;
+import java.util.Map;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
@@ -39,14 +40,18 @@ public class CreateRoleRequest extends AcknowledgedRequest<CreateRoleRequest> {
     @Nullable
     private final JwtProperties jwtProperties;
 
+    private final Map<String, Object> sessionSettings;
+
     public CreateRoleRequest(String roleName,
                              boolean isUser,
                              @Nullable SecureHash attributes,
-                             @Nullable JwtProperties jwtProperties) {
+                             @Nullable JwtProperties jwtProperties,
+                             Map<String, Object> sessionSettings) {
         this.roleName = roleName;
         this.isUser = isUser;
         this.secureHash = attributes;
         this.jwtProperties = jwtProperties;
+        this.sessionSettings = sessionSettings;
     }
 
     public String roleName() {
@@ -67,6 +72,10 @@ public class CreateRoleRequest extends AcknowledgedRequest<CreateRoleRequest> {
         return jwtProperties;
     }
 
+    public Map<String, Object> sessionSettings() {
+        return sessionSettings;
+    }
+
     public CreateRoleRequest(StreamInput in) throws IOException {
         super(in);
         roleName = in.readString();
@@ -81,6 +90,11 @@ public class CreateRoleRequest extends AcknowledgedRequest<CreateRoleRequest> {
         } else {
             this.jwtProperties = null;
         }
+        if (in.getVersion().onOrAfter(Version.V_6_4_3)) {
+            this.sessionSettings = in.readMap();
+        } else {
+            this.sessionSettings = Map.of();
+        }
     }
 
     @Override
@@ -93,6 +107,9 @@ public class CreateRoleRequest extends AcknowledgedRequest<CreateRoleRequest> {
         out.writeOptionalWriteable(secureHash);
         if (out.getVersion().onOrAfter(Version.V_5_7_0)) {
             out.writeOptionalWriteable(jwtProperties);
+        }
+        if (out.getVersion().onOrAfter(Version.V_6_4_3)) {
+            out.writeMap(sessionSettings);
         }
     }
 }

--- a/server/src/main/java/io/crate/role/RoleManager.java
+++ b/server/src/main/java/io/crate/role/RoleManager.java
@@ -38,12 +38,14 @@ public interface RoleManager extends Roles {
      *
      * @param roleName name of the role to create
      * @param jwtProperties contains JWK specific properties if user can be authenticated by providing a JWTtoken.
+     * @param sessionSettings the session settings to apply to new sessions opened by the user.
      * @return 1 if the role was created, otherwise a failed future.
      */
     CompletableFuture<Long> createRole(String roleName,
                                        boolean isUser,
                                        @Nullable SecureHash hashedPw,
-                                       @Nullable JwtProperties jwtProperties);
+                                       @Nullable JwtProperties jwtProperties,
+                                       Map<String, Object> sessionSettings);
 
     /**
      * Delete a roles.

--- a/server/src/main/java/io/crate/role/RoleManagerService.java
+++ b/server/src/main/java/io/crate/role/RoleManagerService.java
@@ -72,8 +72,9 @@ public class RoleManagerService implements RoleManager {
     public CompletableFuture<Long> createRole(String roleName,
                                               boolean isUser,
                                               @Nullable SecureHash hashedPw,
-                                              @Nullable JwtProperties jwtProperties) {
-        CreateRoleRequest request = new CreateRoleRequest(roleName, isUser, hashedPw, jwtProperties);
+                                              @Nullable JwtProperties jwtProperties,
+                                              Map<String, Object> sessionSettings) {
+        CreateRoleRequest request = new CreateRoleRequest(roleName, isUser, hashedPw, jwtProperties, sessionSettings);
         return client.execute(TransportCreateRole.ACTION, request).thenApply(r -> {
             if (r.doesUserExist()) {
                 throw new RoleAlreadyExistsException(String.format(Locale.ENGLISH, "Role '%s' already exists", roleName));

--- a/server/src/main/java/io/crate/role/TransportCreateRole.java
+++ b/server/src/main/java/io/crate/role/TransportCreateRole.java
@@ -41,9 +41,10 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.jspecify.annotations.Nullable;
-import io.crate.common.annotations.VisibleForTesting;
 
+import io.crate.common.annotations.VisibleForTesting;
 import io.crate.exceptions.RoleAlreadyExistsException;
+import io.crate.exceptions.UnsupportedFeatureException;
 import io.crate.role.metadata.RolesMetadata;
 import io.crate.role.metadata.UsersMetadata;
 import io.crate.role.metadata.UsersPrivilegesMetadata;
@@ -90,6 +91,11 @@ public class TransportCreateRole extends TransportMasterNodeAction<CreateRoleReq
         if (state.nodes().getMinNodeVersion().onOrAfter(Version.V_5_6_0) == false) {
             throw new IllegalStateException("Cannot create new users/roles until all nodes are upgraded to 5.6");
         }
+        if (request.sessionSettings().isEmpty() == false
+                && state.nodes().getMinNodeVersion().onOrAfter(Version.V_6_4_3) == false) {
+            throw new IllegalStateException(
+                "Cannot create users with session settings until all nodes are upgraded to 6.4.3");
+        }
 
         clusterService.submitStateUpdateTask("create_role [" + request.roleName() + "]",
                 new AckedClusterStateUpdateTask<>(Priority.IMMEDIATE, request, listener) {
@@ -106,7 +112,7 @@ public class TransportCreateRole extends TransportMasterNodeAction<CreateRoleReq
                             request.isUser(),
                             request.secureHash(),
                             request.jwtProperties(),
-                            Map.of()
+                            request.sessionSettings()
                         );
                         return ClusterState.builder(currentState).metadata(mdBuilder).build();
                     }
@@ -135,6 +141,9 @@ public class TransportCreateRole extends TransportMasterNodeAction<CreateRoleReq
                            @Nullable SecureHash secureHash,
                            @Nullable JwtProperties jwtProperties,
                            Map<String, Object> sessionSettings) {
+        if (isUser == false && sessionSettings.isEmpty() == false) {
+            throw new UnsupportedFeatureException("Setting session settings to a ROLE is not allowed");
+        }
         RolesMetadata oldRolesMetadata = (RolesMetadata) mdBuilder.getCustom(RolesMetadata.TYPE);
         UsersMetadata oldUsersMetadata = (UsersMetadata) mdBuilder.getCustom(UsersMetadata.TYPE);
 

--- a/server/src/main/java/org/elasticsearch/Version.java
+++ b/server/src/main/java/org/elasticsearch/Version.java
@@ -249,6 +249,7 @@ public class Version implements Comparable<Version> {
     public static final Version V_6_4_0 = new Version(9_04_00_99, false, org.apache.lucene.util.Version.LUCENE_10_4_0);
     public static final Version V_6_4_1 = new Version(9_04_01_99, false, org.apache.lucene.util.Version.LUCENE_10_4_0);
     public static final Version V_6_4_2 = new Version(9_04_02_99, false, org.apache.lucene.util.Version.LUCENE_10_4_0);
+    public static final Version V_6_4_3 = new Version(9_04_03_99, true, org.apache.lucene.util.Version.LUCENE_10_4_0);
 
     public static final Version V_6_5_0 = new Version(9_05_00_99, true, org.apache.lucene.util.Version.LUCENE_10_5_0);
 

--- a/server/src/test/java/io/crate/analyze/RoleDDLAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/RoleDDLAnalyzerTest.java
@@ -80,11 +80,12 @@ public class RoleDDLAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     }
 
     @Test
-    public void test_create_user_with_password() throws Exception {
+    public void test_create_user_with_password_and_setting() throws Exception {
         // CrateDB syntax
-        AnalyzedCreateRole analysis = e.analyze("CREATE USER ROOT WITH (PASSWORD = 'ROOT')");
+        AnalyzedCreateRole analysis = e.analyze("CREATE USER ROOT WITH (PASSWORD = 'ROOT', search_path='foo')");
         assertThat(analysis.roleName()).isEqualTo("root");
         assertThat(analysis.properties().get("password")).isLiteral("ROOT");
+        assertThat(analysis.properties().get("search_path")).isLiteral("foo");
         assertThat(analysis.isUser()).isTrue();
 
         analysis = e.analyze("CREATE USER ROOT WITH (PASSWORD = ?)", new ParamTypeHints(List.of(DataTypes.STRING)));
@@ -93,9 +94,10 @@ public class RoleDDLAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(analysis.isUser()).isTrue();
 
         // PostgreSQL syntax
-        analysis = e.analyze("CREATE USER ROOT WITH PASSWORD 'ROOT'");
+        analysis = e.analyze("CREATE USER ROOT WITH PASSWORD 'ROOT' search_path 'foo'");
         assertThat(analysis.roleName()).isEqualTo("root");
         assertThat(analysis.properties().get("password")).isLiteral("ROOT");
+        assertThat(analysis.properties().get("search_path")).isLiteral("foo");
         assertThat(analysis.isUser()).isTrue();
 
         analysis = e.analyze("CREATE USER ROOT WITH PASSWORD ?", new ParamTypeHints(List.of(DataTypes.STRING)));
@@ -136,15 +138,6 @@ public class RoleDDLAnalyzerTest extends CrateDummyClusterServiceUnitTest {
                 .isExactlyInstanceOf(UnsupportedOperationException.class)
                 .hasMessage("Columns cannot be used in this context. " +
                     "Maybe you wanted to use a string literal which requires single quotes: 'no_string'");
-        }
-    }
-
-    @Test
-    public void test_create_user_and_role_with_invalid_settings() throws Exception {
-        for (String userOrRole : List.of("USER", "ROLE")) {
-            assertThatThrownBy(() -> e.analyze("CREATE " + userOrRole + " ROOT WITH (enable_hashjoin = false)"))
-                .isExactlyInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Setting 'enable_hashjoin' is not supported");
         }
     }
 

--- a/server/src/test/java/io/crate/integrationtests/RoleManagementIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/RoleManagementIntegrationTest.java
@@ -323,6 +323,22 @@ public class RoleManagementIntegrationTest extends BaseRolesIntegrationTest {
     }
 
     @Test
+    public void test_user_session_settings_can_be_set_on_create() {
+        execute("CREATE USER new_user WITH (password = 'pwd', search_path = 'my_schema')");
+        assertUserIsCreated("new_user");
+        executeAsSuperuser("SELECT session_settings FROM sys.users WHERE name = 'new_user'");
+        assertThat(response).hasRows("{search_path=my_schema}");
+
+        execute("GRANT DQL ON SCHEMA my_schema TO new_user");
+        execute("CREATE TABLE my_schema.tbl(a int)");
+        execute("INSERT INTO my_schema.tbl(a) values(1),(2)");
+        execute("REFRESH TABLE my_schema.tbl");
+
+        executeAs("SELECT * FROM tbl ORDER BY 1", "new_user");
+        assertThat(response).hasRows("1", "2");
+    }
+
+    @Test
     public void test_information_schema_roles_tables() {
         executeAs("CREATE ROLE role1", GRANTOR_USER);
         executeAs("CREATE ROLE role2", GRANTOR_USER);

--- a/server/src/test/java/io/crate/planner/node/ddl/CreateRolePlanTest.java
+++ b/server/src/test/java/io/crate/planner/node/ddl/CreateRolePlanTest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.node.ddl;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.elasticsearch.client.Client;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import io.crate.analyze.AnalyzedCreateRole;
+import io.crate.data.Row;
+import io.crate.data.testing.TestingRowConsumer;
+import io.crate.expression.symbol.Literal;
+import io.crate.metadata.settings.session.SessionSettingRegistry;
+import io.crate.planner.DependencyCarrier;
+import io.crate.planner.PlannerContext;
+import io.crate.planner.operators.SubQueryResults;
+import io.crate.role.StubRoleManager;
+import io.crate.sql.tree.GenericProperties;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CreateRolePlanTest {
+
+    @Mock
+    Client client;
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    PlannerContext plannerCtx;
+    TestingRowConsumer rowConsumer;
+    @Mock
+    DependencyCarrier dependencyCarrier;
+
+    @Before
+    public void setUp() {
+        rowConsumer = new TestingRowConsumer();
+    }
+
+    @Test
+    public void test_create_user_and_role_with_invalid_settings() {
+        for (String userOrRole : List.of("USER", "ROLE")) {
+            var plan = new CreateRolePlan(
+                new AnalyzedCreateRole("new_user", true, new GenericProperties<>(Map.of("invalid", Literal.of("foo")))),
+                new StubRoleManager(),
+                new SessionSettingRegistry(Set.of()));
+            assertThatThrownBy(() -> plan.executeOrFail(dependencyCarrier, plannerCtx, rowConsumer, Row.EMPTY, SubQueryResults.EMPTY))
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Setting 'invalid' is not supported");
+        }
+    }
+}

--- a/server/src/test/java/io/crate/role/CreateRoleRequestTest.java
+++ b/server/src/test/java/io/crate/role/CreateRoleRequestTest.java
@@ -23,6 +23,8 @@ package io.crate.role;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Map;
+
 import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.settings.SecureString;
@@ -37,7 +39,8 @@ public class CreateRoleRequestTest extends ESTestCase {
             new CreateRoleRequest("testUser",
                 false,
                 SecureHash.of(new SecureString("passwd".toCharArray())),
-                new JwtProperties("https:dummy.org", "test", "test_aud")
+                new JwtProperties("https:dummy.org", "test", "test_aud"),
+                Map.of("enable_hashjoin", false, "statement_timeout", "10m")
             );
 
         BytesStreamOutput out = new BytesStreamOutput();
@@ -51,6 +54,7 @@ public class CreateRoleRequestTest extends ESTestCase {
         assertThat(jwtProps.iss()).isEqualTo("https:dummy.org");
         assertThat(jwtProps.username()).isEqualTo("test");
         assertThat(jwtProps.aud()).isEqualTo("test_aud");
+        assertThat(crr2.sessionSettings()).isEqualTo(crr1.sessionSettings());
 
         out = new BytesStreamOutput();
         out.setVersion(Version.V_5_5_0);
@@ -62,5 +66,17 @@ public class CreateRoleRequestTest extends ESTestCase {
         assertThat(crr2.secureHash()).isEqualTo(crr1.secureHash());
         assertThat(crr2.isUser()).isTrue();
         assertThat(crr2.jwtProperties()).isNull();
+        assertThat(crr2.sessionSettings()).isEmpty();
+
+        // session settings are only streamed to nodes on 6.4.3 or higher
+        out = new BytesStreamOutput();
+        out.setVersion(Version.V_6_4_2);
+        crr1.writeTo(out);
+        in = out.bytes().streamInput();
+        in.setVersion(Version.V_6_4_2);
+        crr2 = new CreateRoleRequest(in);
+        assertThat(crr2.roleName()).isEqualTo(crr1.roleName());
+        assertThat(crr2.jwtProperties()).isEqualTo(crr1.jwtProperties());
+        assertThat(crr2.sessionSettings()).isEmpty();
     }
 }

--- a/server/src/test/java/io/crate/role/TransportCreateRoleTest.java
+++ b/server/src/test/java/io/crate/role/TransportCreateRoleTest.java
@@ -25,6 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 import java.util.EnumSet;
+import java.util.Map;
 
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlock;
@@ -61,7 +62,7 @@ public class TransportCreateRoleTest extends CrateDummyClusterServiceUnitTest {
             .blocks(ClusterBlocks.builder().addGlobalBlock(globalBlock))
             .build();
 
-        assertThat(transportCreateRole.checkBlock(new CreateRoleRequest("test", true, null, null), newState).blocks())
+        assertThat(transportCreateRole.checkBlock(new CreateRoleRequest("test", true, null, null, Map.of()), newState).blocks())
             .containsExactly(globalBlock);
     }
 }

--- a/server/src/test/java/io/crate/role/TransportRoleTest.java
+++ b/server/src/test/java/io/crate/role/TransportRoleTest.java
@@ -77,6 +77,20 @@ public class TransportRoleTest extends CrateDummyClusterServiceUnitTest {
         assertThat(jwtProps.iss()).isEqualTo("https:dummy.org");
         assertThat(jwtProps.username()).isEqualTo("test");
         assertThat(jwtProps.aud()).isEqualTo("test_aud");
+        assertThat(role.sessionSettings()).containsExactly(Map.entry("session_timeout", "1h"));
+    }
+
+    @Test
+    public void test_cannot_create_a_role_with_session_settings() throws Exception {
+        Metadata.Builder mdBuilder = new Metadata.Builder(Metadata.OID_UNASSIGNED);
+        assertThatThrownBy(() -> TransportCreateRole.putRole(mdBuilder,
+                "role1",
+                false,
+                null,
+                null,
+                Map.of("enable_hashjoin", false)))
+            .isExactlyInstanceOf(UnsupportedFeatureException.class)
+            .hasMessage("Setting session settings to a ROLE is not allowed");
     }
 
     @Test

--- a/server/src/testFixtures/java/io/crate/role/StubRoleManager.java
+++ b/server/src/testFixtures/java/io/crate/role/StubRoleManager.java
@@ -51,7 +51,8 @@ public class StubRoleManager implements RoleManager {
     public CompletableFuture<Long> createRole(String roleName,
                                               boolean isUser,
                                               @Nullable SecureHash hashedPw,
-                                              @Nullable JwtProperties jwtProperties) {
+                                              @Nullable JwtProperties jwtProperties,
+                                              Map<String, Object> sessionSettings) {
         return CompletableFuture.failedFuture(new UnsupportedFeatureException("createRole is not implemented in StubRoleManager"));
     }
 


### PR DESCRIPTION
Previously, it was not possible to set valid session settings during creation, as an error for invalid setting was thrown because of a validation that required only password and jwt properties. The validation also takes place later on during plan execution, so it was unecessary during the analysis. (That is not the case for ALTER USER/ROLE where the validation already happens only during execution). Additionally, the session settings were not passed to the `CreateRolePlan` through the relevant request, so even with the validation in analysis removed, the error was no longer thrown but the session settings were not saved on the new user/role.

Fixes: #19858
