### PR TITLE
Restrict message size for unauthenticated pg connections

### DIFF
--- a/docs/appendices/release-notes/6.4.3.rst
+++ b/docs/appendices/release-notes/6.4.3.rst
@@ -93,6 +93,10 @@ Breaking Changes
 Fixes
 =====
 
+- Limited the size of messages accepted from unauthenticated clients using the
+  PostgreSQL wire protocol to make it more difficult to launch Denial of Service
+  attacks.
+
 - Fixed an issue that allowed authenticated users to bypass the ``COPY FROM``
   restriction to read from ``file`` URIs - which is supposed to be restricted to
   superusers.

--- a/server/src/main/java/io/crate/protocols/postgres/PgDecoder.java
+++ b/server/src/main/java/io/crate/protocols/postgres/PgDecoder.java
@@ -105,6 +105,7 @@ public class PgDecoder extends ByteToMessageDecoder {
     private State state = State.STARTUP;
     private byte msgType;
     private int payloadLength;
+    private boolean authenticated = true;
 
 
     public PgDecoder(Supplier<SslContext> getSslContext) {
@@ -212,7 +213,10 @@ public class PgDecoder extends ByteToMessageDecoder {
                 in.markReaderIndex();
                 msgType = in.readByte();
                 payloadLength = in.readInt() - 4; // exclude length itself
-
+                if (!authenticated && payloadLength > MAX_STARTUP_LENGTH) {
+                    in.skipBytes(in.readableBytes());
+                    throw new IllegalStateException("Message too large for unauthenticated user");
+                }
                 if (in.readableBytes() < payloadLength) {
                     in.resetReaderIndex();
                     return null;
@@ -242,5 +246,9 @@ public class PgDecoder extends ByteToMessageDecoder {
 
     public State state() {
         return state;
+    }
+
+    public void setAuthenticated(boolean value) {
+        authenticated = value;
     }
 }

--- a/server/src/main/java/io/crate/protocols/postgres/PostgresWireProtocol.java
+++ b/server/src/main/java/io/crate/protocols/postgres/PostgresWireProtocol.java
@@ -291,6 +291,7 @@ public class PostgresWireProtocol {
 
         @Override
         public void channelRegistered(ChannelHandlerContext ctx) throws Exception {
+            decoder.setAuthenticated(false);
             channel = new DelayableWriteChannel(ctx.channel());
         }
 
@@ -396,6 +397,7 @@ public class PostgresWireProtocol {
         }
 
         private void closeSession() {
+            decoder.setAuthenticated(false);
             if (session != null) {
                 session.close();
                 session = null;
@@ -477,6 +479,7 @@ public class PostgresWireProtocol {
             if (options != null) {
                 applyOptions(options);
             }
+            decoder.setAuthenticated(true);
             Messages.sendAuthenticationOK(channel)
                 .addListener(f -> sendParams(channel, session.sessionSettings()))
                 .addListener(f -> Messages.sendKeyData(channel, session.id(), session.secret()))

--- a/server/src/test/java/io/crate/protocols/postgres/PostgresWireProtocolTest.java
+++ b/server/src/test/java/io/crate/protocols/postgres/PostgresWireProtocolTest.java
@@ -777,6 +777,49 @@ public class PostgresWireProtocolTest extends CrateDummyClusterServiceUnitTest {
     }
 
     @Test
+    public void test_throw_error_after_startup_on_too_large_unauthenticated_message() throws Exception {
+        PostgresWireProtocol ctx =
+            new PostgresWireProtocol(
+                sessions,
+                new SessionSettingRegistry(Set.of()),
+                _ -> AccessControl.DISABLED,
+                _ -> {},
+                (_, _) -> new AuthenticationMethod() {
+                    @Override
+                    public Role authenticate(Credentials credentials, ConnectionProperties connProperties) {
+                        return RolesHelper.userOf("dummy");
+                    }
+
+                    @Override
+                    public String name() {
+                        return "password";
+                    }
+                },
+                () -> null
+            );
+        channel = new EmbeddedChannel(ctx.decoder, ctx.handler);
+
+        ByteBuf buffer = Unpooled.buffer();
+
+        ClientMessages.sendStartupMessage(buffer, "doc", Map.of("user", "arthur"));
+
+        int length = PgDecoder.MAX_STARTUP_LENGTH + 1;
+        buffer.writeChar('Q');
+        buffer.writeInt(length);
+        channel.writeInbound(buffer);
+        channel.releaseInbound();
+
+        ByteBuf respBuf = channel.readOutbound();
+        try {
+            assertThat((char) respBuf.readByte()).isEqualTo('R'); // AuthenticationCleartextPassword
+        } finally {
+            respBuf.release();
+        }
+
+        assertErrorResponse(channel, PGError.Severity.FATAL, "Message too large for unauthenticated user");
+    }
+
+    @Test
     public void test_throw_error_on_invalid_request_code() {
         PostgresWireProtocol ctx =
             new PostgresWireProtocol(


### PR DESCRIPTION
(cherry picked from commit 126b017dd711564f5a77901002eb14ea5d9aae1a)
