### PR TITLE
Add missing explicit permissions to gh actions

### DIFF
--- a/.github/workflows/cla-check.yml
+++ b/.github/workflows/cla-check.yml
@@ -1,9 +1,15 @@
 name: Check PR Author has signed CLA
 on:
   pull_request_target:
-    branches:
-    - 'master'
     types: [opened, synchronize, unlabeled]
+
+# it creates/edits labels (issues) and can post a comment
+# asking the author to sign the CLA (pull-requests).
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   check-author-signed-cla:
     uses: crate/actions/.github/workflows/cla-check-workflow.yml@main

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,6 +12,11 @@ on:
       - '**/*.txt'
       - '**/*.rst'
 
+permissions:
+  contents: read
+  actions: read
+  security-events: write
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: read
+  security-events: write
 
 jobs:
   test:


### PR DESCRIPTION
Avoid implicit inheritance and explicitely list the required permissions, where missing.
