### PR TITLE
Use table OIDs for REROUTE index resolution

### DIFF
--- a/docs/appendices/release-notes/6.5.0.rst
+++ b/docs/appendices/release-notes/6.5.0.rst
@@ -149,8 +149,9 @@ Performance and Resilience Improvements
   :ref:`ADD COLUMN <sql-alter-table-add-column>`,
   :ref:`RENAME COLUMN <sql-alter-table-rename-column>`,
   :ref:`SET/DROP DEFAULT <SQL-alter-table-alter-column-default>`,
-  :ref:`DROP CONSTRAINT <sql-alter-drop-constraint>`, and
-  :ref:`SET/RESET <sql-alter-table-set-reset>`
+  :ref:`DROP CONSTRAINT <sql-alter-drop-constraint>`,
+  :ref:`SET/RESET <sql-alter-table-set-reset>` and
+  :ref:`REROUTE <sql-alter-table-reroute>`
   such that concurrent :ref:`SWAP TABLE <alter_cluster_swap_table>`
   cannot affect aforementioned queries already in progress.
 

--- a/server/src/main/java/io/crate/planner/node/management/AlterTableReroutePlan.java
+++ b/server/src/main/java/io/crate/planner/node/management/AlterTableReroutePlan.java
@@ -22,6 +22,7 @@
 package io.crate.planner.node.management;
 
 import static io.crate.planner.NodeSelection.resolveNodeId;
+import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
 
 import java.util.List;
 import java.util.Locale;
@@ -53,11 +54,13 @@ import io.crate.common.collections.Lists;
 import io.crate.data.Row;
 import io.crate.data.Row1;
 import io.crate.data.RowConsumer;
+import io.crate.exceptions.PartitionUnknownException;
 import io.crate.execution.support.OneRowActionListener;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.PartitionName;
+import io.crate.metadata.blob.BlobTableInfo;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.table.ShardedTable;
 import io.crate.planner.DependencyCarrier;
