### PR TITLE
Remove deprecated USERS & PRIVILEGES from RESTORE snap

### DIFF
--- a/docs/appendices/release-notes/6.5.0.rst
+++ b/docs/appendices/release-notes/6.5.0.rst
@@ -86,6 +86,10 @@ Breaking Changes
   symmetrical join conditions (i.e. ``a = b`` is identical to ``b = a``).
   Query results are not affected.
 
+- Removed the ``USERS`` and ``PRIVILEGES`` keywords for the
+  :ref:`RESTORE SNAPSHOT <sql-restore-snapshot>` statement, which have been
+  deprecated since :ref:`5.6.0 <version_6.5.0>`. Use ``USERMANAGEMENT`` instead.
+
 Deprecations
 ============
 

--- a/libs/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/libs/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -2124,9 +2124,9 @@ public class TestStatementBuilder {
         printStatement("RESTORE SNAPSHOT repo1.snap1 ALL WITH (wait_for_completion = true)");
         printStatement("RESTORE SNAPSHOT repo1.snap1 TABLE t PARTITION (parted_col = ?)");
         printStatement("RESTORE SNAPSHOT repo1.snap1 METADATA");
-        printStatement("RESTORE SNAPSHOT repo1.snap1 USERS WITH (some_option = true)");
-        printStatement("RESTORE SNAPSHOT repo1.snap1 USERS, PRIVILEGES");
-        printStatement("RESTORE SNAPSHOT repo1.snap1 TABLES, PRIVILEGES");
+        printStatement("RESTORE SNAPSHOT repo1.snap1 USERMANAGEMENT WITH (some_option = true)");
+        printStatement("RESTORE SNAPSHOT repo1.snap1 USERMANAGEMENT, UDFS");
+        printStatement("RESTORE SNAPSHOT repo1.snap1 TABLES, USERMANAGEMENT");
     }
 
     @Test

--- a/server/src/main/java/io/crate/analyze/RestoreSnapshotAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/RestoreSnapshotAnalyzer.java
@@ -27,9 +27,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
-import org.apache.logging.log4j.LogManager;
-import org.elasticsearch.common.logging.DeprecationLogger;
-
 import io.crate.analyze.expressions.ExpressionAnalysisContext;
 import io.crate.analyze.expressions.ExpressionAnalyzer;
 import io.crate.analyze.relations.FieldProvider;
