### PR TITLE
Fix UNION outputs when ORDER BY on non-output col

### DIFF
--- a/docs/appendices/release-notes/6.4.3.rst
+++ b/docs/appendices/release-notes/6.4.3.rst
@@ -156,3 +156,12 @@ Fixes
   user. Like with :ref:`ALTER ROLE <ref-alter-role>`, they can only be set for
   a user and not for a role.
 
+- Fixed an issue that caused a ``UNION ALL`` inside a sub-select to return
+  values of the wrong column if the outer query used an ``ORDER BY`` on a
+  column which was not selected. e.g.::
+
+     SELECT ts FROM (
+       SELECT * FROM (SELECT l.k, l.ts FROM a l JOIN a r ON l.k = r.k) j WHERE 1 = 0
+       UNION ALL
+       SELECT * FROM a
+     ) u ORDER BY k;

--- a/server/src/main/java/io/crate/planner/operators/Union.java
+++ b/server/src/main/java/io/crate/planner/operators/Union.java
@@ -32,9 +32,6 @@ import java.util.Set;
 
 import org.jspecify.annotations.Nullable;
 
-import com.carrotsearch.hppc.IntArrayList;
-import com.carrotsearch.hppc.cursors.IntCursor;
-
 import io.crate.analyze.OrderBy;
 import io.crate.common.collections.Lists;
 import io.crate.common.collections.Maps;
@@ -202,9 +199,14 @@ public class Union implements LogicalPlan {
         return new Union(sources.get(0), sources.get(1), outputs);
     }
 
