### PR TITLE
Fix UNION pruning dropping outputs kept by its sources

### DIFF
--- a/docs/appendices/release-notes/6.4.4.rst
+++ b/docs/appendices/release-notes/6.4.4.rst
@@ -46,4 +46,10 @@ series.
 Fixes
 =====
 
-None
+- Fixed an issue that caused a ``UNION ALL`` inside a sub-select to return an
+  additional column, or to fail with ``Index x out of bounds for length y``, if
+  the outer query used an ``ORDER BY`` on a column which was not selected and
+  the sub-select contained further columns which were neither selected nor used
+  by the ``ORDER BY``. e.g::
+
+    SELECT c3 FROM (SELECT * FROM tbl UNION ALL SELECT * FROM tbl) x ORDER BY c1;

--- a/server/src/main/java/io/crate/planner/operators/Union.java
+++ b/server/src/main/java/io/crate/planner/operators/Union.java
@@ -86,6 +86,11 @@ public class Union implements LogicalPlan {
                                Row params,
                                SubQueryResults subQueryResults) {
 
+        assert lhs.outputs().size() == outputs.size() && rhs.outputs().size() == outputs.size()
+            : "The sources of a UNION must have the same number of outputs as the UNION itself, "
+              + "otherwise it streams columns which are not part of its outputs. Got "
+              + "lhs=" + lhs.outputs() + ", rhs=" + rhs.outputs() + ", outputs=" + outputs;
+
         Integer childPageSizeHint = limit != LimitAndOffset.NO_LIMIT
             ? limitAndOffset(limit, offset)
             : null;
@@ -199,9 +204,38 @@ public class Union implements LogicalPlan {
         return new Union(sources.get(0), sources.get(1), outputs);
     }
 
-    private static boolean startsWith(List<Symbol> outputs, List<Symbol> prefix) {
-        return outputs.size() >= prefix.size()
-               && outputs.subList(0, prefix.size()).equals(prefix);
+    private static List<Symbol> outputsAt(List<Symbol> outputs, List<Integer> indices) {
+        ArrayList<Symbol> outputsAtIndices = new ArrayList<>(indices.size());
+        for (int index : indices) {
+            outputsAtIndices.add(outputs.get(index));
+        }
+        return outputsAtIndices;
+    }
+
+    /**
+     * Maps the outputs a source kept after pruning back onto the positions they had within the
+     * outputs of the source before the pruning.
+     *
+     * @return null if an output cannot be mapped
+     */
+    @Nullable
+    private static List<Integer> indicesOfOutputs(List<Symbol> sourceOutputs, List<Symbol> newSourceOutputs) {
+        ArrayList<Integer> indices = new ArrayList<>(newSourceOutputs.size());
+        for (Symbol newSourceOutput : newSourceOutputs) {
+            int index = -1;
+            for (int i = 0; i < sourceOutputs.size() && index < 0; i++) {
+                // Sources can contain identically looking symbols (see `pruneOutputsExcept`),
+                // therefore each position can only be used once.
+                if (sourceOutputs.get(i).equals(newSourceOutput) && indices.contains(i) == false) {
+                    index = i;
+                }
+            }
+            if (index < 0) {
+                return null;
+            }
+            indices.add(index);
+        }
+        return indices;
     }
 
     @Override
@@ -240,31 +274,23 @@ public class Union implements LogicalPlan {
         // by `addCastsForIncompatibleObjects` could then silently cast the wrong columns.
         Collections.sort(outputIndicesToKeep);
 
-        ArrayList<Symbol> toKeepFromLhs = new ArrayList<>();
-        ArrayList<Symbol> toKeepFromRhs = new ArrayList<>();
-        ArrayList<Symbol> newOutputs = new ArrayList<>();
-        for (int idx : outputIndicesToKeep) {
-            toKeepFromLhs.add(lhs.outputs().get(idx));
-            toKeepFromRhs.add(rhs.outputs().get(idx));
-            newOutputs.add(outputs.get(idx));
-        }
-        LogicalPlan newLhs = lhs.pruneOutputsExcept(toKeepFromLhs);
-        LogicalPlan newRhs = rhs.pruneOutputsExcept(toKeepFromRhs);
+        LogicalPlan newLhs = lhs.pruneOutputsExcept(outputsAt(lhs.outputs(), outputIndicesToKeep));
+        LogicalPlan newRhs = rhs.pruneOutputsExcept(outputsAt(rhs.outputs(), outputIndicesToKeep));
         if (newLhs == lhs && newRhs == rhs) {
             return this;
         }
-        // The union streams the outputs of its sources positionally, therefore both sources must
-        // have the same layout and the outputs of the union must be a prefix of it.
-        // A source is free to keep more outputs than requested, e.g. an ORDER BY symbol which was
-        // pushed beneath the union, and it may keep them in front of the requested ones. If that
-        // leaves the sources misaligned, skip the pruning: keeping additional outputs is always
-        // correct, reading the values of another column is not.
-        if (newLhs.outputs().size() != newRhs.outputs().size()
-            || startsWith(newLhs.outputs(), toKeepFromLhs) == false
-            || startsWith(newRhs.outputs(), toKeepFromRhs) == false) {
+        // A source can keep more outputs than requested, and can keep them in a different
+        // order. This happens when an `ORDER BY` or `WHERE` on columns not selected are pushed
+        // down beneath the union to its sources.
+        // The union streams the outputs of its sources positionally, therefore its outputs must
+        // mirror what the sources kept, otherwise it emits columns which are not part of its
+        // outputs and parent operators.
+        List<Integer> newLhsIndices = indicesOfOutputs(lhs.outputs(), newLhs.outputs());
+        List<Integer> newRhsIndices = indicesOfOutputs(rhs.outputs(), newRhs.outputs());
+        if (newLhsIndices == null || newLhsIndices.equals(newRhsIndices) == false) {
             return this;
         }
-        return new Union(newLhs, newRhs, newOutputs);
+        return new Union(newLhs, newRhs, outputsAt(outputs, newLhsIndices));
     }
 
     @Override

--- a/server/src/test/java/io/crate/planner/UnionPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/UnionPlannerTest.java
@@ -297,13 +297,16 @@ public class UnionPlannerTest extends CrateDummyClusterServiceUnitTest {
             ORDER BY name
             """;
         LogicalPlan logicalPlan = e.logicalPlan(stmt);
+        // `name` is not selected but the sources keep it to be able to sort on it, therefore the
+        // union must keep it as an output as well; the `Eval` on top removes it from the result.
         assertThat(logicalPlan).isEqualTo("""
-            Rename[id] AS u
-              └ Union[id]
-                ├ OrderBy[name ASC]
-                │  └ Collect[doc.users | [id, name] | true]
-                └ OrderBy[name ASC]
-                  └ Collect[doc.users | [id, name] | true]
+            Eval[id]
+              └ Rename[id, name] AS u
+                └ Union[id, name]
+                  ├ OrderBy[name ASC]
+                  │  └ Collect[doc.users | [id, name] | true]
+                  └ OrderBy[name ASC]
+                    └ Collect[doc.users | [id, name] | true]
             """
         );
 
@@ -350,6 +353,21 @@ public class UnionPlannerTest extends CrateDummyClusterServiceUnitTest {
                 .as("rhs of the union must be aligned with its outputs, " + orderBy)
                 .isEqualTo(outputTypes);
         }
+    }
+
+    // https://github.com/crate/crate/issues/19852
+    @Test
+    public void test_union_with_aliased_output_and_order_by_on_non_selected_symbol() {
+        ExecutionPlan plan = e.plan("""
+            SELECT name AS n FROM (
+                SELECT id, other_id, name FROM users
+                UNION ALL
+                SELECT id, other_id, name FROM users
+                ) u
+            ORDER BY id
+            """);
+        assertThat(plan.resultDescription().numOutputs()).isEqualTo(1);
+        assertThat(plan.resultDescription().streamOutputs()).containsExactly(DataTypes.STRING);
     }
 
     @Nullable


### PR DESCRIPTION
Keep the outputs the sources ended up with, instead of the requested ones, so that the outputs of the UNION always mirror the outputs of its sources; the `Eval` on top of the UNION removes them from the result. If an output cannot be mapped back, or the two sources kept different ones, skip the pruning as before.

Fixes: #19852
