### PR TITLE
Fix privileges issue with UPDATE/DELETE and sub-queries (backport)

### DIFF
--- a/docs/admin/privileges.rst
+++ b/docs/admin/privileges.rst
@@ -69,6 +69,12 @@ indicates that this user/role is allowed to execute ``INSERT``, ``COPY FROM``,
 ``UPDATE`` and ``DELETE`` statements, on the object for which the privilege
 applies.
 
+Statements which read data in addition to modifying it require the
+:ref:`DQL <privilege_types_dql>` privilege on the objects they read from as
+well. This is the case for ``INSERT INTO ... (SELECT ...)`` and for sub-queries
+used in :ref:`UPDATE <ref-update>` or :ref:`DELETE <sql_reference_delete>`
+statements.
+
 .. _privilege_types_ddl:
 
 ``DDL``

--- a/docs/appendices/release-notes/6.4.3.rst
+++ b/docs/appendices/release-notes/6.4.3.rst
@@ -188,3 +188,9 @@ Fixes
   were large enough to be transferred in more than one page between the nodes.
   Nested joins are now always executed non-distributed, only the very outer join
   is executed distributed. Note that this fix may cause performance degradation.
+
+- Fixed an issue that allowed authenticated users to read data from tables and
+  views, on which they don't have :ref:`DQL <privilege_types_dql>` privileges,
+  by using sub-queries inside :ref:`UPDATE <ref-update>` or
+  :ref:`DELETE <sql_reference_delete>` statements. Sub-queries used in such
+  statements now require the ``DQL`` privilege on all involved tables and views.

--- a/docs/sql/statements/delete.rst
+++ b/docs/sql/statements/delete.rst
@@ -21,6 +21,13 @@ DELETE deletes rows that satisfy the WHERE clause from the specified table. If
 the WHERE clause is absent, the effect is to delete all rows in the table. The
 result is a valid, but empty table.
 
+.. NOTE::
+
+    ``DELETE`` requires the :ref:`DML <privilege_types_dml>` privilege on the
+    table rows are deleted from. Sub-queries used in the ``WHERE`` clause
+    additionally require the :ref:`DQL <privilege_types_dql>` privilege on all
+    relations they read from.
+
 Parameters
 ==========
 