+    private static boolean startsWith(List<Symbol> outputs, List<Symbol> prefix) {
+        return outputs.size() >= prefix.size()
+               && outputs.subList(0, prefix.size()).equals(prefix);
+    }
+
     @Override
     public LogicalPlan pruneOutputsExcept(SequencedCollection<Symbol> outputsToKeep) {
-        IntArrayList outputIndicesToKeep = new IntArrayList();
+        ArrayList<Integer> outputIndicesToKeep = new ArrayList<>();
         for (Symbol outputToKeep : outputsToKeep) {
             Symbols.intersection(outputToKeep, outputs, s -> {
                 // Union can contain identically looking ScopedSymbols due to aliased relations. E.g.:
@@ -230,17 +232,36 @@ public class Union implements LogicalPlan {
                 }
             });
         }
+        // The outputs of both sources must stay aligned with the outputs of the union itself,
+        // therefore pruning must only remove outputs, it must not re-order them. `outputsToKeep`
+        // can be in a different order, e.g. `ORDER BY` appends it symbols at the end.
+        // Sources are free to ignore the requested order, so re-ordering here would make the
+        // sources disagree on which value belongs to which output, and the per-source casts added
+        // by `addCastsForIncompatibleObjects` could then silently cast the wrong columns.
+        Collections.sort(outputIndicesToKeep);
+
         ArrayList<Symbol> toKeepFromLhs = new ArrayList<>();
         ArrayList<Symbol> toKeepFromRhs = new ArrayList<>();
         ArrayList<Symbol> newOutputs = new ArrayList<>();
-        for (IntCursor cursor : outputIndicesToKeep) {
-            toKeepFromLhs.add(lhs.outputs().get(cursor.value));
-            toKeepFromRhs.add(rhs.outputs().get(cursor.value));
-            newOutputs.add(outputs.get(cursor.value));
+        for (int idx : outputIndicesToKeep) {
+            toKeepFromLhs.add(lhs.outputs().get(idx));
+            toKeepFromRhs.add(rhs.outputs().get(idx));
+            newOutputs.add(outputs.get(idx));
         }
         LogicalPlan newLhs = lhs.pruneOutputsExcept(toKeepFromLhs);
         LogicalPlan newRhs = rhs.pruneOutputsExcept(toKeepFromRhs);
         if (newLhs == lhs && newRhs == rhs) {
+            return this;
+        }
+        // The union streams the outputs of its sources positionally, therefore both sources must
+        // have the same layout and the outputs of the union must be a prefix of it.
+        // A source is free to keep more outputs than requested, e.g. an ORDER BY symbol which was
+        // pushed beneath the union, and it may keep them in front of the requested ones. If that
+        // leaves the sources misaligned, skip the pruning: keeping additional outputs is always
+        // correct, reading the values of another column is not.
+        if (newLhs.outputs().size() != newRhs.outputs().size()
+            || startsWith(newLhs.outputs(), toKeepFromLhs) == false
+            || startsWith(newRhs.outputs(), toKeepFromRhs) == false) {
             return this;
         }
         return new Union(newLhs, newRhs, newOutputs);

--- a/server/src/test/java/io/crate/planner/UnionPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/UnionPlannerTest.java
@@ -26,15 +26,18 @@ import static io.crate.analyze.TableDefinitions.USER_TABLE_IDENT;
 import static io.crate.testing.Asserts.assertThat;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.elasticsearch.common.settings.Settings;
+import org.jspecify.annotations.Nullable;
 import org.junit.Before;
 import org.junit.Test;
 
 import io.crate.analyze.TableDefinitions;
 import io.crate.execution.dsl.projection.EvalProjection;
 import io.crate.execution.dsl.projection.LimitAndOffsetProjection;
+import io.crate.expression.symbol.Symbols;
 import io.crate.fdw.ForeignDataWrappers;
 import io.crate.metadata.RelationName;
 import io.crate.planner.node.dql.Collect;
@@ -45,6 +48,7 @@ import io.crate.statistics.Stats;
 import io.crate.statistics.TableStats;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
+import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 
 public class UnionPlannerTest extends CrateDummyClusterServiceUnitTest {
@@ -162,7 +166,7 @@ public class UnionPlannerTest extends CrateDummyClusterServiceUnitTest {
               SELECT 2, id FROM users
               ) o
             ORDER BY x
-             """;
+            """;
         var logicalPlan = e.logicalPlan(stmt);
         String expectedPlan =
             """
@@ -306,5 +310,59 @@ public class UnionPlannerTest extends CrateDummyClusterServiceUnitTest {
         // Ensure that this plan can be built without any exception
         // (Ensure Eval can handle fewer outputs than its source)
         e.plan(stmt);
+    }
+
+    // https://github.com/crate/crate/issues/19913
+    @Test
+    public void test_pruning_a_union_keeps_the_sources_aligned() throws Exception {
+        SQLExecutor executor = SQLExecutor.builder(clusterService)
+            .setNumNodes(2)
+            .build()
+            .addTable("create table tbl (id int, val long)");
+
+        // `ORDER BY id` is pushed beneath the union, the sources therefore keep `id` in addition to
+        // the `val` output of the union. `Union` streams the outputs of its sources positionally,
+        // so the outputs of the union must be a "prefix" of the outputs of both sources, otherwise
+        // the values of `id` end up in the `val` column.
+        for (String orderBy : List.of("", "order by id", "order by val")) {
+            String stmt = """
+                select val from (
+                    select * from (select l.id, l.val from tbl l join tbl r on l.id = r.id) j where 1 = 0
+                    union all
+                    select * from tbl
+                ) u
+                """ + orderBy;
+            Union union = extractUnion(executor.logicalPlan(stmt));
+            assertThat(union).isNotNull();
+
+            // The symbols of the union and of its sources are not equal, they belong to different
+            // virtual relations (AliasSymbols(, therefore compare the types
+            List<DataType<?>> outputTypes = Symbols.typeView(union.outputs());
+            List<DataType<?>> lhsTypes = Symbols.typeView(union.sources().get(0).outputs());
+            List<DataType<?>> rhsTypes = Symbols.typeView(union.sources().get(1).outputs());
+
+            assertThat(lhsTypes).hasSameSizeAs(rhsTypes);
+            assertThat(lhsTypes.size()).isGreaterThanOrEqualTo(outputTypes.size());
+            assertThat(lhsTypes.subList(0, outputTypes.size()))
+                .as("lhs of the union must be aligned with its outputs, " + orderBy)
+                .isEqualTo(outputTypes);
+            assertThat(rhsTypes.subList(0, outputTypes.size()))
+                .as("rhs of the union must be aligned with its outputs, " + orderBy)
+                .isEqualTo(outputTypes);
+        }
+    }
+
+    @Nullable
+    private static Union extractUnion(LogicalPlan plan) {
+        if (plan instanceof Union union) {
+            return union;
+        }
+        for (LogicalPlan source : plan.sources()) {
+            Union union = extractUnion(source);
+            if (union != null) {
+                return union;
+            }
+        }
+        return null;
     }
 }


### PR DESCRIPTION
When pruning the outputs of Union we must consider extra outputs which are not returned (ORDER BY symbols). The pruning must keep the outputs in the same order and union outputs must be "prefix" of the total outputs, otherwise skip the pruning, because it can silently lead to using wrong columns as outputs of UNION.

Fixes: #19913
