### PR TITLE
Fix starts_with(<col>, '') on indexed text cols

### DIFF
--- a/docs/appendices/release-notes/6.4.3.rst
+++ b/docs/appendices/release-notes/6.4.3.rst
@@ -83,3 +83,7 @@ Fixes
 
 - Fixed incorrect results in window function when using
   ``RANGE <offset> FOLLOWING/PRECEDING`` with ``ORDER BY <column> DESC``.
+
+- Fixed an issue that caused ``WHERE starts_with(col, '')`` on an indexed
+  column to only match rows where ``col`` is the empty string, instead of all
+  rows where ``col`` is not ``NULL``.

--- a/server/src/main/java/io/crate/expression/scalar/string/StartsWithFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/StartsWithFunction.java
@@ -22,6 +22,7 @@
 package io.crate.expression.scalar.string;
 
 import io.crate.data.Input;
+import io.crate.expression.predicate.IsNullPredicate;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
@@ -36,8 +37,6 @@ import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
-import io.crate.types.EqQuery;
-import io.crate.types.StorageSupport;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.PrefixQuery;
 import org.apache.lucene.search.Query;
@@ -84,13 +83,9 @@ public final class StartsWithFunction extends Scalar<Boolean, String> {
             assert value instanceof String
                 : "StartsWithFunction is registered for string types. Value must be a string";
             if (((String) value).isEmpty()) {
-                StorageSupport<?> storageSupport = ref.valueType().storageSupport();
-                EqQuery<?> eqQuery = storageSupport == null ? null : storageSupport.eqQuery();
-                if (eqQuery == null) {
-                    return null;
-                }
-                return ((EqQuery<Object>) eqQuery).termQuery(
-                    ref.storageIdent(), value, ref.hasDocValues(), ref.indexType() != IndexType.NONE);
+                // Every non-NULL value starts with the empty string,
+                // so this matches all rows which have a value.
+                return IsNullPredicate.refExistsQuery(ref, context);
             }
             return new PrefixQuery(new Term(ref.storageIdent(), (String) value));
         }

--- a/server/src/test/java/io/crate/expression/scalar/string/StartsWithFunctionQueryTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/string/StartsWithFunctionQueryTest.java
@@ -23,9 +23,9 @@ package io.crate.expression.scalar.string;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.apache.lucene.search.FieldExistsQuery;
 import org.apache.lucene.search.PrefixQuery;
 import org.apache.lucene.search.Query;
-import org.apache.lucene.search.TermQuery;
 import org.junit.Test;
 
 import io.crate.lucene.LuceneQueryBuilderTest;
@@ -51,11 +51,20 @@ public class StartsWithFunctionQueryTest extends LuceneQueryBuilderTest {
         assertThat(query).hasToString("a1:abc*");
     }
 
+    // https://github.com/crate/crate/issues/19923
+    // Every non-NULL value starts with '', therefore all rows which have a value must match
     @Test
-    public void test_starts_with_empty_prefix_creates_term_query() {
+    public void test_starts_with_empty_prefix_creates_field_exists_query() {
         Query query = convert("starts_with(a1, '')");
-        assertThat(query).isExactlyInstanceOf(TermQuery.class);
-        assertThat(query).hasToString("a1:");
+        assertThat(query).isExactlyInstanceOf(FieldExistsQuery.class);
+        assertThat(query).hasToString("FieldExistsQuery [field=a1]");
+    }
+
+    @Test
+    public void test_starts_with_empty_prefix_on_columnstore_disabled_uses_field_names() {
+        // Without doc values the existence of a value is resolved via the _field_names column
+        Query query = convert("starts_with(a3, '')");
+        assertThat(query).hasToString("ConstantScore(_field_names:a3)");
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/LuceneQueryBuilderIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/LuceneQueryBuilderIntegrationTest.java
@@ -26,7 +26,6 @@ import static com.carrotsearch.randomizedtesting.RandomizedTest.$$;
 import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.DataTypeTesting.randomType;
 import static io.crate.testing.TestingHelpers.printedTable;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 import java.util.function.Supplier;
@@ -437,6 +436,24 @@ public class LuceneQueryBuilderIntegrationTest extends IntegTestCase {
         assertThat(response).hasRows(
             "[1, 2, 3]",
             "[3, 4, 5, 1]");
+    }
+
+    // https://github.com/crate/crate/issues/19923
+    @Test
+    public void test_starts_with_empty_prefix_matches_all_non_null_rows() {
+        execute("create table t (name text, name_nodocval text storage with (columnstore = false)) clustered into 1 shards with (number_of_replicas = 0)");
+        execute("insert into t (name, name_nodocval) values ('a', 'a'), ('', ''), ('abc', 'abc'), (null, null)");
+        execute("refresh table t");
+
+        assertThat(execute("select name from t where starts_with(name, '') order by name"))
+            .hasRows("", "a", "abc");
+        assertThat(execute("select name from t where starts_with(name, 'a') order by name"))
+            .hasRows("a", "abc");
+
+        assertThat(execute("select name_nodocval from t where starts_with(name_nodocval, '') order by name"))
+            .hasRows("", "a", "abc");
+        assertThat(execute("select name_nodocval from t where starts_with(name_nodocval, 'a') order by name"))
+            .hasRows("a", "abc");
     }
 
     @Test


### PR DESCRIPTION
Previously, the query for the case of '' literal
was copied from `LIKE` operator, but for `starts_with` it doesn't have the same semantics, `''` for `starts_with` should match all the the non-NULL values.

Fixes: #19923

