### PR TITLE
Fix regexp `~` and `~*` not working for INDEX OFF cols

### DIFF
--- a/docs/appendices/release-notes/6.4.4.rst
+++ b/docs/appendices/release-notes/6.4.4.rst
@@ -64,3 +64,10 @@ Fixes
 
 - Fixed an issue that caused under-accounting of memory usage for queries using
   :ref:`array_agg() <aggregation-array-agg>` aggregation function.
+
+- Fixed and issue that caused ``~`` and ``~*``
+  :ref:`regular expression operators <sql_dql_regexp>` to not match any rows
+  when used in the ``WHERE`` clause of a query on column with
+  :ref:`INDEX OFF <sql_ddl_index_off>`, e.g.::
+
+    SELECT * FROM tbl WHERE no_index_col ~ '[a-z]'

--- a/server/src/main/java/io/crate/expression/operator/RegexpMatchCaseInsensitiveOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/RegexpMatchCaseInsensitiveOperator.java
@@ -31,6 +31,7 @@ import io.crate.expression.symbol.Literal;
 import io.crate.lucene.match.RegexQuery;
 import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
+import io.crate.metadata.IndexType;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
 import io.crate.metadata.TransactionContext;
@@ -77,6 +78,9 @@ public class RegexpMatchCaseInsensitiveOperator extends Operator<String> {
 
     @Override
     public Query toQuery(Reference ref, Literal<?> literal) {
+        if (ref.indexType().equals(IndexType.NONE)) {
+            return null;
+        }
         String pattern = (String) literal.value();
         return new RegexQuery(
             new Term(ref.storageIdent(), pattern),

--- a/server/src/main/java/io/crate/expression/operator/RegexpMatchOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/RegexpMatchOperator.java
@@ -39,6 +39,7 @@ import io.crate.expression.symbol.Literal;
 import io.crate.lucene.match.RegexQuery;
 import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
+import io.crate.metadata.IndexType;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
 import io.crate.metadata.TransactionContext;
@@ -92,6 +93,9 @@ public class RegexpMatchOperator extends Operator<String> {
 
     @Override
     public Query toQuery(Reference ref, Literal<?> literal) {
+        if (ref.indexType().equals(IndexType.NONE)) {
+            return null;
+        }
         String pattern = (String) literal.value();
         Term term = new Term(ref.storageIdent(), pattern);
         if (RegexpFlags.isPcrePattern(pattern)) {

--- a/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
@@ -217,6 +217,14 @@ public class CommonQueryBuilderTest extends LuceneQueryBuilderTest {
         assertThat(scoreQuery.getQuery()).isExactlyInstanceOf(RegexpQuery.class);
     }
 
+    @Test
+    public void test_regex_query_without_index() throws Exception {
+        Query query = convert("text_no_index ~ '[a-z]'");
+        assertThat(query).isExactlyInstanceOf(GenericFunctionQuery.class);
+        query = convert("text_no_index ~* '[a-z]'");
+        assertThat(query).isExactlyInstanceOf(GenericFunctionQuery.class);
+    }
+
     /**
      * When using PCRE features, switch to different
      * regex implementation on top of java.util.regex.
@@ -225,6 +233,14 @@ public class CommonQueryBuilderTest extends LuceneQueryBuilderTest {
     public void testRegexQueryPcre() throws Exception {
         Query query = convert("name ~ '\\D'");
         assertThat(query).isExactlyInstanceOf(RegexQuery.class);
+    }
+
+    @Test
+    public void test_regex_query_prce_without_index() throws Exception {
+        Query query = convert("text_no_index ~ '\\D'");
+        assertThat(query).isExactlyInstanceOf(GenericFunctionQuery.class);
+        query = convert("text_no_index ~* '\\D'");
+        assertThat(query).isExactlyInstanceOf(GenericFunctionQuery.class);
     }
 
     @Test


### PR DESCRIPTION
The `IndexType` was not checked, and a Regex/Regexp query was created which, as expected, didn't work for cols without index. Check for `INDEX OFF` and return `null` to fallback to `GenericFunctionQuery`.

Fixes: #20003
