### PR TITLE
Fix RANK() / DENSE_RANK() with explicit frame returns wrong answer

### DIFF
--- a/docs/appendices/release-notes/6.4.3.rst
+++ b/docs/appendices/release-notes/6.4.3.rst
@@ -194,3 +194,8 @@ Fixes
   by using sub-queries inside :ref:`UPDATE <ref-update>` or
   :ref:`DELETE <sql_reference_delete>` statements. Sub-queries used in such
   statements now require the ``DQL`` privilege on all involved tables and views.
+
+- Fixed incorrect results in :ref:`rank() <window-functions-rank>` and :ref:`dense_rank() <window-functions-dense-rank>` window functions
+  when an explicit window frame is specified. For example: ``SELECT rank() OVER
+  (ORDER BY <column> ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
+  FROM <table>``

--- a/extensions/functions/src/main/java/io/crate/window/RankFunctions.java
+++ b/extensions/functions/src/main/java/io/crate/window/RankFunctions.java
@@ -47,7 +47,7 @@ public class RankFunctions implements WindowFunction {
 
     private final Signature signature;
     private final BoundSignature boundSignature;
-    private int seenLastUpperBound = -1;
+    private int seenLastPeerGroupEnd = -1;
     private int rank;
     private final IntBinaryOperator rankIncrementor;
 
@@ -79,12 +79,12 @@ public class RankFunctions implements WindowFunction {
         }
         if (idxInPartition == 0) {
             rank = 1;
-            seenLastUpperBound = currentFrame.upperBoundExclusive();
+            seenLastPeerGroupEnd = currentFrame.peerGroupWithinPartitionEndExclusive();
         }
 
-        if (currentFrame.upperBoundExclusive() != seenLastUpperBound) {
-            rank = rankIncrementor.applyAsInt(rank, seenLastUpperBound);
-            seenLastUpperBound = currentFrame.upperBoundExclusive();
+        if (currentFrame.peerGroupWithinPartitionEndExclusive() != seenLastPeerGroupEnd) {
+            rank = rankIncrementor.applyAsInt(rank, seenLastPeerGroupEnd);
+            seenLastPeerGroupEnd = currentFrame.peerGroupWithinPartitionEndExclusive();
         }
 
         return rank;

--- a/extensions/functions/src/test/java/io/crate/window/RankFunctionsTest.java
+++ b/extensions/functions/src/test/java/io/crate/window/RankFunctionsTest.java
@@ -62,6 +62,62 @@ public class RankFunctionsTest extends AbstractWindowFunctionTest {
     }
 
     @Test
+    public void test_rank_with_rows_explicit_frames_should_not_depend_on_frames() throws Throwable {
+        assertEvaluate(
+            "rank() over(order by x rows between unbounded preceding and unbounded following)",
+            new Object[] {1, 1, 1, 4, 4},
+            List.of(ColumnIdent.of("x"), ColumnIdent.of("y")),
+            new Object[] {1, 1},
+            new Object[] {2, 1},
+            new Object[] {1, 1},
+            new Object[] {1, 0},
+            new Object[] {2, 1}
+        );
+    }
+
+    @Test
+    public void test_rank_with_range_explicit_frames_should_not_depend_on_frames() throws Throwable {
+        assertEvaluate(
+            "rank() over(order by x range between unbounded preceding and unbounded following)",
+            new Object[] {1, 1, 1, 4, 4},
+            List.of(ColumnIdent.of("x"), ColumnIdent.of("y")),
+            new Object[] {1, 1},
+            new Object[] {2, 1},
+            new Object[] {1, 1},
+            new Object[] {1, 0},
+            new Object[] {2, 1}
+        );
+    }
+
+    @Test
+    public void test_rank_with_partition_and_rows_explicit_frames_should_depend_only_on_partition() throws Throwable {
+        assertEvaluate(
+            "rank() over(partition by y order by x rows between unbounded preceding and unbounded following)",
+            new Object[] {1, 2, 2, 4, 1},
+            List.of(ColumnIdent.of("x"), ColumnIdent.of("y")),
+            new Object[] {1, 1},
+            new Object[] {2, 1},
+            new Object[] {2, 1},
+            new Object[] {2, 2},
+            new Object[] {3, 1}
+        );
+    }
+
+    @Test
+    public void test_rank_with_partition_and_range_explicit_frames_should_depend_only_on_partition() throws Throwable {
+        assertEvaluate(
+            "rank() over(partition by y order by x range between unbounded preceding and unbounded following)",
+            new Object[] {1, 2, 2, 4, 1},
+            List.of(ColumnIdent.of("x"), ColumnIdent.of("y")),
+            new Object[] {1, 1},
+            new Object[] {2, 1},
+            new Object[] {2, 1},
+            new Object[] {2, 2},
+            new Object[] {3, 1}
+        );
+    }
+
+    @Test
     public void testRankUseSymbolMultipleTimes() throws Throwable {
         assertEvaluate(
             "rank() over(order by y, x)",
@@ -177,6 +233,63 @@ public class RankFunctionsTest extends AbstractWindowFunctionTest {
             new Object[] {2, 0},
             new Object[] {3, 0});
     }
+
+    @Test
+    public void test_dense_rank_with_rows_explicit_frames_should_not_depend_on_frames() throws Throwable {
+        assertEvaluate(
+            "dense_rank() over(order by x rows between unbounded preceding and unbounded following)",
+            new Object[] {1, 1, 1, 2, 2},
+            List.of(ColumnIdent.of("x"), ColumnIdent.of("y")),
+            new Object[] {1, 1},
+            new Object[] {2, 1},
+            new Object[] {1, 1},
+            new Object[] {1, 0},
+            new Object[] {2, 1}
+        );
+    }
+
+    @Test
+    public void test_dense_rank_with_range_explicit_frames_should_not_depend_on_frames() throws Throwable {
+        assertEvaluate(
+            "dense_rank() over(order by x range between unbounded preceding and unbounded following)",
+            new Object[] {1, 1, 1, 2, 2},
+            List.of(ColumnIdent.of("x"), ColumnIdent.of("y")),
+            new Object[] {1, 1},
+            new Object[] {2, 1},
+            new Object[] {1, 1},
+            new Object[] {1, 0},
+            new Object[] {2, 1}
+        );
+    }
+
+    @Test
+    public void test_dense_rank_with_partition_and_rows_explicit_frames_should_depend_only_on_partition() throws Throwable {
+        assertEvaluate(
+            "dense_rank() over(partition by y order by x rows between unbounded preceding and unbounded following)",
+            new Object[] {1, 2, 2, 3, 1},
+            List.of(ColumnIdent.of("x"), ColumnIdent.of("y")),
+            new Object[] {1, 1},
+            new Object[] {2, 1},
+            new Object[] {2, 1},
+            new Object[] {2, 2},
+            new Object[] {3, 1}
+        );
+    }
+
+    @Test
+    public void test_dense_rank_with_partition_and_range_explicit_frames_should_depend_only_on_partition() throws Throwable {
+        assertEvaluate(
+            "dense_rank() over(partition by y order by x range between unbounded preceding and unbounded following)",
+            new Object[] {1, 2, 2, 3, 1},
+            List.of(ColumnIdent.of("x"), ColumnIdent.of("y")),
+            new Object[] {1, 1},
+            new Object[] {2, 1},
+            new Object[] {2, 1},
+            new Object[] {2, 2},
+            new Object[] {3, 1}
+        );
+    }
+
 
     @Test
     public void testIgnoreNullsFlagThrows() {

--- a/server/src/main/java/io/crate/execution/engine/window/WindowFrameState.java
+++ b/server/src/main/java/io/crate/execution/engine/window/WindowFrameState.java
@@ -34,6 +34,7 @@ public final class WindowFrameState {
     private int upperBoundExclusive;
     private int partitionStart;
     private int partitionEnd;
+    private int peerGroupWithinPartitionEndExclusive;
 
     WindowFrameState(int lowerBound, int upperBoundExclusive, List<Object[]> rows) {
         this.lowerBound = lowerBound;
@@ -51,6 +52,10 @@ public final class WindowFrameState {
 
     public int partitionEnd() {
         return partitionEnd;
+    }
+
+    public int peerGroupWithinPartitionEndExclusive() {
+        return peerGroupWithinPartitionEndExclusive;
     }
 
     public Iterable<Object[]> getRows() {
@@ -88,11 +93,12 @@ public final class WindowFrameState {
         return rows.get(idxInPartition);
     }
 
-    void updateBounds(int pStart, int pEnd, int wBegin, int wEnd) {
+    void updateBounds(int pStart, int pEnd, int wBegin, int wEnd, int peerGroupWithinPartitionEnd) {
         this.partitionStart = pStart;
         this.partitionEnd = pEnd;
         this.lowerBound = wBegin - pStart;
         this.upperBoundExclusive = wEnd - pStart;
+        this.peerGroupWithinPartitionEndExclusive = peerGroupWithinPartitionEnd - pStart;
     }
 
     @Override
@@ -102,6 +108,7 @@ public final class WindowFrameState {
                ", upperBoundExclusive=" + upperBoundExclusive +
                ", partitionStart=" + partitionStart +
                ", partitionEnd=" + partitionEnd +
+               ", peerGroupWithinPartitionEndExclusive=" + peerGroupWithinPartitionEndExclusive +
                '}';
     }
 

--- a/server/src/main/java/io/crate/execution/engine/window/WindowFunctionBatchIterator.java
+++ b/server/src/main/java/io/crate/execution/engine/window/WindowFunctionBatchIterator.java
@@ -153,6 +153,7 @@ public final class WindowFunctionBatchIterator {
             computeFrameStart,
             computeFrameEnd,
             cmpPartitionBy,
+            cmpOrderBy,
             numCellsInSourceRow,
             windowFunctions,
             argsExpressions,
@@ -174,6 +175,7 @@ public final class WindowFunctionBatchIterator {
                                                              ComputeFrameBoundary<Object[]> computeFrameStart,
                                                              ComputeFrameBoundary<Object[]> computeFrameEnd,
                                                              @Nullable Comparator<Object[]> cmpPartitionBy,
+                                                             @Nullable Comparator<Object[]> cmpOrderBy,
                                                              int numCellsInSourceRow,
                                                              List<WindowFunction> windowFunctions,
                                                              List<? extends CollectExpression<Row, ?>> argsExpressions,
@@ -188,6 +190,7 @@ public final class WindowFunctionBatchIterator {
 
             private int pStart = start;
             private int pEnd = findFirstNonPeer(sortedRows, pStart, end, cmpPartitionBy);
+            private int peerGroupWithinPartitionEnd = findFirstNonPeer(sortedRows, pStart, pEnd, cmpOrderBy);
             private int i = 0;
 
             private int idxInPartition = 0;
@@ -206,17 +209,20 @@ public final class WindowFunctionBatchIterator {
                     pStart = i;
                     idxInPartition = 0;
                     pEnd = findFirstNonPeer(sortedRows, pStart, end, cmpPartitionBy);
+                    peerGroupWithinPartitionEnd = findFirstNonPeer(sortedRows, pStart, pEnd, cmpOrderBy);
+                } else if (i == peerGroupWithinPartitionEnd) {
+                    peerGroupWithinPartitionEnd = findFirstNonPeer(sortedRows, i, pEnd, cmpOrderBy);
                 }
                 int wBegin = computeFrameStart.apply(pStart, pEnd, i, sortedRows);
                 int wEnd = computeFrameEnd.apply(pStart, pEnd, i, sortedRows);
-                frame.updateBounds(pStart, pEnd, wBegin, wEnd);
+                frame.updateBounds(pStart, pEnd, wBegin, wEnd, peerGroupWithinPartitionEnd);
                 final Object[] row = computeAndInjectResults(
                     sortedRows, allocateBytes, numCellsInSourceRow, windowFunctions, frame, i, idxInPartition, argsExpressions, ignoreNulls, args);
 
                 if (isTraceEnabled) {
                     LOGGER.trace(
-                        "idx={} idxInPartition={} pStart={} pEnd={} wBegin={} wEnd={} row={}",
-                        i, idxInPartition, pStart, pEnd, wBegin, wEnd, Arrays.toString(sortedRows.get(i)));
+                        "idx={} idxInPartition={} pStart={} pEnd={} wBegin={} wEnd={} peerGroupWithinPartitionEnd={} row={}",
+                        i, idxInPartition, pStart, pEnd, wBegin, wEnd, peerGroupWithinPartitionEnd ,Arrays.toString(sortedRows.get(i)));
                 }
                 i++;
                 idxInPartition++;

--- a/server/src/test/java/io/crate/execution/engine/window/WindowFrameStateTest.java
+++ b/server/src/test/java/io/crate/execution/engine/window/WindowFrameStateTest.java
@@ -41,13 +41,13 @@ public class WindowFrameStateTest {
 
     @Test
     public void testGetRowWithinRangeInSinglePartition() {
-        wfs.updateBounds(0, 6, 0, 6);
+        wfs.updateBounds(0, 6, 0, 6, 6);
         assertThat(wfs.getRowInPartitionAtIndexOrNull(1)).isEqualTo(rows.get(1));
     }
 
     @Test
     public void testGetRowOutOfRangeInSinglePartition() {
-        wfs.updateBounds(0, 6, 0, 6);
+        wfs.updateBounds(0, 6, 0, 6, 6);
         assertThat(wfs.getRowInPartitionAtIndexOrNull(-1)).isNull();
         assertThat(wfs.getRowInPartitionAtIndexOrNull(rows.size())).isNull();
     }
@@ -55,12 +55,12 @@ public class WindowFrameStateTest {
     @Test
     public void testGetRowsWithinRangeInTwoPartitionReturnsNull() {
         // Partition 1 index range: [0, 3); frame [0, 1)
-        wfs.updateBounds(0, 3, 0, 1);
+        wfs.updateBounds(0, 3, 0, 1, 3);
         assertThat(wfs.getRowInPartitionAtIndexOrNull(0)).isEqualTo(rows.get(0));
         assertThat(wfs.getRowInPartitionAtIndexOrNull(2)).isEqualTo(rows.get(2));
 
         // Partition 2 index range: [3, 6); frame [3, 6)
-        wfs.updateBounds(3, 6, 3, 6);
+        wfs.updateBounds(3, 6, 3, 6, 6);
         assertThat(wfs.getRowInPartitionAtIndexOrNull(0)).isEqualTo(rows.get(3));
         assertThat(wfs.getRowInPartitionAtIndexOrNull(2)).isEqualTo(rows.get(5));
     }
@@ -68,12 +68,12 @@ public class WindowFrameStateTest {
     @Test
     public void testGetRowsOutOfRangeInTwoPartitionReturnsNull() {
         // Partition 1 index range: [0, 3); frame [0, 1)
-        wfs.updateBounds(0, 3, 0, 1);
+        wfs.updateBounds(0, 3, 0, 1, 3);
         assertThat(wfs.getRowInPartitionAtIndexOrNull(-1)).isNull();
         assertThat(wfs.getRowInPartitionAtIndexOrNull(3)).isNull();
 
         // Partition 2 index range: [3, 6); frame [3, 6)
-        wfs.updateBounds(3, 6, 3, 6);
+        wfs.updateBounds(3, 6, 3, 6, 6);
         assertThat(wfs.getRowInPartitionAtIndexOrNull(-1)).isNull();
         assertThat(wfs.getRowInPartitionAtIndexOrNull(3)).isNull();
     }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB


Fixes https://github.com/crate/crate/issues/19853

Currently, CrateDB returns incorrect results when `rank()` or `dense_rank()` is used in combination with explicit window frames.

`rank()` and `dense_rank()` should not depend on the window frame. 
Postgres and SQLite "ignore" the window definition in the query with `rank()`and `dense_rank()`. 
The SQLite window functions documentation mentions (as of the date of this commit):

> "Some of the window functions (rank(), dense_rank(), percent_rank() and ntile()) use the concept of "peer groups"
> (rows within the same partition that have the same values for all ORDER BY expressions).
> In these cases, it does not matter whether the frame-spec specifies ROWS, GROUPS, or RANGE." [1](https://sqlite.org/windowfunctions.html)

The reason CrateDB returns incorrect results currently is because the implementation of `rank()`
is dependent on the window definition. `rank()` uses the `uppperBoundExclusive` of the window frame as a proxy for the end of the peer group. 

When there is no window definition (i.e. `... rank() over (order by x) from t1`) a default window frame is applied in ExpressionAnalyzer: `ORDER BY <column> RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW`
The default frame causes the end of the window frame coincide with the bounds of the
peer group. We can see this also in that our current implementation of the `rank()` function returns correctly if the query is written with this window definition. 

However, if a user specifies a different window definition -- for example:
"ROWS UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING" like in https://github.com/crate/crate/issues/19853 -- our current implementation returns the wrong
answer because the bounds of the window definition no longer coincides to the bounds of the correct "peer groups".

In this PR, we ignore the window definition completely by decoupling the calculation of rank()
and dense_rank() from the window definition. We now calculate the
end boundary of the peer group (instead of the end boundary of the window frame), and do so per partition.
We then use this peer group end boundary to calculate the rank.



### Some notes as context when reading the discussion in the comments in the future



I explored two approaches to fix this error. The other approach I explored was to override any window definition in the query in the ExpressionAnalyzer if the rank() or dense_rank() window function is used. This is a similar strategy used by SQLite's implementation [2](https://github.com/sqlite/sqlite/blob/bea60d9466ebd4c690a3444eb9055690439514a4/src/window.c#L700)
- This strategy keeps the implementation of the rank() window function the same. It is still coupled to the window definition, we just now always override the window definition to the "correct" one


I think the other approach, the one we ended up going with in the PR, is more consistent with our codebase. For example,`row_number()` is another window function that is independent from the window definition. In our implementation, `row_number()` is not dependent on the window definition -- it just returns `idxInPartition + 1` regardless of the window definition -- and we do not override window definitions in the ExpressionAnalyzer if `row_number()` is a window function. We just keep whatever is in the query and ignore it.



## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes.
       If you're an external contributor you can give yourself attribution and include your name and Github handle.
       e.g.:
       ```
       `John Doe <https://github.com/John_Doe>`_ added support for ...
       ```
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