--- a/docs/sql/statements/update.rst
+++ b/docs/sql/statements/update.rst
@@ -30,6 +30,13 @@ specified values from each row that was updated. Any :ref:`expression
 (post-update) values of the table's columns are used. The syntax of the
 ``RETURNING`` list is identical to that of the output list of ``SELECT``.
 
+.. NOTE::
+
+    ``UPDATE`` requires the :ref:`DML <privilege_types_dml>` privilege on the
+    table which is updated. Sub-queries used in the ``SET``, ``WHERE`` or
+    ``RETURNING`` clause additionally require the
+    :ref:`DQL <privilege_types_dql>` privilege on all relations they read from.
+
 Parameters
 ==========
 

--- a/server/src/main/java/io/crate/auth/AccessControlImpl.java
+++ b/server/src/main/java/io/crate/auth/AccessControlImpl.java
@@ -462,6 +462,7 @@ public final class AccessControlImpl implements AccessControl {
         @Override
         protected Void visitAnalyzedDeleteStatement(AnalyzedDeleteStatement delete, Role user) {
             visitRelation(delete.relation(), user, Permission.DML);
+            visitSubQueries(delete, user);
             return null;
         }
 
@@ -487,6 +488,7 @@ public final class AccessControlImpl implements AccessControl {
         @Override
         public Void visitAnalyzedUpdateStatement(AnalyzedUpdateStatement update, Role user) {
             visitRelation(update.table(), user, Permission.DML);
+            visitSubQueries(update, user);
             return null;
         }
 
@@ -1001,6 +1003,12 @@ public final class AccessControlImpl implements AccessControl {
                 Securable.TABLE,
                 tableFqn
             );
+        }
+
+        private void visitSubQueries(AnalyzedStatement stmt, Role user) {
+            var ctx = new RelationContext(user, Permission.DQL);
+            stmt.visitSymbols(symbol ->
+                symbol.visit(SelectSymbol.class, s -> s.relation().accept(relationVisitor, ctx)));
         }
     }
 

--- a/server/src/test/java/io/crate/auth/AccessControlMayExecuteTest.java
+++ b/server/src/test/java/io/crate/auth/AccessControlMayExecuteTest.java
@@ -340,6 +340,22 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
     }
 
     @Test
+    public void test_delete_with_subqueries_requires_dql_on_subquery_relation() {
+        analyze("delete from users where name = (select a from t1 where a = (select b from t2))");
+        assertAskedForTable(Permission.DML, "doc.users");
+        assertAskedForTable(Permission.DQL, "doc.t1");
+        assertAskedForTable(Permission.DQL, "doc.t2");
+    }
+
+    @Test
+    public void test_delete_with_subquery_on_view_requires_owner_to_have_privileges() {
+        analyze("delete from users where name in (select name from doc.v1)");
+        assertAskedForTable(Permission.DML, "doc.users");
+        assertAskedForView(Permission.DQL, "doc.v1");
+        assertAskedForTable(Permission.DQL, "doc.users", superUser);
+    }
+
+    @Test
     public void testInsertFromValues() throws Exception {
         analyze("insert into users (id) values (1)");
         assertAskedForTable(Permission.DML, "doc.users");
@@ -356,6 +372,27 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
     public void testUpdate() throws Exception {
         analyze("update users set name = 'ford' where id = 1");
         assertAskedForTable(Permission.DML, "doc.users");
+    }
+
+    @Test
+    public void test_update_with_subqueries_requires_dql_on_subquery_relation() {
+        analyze("update users set name = 'ford' where name = (select a from t1)");
+        assertAskedForTable(Permission.DML, "doc.users");
+        assertAskedForTable(Permission.DQL, "doc.t1");
+        analyze("update users set name = (select name from users) where name = " +
+                "(select a from t1 where a = (select b from t2))");
+        assertAskedForTable(Permission.DML, "doc.users");
+        assertAskedForTable(Permission.DQL, "doc.users");
+        assertAskedForTable(Permission.DQL, "doc.t1");
+        assertAskedForTable(Permission.DQL, "doc.t2");
+    }
+
+    @Test
+    public void test_update_with_subquery_on_view_requires_owner_to_have_privileges() {
+        analyze("update users set name = 'foo' where name in (select name from doc.v1)");
+        assertAskedForTable(Permission.DML, "doc.users");
+        assertAskedForView(Permission.DQL, "doc.v1");
+        assertAskedForTable(Permission.DQL, "doc.users", superUser);
     }
 
     @Test

--- a/server/src/test/java/io/crate/auth/AccessControlMayExecuteTest.java
+++ b/server/src/test/java/io/crate/auth/AccessControlMayExecuteTest.java
@@ -388,6 +388,13 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
     }
 
     @Test
+    public void test_update_with_subquery_in_returning_clause_requires_dql_on_subquery_relation() {
+        analyze("update users set name = 'ford' returning (select a from t1) as a");
+        assertAskedForTable(Permission.DML, "doc.users");
+        assertAskedForTable(Permission.DQL, "doc.t1");
+    }
+
+    @Test
     public void test_update_with_subquery_on_view_requires_owner_to_have_privileges() {
         analyze("update users set name = 'foo' where name in (select name from doc.v1)");
         assertAskedForTable(Permission.DML, "doc.users");


### PR DESCRIPTION
 - Previously, UPDATE and DELETE statements with subqueries didn't
    check for `DQL` privileges on the relations (tables/views) involved
    in the subqueries, thus allowing users to indirectly read data from
    those relations. Add a visitor pattern call to ensure DQL privileges
    on the involved tables and views.

    (cherry picked from commit aa1038630be50ad2c9735707f39b19a90d99583d)

  - Add more tests and docs for DQL on subqueries (#19973)

    (cherry picked from commit 064a12490306b5c68f29a08c3e7d419081260e3f)
