### PR TITLE
Honor `cluster.graceful_stop.force=false` on cluster health timeout

### DIFF
--- a/docs/appendices/release-notes/6.4.4.rst
+++ b/docs/appendices/release-notes/6.4.4.rst
@@ -71,3 +71,7 @@ Fixes
   :ref:`INDEX OFF <sql_ddl_index_off>`, e.g.::
 
     SELECT * FROM tbl WHERE no_index_col ~ '[a-z]'
+
+- Fixed an issue where a node could still shut down when the cluster health
+  wait timed out during decommissioning despite
+  ``cluster.graceful_stop.force=false``.

--- a/server/src/main/java/io/crate/cluster/gracefulstop/DecommissioningService.java
+++ b/server/src/main/java/io/crate/cluster/gracefulstop/DecommissioningService.java
@@ -32,6 +32,7 @@ import java.util.function.IntSupplier;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.ElasticsearchTimeoutException;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.admin.cluster.health.TransportClusterHealth;
@@ -205,12 +206,16 @@ public class DecommissioningService extends AbstractLifecycleComponent implement
             })
             // changing settings triggers AllocationService.reroute -> shards will be relocated
             .thenCompose(_ -> clusterHealthGet())
-            .handle((_, error) -> {
-                if (error == null) {
+            .handle((clusterHealthResponse, error) -> {
+                if (error != null) {
+                    executorService.submit(() -> forceStopOrAbort(error));
+                } else if (clusterHealthResponse != null && clusterHealthResponse.isTimedOut()) {
+                    executorService.submit(() -> forceStopOrAbort(
+                        new ElasticsearchTimeoutException("Cluster health wait timed out")
+                    ));
+                } else {
                     final long startTime = System.nanoTime();
                     executorService.submit(() -> exitIfNoActiveRequests(startTime));
-                } else {
-                    executorService.submit(() -> forceStopOrAbort(error));
                 }
                 return null;
             });

--- a/server/src/test/java/io/crate/cluster/gracefulstop/DecommissioningServiceTest.java
+++ b/server/src/test/java/io/crate/cluster/gracefulstop/DecommissioningServiceTest.java
@@ -22,16 +22,22 @@
 package io.crate.cluster.gracefulstop;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.admin.cluster.health.TransportClusterHealth;
+import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsResponse;
 import org.elasticsearch.action.admin.cluster.settings.TransportClusterUpdateSettingsAction;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
@@ -129,5 +135,51 @@ public class DecommissioningServiceTest extends CrateDummyClusterServiceUnitTest
         @Override
         protected void removeDecommissioningSetting() {
         }
+    }
+
+    @Test
+    public void test_abort_decommission_if_cluster_health_time_out() {
+        var healthAction = mock(TransportClusterHealth.class);
+        var updateSettingsAction = mock(TransportClusterUpdateSettingsAction.class);
+
+        var healthResponse = mock(ClusterHealthResponse.class);
+        when(healthResponse.isTimedOut()).thenReturn(true);
+
+        when(healthAction.execute(any()))
+            .thenReturn(CompletableFuture.completedFuture(healthResponse));
+
+        when(updateSettingsAction.execute(any()))
+            .thenReturn(CompletableFuture.completedFuture(
+                mock(ClusterUpdateSettingsResponse.class)
+            ));
+
+        // forces the executor service to execute the given runnable immediately:
+        // `executorService.submit(() -> forceStopOrAbort(error));`
+        doAnswer(invocation -> {
+            Runnable runnable = invocation.getArgument(0);
+            runnable.run();
+            return CompletableFuture.completedFuture(null);
+        }).when(executorService).submit(any(Runnable.class));
+
+        var settings = Settings.builder()
+            .put(DecommissioningService.GRACEFUL_STOP_FORCE_SETTING.getKey(), false)
+            .build();
+
+        var decommissioningService = new TestableDecommissioningService(
+            settings,
+            clusterService,
+            jobsLogs,
+            executorService,
+            sqlOperations,
+            () -> exited.set(true),
+            healthAction,
+            updateSettingsAction
+        );
+
+        decommissioningService.decommission().join();
+
+        assertThat(exited.get()).isFalse();
+        assertThat(decommissioningService.forceStopOrAbortCalled).isTrue();
+        verify(sqlOperations).enable();
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes https://github.com/crate/crate/issues/19914.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes.
       If you're an external contributor you can give yourself attribution and include your name and Github handle.
       e.g.:
       ```
       `John Doe <https://github.com/John_Doe>`_ added support for ...
       ```
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
