### PR TITLE
Avoid ConnectionStats object allocation per Connections bean property

### DIFF
--- a/extensions/jmx-monitoring/src/main/java/io/crate/beans/Connections.java
+++ b/extensions/jmx-monitoring/src/main/java/io/crate/beans/Connections.java
@@ -21,20 +21,18 @@
 
 package io.crate.beans;
 
-import java.util.function.Supplier;
-
-import io.crate.protocols.ConnectionStats;
+import org.elasticsearch.transport.StatsTracker;
 
 public final class Connections implements ConnectionsMBean {
 
     public static final String NAME = "io.crate.monitoring:type=Connections";
-    private final Supplier<ConnectionStats> httpStats;
-    private final Supplier<ConnectionStats> psqlStats;
-    private final Supplier<ConnectionStats> transportStats;
+    private final StatsTracker httpStats;
+    private final StatsTracker psqlStats;
+    private final StatsTracker transportStats;
 
-    public Connections(Supplier<ConnectionStats> httpStats,
-                       Supplier<ConnectionStats> psqlStats,
-                       Supplier<ConnectionStats> transportStats) {
+    public Connections(StatsTracker httpStats,
+                       StatsTracker psqlStats,
+                       StatsTracker transportStats) {
         this.httpStats = httpStats;
         this.psqlStats = psqlStats;
         this.transportStats = transportStats;
@@ -43,91 +41,91 @@ public final class Connections implements ConnectionsMBean {
 
     @Override
     public long getHttpOpen() {
-        return httpStats.get().open();
+        return httpStats.openConnections();
     }
 
     @Override
     public long getHttpTotal() {
-        return httpStats.get().total();
+        return httpStats.totalConnections();
     }
 
     @Override
     public long getHttpMessagesReceived() {
-        return httpStats.get().receivedMessages();
+        return httpStats.messagesReceived();
     }
 
     @Override
     public long getHttpBytesReceived() {
-        return httpStats.get().receivedBytes();
+        return httpStats.bytesReceived();
     }
 
     @Override
     public long getHttpMessagesSent() {
-        return httpStats.get().sentMessages();
+        return httpStats.messagesSent();
     }
 
     @Override
     public long getHttpBytesSent() {
-        return httpStats.get().sentBytes();
+        return httpStats.bytesSent();
     }
 
     @Override
     public long getPsqlOpen() {
-        return psqlStats.get().open();
+        return psqlStats.openConnections();
     }
 
     @Override
     public long getPsqlTotal() {
-        return psqlStats.get().total();
+        return psqlStats.totalConnections();
     }
 
     @Override
     public long getPsqlMessagesReceived() {
-        return psqlStats.get().receivedMessages();
+        return psqlStats.messagesReceived();
     }
 
     @Override
     public long getPsqlBytesReceived() {
-        return psqlStats.get().receivedBytes();
+        return psqlStats.bytesReceived();
     }
 
     @Override
     public long getPsqlMessagesSent() {
-        return psqlStats.get().sentMessages();
+        return psqlStats.messagesSent();
     }
 
     @Override
     public long getPsqlBytesSent() {
-        return psqlStats.get().sentBytes();
+        return psqlStats.bytesSent();
     }
 
     @Override
     public long getTransportOpen() {
-        return transportStats.get().open();
+        return transportStats.openConnections();
     }
 
     @Override
     public long getTransportTotal() {
-        return transportStats.get().total();
+        return transportStats.totalConnections();
     }
 
     @Override
     public long getTransportMessagesReceived() {
-        return transportStats.get().receivedMessages();
+        return transportStats.messagesReceived();
     }
 
     @Override
     public long getTransportBytesReceived() {
-        return transportStats.get().receivedBytes();
+        return transportStats.bytesReceived();
     }
 
     @Override
     public long getTransportMessagesSent() {
-        return transportStats.get().sentMessages();
+        return transportStats.messagesSent();
     }
 
     @Override
     public long getTransportBytesSent() {
-        return transportStats.get().sentBytes();
+        return transportStats.bytesSent();
     }
 }

--- a/extensions/jmx-monitoring/src/main/java/io/crate/plugin/CrateMonitor.java
+++ b/extensions/jmx-monitoring/src/main/java/io/crate/plugin/CrateMonitor.java
@@ -41,7 +41,6 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.jspecify.annotations.Nullable;
 
-import io.crate.session.Sessions;
 import io.crate.beans.CircuitBreakers;
 import io.crate.beans.Connections;
 import io.crate.beans.NodeInfo;
@@ -50,6 +49,7 @@ import io.crate.beans.QueryStats;
 import io.crate.beans.ThreadPools;
 import io.crate.execution.engine.collect.stats.JobsLogs;
 import io.crate.protocols.postgres.PostgresNetty;
+import io.crate.session.Sessions;
 
 public class CrateMonitor {
 
@@ -71,9 +71,9 @@ public class CrateMonitor {
         registerMBean(NodeStatus.NAME, new NodeStatus(sqlOperations::isEnabled));
         registerMBean(NodeInfo.NAME, new NodeInfo(clusterService::state, new NodeInfo.ShardStateAndSizeProvider(indicesService)));
         registerMBean(Connections.NAME, new Connections(
-            () -> httpServerTransport == null ? null : httpServerTransport.stats(),
-            postgresNetty::stats,
-            transportService::stats
+            httpServerTransport == null ? null : httpServerTransport.stats(),
+            postgresNetty.stats(),
+            transportService.stats()
         ));
         registerMBean(ThreadPools.NAME, new ThreadPools(threadPool));
         registerMBean(CircuitBreakers.NAME, new CircuitBreakers(breakerService));

--- a/server/src/main/java/io/crate/expression/reference/sys/node/NodeStatsContextFieldResolver.java
+++ b/server/src/main/java/io/crate/expression/reference/sys/node/NodeStatsContextFieldResolver.java
@@ -54,14 +54,14 @@ import org.elasticsearch.monitor.os.OsService;
 import org.elasticsearch.monitor.process.ProcessService;
 import org.elasticsearch.node.NodeService;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.StatsTracker;
 import org.elasticsearch.transport.TransportService;
 import org.jspecify.annotations.Nullable;
-import io.crate.common.annotations.VisibleForTesting;
 
+import io.crate.common.annotations.VisibleForTesting;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.sys.SysNodesTableInfo;
 import io.crate.monitor.ExtendedNodeInfo;
-import io.crate.protocols.ConnectionStats;
 import io.crate.protocols.postgres.PostgresNetty;
 
 @Singleton
@@ -71,12 +71,12 @@ public class NodeStatsContextFieldResolver {
     private final Supplier<DiscoveryNode> localNode;
     private final BooleanSupplier isMaster;
     private final Supplier<TransportAddress> boundHttpAddress;
-    private final Supplier<ConnectionStats> httpStats;
+    private final StatsTracker httpStats;
     private final ThreadPool threadPool;
     private final ExtendedNodeInfo extendedNodeInfo;
-    private final Supplier<ConnectionStats> psqlStats;
+    private final StatsTracker psqlStats;
     private final Supplier<TransportAddress> boundPostgresAddress;
-    private final Supplier<ConnectionStats> transportStats;
+    private final StatsTracker transportStats;
     private final ProcessService processService;
     private final OsService osService;
     private final JvmService jvmService;
@@ -97,10 +97,10 @@ public class NodeStatsContextFieldResolver {
             clusterService::localNode,
             nodeService.getMonitorService(),
             () -> httpServerTransport == null ? null : httpServerTransport.boundAddress().publishAddress(),
-            () -> httpServerTransport == null ? null : httpServerTransport.stats(),
+            httpServerTransport == null ? null : httpServerTransport.stats(),
             threadPool,
             extendedNodeInfo,
-            postgresNetty::stats,
+            postgresNetty.stats(),
             () -> {
                 BoundTransportAddress boundTransportAddress = postgresNetty.boundAddress();
                 if (boundTransportAddress == null) {
@@ -108,7 +108,7 @@ public class NodeStatsContextFieldResolver {
                 }
                 return boundTransportAddress.publishAddress();
             },
-            transportService::stats,
+            transportService.stats(),
             () -> clusterService.state().version()
         );
     }
@@ -118,12 +118,12 @@ public class NodeStatsContextFieldResolver {
                                   Supplier<DiscoveryNode> localNode,
                                   MonitorService monitorService,
                                   Supplier<TransportAddress> boundHttpAddress,
-                                  Supplier<ConnectionStats> httpStats,
+                                  StatsTracker httpStats,
                                   ThreadPool threadPool,
                                   ExtendedNodeInfo extendedNodeInfo,
-                                  Supplier<ConnectionStats> psqlStats,
+                                  StatsTracker psqlStats,
                                   Supplier<TransportAddress> boundPostgresAddress,
-                                  Supplier<ConnectionStats> transportStats,
+                                  StatsTracker transportStats,
                                   LongSupplier clusterStateVersion) {
         this.isMaster = isMaster;
         this.localNode = localNode;
@@ -266,9 +266,9 @@ public class NodeStatsContextFieldResolver {
         entry(SysNodesTableInfo.Columns.CONNECTIONS, new Consumer<>() {
             @Override
             public void accept(NodeStatsContext nodeStatsContext) {
-                nodeStatsContext.httpStats(httpStats.get());
-                nodeStatsContext.psqlStats(psqlStats.get());
-                nodeStatsContext.transportStats(transportStats.get());
+                nodeStatsContext.httpStats(httpStats.stats());
+                nodeStatsContext.psqlStats(psqlStats.stats());
+                nodeStatsContext.transportStats(transportStats.stats());
             }
         }),
         entry(SysNodesTableInfo.Columns.OS, new Consumer<>() {

--- a/server/src/main/java/io/crate/protocols/postgres/PostgresNetty.java
+++ b/server/src/main/java/io/crate/protocols/postgres/PostgresNetty.java
@@ -58,14 +58,13 @@ import org.jspecify.annotations.Nullable;
 import com.carrotsearch.hppc.IntHashSet;
 import com.carrotsearch.hppc.IntSet;
 
-import io.crate.session.Sessions;
 import io.crate.auth.Authentication;
 import io.crate.metadata.settings.session.SessionSettingRegistry;
 import io.crate.netty.NettyBootstrap;
-import io.crate.protocols.ConnectionStats;
 import io.crate.protocols.ssl.SslContextProvider;
 import io.crate.protocols.ssl.SslSettings;
 import io.crate.role.Roles;
+import io.crate.session.Sessions;
 import io.crate.types.DataTypes;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.Channel;
@@ -304,7 +303,7 @@ public class PostgresNetty extends AbstractLifecycleComponent {
         // nothing to close here, see doStop()
     }
 
-    public ConnectionStats stats() {
-        return statsTracker.stats();
+    public StatsTracker stats() {
+        return statsTracker;
     }
 }

--- a/server/src/main/java/org/elasticsearch/http/HttpServerTransport.java
+++ b/server/src/main/java/org/elasticsearch/http/HttpServerTransport.java
@@ -21,12 +21,11 @@ package org.elasticsearch.http;
 
 import org.elasticsearch.common.component.LifecycleComponent;
 import org.elasticsearch.common.transport.BoundTransportAddress;
-
-import io.crate.protocols.ConnectionStats;
+import org.elasticsearch.transport.StatsTracker;
 
 public interface HttpServerTransport extends LifecycleComponent {
 
     BoundTransportAddress boundAddress();
 
-    ConnectionStats stats();
+    StatsTracker stats();
 }

--- a/server/src/main/java/org/elasticsearch/http/netty4/Netty4HttpServerTransport.java
+++ b/server/src/main/java/org/elasticsearch/http/netty4/Netty4HttpServerTransport.java
@@ -106,7 +106,6 @@ import io.crate.auth.Protocol;
 import io.crate.blob.BlobService;
 import io.crate.common.exceptions.Exceptions;
 import io.crate.netty.NettyBootstrap;
-import io.crate.protocols.ConnectionStats;
 import io.crate.protocols.http.HttpBlobHandler;
 import io.crate.protocols.http.MainAndStaticFileHandler;
 import io.crate.protocols.ssl.SslContextProvider;
@@ -518,8 +517,8 @@ public class Netty4HttpServerTransport extends AbstractLifecycleComponent implem
     }
 
     @Override
-    public ConnectionStats stats() {
-        return statsTracker.stats();
+    public StatsTracker stats() {
+        return statsTracker;
     }
 
     public Netty4CorsConfig getCorsConfig() {

--- a/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
+++ b/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
@@ -85,7 +85,6 @@ import io.crate.common.exceptions.Exceptions;
 import io.crate.common.unit.TimeValue;
 import io.crate.concurrent.CountDown;
 import io.crate.exceptions.TransportNotReady;
-import io.crate.protocols.ConnectionStats;
 import io.crate.rest.action.HttpErrorStatus;
 import io.netty.channel.ChannelFuture;
 
@@ -154,10 +153,6 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
 
     public Version getVersion() {
         return version;
-    }
-
-    public StatsTracker getStatsTracker() {
-        return statsTracker;
     }
 
     public ThreadPool getThreadPool() {
@@ -828,8 +823,8 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
     }
 
     @Override
-    public final ConnectionStats getStats() {
-        return statsTracker.stats();
+    public final StatsTracker getStats() {
+        return statsTracker;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/transport/Transport.java
+++ b/server/src/main/java/org/elasticsearch/transport/Transport.java
@@ -42,7 +42,6 @@ import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 
 import io.crate.common.collections.MapBuilder;
 import io.crate.common.unit.TimeValue;
-import io.crate.protocols.ConnectionStats;
 
 public interface Transport extends LifecycleComponent {
 
@@ -80,7 +79,7 @@ public interface Transport extends LifecycleComponent {
      */
     void openConnection(DiscoveryNode node, ConnectionProfile profile, ActionListener<Transport.Connection> listener);
 
-    ConnectionStats getStats();
+    StatsTracker getStats();
 
     ResponseHandlers getResponseHandlers();
 

--- a/server/src/main/java/org/elasticsearch/transport/TransportService.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportService.java
@@ -60,7 +60,6 @@ import io.crate.common.annotations.VisibleForTesting;
 import io.crate.common.io.IOUtils;
 import io.crate.common.unit.TimeValue;
 import io.crate.exceptions.TransportNotReady;
-import io.crate.protocols.ConnectionStats;
 
 public class TransportService extends AbstractLifecycleComponent implements TransportMessageListener, TransportConnectionListener {
 
@@ -305,7 +304,7 @@ public class TransportService extends AbstractLifecycleComponent implements Tran
         handleIncomingRequests.set(true);
     }
 
-    public ConnectionStats stats() {
+    public StatsTracker stats() {
         return transport.getStats();
     }
 

--- a/server/src/main/java/org/elasticsearch/transport/netty4/Netty4MessageChannelHandler.java
+++ b/server/src/main/java/org/elasticsearch/transport/netty4/Netty4MessageChannelHandler.java
@@ -51,7 +51,7 @@ public final class Netty4MessageChannelHandler extends ChannelDuplexHandler {
         final ThreadPool threadPool = transport.getThreadPool();
         final Transport.RequestHandlers requestHandlers = transport.getRequestHandlers();
         this.pipeline = new InboundPipeline(
-            transport.getStatsTracker(),
+            transport.getStats(),
             threadPool::relativeTimeInMillis,
             new InboundDecoder(recycler),
             new InboundAggregator(transport.getInflightBreaker(), requestHandlers::getHandler),

--- a/server/src/test/java/io/crate/expression/reference/sys/node/NodeStatsContextFieldResolverTest.java
+++ b/server/src/test/java/io/crate/expression/reference/sys/node/NodeStatsContextFieldResolverTest.java
@@ -39,6 +39,7 @@ import org.elasticsearch.monitor.MonitorService;
 import org.elasticsearch.monitor.os.OsService;
 import org.elasticsearch.monitor.os.OsStats;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.StatsTracker;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -47,13 +48,14 @@ import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.expressions.RowCollectExpressionFactory;
 import io.crate.metadata.sys.SysNodesTableInfo;
 import io.crate.monitor.ExtendedNodeInfo;
-import io.crate.protocols.ConnectionStats;
 
 public class NodeStatsContextFieldResolverTest {
 
     private NodeStatsContextFieldResolver resolver;
 
     private TransportAddress postgresAddress;
+
+    private StatsTracker statsTracker;
 
     @Before
     public void setup() throws UnknownHostException {
@@ -65,18 +67,20 @@ public class NodeStatsContextFieldResolverTest {
         when(osService.stats()).thenReturn(osStats);
         DiscoveryNode discoveryNode = newNode("node_name", "node_id");
 
+        statsTracker = new StatsTracker();
+
         postgresAddress = new TransportAddress(Inet4Address.getLocalHost(), 5432);
         resolver = new NodeStatsContextFieldResolver(
             () -> true,
             () -> discoveryNode,
             monitorService,
             () -> null,
-            () -> new ConnectionStats(1, 2, 3, 4, 5, 6),
+            statsTracker,
             mock(ThreadPool.class),
             new ExtendedNodeInfo(),
-            () -> new ConnectionStats(11, 22, 33, 44, 55, 66),
+            statsTracker,
             () -> postgresAddress,
-            () -> new ConnectionStats(111, 222, 333, 444, 555, 666),
+            statsTracker,
             () -> 1L
         );
     }
@@ -90,11 +94,16 @@ public class NodeStatsContextFieldResolverTest {
     @SuppressWarnings("rawtypes")
     @Test
     public void testConnectionsHttpLookupAndExpression() {
+        statsTracker.incrementOpenChannels();
+        statsTracker.incrementOpenChannels();
+        statsTracker.decrementOpenChannels();
+
         NodeStatsContext statsContext = resolver.forTopColumnIdents(
             Collections.singletonList(SysNodesTableInfo.Columns.CONNECTIONS));
         RowCollectExpressionFactory<NodeStatsContext> expressionFactory =
             SysNodesTableInfo.INSTANCE.expressions().get(SysNodesTableInfo.Columns.CONNECTIONS);
         NestableCollectExpression<NodeStatsContext, ?> expression = expressionFactory.create();
+
 
         NestableCollectExpression http = (NestableCollectExpression) expression.getChild("http");
         NestableCollectExpression open = (NestableCollectExpression) http.getChild("open");
@@ -109,6 +118,11 @@ public class NodeStatsContextFieldResolverTest {
     @SuppressWarnings("rawtypes")
     @Test
     public void testNumberOfPSqlConnectionsCanBeRetrieved() {
+        statsTracker.incrementOpenChannels();
+        statsTracker.incrementOpenChannels();
+        statsTracker.incrementOpenChannels();
+        statsTracker.decrementOpenChannels();
+
         // tests the resolver and the expression
         NodeStatsContext statsContext = resolver.forTopColumnIdents(
             Collections.singletonList(SysNodesTableInfo.Columns.CONNECTIONS));
@@ -119,16 +133,19 @@ public class NodeStatsContextFieldResolverTest {
         NestableCollectExpression psql = (NestableCollectExpression) expression.getChild("psql");
         NestableCollectExpression open = (NestableCollectExpression) psql.getChild("open");
         open.setNextRow(statsContext);
-        assertThat(open.value()).isEqualTo(11L);
+        assertThat(open.value()).isEqualTo(2L);
 
         NestableCollectExpression total = (NestableCollectExpression) psql.getChild("total");
         total.setNextRow(statsContext);
-        assertThat(total.value()).isEqualTo(22L);
+        assertThat(total.value()).isEqualTo(3L);
     }
 
     @SuppressWarnings("rawtypes")
     @Test
     public void testNumberOfTransportConnectionsCanBeRetrieved() {
+        statsTracker.incrementOpenChannels();
+        statsTracker.decrementOpenChannels();
+
         // tests the resolver and the expression
         NodeStatsContext statsContext = resolver.forTopColumnIdents(
             Collections.singletonList(SysNodesTableInfo.Columns.CONNECTIONS));
@@ -139,11 +156,11 @@ public class NodeStatsContextFieldResolverTest {
         NestableCollectExpression psql = (NestableCollectExpression) expression.getChild("transport");
         NestableCollectExpression open = (NestableCollectExpression) psql.getChild("open");
         open.setNextRow(statsContext);
-        assertThat(open.value()).isEqualTo(111L);
+        assertThat(open.value()).isEqualTo(0L);
 
         NestableCollectExpression total = (NestableCollectExpression) psql.getChild("total");
         total.setNextRow(statsContext);
-        assertThat(total.value()).isEqualTo(222L);
+        assertThat(total.value()).isEqualTo(1L);
     }
 
     @Test

--- a/server/src/test/java/org/elasticsearch/cluster/NodeConnectionsServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/NodeConnectionsServiceTests.java
@@ -64,6 +64,7 @@ import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.ConnectTransportException;
 import org.elasticsearch.transport.ConnectionProfile;
+import org.elasticsearch.transport.StatsTracker;
 import org.elasticsearch.transport.Transport;
 import org.elasticsearch.transport.TransportException;
 import org.elasticsearch.transport.TransportMessageListener;
@@ -73,8 +74,6 @@ import org.elasticsearch.transport.TransportService;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
-import io.crate.protocols.ConnectionStats;
 
 public class NodeConnectionsServiceTests extends ESTestCase {
 
@@ -595,7 +594,7 @@ public class NodeConnectionsServiceTests extends ESTestCase {
         }
 
         @Override
-        public ConnectionStats getStats() {
+        public StatsTracker getStats() {
             throw new UnsupportedOperationException();
         }
 

--- a/server/src/testFixtures/java/org/elasticsearch/test/MockHttpTransport.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/MockHttpTransport.java
@@ -24,8 +24,7 @@ import org.elasticsearch.common.transport.BoundTransportAddress;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.http.HttpServerTransport;
 import org.elasticsearch.plugins.Plugin;
-
-import io.crate.protocols.ConnectionStats;
+import org.elasticsearch.transport.StatsTracker;
 
 /**
  * A dummy http transport used by tests when not wanting to actually bind to a real address.
@@ -43,6 +42,8 @@ public class MockHttpTransport extends AbstractLifecycleComponent implements Htt
     private static final BoundTransportAddress DUMMY_BOUND_ADDRESS = new BoundTransportAddress(
         new TransportAddress[] { DUMMY_TRANSPORT_ADDRESS }, DUMMY_TRANSPORT_ADDRESS);
 
+    private final StatsTracker statsTracker = new StatsTracker();
+
     @Override
     protected void doStart() {}
 
@@ -58,7 +59,7 @@ public class MockHttpTransport extends AbstractLifecycleComponent implements Htt
     }
 
     @Override
-    public ConnectionStats stats() {
-        return new ConnectionStats(0, 0, 0, 0, 0, 0);
+    public StatsTracker stats() {
+        return statsTracker;
     }
 }

--- a/server/src/testFixtures/java/org/elasticsearch/test/transport/FakeTransport.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/transport/FakeTransport.java
@@ -29,12 +29,11 @@ import org.elasticsearch.common.transport.BoundTransportAddress;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.transport.CloseableConnection;
 import org.elasticsearch.transport.ConnectionProfile;
+import org.elasticsearch.transport.StatsTracker;
 import org.elasticsearch.transport.Transport;
 import org.elasticsearch.transport.TransportMessageListener;
 import org.elasticsearch.transport.TransportRequest;
 import org.elasticsearch.transport.TransportRequestOptions;
-
-import io.crate.protocols.ConnectionStats;
 
 /**
  * A transport that does nothing. Normally wrapped by {@link StubbableTransport}.
@@ -43,6 +42,7 @@ public class FakeTransport extends AbstractLifecycleComponent implements Transpo
 
     private final RequestHandlers requestHandlers = new RequestHandlers();
     private final ResponseHandlers responseHandlers = new ResponseHandlers();
+    private final StatsTracker statsTracker = new StatsTracker();
     private TransportMessageListener listener;
 
     @Override
@@ -84,8 +84,8 @@ public class FakeTransport extends AbstractLifecycleComponent implements Transpo
     }
 
     @Override
-    public ConnectionStats getStats() {
-        return new ConnectionStats(0, 0, 0, 0, 0, 0);
+    public StatsTracker getStats() {
+        return statsTracker;
     }
 
     @Override

--- a/server/src/testFixtures/java/org/elasticsearch/test/transport/StubbableTransport.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/transport/StubbableTransport.java
@@ -34,6 +34,7 @@ import org.elasticsearch.common.transport.BoundTransportAddress;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.transport.ConnectionProfile;
 import org.elasticsearch.transport.RequestHandlerRegistry;
+import org.elasticsearch.transport.StatsTracker;
 import org.elasticsearch.transport.Transport;
 import org.elasticsearch.transport.TransportChannel;
 import org.elasticsearch.transport.TransportException;
@@ -41,8 +42,6 @@ import org.elasticsearch.transport.TransportMessageListener;
 import org.elasticsearch.transport.TransportRequest;
 import org.elasticsearch.transport.TransportRequestHandler;
 import org.elasticsearch.transport.TransportRequestOptions;
-
-import io.crate.protocols.ConnectionStats;
 
 public class StubbableTransport implements Transport {
 
@@ -171,7 +170,7 @@ public class StubbableTransport implements Transport {
     }
 
     @Override
-    public ConnectionStats getStats() {
+    public StatsTracker getStats() {
         return delegate.getStats();
     }
 


### PR DESCRIPTION
Each property of the `Connections` bean created a new `ConnectionStats`
object which in turn is derived from the `StatsTracker`s state.

This gives the `Connections` bean direct access to the `StatsTracker` to
avoid the intermediate allocations.
