### PR TITLE
Allow project board actions for PRs from forks

### DIFF
--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -1,9 +1,12 @@
 ---
 name: Add PR to CrateDB project board
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened]
 
+# No repository code is checked out or executed, so pull_request_target is safe
+# here. It is required so that secrets are available for PRs opened from forks.
+permissions: {}
 
 jobs:
   automate-project:


### PR DESCRIPTION
Since there is no action run on the repo itself, seems safe to enable it.
(happy to close it and leave the situation as is, if you think it's not important).
