### PR TITLE
Fix array_agg() for explicit window frames

### DIFF
--- a/docs/appendices/release-notes/6.4.4.rst
+++ b/docs/appendices/release-notes/6.4.4.rst
@@ -95,3 +95,12 @@ Fixes
     FROM t q;
 
   In this example, the ``q.flag`` filter was dropped.
+  :ref:`array_agg() <aggregation-array-agg>` aggregation function.
+
+- Fixed an issue that caused wrong results when
+  :ref:`array_agg() <aggregation-array-agg>` aggregation function was used with
+  :ref:`window functions <window-functions>` with an explicit window frame,
+  e.g.::
+
+    SELECT array_agg(x) OVER(
+      ORDER BY x ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) FROM tbl

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/ArrayAgg.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/ArrayAgg.java
@@ -41,7 +41,7 @@ import io.crate.metadata.functions.TypeVariableConstraint;
 import io.crate.types.DataType;
 import io.crate.types.TypeSignature;
 
-public final class ArrayAgg extends AggregationFunction<List<Object>, List<Object>> {
+public class ArrayAgg extends AggregationFunction<List<Object>, List<Object>> {
 
     public static final String NAME = "array_agg";
     public static final Signature SIGNATURE = Signature.builder(NAME, FunctionType.AGGREGATE)
@@ -110,5 +110,38 @@ public final class ArrayAgg extends AggregationFunction<List<Object>, List<Objec
     @Override
     public DataType<?> partialType() {
         return boundSignature.returnType();
+    }
+
+    @Override
+    public AggregationFunction<?, List<Object>> optimizeForExecutionAsWindowFunction(Version minNodeVersion) {
+        return new ArrayAggWindowFuncs(signature, boundSignature);
+    }
+
+    private final class ArrayAggWindowFuncs extends ArrayAgg {
+
+        public ArrayAggWindowFuncs(Signature signature, BoundSignature boundSignature) {
+            super(signature, boundSignature);
+        }
+
+        @Override
+        public List<Object> terminatePartial(RamAccounting ramAccounting, List<Object> state) {
+            ramAccounting.addBytes(RamUsageEstimator.alignObjectSize(40L)); // ArrayList overhead
+            return new ArrayList<>(state);
+        }
+
+        @Override
+        public boolean isRemovableCumulative() {
+            return true;
+        }
+
+        @Override
+        public List<Object> removeFromAggregatedState(RamAccounting ramAccounting, List<Object> previousAggState, Input<?>[] stateToRemove) {
+            Object value = stateToRemove[0].value();
+
+            Object removed = previousAggState.removeFirst();
+            assert removed.equals(value) : "AggregateToWindowFunctionAdapter should always remove the first state";
+            ramAccounting.addBytes(- elementType.valueBytes(value));
+            return previousAggState;
+        }
     }
 }

--- a/server/src/main/java/io/crate/execution/engine/window/AggregateToWindowFunctionAdapter.java
+++ b/server/src/main/java/io/crate/execution/engine/window/AggregateToWindowFunctionAdapter.java
@@ -132,7 +132,6 @@ public class AggregateToWindowFunctionAdapter implements WindowFunction {
             }
             Boolean match = filter.value(row);
             if (match != null && match) {
-                //noinspection unchecked
                 accumulatedState = aggregationFunction.removeFromAggregatedState(
                     ramAccounting,
                     accumulatedState,
@@ -183,7 +182,6 @@ public class AggregateToWindowFunctionAdapter implements WindowFunction {
             }
             Boolean match = filter.value(row);
             if (match != null && match) {
-                //noinspection unchecked
                 accumulatedState = aggregationFunction.iterate(
                     ramAccounting,
                     memoryManager,

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/ArrayAggTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/ArrayAggTest.java
@@ -28,6 +28,7 @@ import java.util.List;
 import org.elasticsearch.Version;
 import org.junit.Test;
 
+import io.crate.data.Input;
 import io.crate.data.breaker.RamAccounting;
 import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.expression.symbol.Literal;
@@ -93,5 +94,36 @@ public class ArrayAggTest extends AggregationTestCase {
         impl.iterate(ramAccounting, memoryManager, state, Literal.of("trillian"));
         impl.iterate(ramAccounting, memoryManager, state, Literal.of("arthur"));
         assertThat(ramAccounting.totalBytes()).isEqualTo(152L);
+        impl.terminatePartial(ramAccounting, state);
+        assertThat(ramAccounting.totalBytes()).isEqualTo(152L);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void test_array_agg_for_window_functions_accounts_memory_for_state() throws Exception {
+        var agg = (AggregationFunction<Object, ?>) nodeCtx.functions().getQualified(
+            Signature.builder(ArrayAgg.NAME, FunctionType.AGGREGATE)
+                .argumentTypes(TypeSignature.E)
+                .returnType(TypeSignature.ARRAY_E)
+                .features(Scalar.Feature.DETERMINISTIC)
+                .typeVariableConstraints(TypeVariableConstraint.E)
+                .build(),
+            List.of(DataTypes.STRING),
+            DataTypes.STRING_ARRAY
+        );
+        var impl = (AggregationFunction<Object, Object>) agg.optimizeForExecutionAsWindowFunction(Version.CURRENT);
+        RamAccounting ramAccounting = new PlainRamAccounting();
+        Object state = impl.newState(ramAccounting, Version.CURRENT, memoryManager);
+        assertThat(ramAccounting.totalBytes()).isEqualTo(40L);
+        impl.iterate(ramAccounting, memoryManager, state, Literal.of("trillian"));
+        impl.iterate(ramAccounting, memoryManager, state, Literal.of("arthur"));
+        impl.iterate(ramAccounting, memoryManager, state, Literal.of("john"));
+        assertThat(ramAccounting.totalBytes()).isEqualTo(200L);
+
+        impl.removeFromAggregatedState(ramAccounting, state, new Input[] { Literal.of("trillian") });
+        assertThat(ramAccounting.totalBytes()).isEqualTo(144L);
+
+        impl.terminatePartial(ramAccounting, state);
+        assertThat(ramAccounting.totalBytes()).isEqualTo(184L);
     }
 }

--- a/server/src/test/java/io/crate/execution/engine/window/AggregationWindowFunctionsTest.java
+++ b/server/src/test/java/io/crate/execution/engine/window/AggregationWindowFunctionsTest.java
@@ -24,6 +24,7 @@ package io.crate.execution.engine.window;
 import static com.carrotsearch.randomizedtesting.RandomizedTest.$;
 
 import java.math.BigDecimal;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -519,5 +520,190 @@ public class AggregationWindowFunctionsTest extends AbstractWindowFunctionTest {
                 new Object[] { 2 },
             }
         );
+    }
+
+    @Test
+    public void test_array_agg_over_rows_unbounded_preceding_current_row_frame() throws Throwable {
+        Object[] expected = new Object[]{
+            List.of(10),
+            List.of(10, 20),
+            List.of(10, 20, 30)
+        };
+        assertEvaluate(
+            """
+                array_agg(x) OVER(
+                    ORDER BY x ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+                )
+            """,
+            expected,
+            List.of(ColumnIdent.of("x")),
+            new Object[]{10},
+            new Object[]{20},
+            new Object[]{30});
+    }
+
+    @Test
+    public void test_array_agg_over_default_range_frame_includes_peers() throws Throwable {
+        Object[] expected = new Object[]{
+            List.of(10),
+            List.of(10, 20, 20),
+            List.of(10, 20, 20),
+            List.of(10, 20, 20, 30)
+        };
+        assertEvaluate(
+            "array_agg(x) OVER(ORDER BY x)",
+            expected,
+            List.of(ColumnIdent.of("x")),
+            new Object[]{10},
+            new Object[]{20},
+            new Object[]{20},
+            new Object[]{30});
+    }
+
+    @Test
+    public void test_array_agg_over_rows_1_preceding_current_row_frame() throws Throwable {
+        Object[] expected = new Object[]{
+            List.of(10),
+            List.of(10, 20),
+            List.of(20, 30)
+        };
+        assertEvaluate(
+            """
+                array_agg(x) OVER(
+                    ORDER BY x ROWS BETWEEN 1 PRECEDING AND CURRENT ROW
+                )
+            """,
+            expected,
+            List.of(ColumnIdent.of("x")),
+            new Object[]{10},
+            new Object[]{20},
+            new Object[]{30});
+    }
+
+    @Test
+    public void test_array_agg_over_rows_current_row_unbounded_following_frame() throws Throwable {
+        Object[] expected = new Object[]{
+            List.of(10, 20, 30),
+            List.of(20, 30),
+            List.of(30)
+        };
+        assertEvaluate(
+            """
+                array_agg(x) OVER(
+                   ORDER BY x ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING
+                )
+            """,
+            expected,
+            List.of(ColumnIdent.of("x")),
+            new Object[]{10},
+            new Object[]{20},
+            new Object[]{30});
+    }
+
+    @Test
+    public void test_array_agg_over_partitioned_rows_unbounded_preceding_current_row_frame() throws Throwable {
+        Object[] expected = new Object[]{
+            List.of(10),
+            List.of(10, 20),
+            List.of(30),
+            List.of(30, 40)
+        };
+        assertEvaluate(
+            """
+                array_agg(x) OVER(
+                   PARTITION BY x > 20 ORDER BY x ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+                )
+            """,
+            expected,
+            List.of(ColumnIdent.of("x")),
+            new Object[]{10},
+            new Object[]{20},
+            new Object[]{30},
+            new Object[]{40});
+    }
+
+    @Test
+    public void test_array_agg_over_rows_unbounded_preceding_current_row_frame_keeps_nulls() throws Throwable {
+        Object[] expected = new Object[]{
+            List.of(10),
+            List.of(10, 20),
+            Arrays.asList(10, 20, null),
+        };
+        assertEvaluate(
+            """
+                array_agg(x) OVER(
+                   ORDER BY x NULLS LAST ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+                )
+            """,
+            expected,
+            List.of(ColumnIdent.of("x")),
+            new Object[]{10},
+            new Object[]{20},
+            new Object[]{null}
+        );
+    }
+
+    @Test
+    public void test_array_agg_over_rows_1_preceding_1_following_frame() throws Throwable {
+        Object[] expected = new Object[]{
+            List.of(10, 20),
+            List.of(10, 20, 30),
+            List.of(20, 30, 40),
+            List.of(30, 40)
+        };
+        assertEvaluate(
+            """
+                array_agg(x) OVER(
+                   ORDER BY x ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING
+                )
+            """,
+            expected,
+            List.of(ColumnIdent.of("x")),
+            new Object[]{10},
+            new Object[]{20},
+            new Object[]{30},
+            new Object[]{40});
+    }
+
+    @Test
+    public void test_array_agg_over_text_values_keeps_frame_order() throws Throwable {
+        Object[] expected = new Object[]{
+            List.of("c"),
+            List.of("c", "a"),
+            List.of("c", "a", "b")
+        };
+        assertEvaluate(
+            """
+                array_agg(z) OVER(
+                    ORDER BY x ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+                )
+            """,
+            expected,
+            List.of(ColumnIdent.of("x"), ColumnIdent.of("z")),
+            new Object[]{1, "c"},
+            new Object[]{2, "a"},
+            new Object[]{3, "b"});
+    }
+
+    @Test
+    public void test_array_agg_over_shrinking_frame_with_duplicate_text_values() throws Throwable {
+        Object[] expected = new Object[]{
+            List.of("b"),
+            List.of("b", "a"),
+            List.of("a", "b"),
+            List.of("b", "a")
+        };
+        assertEvaluate(
+            """
+                array_agg(z) OVER(
+                   ORDER BY x ROWS BETWEEN 1 PRECEDING AND CURRENT ROW
+                )
+            """,
+            expected,
+            List.of(ColumnIdent.of("x"), ColumnIdent.of("z")),
+            new Object[]{1, "b"},
+            new Object[]{2, "a"},
+            new Object[]{3, "b"},
+            new Object[]{4, "a"});
     }
 }


### PR DESCRIPTION
Previously `array_agg`'s `terminatePartial()` was returning a shared
state, therefore a new window frame would simply add values to the
existing state (`List<Object>`) without resetting.

Implement `optimizeForExecutionAsWindowFunction()` by returning a
sub-class which overrides `terminatePartial()` and
`removeFromAggregatedState()`.

Fixes: #19980