### PR TITLE
Improve error msg for uncorrelated subqueries in join conditions

### DIFF
--- a/docs/appendices/release-notes/6.4.4.rst
+++ b/docs/appendices/release-notes/6.4.4.rst
@@ -76,3 +76,9 @@ Fixes
 - Fixed an issue where a node could still shut down when the cluster health
   wait timed out during decommissioning despite
   ``cluster.graceful_stop.force=false``.
+
+- Improved the error message for queries involving an uncorrelated subquery in
+  join condition. e.g::
+
+    SELECT * FROM t JOIN t AS t2 ON t.c = (select 1)
+

--- a/server/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
@@ -60,9 +60,11 @@ import io.crate.exceptions.UnsupportedFeatureException;
 import io.crate.expression.eval.EvaluatingNormalizer;
 import io.crate.expression.scalar.arithmetic.ArrayFunction;
 import io.crate.expression.scalar.cast.CastMode;
+import io.crate.expression.symbol.DefaultTraversalSymbolVisitor;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.GroupAndAggregateSemantics;
 import io.crate.expression.symbol.Literal;
+import io.crate.expression.symbol.SelectSymbol;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.format.Style;
 import io.crate.expression.tablefunctions.TableFunctionFactory;
@@ -277,6 +279,7 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
                     new SubqueryAnalyzer(this, statementContext));
                 var expressionAnalysisContext = statementContext.currentRelationContext().expressionAnalysisContext();
                 joinCondition = expressionAnalyzer.convert(expression, expressionAnalysisContext);
+                rejectUncorrelatedSubqueriesInJoinCondition(joinCondition);
             } catch (RelationUnknown e) {
                 throw new RelationValidationException(
                     e.getTableIdents(),
@@ -883,5 +886,21 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
         context.currentRelationContext().addSourceRelation(relation);
         context.endRelation();
         return relation;
+    }
+
+    private void rejectUncorrelatedSubqueriesInJoinCondition(Symbol joinCondition) {
+        if (joinCondition != null) {
+            joinCondition.accept(
+                new DefaultTraversalSymbolVisitor<Void, Void>() {
+                    @Override
+                    public Void visitSelectSymbol(SelectSymbol selectSymbol, Void context) {
+                        if (!selectSymbol.isCorrelated()) {
+                            throw new UnsupportedOperationException("uncorrelated subqueries are not supported in the JOIN ON clause");
+                        }
+                        return null;
+                    }
+                }, null
+            );
+        }
     }
 }

--- a/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -3163,4 +3163,14 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
             "SELECT * FROM sys.nodes WHERE EXISTS (SELECT FROM sys.nodes WHERE id = 'foo')");
         assertThat(relation.where()).isFunction("_exists");
     }
+
+    @Test
+    public void test_uncorrelated_subquery_in_join_condition() throws IOException {
+        var executor = SQLExecutor.of(clusterService)
+            .addTable("create table t (c int)");
+        assertThatThrownBy(() -> executor.analyze(
+            "SELECT * FROM t JOIN t AS tt ON t.c = (SELECT 1)"))
+            .isExactlyInstanceOf(UnsupportedOperationException.class)
+            .hasMessage("uncorrelated subqueries are not supported in the JOIN ON clause");
+    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Improves the error message for:
```
cr> create table t1 (c1 int);
CREATE OK, 1 row affected (1.687 sec)

cr> SELECT *
    FROM t1
    JOIN t1 AS t2
      ON t1.c1 = (SELECT 1);
SQLParseException[Couldn't create execution plan from logical plan because of: Couldn't resolve value for subQuery: (SELECT 1 FROM (empty_row)):
NestedLoopJoin[INNER | (c1 = (SELECT 1 FROM (empty_row)))] (rows=unknown)
  ├ Collect[doc.t1 | [c1] | true] (rows=unknown)
  └ Rename[c1] AS t2 (rows=unknown)
    └ Collect[doc.t1 | [c1] | true] (rows=unknown)]
```

```
UnsupportedFeatureException[uncorrelated subqueries are not supported in the JOIN ON clause]
```

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes.
       If you're an external contributor you can give yourself attribution and include your name and Github handle.
       e.g.:
       ```
       `John Doe <https://github.com/John_Doe>`_ added support for ...
       ```
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
