### PR TITLE
Fix slow ROUND() with a large precision argument

### DIFF
--- a/docs/appendices/release-notes/6.4.3.rst
+++ b/docs/appendices/release-notes/6.4.3.rst
@@ -91,3 +91,13 @@ Fixes
 - Fixed an issue that caused range queries, e.g. ``<``, ``>=`` or ``BETWEEN``,
   on a :ref:`NUMERIC <type-numeric>` column with a precision of ``18`` or less
   which was created with ``INDEX OFF`` to not match any rows.
+
+- Fixed an issue that caused :ref:`round(x, precision) <scalar-round>` to take
+  a very long time, up to the point where a query seems to hang, if a negative
+  number of large magnitude is used for ``precision``, e.g.::
+
+    SELECT round(-1479165877, -556375977);
+
+  A large positive ``precision`` had the same effect and now is capped to
+  ``16383``, meaning, if the ``precision`` exceeds ``16383`` the function would
+  yield results as if the precision was set to the maximum value of ``16383``.

--- a/docs/general/builtins/scalar-functions.rst
+++ b/docs/general/builtins/scalar-functions.rst
@@ -2464,6 +2464,11 @@ precision and scale with the input. If it's of any other arithmetic type, the
 Notice that ``round(number)`` and ``round(number, 0)`` may return different
 result types.
 
+A positive ``precision`` is capped to ``16383``, any larger precision specified
+would yield the same results as if it was set to ``16383``. A negative
+``precision`` rounds to the left of the decimal point, if the negative precision
+is equal to or exceeds the number of digits of the number, the result is ``0``.
+
 
 Examples::
 
@@ -2480,6 +2485,22 @@ Examples::
     | round |
     +-------+
     |  42.2 |
+    +-------+
+    SELECT 1 row in set (... sec)
+
+    cr> select round(1234, -2) AS round;
+    +-------+
+    | round |
+    +-------+
+    |  1200 |
+    +-------+
+    SELECT 1 row in set (... sec)
+
+    cr> select round(1234, -4) AS round;
+    +-------+
+    | round |
+    +-------+
+    |     0 |
     +-------+
     SELECT 1 row in set (... sec)
 

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/RoundFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/RoundFunction.java
@@ -24,6 +24,7 @@ package io.crate.expression.scalar.arithmetic;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 
+import io.crate.common.annotations.VisibleForTesting;
 import io.crate.data.Input;
 import io.crate.expression.scalar.UnaryScalar;
 import io.crate.metadata.FunctionType;
@@ -39,6 +40,14 @@ import io.crate.types.DataTypes;
 public final class RoundFunction {
 
     public static final String NAME = "round";
+
+    /**
+     * The maximum supported `precision` argument of `round(x, precision)`. Matches the maximum
+     * scale of PostgreSQL's `numeric` type. Without an upper bound, `setScale()` has to materialize
+     * an unscaled value with `precision` digits, which runs out of memory or seems hang.
+     */
+    @VisibleForTesting
+    static final int MAX_PRECISION = 16383;
 
     private RoundFunction() {}
 
@@ -121,7 +130,18 @@ public final class RoundFunction {
                 }
 
                 if (numDecimals < 0) {
+                    // Rounding to a power of ten which is larger than the value itself always
+                    // results in 0. Short-circuit those cases, otherwise `movePointRight()` creates
+                    // a BigDecimal with a scale of `numDecimals`, and rounding it requires to
+                    // materialize an unscaled value with that many digits, which increases execution
+                    // time as `numDecimals` grows.
+                    if (-(long) numDecimals > val.precision() - val.scale()) {
+                        return BigDecimal.ZERO;
+                    }
                     return val.movePointRight(numDecimals).setScale(0, RoundingMode.HALF_UP).movePointLeft(numDecimals);
+                }
+                if (numDecimals > MAX_PRECISION) {
+                    return val.setScale(MAX_PRECISION, RoundingMode.HALF_UP);
                 }
                 return val.setScale(numDecimals, RoundingMode.HALF_UP);
             }

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/RoundFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/RoundFunctionTest.java
@@ -26,6 +26,7 @@ import static io.crate.testing.Asserts.isLiteral;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.List;
 
 import org.junit.Test;
@@ -87,6 +88,34 @@ public class RoundFunctionTest extends ScalarTestCase {
         assertEvaluateNull("round(1,null)");
         assertEvaluateNull("round(null,null)");
         assertEvaluateNull("round(null,1)");
+    }
+
+    @Test
+    public void test_round_with_negative_precision_at_the_magnitude_of_the_value() {
+        // The value is rounded up to the next power of ten, it does not become 0
+        assertEvaluate("round(999.9, -3)", new BigDecimal("1000"));
+        assertEvaluate("round(999.9, -4)", BigDecimal.ZERO);
+        assertEvaluate("round(5000, -4)", new BigDecimal("10000"));
+        assertEvaluate("round(500, -4)", BigDecimal.ZERO);
+        assertEvaluate("round(0.5, -1)", BigDecimal.ZERO);
+    }
+
+    // https://github.com/crate/crate/issues/19918
+    @Test
+    public void test_round_with_large_negative_precision_returns_zero() {
+        assertEvaluate("round(-1479165877, -1000000)", BigDecimal.ZERO);
+        assertEvaluate("round('-1479165877'::NUMERIC, -556375977)", BigDecimal.ZERO);
+        assertEvaluate("round('92233720368547758070.123'::NUMERIC, -2000000000)", BigDecimal.ZERO);
+        assertEvaluate("round(0.0, -2000000000)", BigDecimal.ZERO);
+    }
+
+    // Similar to: https://github.com/crate/crate/issues/19918
+    @Test
+    public void test_round_with_too_large_precision_raises_an_error() {
+        assertEvaluate("round(1.5, " + RoundFunction.MAX_PRECISION + ")",
+            BigDecimal.valueOf(15, 1).setScale(RoundFunction.MAX_PRECISION, RoundingMode.HALF_UP));
+        assertEvaluate("round(1.5, " + (RoundFunction.MAX_PRECISION + 100) + ")",
+            BigDecimal.valueOf(15, 1).setScale(RoundFunction.MAX_PRECISION, RoundingMode.HALF_UP));
     }
 
     @Test


### PR DESCRIPTION
Previously, `round(x, precision)` could take long time to execute, or appear to hang entirely, when called with a precision of a large magnitude, e.g.:
```
    SELECT round(-1479165877, -556375977);  -- 350s, returns 0
```

For a negative precision, `movePointRight()` only sets the scale of the BigDecimal, which is cheap, but the following `setScale(0, HALF_UP)` has to materialize an unscaled BigInteger with many digits. The cost therefore grows with the magnitude of the precision. `Integer.MIN_VALUE` additionally overflowed inside `movePointLeft()`.

Rounding to a power of ten larger than the value itself always yields 0, so short-circuit those cases and return 0 directly.

A large positive precision had the same problem, as `setScale()` pads the value with many zeros. It cannot be short-circuited, because the trailing zeros need to be part of the result, so limit it to 16383 instead, following PostgreSQL's `numeric` type max precision.

Fixes: #19918
