### PR TITLE
Remove `master` branch filter from cla-check

### DIFF
--- a/.github/workflows/cla-check.yml
+++ b/.github/workflows/cla-check.yml
@@ -1,8 +1,6 @@
 name: Check PR Author has signed CLA
 on:
   pull_request_target:
-    branches:
-    - 'master'
     types: [opened, synchronize, unlabeled]
 jobs:
   check-author-signed-cla:


### PR DESCRIPTION
Becaue of this filter `cla-check` is not ran on branches (e.g. 6.4, 6.3, etc.) so, in turn, mergify cannot automatically merge backport PRs there.