@@ -280,16 +283,37 @@ public class AlterTableReroutePlan implements Plan {
                                               List<Assignment<Object>> partitionsProperties,
                                               Metadata metadata) {
             if (shardedTable instanceof DocTableInfo docTableInfo) {
-                PartitionName partitionName;
-                if (docTableInfo.isPartitioned()) {
-                    partitionName = PartitionName.ofAssignments(docTableInfo, partitionsProperties, metadata);
-                } else {
-                    partitionName = new PartitionName(docTableInfo.ident(), List.of());
+                if (docTableInfo.oid() == OID_UNASSIGNED) {
+                    PartitionName partitionName = docTableInfo.isPartitioned()
+                        ? PartitionName.ofAssignments(docTableInfo, partitionsProperties, metadata)
+                        : new PartitionName(docTableInfo.ident(), List.of());
+                    return metadata.getIndex(partitionName.relationName(), partitionName.values(), true, IndexMetadata::getIndexUUID);
                 }
-                return metadata.getIndex(partitionName.relationName(), partitionName.values(), true, IndexMetadata::getIndexUUID);
+
+                if (docTableInfo.isPartitioned()) {
+                    PartitionName partitionName = PartitionName.ofAssignmentsUnsafe(docTableInfo, partitionsProperties);
+                    String index = metadata.getIndex(
+                        docTableInfo.oid(),
+                        partitionName.values(),
+                        true,
+                        IndexMetadata::getIndexUUID
+                    );
+                    if (index == null) {
+                        throw new PartitionUnknownException(partitionName);
+                    }
+                    return index;
+                }
+                return metadata.getIndex(docTableInfo.oid(), List.of(), true, IndexMetadata::getIndexUUID);
             }
 
-            // Table is a blob table
+            if (shardedTable instanceof BlobTableInfo blobTableInfo && blobTableInfo.oid() != OID_UNASSIGNED) {
+                return metadata.getIndex(
+                    blobTableInfo.oid(),
+                    List.of(),
+                    true,
+                    IndexMetadata::getIndexUUID
+                );
+            }
             assert shardedTable.concreteIndices(metadata).length == 1 : "table has to contain only 1 index name";
             return shardedTable.concreteIndices(metadata)[0];
         }

--- a/server/src/test/java/io/crate/analyze/AlterTableRerouteAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/AlterTableRerouteAnalyzerTest.java
@@ -23,6 +23,7 @@ package io.crate.analyze;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
 
 import java.io.IOException;
 import java.util.List;
@@ -30,7 +31,10 @@ import java.util.Map;
 import java.util.Set;
 
 import org.elasticsearch.Version;
+import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.metadata.RelationMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.allocation.command.AllocateEmptyPrimaryAllocationCommand;
@@ -38,6 +42,7 @@ import org.elasticsearch.cluster.routing.allocation.command.AllocateReplicaAlloc
 import org.elasticsearch.cluster.routing.allocation.command.AllocateStalePrimaryAllocationCommand;
 import org.elasticsearch.cluster.routing.allocation.command.CancelAllocationCommand;
 import org.elasticsearch.cluster.routing.allocation.command.MoveAllocationCommand;
+import org.elasticsearch.test.ClusterServiceUtils;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -62,6 +67,7 @@ public class AlterTableRerouteAnalyzerTest extends CrateDummyClusterServiceUnitT
         e = SQLExecutor.of(clusterService)
             .addBlobTable("create blob table blobs;")
             .addTable(TableDefinitions.USER_TABLE_DEFINITION)
+            .addTable("create table other (id int) clustered into 1 shards")
             .addTable(
                 TableDefinitions.TEST_PARTITIONED_TABLE_DEFINITION,
                 TableDefinitions.TEST_PARTITIONED_TABLE_PARTITIONS
@@ -77,6 +83,11 @@ public class AlterTableRerouteAnalyzerTest extends CrateDummyClusterServiceUnitT
 
     @SuppressWarnings("unchecked")
     private <S> S analyze(String stmt, Object... arguments) {
+        return analyze(stmt, plannerContext.clusterState().metadata(), arguments);
+    }
+
+    @SuppressWarnings("unchecked")
+    private <S> S analyze(String stmt, Metadata metadata, Object... arguments) {
         AnalyzedStatement analyzedStatement = e.analyze(stmt);
         return (S) AlterTableReroutePlan.createRerouteCommand(
             analyzedStatement,
@@ -93,7 +104,7 @@ public class AlterTableRerouteAnalyzerTest extends CrateDummyClusterServiceUnitT
                     Set.of(),
                     Version.CURRENT))
                 .build(),
-            plannerContext.clusterState().metadata()
+            metadata
         );
     }
 
@@ -140,6 +151,192 @@ public class AlterTableRerouteAnalyzerTest extends CrateDummyClusterServiceUnitT
     }
 
     @Test
