### PR TITLE
Fix `lag()` and `lead()` ignores row-dependent offset expression

### DIFF
--- a/docs/appendices/release-notes/6.4.3.rst
+++ b/docs/appendices/release-notes/6.4.3.rst
@@ -205,3 +205,12 @@ Fixes
 
 - Fixed an issue causing queries with an ``OUTER JOIN`` return incorrect
   results if ``WHERE`` clause had a subquery.
+
+- Fixed an issue where :ref:`lag <window-functions-lag>` and :ref:`lead <window-functions-lead>` ignored row-dependent
+  offset and default value expressions. e.g::
+
+    SELECT id,
+       offset,
+       lag(x, offset, -1) OVER (ORDER BY id) AS v
+    FROM t
+    ORDER BY id;

--- a/extensions/functions/src/main/java/io/crate/window/OffsetValueFunctions.java
+++ b/extensions/functions/src/main/java/io/crate/window/OffsetValueFunctions.java
@@ -164,10 +164,7 @@ public class OffsetValueFunctions implements WindowFunction {
                 allocateBytes.accept(deltaUsed);
             }
         }
-        sharedRow.cells(row);
-        for (CollectExpression<Row, ?> expression : expressions) {
-            expression.setNextRow(sharedRow);
-        }
+        bindExpressionsToRow(row, expressions);
         return args[0].value();
     }
 
@@ -208,6 +205,13 @@ public class OffsetValueFunctions implements WindowFunction {
         return boundSignature;
     }
 
+    private void bindExpressionsToRow(Object[] row, List<? extends CollectExpression<Row, ?>> expressions) {
+        sharedRow.cells(row);
+        for (CollectExpression<Row, ?> expression : expressions) {
+            expression.setNextRow(sharedRow);
+        }
+    }
+
     @Override
     public Object execute(LongConsumer allocateBytes,
                           int idxInPartition,
@@ -218,6 +222,9 @@ public class OffsetValueFunctions implements WindowFunction {
         boolean ignoreNullsOrFalse = ignoreNulls != null && ignoreNulls;
         final int offset;
         if (args.length > 1) {
+            Object[] row = currentFrame.getRowInPartitionAtIndexOrNull(idxInPartition);
+            assert row != null;
+            bindExpressionsToRow(row, expressions);
             Object offsetValue = args[1].value();
             if (offsetValue != null) {
                 offset = ((Number) offsetValue).intValue();

--- a/extensions/functions/src/test/java/io/crate/window/OffsetValueFunctionsTest.java
+++ b/extensions/functions/src/test/java/io/crate/window/OffsetValueFunctionsTest.java
@@ -494,6 +494,32 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
     }
 
     @Test
+    public void test_lead_with_row_dependent_offset_expression() throws Throwable {
+        assertEvaluate(
+            "lead(x, y, -1) over(order by x)",
+            new Object[]{10, 30, -1},
+            List.of(ColumnIdent.of("x"), ColumnIdent.of("y")),
+            new Object[][]{
+                new Object[]{10, 0},
+                new Object[]{20, 1},
+                new Object[]{30, 1}
+            });
+    }
+
+    @Test
+    public void test_lead_with_row_dependent_default_expression() throws Throwable {
+        assertEvaluate(
+            "lead(x, 1, y) over(order by x)",
+            new Object[]{20L, 30L, 1L},
+            List.of(ColumnIdent.of("x"), ColumnIdent.of("y")),
+            new Object[][]{
+                new Object[]{10, 0},
+                new Object[]{20, 1},
+                new Object[]{30, 1}
+            });
+    }
+
+    @Test
     public void testLagWithNegativeOffsetIgnoringNullsWithMultipleGroupsOfNulls() throws Throwable {
         assertEvaluate(
             "lag(x,-2,123) ignore nulls over()",
@@ -501,6 +527,32 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
             List.of(ColumnIdent.of("x")),
             new Object[][]{{1}, {2}, {null}, {3}, {null}, {null}, {4}, {5}, {null}, {6}, {null}, {7}}
         );
+    }
+
+    @Test
+    public void test_lag_with_row_dependent_offset_expression() throws Throwable {
+        assertEvaluate(
+            "lag(x, y, -1) over(order by x)",
+            new Object[]{10, 10, 20},
+            List.of(ColumnIdent.of("x"), ColumnIdent.of("y")),
+            new Object[][]{
+                new Object[]{10, 0},
+                new Object[]{20, 1},
+                new Object[]{30, 1}
+            });
+    }
+
+    @Test
+    public void test_lag_with_row_dependent_default_value_expression() throws Throwable {
+        assertEvaluate(
+            "lag(x, 100, y) over(order by x)",
+            new Object[]{0L, 1L, 2L},
+            List.of(ColumnIdent.of("x"), ColumnIdent.of("y")),
+            new Object[][]{
+                new Object[]{10, 0},
+                new Object[]{20, 1},
+                new Object[]{30, 2}
+            });
     }
 
     private static final List<ColumnIdent> INTERVAL_COLS = List.of(ColumnIdent.of("x"), ColumnIdent.of("y"));


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Fixes https://github.com/crate/crate/issues/19870

Previously, we did not bind any expressions to the row that was collected by a child `CollectExpression` before processing the input arguments. Therefore, accessing the offset
input's value -- args[1] -- would return null because the expression's value was not yet bound to the data from the row. This was fine to do if the offset was a literal because the value was already set and no further binding is required

Likewise for the default value input. Previously, this wouldn't work correctly if the default value was row-dependent (i.e. `lag(x, 1, <column from table>) ...`) This commit also fixes that scenario


## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes.
       If you're an external contributor you can give yourself attribution and include your name and Github handle.
       e.g.:
       ```
       `John Doe <https://github.com/John_Doe>`_ added support for ...
       ```
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
