### PR TITLE
Fix file scheme check for COPY FROM superuser restriction

### DIFF
--- a/docs/appendices/release-notes/6.4.3.rst
+++ b/docs/appendices/release-notes/6.4.3.rst
@@ -81,6 +81,10 @@ Breaking Changes
 Fixes
 =====
 
+- Fixed an issue that allowed authenticated users to bypass the ``COPY FROM``
+  restriction to read from ``file`` URIs - which is supposed to be restricted to
+  superusers.
+
 - Fixed a security vulnerability that could allow clients to spoof the IP
   address used for host based authentication as a ``_local`` address if
   ``auth.trust.http_support_x_real_ip=true`` was set to true, and if there

--- a/server/src/main/java/io/crate/execution/engine/collect/sources/FileCollectSource.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/sources/FileCollectSource.java
@@ -35,11 +35,11 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
 import org.elasticsearch.threadpool.ThreadPool;
-import io.crate.common.annotations.VisibleForTesting;
 
 import io.crate.analyze.AnalyzedCopyFrom;
 import io.crate.analyze.CopyFromParserProperties;
 import io.crate.analyze.SymbolEvaluator;
+import io.crate.common.annotations.VisibleForTesting;
 import io.crate.data.BatchIterator;
 import io.crate.data.Row;
 import io.crate.data.SkippingBatchIterator;
@@ -100,7 +100,7 @@ public class FileCollectSource implements CollectSource {
         List<URI> fileUris = targetUriToStringList(txnCtx, nodeCtx, fileUriCollectPhase.targetUri()).stream()
             .map(s -> {
                 var uri = FileReadingIterator.toURI(s);
-                if (uri.getScheme().equals("file") && user.isSuperUser() == false) {
+                if (uri.getScheme().equalsIgnoreCase("file") && user.isSuperUser() == false) {
                     throw new UnauthorizedException("Only a superuser can read from the local file system");
                 }
                 return uri;

--- a/server/src/test/java/io/crate/integrationtests/CopyIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/CopyIntegrationTest.java
@@ -26,6 +26,7 @@ import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
 import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.TestingHelpers.printedTable;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
@@ -1199,7 +1200,13 @@ public class CopyIntegrationTest extends SQLHttpIntegrationTest {
         Sessions sqlOperations = cluster().getInstance(Sessions.class);
         try (var session = sqlOperations.newSession(
             new ConnectionProperties(null, null, Protocol.HTTP, null), null, user)) {
-            assertThatThrownBy(() -> execute("COPY quotes FROM ?", new Object[]{copyFilePath + "test_copy_from.json"}, session))
+            String fullPath = copyFilePath + "test_copy_from.json";
+            assertThatThrownBy(() -> execute("COPY quotes FROM ?", new Object[]{fullPath}, session))
+                .isExactlyInstanceOf(UnauthorizedException.class)
+                .hasMessage("Only a superuser can read from the local file system");
+
+            String upperCasePath = fullPath.replace("file", "FILE");
+            assertThatThrownBy(() -> execute("COPY quotes FROM ?", new Object[]{upperCasePath}, session))
                 .isExactlyInstanceOf(UnauthorizedException.class)
                 .hasMessage("Only a superuser can read from the local file system");
         }


### PR DESCRIPTION
Part of https://github.com/crate/crate/security/advisories/GHSA-xw2x-w5xq-9w8r

(cherry picked from commit 533fa71c17a167acf7343c270d764185471d995d)