+    public void test_reroute_uses_table_oid_if_source_name_points_to_another_table() {
+        RelationName usersName = new RelationName("doc", "users");
+        RelationName otherName = new RelationName("doc", "other");
+
+        Metadata metadata = plannerContext.clusterState().metadata();
+
+        RelationMetadata.Table users = metadata.getRelation(usersName);
+        RelationMetadata.Table other = metadata.getRelation(otherName);
+
+        Metadata metadataAfterSwap = Metadata.builder(metadata)
+            .dropRelation(usersName)
+            .dropRelation(otherName)
+            .setTable(
+                usersName,
+                other.columns().stream().map(ref -> ref.withRelation(usersName)).toList(),
+                other.settings(),
+                other.routingColumn(),
+                other.columnPolicy(),
+                other.pkConstraintName(),
+                other.checkConstraints(),
+                other.primaryKeys(),
+                other.partitionedBy(),
+                other.state(),
+                other.indexUUIDs(),
+                other.tableVersion() + 1,
+                other.oid()
+            )
+            .setTable(
+                otherName,
+                users.columns().stream().map(ref -> ref.withRelation(otherName)).toList(),
+                users.settings(),
+                users.routingColumn(),
+                users.columnPolicy(),
+                users.pkConstraintName(),
+                users.checkConstraints(),
+                users.primaryKeys(),
+                users.partitionedBy(),
+                users.state(),
+                users.indexUUIDs(),
+                users.tableVersion() + 1,
+                users.oid()
+            )
+            .build();
+
+        MoveAllocationCommand command = analyze(
+            "ALTER TABLE users REROUTE MOVE SHARD 0 FROM 'n2' TO 'n1'",
+            metadataAfterSwap);
+        assertThat(command.index()).isEqualTo(usersIndexUUID);
+    }
+
+    @Test
+    public void test_reroute_partition_uses_table_oid_if_source_name_points_to_another_table() {
+        RelationName partedName = new RelationName("doc", "parted");
+        RelationName otherName = new RelationName("doc", "other");
+
+        Metadata metadata = plannerContext.clusterState().metadata();
+
+        RelationMetadata.Table parted = metadata.getRelation(partedName);
+        RelationMetadata.Table other = metadata.getRelation(otherName);
+        String partedIndexUUID = metadata.getIndex(
+            partedName,
+            List.of("1395874800000"),
+            true,
+            IndexMetadata::getIndexUUID
+        );
+
+        Metadata metadataAfterSwap = Metadata.builder(metadata)
+            .dropRelation(partedName)
+            .dropRelation(otherName)
+            .setTable(
+                partedName,
+                other.columns().stream().map(ref -> ref.withRelation(partedName)).toList(),
+                other.settings(),
+                other.routingColumn(),
+                other.columnPolicy(),
+                other.pkConstraintName(),
+                other.checkConstraints(),
+                other.primaryKeys(),
+                other.partitionedBy(),
+                other.state(),
+                other.indexUUIDs(),
+                other.tableVersion() + 1,
+                other.oid()
+            )
+            .setTable(
+                otherName,
+                parted.columns().stream().map(ref -> ref.withRelation(otherName)).toList(),
+                parted.settings(),
+                parted.routingColumn(),
+                parted.columnPolicy(),
+                parted.pkConstraintName(),
+                parted.checkConstraints(),
+                parted.primaryKeys(),
+                parted.partitionedBy(),
+                parted.state(),
+                parted.indexUUIDs(),
+                parted.tableVersion() + 1,
+                parted.oid()
+            )
+            .build();
+
+        MoveAllocationCommand command = analyze(
+            "ALTER TABLE parted PARTITION (date = 1395874800000) REROUTE MOVE SHARD 0 FROM 'n1' TO 'n2'",
+            metadataAfterSwap);
+        assertThat(command.index()).isEqualTo(partedIndexUUID);
+    }
+
+    @Test
+    public void test_reroute_partition_falls_back_to_relation_name_if_table_oid_is_unassigned() {
+        RelationName partedName = new RelationName("doc", "parted");
+
+        Metadata metadata = plannerContext.clusterState().metadata();
+        RelationMetadata.Table parted = metadata.getRelation(partedName);
+        Metadata metadataWithUnassignedOid = Metadata.builder(metadata)
+            .dropRelation(partedName)
+            .setTable(
+                partedName,
+                parted.columns(),
+                parted.settings(),
+                parted.routingColumn(),
+                parted.columnPolicy(),
+                parted.pkConstraintName(),
+                parted.checkConstraints(),
+                parted.primaryKeys(),
+                parted.partitionedBy(),
+                parted.state(),
+                parted.indexUUIDs(),
+                parted.tableVersion(),
+                OID_UNASSIGNED
+            )
+            .version(metadata.version() + 1)
+            .build();
+        ClusterServiceUtils.setState(
+            clusterService,
+            ClusterState.builder(clusterService.state()).metadata(metadataWithUnassignedOid).build()
+        );
+        plannerContext = e.getPlannerContext();
+
+        String partedIndexUUID = metadataWithUnassignedOid.getIndex(
+            partedName,
+            List.of("1395874800000"),
+            true,
+            IndexMetadata::getIndexUUID
+        );
+        MoveAllocationCommand command = analyze(
+            "ALTER TABLE parted PARTITION (date = 1395874800000) REROUTE MOVE SHARD 0 FROM 'n1' TO 'n2'");
+        assertThat(command.index()).isEqualTo(partedIndexUUID);
+    }
+
+    @Test
+    public void test_reroute_falls_back_to_relation_name_if_table_oid_is_unassigned() {
+        RelationName usersName = new RelationName("doc", "users");
+
+        Metadata metadata = plannerContext.clusterState().metadata();
+        RelationMetadata.Table users = metadata.getRelation(usersName);
+        Metadata metadataWithUnassignedOid = Metadata.builder(metadata)
+            .dropRelation(usersName)
+            .setTable(
+                usersName,
+                users.columns(),
+                users.settings(),
+                users.routingColumn(),
+                users.columnPolicy(),
+                users.pkConstraintName(),
+                users.checkConstraints(),
+                users.primaryKeys(),
+                users.partitionedBy(),
+                users.state(),
+                users.indexUUIDs(),
+                users.tableVersion(),
+                OID_UNASSIGNED
+            )
+            .version(metadata.version() + 1)
+            .build();
+        ClusterServiceUtils.setState(
+            clusterService,
+            ClusterState.builder(clusterService.state()).metadata(metadataWithUnassignedOid).build()
+        );
+        plannerContext = e.getPlannerContext();
+
+        MoveAllocationCommand command = analyze(
+            "ALTER TABLE users REROUTE MOVE SHARD 0 FROM 'n2' TO 'n1'");
+        assertThat(command.index()).isEqualTo(usersIndexUUID);
+    }
+
+    @Test
     public void testRerouteMoveShardWithNullShardId() {
         assertThatThrownBy(() -> analyze("ALTER TABLE users REROUTE MOVE SHARD null FROM 'n2' TO 'n1'"))
             .isExactlyInstanceOf(IllegalArgumentException.class)
@@ -173,6 +370,34 @@ public class AlterTableRerouteAnalyzerTest extends CrateDummyClusterServiceUnitT
         MoveAllocationCommand command = analyze(
             "ALTER TABLE blob.blobs REROUTE MOVE SHARD 0 FROM 'n1' TO 'n2'");
         assertThat(command.index()).isEqualTo(indexUUID);
+    }
+
+    @Test
+    public void test_reroute_blob_table_falls_back_to_concrete_index_if_table_oid_is_unassigned() {
+        RelationName blobsName = new RelationName(BlobSchemaInfo.NAME, "blobs");
+
+        Metadata metadata = plannerContext.clusterState().metadata();
+        RelationMetadata.BlobTable blobs = metadata.getRelation(blobsName);
+        Metadata metadataWithUnassignedOid = Metadata.builder(metadata)
+            .dropRelation(blobsName)
+            .setBlobTable(
+                blobsName,
+                blobs.indexUUID(),
+                blobs.settings(),
+                blobs.state(),
+                OID_UNASSIGNED
+            )
+            .version(metadata.version() + 1)
+            .build();
+        ClusterServiceUtils.setState(
+            clusterService,
+            ClusterState.builder(clusterService.state()).metadata(metadataWithUnassignedOid).build()
+        );
+        plannerContext = e.getPlannerContext();
+
+        MoveAllocationCommand command = analyze(
+            "ALTER TABLE blob.blobs REROUTE MOVE SHARD 0 FROM 'n1' TO 'n2'");
+        assertThat(command.index()).isEqualTo(blobs.indexUUID());
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Similar to https://github.com/crate/crate/pull/19895.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes.
       If you're an external contributor you can give yourself attribution and include your name and Github handle.
       e.g.:
       ```
       `John Doe <https://github.com/John_Doe>`_ added support for ...
       ```
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
