### PR TITLE
Copy OpenDAL's native libraries into the lib/ directory

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -76,6 +76,34 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>${versions.plugin.dependency}</version>
+                <executions>
+                    <execution>
+                        <!-- The goal is to copy native libraries into the `lib/` directory,
+                         and this is the first part, to unpack them. -->
+                        <id>unpack-opendal-native-lib</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.apache.opendal</groupId>
+                                    <artifactId>opendal</artifactId>
+                                    <version>${versions.opendal}</version>
+                                    <classifier>${os.classifier}</classifier>
+                                    <outputDirectory>${project.build.directory}/opendal-native</outputDirectory>
+                                    <includes>native/**</includes>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>io.github.git-commit-id</groupId>
                 <artifactId>git-commit-id-maven-plugin</artifactId>
                 <version>${versions.plugin.git-commit}</version>

--- a/app/src/assembly/src.xml
+++ b/app/src/assembly/src.xml
@@ -44,6 +44,10 @@
       </includes>
     </fileSet>
     <fileSet>
+      <directory>${project.build.directory}/opendal-native/native/${os.classifier}</directory>
+      <outputDirectory>lib</outputDirectory>
+    </fileSet>
+    <fileSet>
       <directory>src/main/dist/config</directory>
       <outputDirectory>config</outputDirectory>
       <includes>
@@ -134,6 +138,9 @@
         <exclude>io.crate:es-repository-azure</exclude>
         <exclude>io.crate:repository-gcs</exclude>
         <exclude>io.crate:dns-discovery</exclude>
+
+        <!-- native lib is copied flat into lib/ instead, see opendal-native fileSet above -->
+        <exclude>org.apache.opendal:opendal:jar:${os.classifier}</exclude>
       </excludes>
     </dependencySet>
   </dependencySets>

--- a/app/src/main/dist/bin/crate
+++ b/app/src/main/dist/bin/crate
@@ -170,6 +170,8 @@ if [ "x$CRATE_HEAP_DUMP_PATH" != "x" ]; then
     JAVA_OPTS="$JAVA_OPTS -XX:HeapDumpPath=$CRATE_HEAP_DUMP_PATH"
 fi
 
+JAVA_OPTS="$JAVA_OPTS -Djava.library.path=$CRATE_HOME/lib"
+
 JAVA="$CRATE_HOME/jdk/bin/java"
 
 if [ -z "$CRATE_CLASSPATH" ]; then

--- a/app/src/main/dist/bin/crate.bat
+++ b/app/src/main/dist/bin/crate.bat
@@ -100,6 +100,8 @@ if NOT "%CRATE_HEAP_DUMP_PATH%" == "" (
     set JAVA_OPTS=%JAVA_OPTS% -XX:HeapDumpPath=%CRATE_HEAP_DUMP_PATH%
 )
 
+set JAVA_OPTS=%JAVA_OPTS% -Djava.library.path=%CRATE_HOME%\lib
+
 if "%CRATE_CLASSPATH%" == "" (
     set CRATE_CLASSPATH=%CRATE_HOME%/lib/*
 ) else (


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Fixes #19827.

The OpenDAL Java binding uses the OpenDAL Core in the form of a native library (DLL for Windows). Native libraries cannot be loaded from JARs directly, which is why they are first extracted into a temporary directory. 

On Windows, every extracted native library gets a random name. The temporary DLL is locked until the JVM fully exists, and  there's no automatic process that cleans up those.

Hence, to solve that, we can either:

* make sure the temp. files when CrateDB starts up (e.g., by using a fixed tmp. sub-directory, and then always deleting when bootstraping)
  - cons: there will be edge cases, like when someone changes the tmp. directory, which can't be handled.  
* make sure the DLL is **not** part of a JAR, so that it doesn't need to extracted in the first place
  -  pros: can be a uniform solution for all platforms, already supported by JVM and OpenDAL (we can use the -Djava.library.path variable)
* lazily load the native libraries 
  - could work as well, but still more complex then (2).

This PR implements option 2 ("move" the native libraries out of the OpenDAL JAR, into the CrateDB distribution).

**Testing**:

I tested the Linux distribution, which is built in the same way as a Windows one. With `lib/libopendal_java.so`, without `lib/opendal-0.50.1-linux-x86_64.jar`, and without `java.library.path` set, CrateDB can't start. With `java.library.path` it starts correctly, which means that `lib/libopendal_java.so` is loaded.

I also tested it by creating an Azure repository (using Azurite), and taking a snapshot, that worked too.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes.
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [x] This does not contain breaking changes
