### PR TITLE
Fix restoring user/roles/privileges metadata from a SNAPSHOT

### DIFF
--- a/docs/admin/privileges.rst
+++ b/docs/admin/privileges.rst
@@ -48,6 +48,8 @@ themselves to other users or roles as well.
 Privilege types
 ===============
 
+.. _privilege_types_dql:
+
 ``DQL``
 .......
 
@@ -57,6 +59,7 @@ that this user/role is allowed to execute ``SELECT``, ``SHOW``, ``REFRESH`` and
 :ref:`user-defined functions <user-defined-functions>`, on the object for which
 the privilege applies.
 
+.. _privilege_types_dml:
 
 ``DML``
 .......
@@ -65,6 +68,8 @@ Granting ``Data Manipulation Language (DML)`` privilege to a user or role,
 indicates that this user/role is allowed to execute ``INSERT``, ``COPY FROM``,
 ``UPDATE`` and ``DELETE`` statements, on the object for which the privilege
 applies.
+
+.. _privilege_types_ddl:
 
 ``DDL``
 .......
@@ -86,6 +91,8 @@ objects for which the privilege applies:
 - ``RESTORE SNAPSHOT``
 - ``ALTER TABLE``
 
+.. _privilege_types_al:
+
 ``AL``
 ......
 
@@ -95,6 +102,8 @@ the user/role to execute the following statements:
 - ``CREATE USER/ROLE``
 - ``DROP USER/ROLE``
 - ``SET GLOBAL``
+- ``RESTORE SNAPSHOT``, if the restored sections include user management
+  metadata, see :ref:`sql-restore-snapshot` for details.
 
 All statements enabled via the ``AL`` privilege operate on a cluster level. So
 granting this on a schema or table level will have no effect.

--- a/docs/appendices/release-notes/6.4.3.rst
+++ b/docs/appendices/release-notes/6.4.3.rst
@@ -77,6 +77,18 @@ Breaking Changes
         ]
     }
 
+- Added requirement for :ref:`AL <privilege_types_al>` privilege on cluster
+  level in addition to the :ref:`DDL <privilege_types_ddl>` privilege when
+  issuing :ref:`RESTORE SNAPSHOT <sql-restore-snapshot>`, if the restored
+  sections include user management metadata, (users, roles and privileges). This
+  is the case for:
+
+  * ``RESTORE SNAPSHOT ... ALL``
+  * ``RESTORE SNAPSHOT ... METADATA``
+  * ``RESTORE SNAPSHOT ... USERMANAGEMENT``
+
+  Previously the ``DDL`` privilege alone was sufficient.
+
 
 Fixes
 =====

--- a/docs/sql/statements/restore-snapshot.rst
+++ b/docs/sql/statements/restore-snapshot.rst
@@ -61,6 +61,17 @@ multiple concrete sections at once.
 
 To cancel a restore operation simply drop the tables that are being restored.
 
+.. NOTE::
+
+    ``RESTORE SNAPSHOT`` requires the :ref:`DDL <privilege_types>` privilege on
+    the cluster level. If the restored sections include user management
+    metadata (users, roles and privileges) the :ref:`AL <privilege_types>`
+    privilege on the cluster level is required as well. This is the case for:
+
+    - ``RESTORE SNAPSHOT ... ALL``
+    - ``RESTORE SNAPSHOT ... METADATA``
+    - ``RESTORE SNAPSHOT ... USERMANAGEMENT``
+
 .. CAUTION::
 
     If you try to restore a table that already exists, CrateDB will return an

--- a/server/src/main/java/io/crate/analyze/RestoreSnapshotAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/RestoreSnapshotAnalyzer.java
@@ -48,9 +48,9 @@ import io.crate.sql.tree.GenericProperties;
 import io.crate.sql.tree.RestoreSnapshot;
 import io.crate.sql.tree.Table;
 
