### PR TITLE
Fix wrong multi-table NL block join results

### DIFF
--- a/libs/dex/src/main/java/io/crate/data/join/LeftJoinNLBatchIterator.java
+++ b/libs/dex/src/main/java/io/crate/data/join/LeftJoinNLBatchIterator.java
@@ -52,6 +52,12 @@ public class LeftJoinNLBatchIterator<L, R, C> extends JoinBatchIterator<L, R, C>
     }
 
     @Override
+    public void moveToStart() {
+        super.moveToStart();
+        hadMatch = false;
+    }
+
+    @Override
     public boolean moveNext() {
         while (true) {
             if (activeIt == left) {

--- a/libs/dex/src/test/java/io/crate/data/CollectingBatchIteratorTest.java
+++ b/libs/dex/src/test/java/io/crate/data/CollectingBatchIteratorTest.java
@@ -29,6 +29,9 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -41,12 +44,23 @@ import io.crate.data.testing.TestingBatchIterators;
 
 class CollectingBatchIteratorTest {
 
-    private static final List<Object[]> EXPECTED_RESULT = Collections.singletonList(new Object[] {45L});
+    private List<Object[]> expectedResult;
     private ExecutorService executor;
+
+    private static BatchIterator<Row> collectingIterator(BatchIterator<Row> source) {
+        Collector<Row, ?, List<Row>> toRows = Collectors.mapping(
+            row -> new Row1(row.get(0)),
+            Collectors.toList()
+        );
+        return CollectingBatchIterator.newInstance(source, toRows);
+    }
 
     @BeforeEach
     public void setUp() {
         executor = Executors.newFixedThreadPool(2);
+        expectedResult = LongStream.range(0, 10)
+            .mapToObj(i -> new Object[]{i})
+            .collect(Collectors.toList());
     }
 
     @AfterEach
@@ -58,19 +72,29 @@ class CollectingBatchIteratorTest {
     @Test
     void testCollectingBatchIterator() throws Exception {
         var tester = BatchIteratorTester.forRows(
-            () -> CollectingBatchIterator.summingLong(TestingBatchIterators.range(0L, 10L)), ResultOrder.EXACT
+            () -> collectingIterator(TestingBatchIterators.range(0L, 10L)), ResultOrder.EXACT
         );
-        tester.verifyResultAndEdgeCaseBehaviour(EXPECTED_RESULT);
+        tester.verifyResultAndEdgeCaseBehaviour(expectedResult);
     }
 
     @Test
     void testCollectingBatchIteratorWithPagedSource() throws Exception {
         var tester = BatchIteratorTester.forRows(
-            () -> CollectingBatchIterator.summingLong(
+            () -> collectingIterator(
                 new BatchSimulatingIterator<>(TestingBatchIterators.range(0L, 10L), 2, 5, executor)
             ), ResultOrder.EXACT
         );
-        tester.verifyResultAndEdgeCaseBehaviour(EXPECTED_RESULT);
+        tester.verifyResultAndEdgeCaseBehaviour(expectedResult);
+    }
+
+    @Test
+    void testSummingLong() throws Exception {
+        var tester = BatchIteratorTester.forRows(
+            () -> CollectingBatchIterator.summingLong(TestingBatchIterators.range(0L, 10L)),
+            ResultOrder.EXACT,
+            false
+        );
+        tester.verifyResultAndEdgeCaseBehaviour(Collections.singletonList(new Object[] { 45L }));
     }
 
     @Test

--- a/libs/dex/src/testFixtures/java/io/crate/data/testing/BatchIteratorTester.java
+++ b/libs/dex/src/testFixtures/java/io/crate/data/testing/BatchIteratorTester.java
@@ -37,6 +37,7 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import org.assertj.core.api.Assertions;
 import org.jspecify.annotations.Nullable;
 
 import io.crate.common.exceptions.Exceptions;
@@ -63,21 +64,37 @@ public class BatchIteratorTester<T> {
          **/
         ANY
     }
+    private final boolean supportRestartAnyTime;
 
-    public static BatchIteratorTester<Object[]> forRows(Supplier<BatchIterator<Row>> it, ResultOrder resultOrder) {
+    public static BatchIteratorTester<Object[]> forRows(Supplier<BatchIterator<Row>> it,
+                                                        ResultOrder resultOrder) {
+        return forRows(it, resultOrder, true);
+    }
+
+    public static BatchIteratorTester<Object[]> forRows(Supplier<BatchIterator<Row>> it,
+                                                        ResultOrder resultOrder,
+                                                        boolean supportRestartAnyTime) {
         return new BatchIteratorTester<>(
             () -> it.get().map(row -> row == null ? null : row.materialize()),
-            resultOrder
+            resultOrder,
+            supportRestartAnyTime
         );
     }
 
-    public BatchIteratorTester(Supplier<BatchIterator<T>> it, ResultOrder resultOrder) {
+    public BatchIteratorTester(Supplier<BatchIterator<T>> it, ResultOrder resultOrder, boolean supportRestartAnyTime) {
         this.it = it;
         this.resultOrder = resultOrder;
+        this.supportRestartAnyTime = supportRestartAnyTime;
     }
 
-    public void verifyResultAndEdgeCaseBehaviour(List<T> expectedResult,
-                                                 @Nullable Consumer<BatchIterator<T>> verifyAfterProperConsumption) throws Exception {
+    public void verifyResultAndEdgeCaseBehaviour(List<T> expectedResult) throws Exception {
+        verifyResultAndEdgeCaseBehaviour(expectedResult, null);
+    }
+
+    public void verifyResultAndEdgeCaseBehaviour(
+        List<T> expectedResult,
+        @Nullable Consumer<BatchIterator<T>> verifyAfterProperConsumption) throws Exception {
+
         BatchIterator<T> firstBatchIterator = this.it.get();
         testProperConsumption(firstBatchIterator, expectedResult);
         if (verifyAfterProperConsumption != null) {
@@ -89,6 +106,9 @@ public class BatchIteratorTester<T> {
         testIllegalNextBatchCall(this.it.get());
         testMoveNextAfterMoveNextReturnedFalse(this.it.get());
         testMoveToStartAndReConsumptionMatchesRowsOnFirstConsumption(this.it.get());
+        if (supportRestartAnyTime) {
+            testMoveToStartWhileConsumptionIsInProgress(this.it, expectedResult);
+        }
         testAllLoadedNeverRaises(this.it);
         testLoadNextBatchFutureCompletesOnKill(this.it.get());
     }
@@ -108,10 +128,6 @@ public class BatchIteratorTester<T> {
         }
     }
 
-    public void verifyResultAndEdgeCaseBehaviour(List<T> expectedResult) throws Exception {
-        verifyResultAndEdgeCaseBehaviour(expectedResult, null);
-    }
-
     private void testAllLoadedNeverRaises(Supplier<BatchIterator<T>> batchIterator) {
         BatchIterator<T> bi = batchIterator.get();
         bi.allLoaded();
@@ -129,6 +145,30 @@ public class BatchIteratorTester<T> {
         List<T> secondResult = it.collect(Collectors.toList(), false).get(5, TimeUnit.SECONDS);
         it.close();
         checkResult(firstResult, secondResult, resultOrder);
+    }
+
+    private void testMoveToStartWhileConsumptionIsInProgress(Supplier<BatchIterator<T>> batchIterator,
+                                                             List<T> expectedResult) throws Exception {
+        if (expectedResult.size() < 2) {
+            Assertions.fail("expectedResult should contain at least 2 rows, " +
+                "to be able to test partial consumption and move to start");
+        }
+        // Stop at different positions, to test different internal batch/segment/page boundaries
+        int maxRowsBeforeRestart = Math.min(3, expectedResult.size());
+        for (int rowsBeforeRestart = 1; rowsBeforeRestart <= maxRowsBeforeRestart; rowsBeforeRestart++) {
+            BatchIterator<T> it = batchIterator.get();
+            for (int i = 0; i < rowsBeforeRestart; i++) {
+                getFirstElement(it);
+            }
+            it.moveToStart();
+            List<T> result = it.collect(Collectors.toList(), false).get(5, TimeUnit.SECONDS);
+            it.close();
+            checkResult(
+                expectedResult,
+                result,
+                resultOrder
+            );
+        }
     }
 
     private void testMoveNextAfterMoveNextReturnedFalse(BatchIterator<T> it) throws Exception {

--- a/server/src/main/java/io/crate/execution/engine/collect/collectors/LuceneBatchIterator.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/collectors/LuceneBatchIterator.java
@@ -97,6 +97,7 @@ public class LuceneBatchIterator implements BatchIterator<Row> {
     @Override
     public void moveToStart() {
         raiseIfKilled();
+        clearState();
         leavesIt = leaves.iterator();
     }
 

--- a/server/src/test/java/io/crate/execution/engine/collect/collectors/OrderedLuceneBatchIteratorFactoryTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/collectors/OrderedLuceneBatchIteratorFactoryTest.java
@@ -142,7 +142,9 @@ public class OrderedLuceneBatchIteratorFactoryTest extends ESTestCase {
                     () -> 1,
                     true
                 );
-            }, ResultOrder.EXACT
+            },
+            ResultOrder.EXACT,
+            false
         );
         tester.verifyResultAndEdgeCaseBehaviour(expectedResult);
     }

--- a/server/src/test/java/io/crate/execution/engine/collect/files/FileReadingIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/files/FileReadingIteratorTest.java
@@ -136,7 +136,8 @@ public class FileReadingIteratorTest extends ESTestCase {
             "name,id,age",
             "Trillian,5,33"
         );
-        var tester = new BatchIteratorTester<>(() -> batchIteratorSupplier.get().map(LineCursor::line), ResultOrder.EXACT);
+        var tester = new BatchIteratorTester<>(
+            () -> batchIteratorSupplier.get().map(LineCursor::line), ResultOrder.EXACT, false);
         tester.verifyResultAndEdgeCaseBehaviour(expectedResult);
     }
 
@@ -184,7 +185,8 @@ public class FileReadingIteratorTest extends ESTestCase {
                 }
             };
 
-        var tester = new BatchIteratorTester<>(() -> batchIteratorSupplier.get().map(LineCursor::line), ResultOrder.EXACT);
+        var tester = new BatchIteratorTester<>(
+            () -> batchIteratorSupplier.get().map(LineCursor::line), ResultOrder.EXACT, false);
         tester.verifyResultAndEdgeCaseBehaviour(lines);
     }
 

--- a/server/src/test/java/io/crate/execution/engine/distribution/merge/BatchPagingIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/distribution/merge/BatchPagingIteratorTest.java
@@ -71,16 +71,18 @@ public class BatchPagingIteratorTest {
         List<Object[]> expectedResult = StreamSupport.stream(rows.spliterator(), false)
             .map(Row::materialize)
             .collect(Collectors.toList());
-        var tester = BatchIteratorTester.forRows(() -> {
-            PassThroughPagingIterator<Integer, Row> pagingIterator = PassThroughPagingIterator.repeatable();
-            pagingIterator.merge(singletonList(new KeyIterable<>(0, rows)));
-            return new BatchPagingIterator<>(
-                pagingIterator,
-                exhaustedIt -> CompletableFuture.failedStage(new IllegalStateException("upstreams exhausted")),
-                () -> true,
-                throwable -> {}
-            );
-        }, ResultOrder.EXACT);
+        var tester = BatchIteratorTester.forRows(
+            () -> {
+                PassThroughPagingIterator<Integer, Row> pagingIterator = PassThroughPagingIterator.repeatable();
+                pagingIterator.merge(singletonList(new KeyIterable<>(0, rows)));
+                return new BatchPagingIterator<>(
+                    pagingIterator,
+                    exhaustedIt -> CompletableFuture.failedStage(new IllegalStateException("upstreams exhausted")),
+                    () -> true,
+                    throwable -> {});
+            },
+            ResultOrder.EXACT,
+            false);
         tester.verifyResultAndEdgeCaseBehaviour(expectedResult);
     }
 
@@ -127,7 +129,7 @@ public class BatchPagingIteratorTest {
                 }
             );
         };
-        var tester = BatchIteratorTester.forRows(batchIteratorSupplier, ResultOrder.EXACT);
+        var tester = BatchIteratorTester.forRows(batchIteratorSupplier, ResultOrder.EXACT, false);
         tester.verifyResultAndEdgeCaseBehaviour(expectedResult);
     }
 


### PR DESCRIPTION
LuceneBatchIterator didn't reset its state properly when
`moveToStart()` was called, and as result already consumed
rows before that call were emmitted twice. Clear the state
inside `moveToStart()` to prevent this.

The issue was uncovered with: #19824

Additionally:
- Add a test in generic `BatchIteratorTester` which catches
such cases, under a flag, to disable it for iterators that
don't support partial consumption and restart.

- Fix an issue with LeftJoinNLBatchIterator which was uncovered
by the new test and led to not emmitting the in-progress row
(before `moveToStart()`).