### PR TITLE
Revert "Verify JWT token only when connection gets established"

### DIFF
--- a/docs/admin/auth/methods.rst
+++ b/docs/admin/auth/methods.rst
@@ -160,11 +160,6 @@ both values are compared and in case of a mismatch the token is rejected.
    JWT is supported only for the HTTP protocol. An :ref:`HBA <admin_hba>` entry
    for ``jwt`` MUST be combined with ``protocol: http``.
 
-.. NOTE::
-
-   Token is verified only when connection gets established. An expired token
-   might be used throughout the lifetime of the connection.
-
 .. SEEALSO::
 
   :ref:`admin_hba`

--- a/server/src/main/java/io/crate/auth/HttpAuthUpstreamHandler.java
+++ b/server/src/main/java/io/crate/auth/HttpAuthUpstreamHandler.java
@@ -111,7 +111,10 @@ public class HttpAuthUpstreamHandler extends SimpleChannelInboundHandler<Object>
         }
 
         String username = credentials.username();
-        if (username != null && username.equals(authorizedUser)) {
+        if (username != null && username.equals(authorizedUser) && credentials.decodedToken() == null) {
+            // Don't short circuit authentication and force token verification for JWT.
+            // Token can contain an expiration date, and it has to be checked on each request
+            // to avoid situation when expired token can be used throughout the lifetime of the connection.
             ctx.fireChannelRead(request);
             return;
         }

--- a/server/src/test/java/io/crate/auth/HttpAuthUpstreamHandlerTest.java
+++ b/server/src/test/java/io/crate/auth/HttpAuthUpstreamHandlerTest.java
@@ -354,7 +354,7 @@ public class HttpAuthUpstreamHandlerTest extends ESTestCase {
     }
 
     @Test
-    public void test_user_authentication_with_jwt_token_verified_per_connection() throws Exception {
+    public void test_user_authentication_with_jwt_token_verified_per_request() throws Exception {
         Roles roles = () -> List.of(JWT_USER);
         Authentication authentication = mock(Authentication.class);
         AuthenticationMethod jwtAuth = mock(JWTAuthenticationMethod.class);
@@ -377,7 +377,7 @@ public class HttpAuthUpstreamHandlerTest extends ESTestCase {
         request2.headers().add(HttpHeaderNames.AUTHORIZATION.toString(), "Bearer " + JWT_TOKEN);
         ch.writeInbound(request2);
         ch.releaseInbound();
-        verify(jwtAuth, times(1)).authenticate(any(Credentials.class), any(ConnectionProperties.class));
+        verify(jwtAuth, times(2)).authenticate(any(Credentials.class), any(ConnectionProperties.class));
     }
 
     @Test


### PR DESCRIPTION
This reverts commit 09adc3ebe15c00e61baf18179dcc88e16942d613.

Main motivation of doing it per request was to avoid accessing JWK endpoint on each request. 
Since then, we implemented caching of public keys in https://github.com/crate/crate/commit/21e4d6f91acc5dcd957dfbb62f77f6289140baac,

Doing JWT authentication per request won't be a problem anymore and will also avoid using a token that could be expired during a long living connection.