-class RestoreSnapshotAnalyzer {
+public class RestoreSnapshotAnalyzer {
 
-    static final DeprecationLogger DEPRECATION_LOGGER =
+    public static final DeprecationLogger DEPRECATION_LOGGER =
         new DeprecationLogger(LogManager.getLogger(RestoreSnapshotAnalyzer.class));
 
     public static final List<String> USER_MANAGEMENT_METADATA = List.of(

--- a/server/src/main/java/io/crate/auth/AccessControlImpl.java
+++ b/server/src/main/java/io/crate/auth/AccessControlImpl.java
@@ -98,6 +98,7 @@ import io.crate.analyze.AnalyzedUpdateStatement;
 import io.crate.analyze.CreateViewStmt;
 import io.crate.analyze.ExplainAnalyzedStatement;
 import io.crate.analyze.QueriedSelectRelation;
+import io.crate.analyze.RestoreSnapshotAnalyzer;
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.AnalyzedRelationVisitor;
 import io.crate.analyze.relations.AnalyzedView;
@@ -705,6 +706,12 @@ public final class AccessControlImpl implements AccessControl {
                 Securable.CLUSTER,
                 null
             );
+            boolean restoreUsersAndPrivileges = analysis.includeCustomMetadata()
+                && (analysis.customMetadataTypes().isEmpty()   // ALL
+                || analysis.customMetadataTypes().stream().anyMatch(RestoreSnapshotAnalyzer.USER_MANAGEMENT_METADATA::contains));
+            if (restoreUsersAndPrivileges) {
+                hasALPrivileges(user);
+            }
             return null;
         }
 

--- a/server/src/test/java/io/crate/auth/AccessControlMayExecuteTest.java
+++ b/server/src/test/java/io/crate/auth/AccessControlMayExecuteTest.java
@@ -47,6 +47,7 @@ import org.junit.Test;
 
 import io.crate.analyze.FunctionArgumentDefinition;
 import io.crate.analyze.ParamTypeHints;
+import io.crate.analyze.RestoreSnapshotAnalyzer;
 import io.crate.analyze.TableDefinitions;
 import io.crate.exceptions.MissingPrivilegeException;
 import io.crate.exceptions.RelationUnknown;
@@ -188,6 +189,11 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
             s -> assertThat(s).containsExactly(permission, Securable.CLUSTER, null, user.name()));
     }
 
+    private void assertNotAskedForCluster(Permission permission) {
+        assertThat(validationCallArguments).noneSatisfy(
+            s -> assertThat(s).containsExactly(permission, Securable.CLUSTER, null, normalUser.name()));
+    }
+
     private void assertAskedForSchema(Permission permission, String ident) {
         assertThat(validationCallArguments).anySatisfy(
             s -> assertThat(s).containsExactly(permission, Securable.SCHEMA, ident, normalUser.name()));
@@ -299,9 +305,26 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
     }
 
     @Test
-    public void testRestoreSnapshot() throws Exception {
+    public void test_restore_snapshot_with_user_metadata_requires_al_and_ddl() throws Exception {
+        for (var type : List.of("ALL", "METADATA", "USERMANAGEMENT", "USERS", "PRIVILEGES")) {
+            RestoreSnapshotAnalyzer.DEPRECATION_LOGGER.resetLRU();
+            analyze("restore snapshot my_repo.my_snapshot " + type);
+            if ("USERS".equals(type) || "PRIVILEGES".equals(type)) {
+                assertWarnings(type + " keyword is deprecated, please use USERMANAGEMENT instead");
+            }
+            assertAskedForCluster(Permission.DDL);
+            assertAskedForCluster(Permission.AL);
+        }
+    }
+
+    @Test
+    public void test_restore_snapshot_without_user_management_metadata_does_not_require_al() throws Exception {
         analyze("restore snapshot my_repo.my_snapshot table my_table");
+        for (var type : List.of("TABLES", "VIEWS", "ANALYZERS", "UDFS")) {
+            analyze("restore snapshot my_repo.my_snapshot " + type);
+        }
         assertAskedForCluster(Permission.DDL);
+        assertNotAskedForCluster(Permission.AL);
     }
 
     @Test


### PR DESCRIPTION
Since restoring users/roles/privileges metadata on a cluster from a snapshot is equivalent to creating/altering/dropping roles or users and granting or denying privileges to roles or users, add requirement for `AL` cluster privilege on top of `DDL`, to permit such restore actions.

(cherry picked from commit 7a6aae0994693136a09488978bb9b8cb02d4995a)