@@ -50,9 +47,6 @@ import io.crate.sql.tree.Table;
 
 public class RestoreSnapshotAnalyzer {
 
-    public static final DeprecationLogger DEPRECATION_LOGGER =
-        new DeprecationLogger(LogManager.getLogger(RestoreSnapshotAnalyzer.class));
-
     public static final List<String> USER_MANAGEMENT_METADATA = List.of(
         UsersMetadata.TYPE, // Also restore old UsersMetadata
         RolesMetadata.TYPE,
@@ -60,8 +54,6 @@ public class RestoreSnapshotAnalyzer {
 
     public static final Map<String, List<String>> METADATA_CUSTOM_TYPE_MAP = Map.of(
         "UDFS", List.of(UserDefinedFunctionsMetadata.TYPE),
-        "USERS", USER_MANAGEMENT_METADATA,    // Deprecated, keeping for BWC
-        "PRIVILEGES", USER_MANAGEMENT_METADATA,   // Deprecated, keeping for BWC
         "USERMANAGEMENT", USER_MANAGEMENT_METADATA
     );
 
@@ -146,10 +138,6 @@ public class RestoreSnapshotAnalyzer {
                         var customTypes = METADATA_CUSTOM_TYPE_MAP.get(typeName);
                         if (customTypes == null) {
                             throw new IllegalArgumentException("Unknown metadata type '" + typeName + "'");
-                        }
-                        if ("USERS".equals(typeName) || "PRIVILEGES".equals(typeName)) {
-                            DEPRECATION_LOGGER.deprecatedAndMaybeLog("restore_snapshot.metadata",
-                                typeName + " keyword is deprecated, please use USERMANAGEMENT instead");
                         }
                         includeCustomMetadata = true;
                         customMetadataTypes.addAll(customTypes);

--- a/server/src/test/java/io/crate/analyze/RestoreSnapshotAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/RestoreSnapshotAnalyzerTest.java
@@ -391,27 +391,15 @@ public class RestoreSnapshotAnalyzerTest extends CrateDummyClusterServiceUnitTes
 
     @Test
     public void test_restore_user_mananagement_metadata() {
-        for (var meta : List.of("USERS", "PRIVILEGES", "USERMANAGEMENT")) {
-            RestoreSnapshotAnalyzer.DEPRECATION_LOGGER.resetLRU();
-
-            BoundRestoreSnapshot statement =
-                analyze(e, "RESTORE SNAPSHOT my_repo.my_snapshot " + meta);
-            assertThat(statement.repository()).isEqualTo("my_repo");
-            assertThat(statement.snapshot()).isEqualTo("my_snapshot");
-            assertThat(statement.includeTables()).isFalse();
-            assertThat(statement.restoreTables().isEmpty()).isTrue();
-            assertThat(statement.includeCustomMetadata()).isTrue();
-            assertThat(statement.customMetadataTypes()).containsExactlyInAnyOrderElementsOf(USER_MANAGEMENT_METADATA);
-            assertThat(statement.includeGlobalSettings()).isFalse();
-            assertThat(statement.globalSettings().isEmpty()).isTrue();
-
-            if ("USERS".equals(meta)) {
-                assertWarnings("USERS keyword is deprecated, please use USERMANAGEMENT instead");
-            }
-            if ("PRIVILEGES".equals(meta)) {
-                assertWarnings("PRIVILEGES keyword is deprecated, please use USERMANAGEMENT instead");
-            }
-        }
+        BoundRestoreSnapshot statement = analyze(e, "RESTORE SNAPSHOT my_repo.my_snapshot USERMANAGEMENT");
+        assertThat(statement.repository()).isEqualTo("my_repo");
+        assertThat(statement.snapshot()).isEqualTo("my_snapshot");
+        assertThat(statement.includeTables()).isFalse();
+        assertThat(statement.restoreTables().isEmpty()).isTrue();
+        assertThat(statement.includeCustomMetadata()).isTrue();
+        assertThat(statement.customMetadataTypes()).containsExactlyInAnyOrderElementsOf(USER_MANAGEMENT_METADATA);
+        assertThat(statement.includeGlobalSettings()).isFalse();
+        assertThat(statement.globalSettings().isEmpty()).isTrue();
     }
 
     @Test

--- a/server/src/test/java/io/crate/auth/AccessControlMayExecuteTest.java
+++ b/server/src/test/java/io/crate/auth/AccessControlMayExecuteTest.java
@@ -47,7 +47,6 @@ import org.junit.Test;
 
 import io.crate.analyze.FunctionArgumentDefinition;
 import io.crate.analyze.ParamTypeHints;
-import io.crate.analyze.RestoreSnapshotAnalyzer;
 import io.crate.analyze.TableDefinitions;
 import io.crate.exceptions.MissingPrivilegeException;
 import io.crate.exceptions.RelationUnknown;
@@ -306,12 +305,8 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
 
     @Test
     public void test_restore_snapshot_with_user_metadata_requires_al_and_ddl() throws Exception {
-        for (var type : List.of("ALL", "METADATA", "USERMANAGEMENT", "USERS", "PRIVILEGES")) {
-            RestoreSnapshotAnalyzer.DEPRECATION_LOGGER.resetLRU();
+        for (var type : List.of("ALL", "METADATA", "USERMANAGEMENT")) {
             analyze("restore snapshot my_repo.my_snapshot " + type);
-            if ("USERS".equals(type) || "PRIVILEGES".equals(type)) {
-                assertWarnings(type + " keyword is deprecated, please use USERMANAGEMENT instead");
-            }
             assertAskedForCluster(Permission.DDL);
             assertAskedForCluster(Permission.AL);
         }

--- a/server/src/test/java/io/crate/integrationtests/SnapshotRestoreIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SnapshotRestoreIntegrationTest.java
@@ -30,7 +30,6 @@ import static io.crate.testing.Asserts.assertThat;
 import static io.netty.handler.codec.http.HttpResponseStatus.CONFLICT;
 import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
@@ -796,7 +795,7 @@ public class SnapshotRestoreIntegrationTest extends IntegTestCase {
     }
 
     /**
-     * Restoring USERS will result in restoring custom metadata only and NO global settings.
+     * Restoring USERMANAGEMENT will result in restoring custom metadata only and NO global settings.
      * This test a regression which resulted in restoring the custom metadata only if global settings
      * were also marked to be restored.
      */
@@ -804,7 +803,7 @@ public class SnapshotRestoreIntegrationTest extends IntegTestCase {
     public void test_restore_custom_metadata_only() throws Exception {
         createSnapshotWithTablesAndMetadata();
 
-        execute("RESTORE SNAPSHOT " + snapshotName() + " USERS WITH (wait_for_completion=true)");
+        execute("RESTORE SNAPSHOT " + snapshotName() + " USERMANAGEMENT WITH (wait_for_completion=true)");
         waitNoPendingTasksOnAll();
 
         execute("SELECT name FROM sys.users WHERE name = 'my_user'");
@@ -1094,7 +1093,7 @@ public class SnapshotRestoreIntegrationTest extends IntegTestCase {
         // CREATE USER "John";
         // GRANT DQL ON SCHEMA "sys" TO "John";
         // GRANT AL TO "Ford";
-        execute("RESTORE SNAPSHOT users_repo.usersnap USERS with (wait_for_completion=true)");
+        execute("RESTORE SNAPSHOT users_repo.usersnap USERMANAGEMENT with (wait_for_completion=true)");
 
         execute("SELECT name, granted_roles, password, superuser FROM sys.users ORDER BY name");
         assertThat(response).hasRows(


### PR DESCRIPTION
They have been deprecated since 5.6.0 and they were already just aliases for `USERMANAGEMENT` since it was not possible to restore only USERS or ONLY PRIVILEGES since then.

