### PR TITLE
Don't push down filters containing non-deterministic functions

### DIFF
--- a/docs/appendices/release-notes/6.4.4.rst
+++ b/docs/appendices/release-notes/6.4.4.rst
@@ -53,3 +53,11 @@ Fixes
   by the ``ORDER BY``. e.g::
 
     SELECT c3 FROM (SELECT * FROM tbl UNION ALL SELECT * FROM tbl) x ORDER BY c1;
+
+- Fixed an issue that could return wrong results if a ``WHERE`` clause contained
+  a non-deterministic function, like :ref:`random() <scalar-random>`, and was
+  applied on a virtual relation which uses
+  :ref:`window functions <window-functions>`, :ref:`GROUP BY <sql_dql_group_by>`
+  or :ref:`table functions <table-functions>`. Prevent the push down for such
+  filters, as they can produce different results than if applied after those
+  operations as intended.

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathGroupBy.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathGroupBy.java
@@ -74,28 +74,30 @@ public final class MoveFilterBeneathGroupBy implements Rule<Filter> {
                              Rule.Context ruleContext) {
         // Since something like `SELECT x, sum(y) FROM t GROUP BY x HAVING y > 10` is not valid
         // (y would have to be declared as group key) any parts of a HAVING that is not an aggregation can be moved.
+        // A non-deterministic part, e.g. `random() < 0.5`, must not be pushed down either. It would be
+        // evaluated per row of the source instead of per group, which changes the result.
         Symbol predicate = filter.query();
         List<Symbol> parts = AndOperator.split(predicate);
-        ArrayList<Symbol> withAggregates = new ArrayList<>();
-        ArrayList<Symbol> withoutAggregates = new ArrayList<>();
+        ArrayList<Symbol> toKeep = new ArrayList<>();
+        ArrayList<Symbol> toPushDown = new ArrayList<>();
         for (Symbol part : parts) {
-            if (part.hasFunctionType(FunctionType.AGGREGATE)) {
-                withAggregates.add(part);
+            if (part.hasFunctionType(FunctionType.AGGREGATE) || part.isDeterministic() == false) {
+                toKeep.add(part);
             } else {
-                withoutAggregates.add(part);
+                toPushDown.add(part);
             }
         }
-        if (withoutAggregates.isEmpty()) {
+        if (toPushDown.isEmpty()) {
             return null;
         }
         GroupHashAggregate groupBy = captures.get(groupByCapture);
-        if (withoutAggregates.size() == parts.size()) {
+        if (toKeep.isEmpty()) {
             return transpose(filter, groupBy);
         }
 
         /* HAVING `count(*) > 1 AND x = 10`
-         * withAggregates:    [count(*) > 1]
-         * withoutAggregates: [x = 10]
+         * toKeep:     [count(*) > 1]
+         * toPushDown: [x = 10]
          *
          * Filter
          *  |
@@ -110,9 +112,9 @@ public final class MoveFilterBeneathGroupBy implements Rule<Filter> {
          * Filter (x = 10)
          */
         LogicalPlan newGroupBy = groupBy.replaceSources(
-            List.of(new Filter(groupBy.source(), AndOperator.join(withoutAggregates))));
+            List.of(new Filter(groupBy.source(), AndOperator.join(toPushDown))));
 
-        return new Filter(newGroupBy, AndOperator.join(withAggregates));
+        return new Filter(newGroupBy, AndOperator.join(toKeep));
     }
 
 }

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathProjectSet.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathProjectSet.java
@@ -73,9 +73,13 @@ public final class MoveFilterBeneathProjectSet implements Rule<Filter> {
         var queryParts = AndOperator.split(filter.query());
         ArrayList<Symbol> toPushDown = new ArrayList<>();
         ArrayList<Symbol> toKeep = new ArrayList<>();
+        // A non-deterministic filter part, e.g. `random() < 0.5`, must not be pushed beneath the ProjectSet.
+        // The table functions of the ProjectSet can generate multiple rows per input row, therefore the
+        // filter would operate on fewer rows.
         for (var part : queryParts) {
             Set<Symbol> partColumns = extractColumns(part);
-            if (!part.any(MoveFilterBeneathProjectSet::isTableFunction)
+            if (part.isDeterministic()
+                    && !part.any(MoveFilterBeneathProjectSet::isTableFunction)
                     && partColumns.stream().allMatch(x -> Symbols.contains(outputs, x))) {
                 toPushDown.add(part);
             } else {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathWindowAgg.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathWindowAgg.java
@@ -75,8 +75,12 @@ public final class MoveFilterBeneathWindowAgg implements Rule<Filter> {
         ArrayList<Symbol> remainingFilterSymbols = new ArrayList<>();
         ArrayList<Symbol> windowPartitionedBasedFilters = new ArrayList<>();
 
+        // A non-deterministic filter part, e.g. `random() < 0.5`, must not be pushed beneath the WindowAgg.
+        // It would be evaluated on the input rows of the window functions instead of on their result,
+        // which affects the values which the window functions use to compute.
         for (Symbol part : filterParts) {
-            if (part.any(containsWindowFunction) == false
+            if (part.isDeterministic()
+                && part.any(containsWindowFunction) == false
                 && windowDefinition.partitions().containsAll(extractColumns(part))) {
                 windowPartitionedBasedFilters.add(part);
             } else {

--- a/server/src/test/java/io/crate/planner/operators/PushDownTest.java
+++ b/server/src/test/java/io/crate/planner/operators/PushDownTest.java
@@ -121,7 +121,7 @@ public class PushDownTest extends CrateDummyClusterServiceUnitTest {
               │  └ Collect[doc.t2 | [b] | true]
               └ Rename[a] AS t3
                 └ Collect[doc.t1 | [a] | true]
-             """
+            """
         );
     }
 
@@ -436,6 +436,60 @@ public class PushDownTest extends CrateDummyClusterServiceUnitTest {
             Rename[x, sum] AS sums
               └ WindowAgg[x] | [sum(x) OVER (PARTITION BY x)]
                 └ Collect[doc.t1 | [x] | (x = 10)]
+            """;
+        assertThat(plan).isEqualTo(expectedPlan);
+    }
+
+    @Test
+    public void test_non_deterministic_filter_is_not_pushed_beneath_project_set() {
+        var plan = sqlExecutor.logicalPlan(
+            """
+            SELECT *
+            FROM
+              (SELECT x, generate_series(1::int, x) FROM t1) tt
+            WHERE x > 1 AND random() < 0.5
+            """
+        );
+        var expectedPlan =
+            """
+            Rename[x, generate_series] AS tt
+              └ Eval[x, pg_catalog.generate_series(1, x)]
+                └ Filter[(random() < 0.5)]
+                  └ ProjectSet[pg_catalog.generate_series(1, x), x]
+                    └ Collect[doc.t1 | [x] | (x > 1)]
+            """;
+        assertThat(plan).isEqualTo(expectedPlan);
+    }
+
+    @Test
+    public void test_non_deterministic_filter_is_not_pushed_beneath_group_by() {
+        var plan = sqlExecutor.logicalPlan(
+            "SELECT x, count(*) FROM t1 GROUP BY 1 HAVING x > 1 AND random() < 0.5"
+        );
+        var expectedPlan =
+            """
+            Filter[(random() < 0.5)]
+              └ GroupHashAggregate[x | count(*)]
+                └ Collect[doc.t1 | [x] | (x > 1)]
+            """;
+        assertThat(plan).isEqualTo(expectedPlan);
+    }
+
+    @Test
+    public void test_non_deterministic_filter_is_not_pushed_beneath_window_agg() {
+        var plan = sqlExecutor.logicalPlan(
+            """
+            SELECT * FROM
+              (SELECT x, sum(x) over (partition by x) FROM t1) sums
+            WHERE sums.x = 10 AND random() < 0.5
+            """
+        );
+        var expectedPlan =
+            """
+            Rename[x, sum] AS sums
+              └ Filter[(random() < 0.5)]
+                └ WindowAgg[x] | [sum(x) OVER (PARTITION BY x)]
+                  └ Collect[doc.t1 | [x] | (x = 10)]
             """;
         assertThat(plan).isEqualTo(expectedPlan);
     }

--- a/server/src/test/java/io/crate/planner/optimizer/rule/MoveFilterBeneathWindowAggTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/rule/MoveFilterBeneathWindowAggTest.java
@@ -164,6 +164,38 @@ public class MoveFilterBeneathWindowAggTest extends CrateDummyClusterServiceUnit
     }
 
     @Test
+    public void test_only_deterministic_filter_part_is_pushed_down() {
+        var collect = e.logicalPlan("SELECT id FROM t1");
+
+        WindowFunction windowFunction = (WindowFunction) e.asSymbol("ROW_NUMBER() OVER(PARTITION BY id)");
+        WindowAgg windowAgg = (WindowAgg) WindowAgg.create(collect, List.of(windowFunction));
+
+        Symbol query = e.asSymbol("id = 10 AND random() < 0.5");
+        Filter filter = new Filter(windowAgg, query);
+
+        var rule = new MoveFilterBeneathWindowAgg();
+        Match<Filter> match = rule.pattern().accept(filter, Captures.empty());
+
+        assertThat(match.isPresent()).isTrue();
+        assertThat(match.value()).isSameAs(filter);
+
+        LogicalPlan newPlan = rule.apply(
+            match.value(),
+            match.captures(),
+            e.ruleContext()
+        );
+        var expectedPlan =
+            """
+            Filter[(random() < 0.5)]
+              └ WindowAgg[id] | [row_number() OVER (PARTITION BY id)]
+                └ Filter[(id = 10)]
+                  └ Collect[doc.t1 | [id] | true]
+            """;
+
+        assertThat(newPlan).isEqualTo(expectedPlan);
+    }
+
+    @Test
     public void test_filters_combined_by_OR_cannot_be_moved() {
         var collect = e.logicalPlan("SELECT id FROM t1");
 


### PR DESCRIPTION
Prevent non-deterministic filter parts from beign pushed down beneath operators which compute values over a set of rows, i as it changes the semantics and therefore their result:

- `MoveFilterBeneathWindowAgg`: such a filter contains no column at all, therefore `windowDefinition.partitions().containsAll(...)` was trivially true and the part was treated as partition based.
- `MoveFilterBeneathGroupBy`: the filter would be evaluated per source row instead of per group.
- `MoveFilterBeneathProjectSet`: the table functions can generate multiple rows per input row, so the filter would be evaluated before the row generation.

The push down of the remaining, deterministic parts of the filter takes place as before, since all three rules already split the query on `AND`.

Fixes: #19982
