### PR TITLE
Fix RamAccounting for `collect_set`

### DIFF
--- a/docs/appendices/release-notes/6.4.4.rst
+++ b/docs/appendices/release-notes/6.4.4.rst
@@ -63,9 +63,10 @@ Fixes
   operations as intended.
 
 - Fixed an issue that caused under-accounting of memory usage for queries using
-  :ref:`array_agg() <aggregation-array-agg>` aggregation function.
+  :ref:`array_agg() <aggregation-array-agg>` aggregation function and
+  aggregation queries using ``DISTINCT``.
 
-- Fixed and issue that caused ``~`` and ``~*``
+- Fixed an issue that caused ``~`` and ``~*``
   :ref:`regular expression operators <sql_dql_regexp>` to not match any rows
   when used in the ``WHERE`` clause of a query on column with
   :ref:`INDEX OFF <sql_ddl_index_off>`, e.g.::

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/ArrayAgg.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/ArrayAgg.java
@@ -81,9 +81,8 @@ public final class ArrayAgg extends AggregationFunction<List<Object>, List<Objec
     public List<Object> newState(RamAccounting ramAccounting,
                                  Version minNodeInCluster,
                                  MemoryManager memoryManager) {
-        List<Object> state = new ArrayList<>();
-        ramAccounting.addBytes(RamUsageEstimator.sizeOfCollection(state));
-        return state;
+        ramAccounting.addBytes(RamUsageEstimator.alignObjectSize(40L)); // ArrayList overhead
+        return new ArrayList<>();
     }
 
     @Override

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/CollectSetAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/CollectSetAggregation.java
@@ -147,6 +147,7 @@ public class CollectSetAggregation extends AggregationFunction<Map<Object, Objec
 
     @Override
     public List<Object> terminatePartial(RamAccounting ramAccounting, Map<Object, Object> state) {
+        ramAccounting.addBytes(RamUsageEstimator.alignObjectSize(40L)); // Overhead for ArrayList
         return new ArrayList<>(state.keySet());
     }
 
@@ -265,6 +266,7 @@ public class CollectSetAggregation extends AggregationFunction<Map<Object, Objec
 
         @Override
         public List<Object> terminatePartial(RamAccounting ramAccounting, Map<Object, Long> state) {
+            ramAccounting.addBytes(RamUsageEstimator.alignObjectSize(40L)); // Overhead for ArrayList
             return new ArrayList<>(state.keySet());
         }
 

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/CollectSetAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/CollectSetAggregationTest.java
@@ -31,6 +31,7 @@ import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.junit.Test;
 
 import io.crate.data.Input;
+import io.crate.data.breaker.RamAccounting;
 import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.expression.symbol.Literal;
 import io.crate.metadata.FunctionImplementation;
@@ -39,6 +40,7 @@ import io.crate.metadata.Scalar;
 import io.crate.metadata.SearchPath;
 import io.crate.metadata.functions.Signature;
 import io.crate.operation.aggregation.AggregationTestCase;
+import io.crate.testing.PlainRamAccounting;
 import io.crate.types.ArrayType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -104,18 +106,42 @@ public class CollectSetAggregationTest extends AggregationTestCase {
     @SuppressWarnings("unchecked")
     @Test
     public void test_value_adding_and_removal() {
+        var aggregationFunction = (AggregationFunction<Object, Object>) nodeCtx.functions().get(
+            null, "collect_set", List.of(Literal.of(DataTypes.LONG, null)), SearchPath.pathWithPGCatalogAndDoc());
+
+        RamAccounting ramAccounting = new PlainRamAccounting();
+        Object state = aggregationFunction.newState(ramAccounting, Version.CURRENT, memoryManager);
+        assertThat(ramAccounting.totalBytes()).isEqualTo(64L);
+        state = aggregationFunction.iterate(ramAccounting, memoryManager, state, Literal.of(10L));
+        state = aggregationFunction.iterate(ramAccounting, memoryManager, state, Literal.of(20L));
+        state = aggregationFunction.iterate(ramAccounting, memoryManager, state, Literal.of(10L));
+        assertThat(ramAccounting.totalBytes()).isEqualTo(256L);
+
+        Object values = aggregationFunction.terminatePartial(ramAccounting, state);
+        assertThat(ramAccounting.totalBytes()).isEqualTo(296L);
+        assertThat((List<Object>) values).containsExactlyInAnyOrder(10L, 20L);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void test_value_adding_and_removal_window_function_opt() {
         var impl = (AggregationFunction<Object, Object>) nodeCtx.functions().get(
             null, "collect_set", List.of(Literal.of(DataTypes.LONG, null)), SearchPath.pathWithPGCatalogAndDoc());
         var aggregationFunction = (AggregationFunction<Object, Object>) impl.optimizeForExecutionAsWindowFunction(Version.CURRENT);
 
-        Object state = aggregationFunction.newState(RAM_ACCOUNTING, Version.CURRENT, memoryManager);
-        state = aggregationFunction.iterate(RAM_ACCOUNTING, memoryManager, state, Literal.of(10L));
-        state = aggregationFunction.iterate(RAM_ACCOUNTING, memoryManager, state, Literal.of(10L));
+        RamAccounting ramAccounting = new PlainRamAccounting();
+        Object state = aggregationFunction.newState(ramAccounting, Version.CURRENT, memoryManager);
+        assertThat(ramAccounting.totalBytes()).isEqualTo(64L);
+        state = aggregationFunction.iterate(ramAccounting, memoryManager, state, Literal.of(10L));
+        state = aggregationFunction.iterate(ramAccounting, memoryManager, state, Literal.of(10L));
+        assertThat(ramAccounting.totalBytes()).isEqualTo(136L);
 
-        aggregationFunction.removeFromAggregatedState(RAM_ACCOUNTING, state, new Input[] { Literal.of(10L) });
-        aggregationFunction.removeFromAggregatedState(RAM_ACCOUNTING, state, new Input[] { Literal.of(10L) });
+        aggregationFunction.removeFromAggregatedState(ramAccounting, state, new Input[] { Literal.of(10L) });
+        aggregationFunction.removeFromAggregatedState(ramAccounting, state, new Input[] { Literal.of(10L) });
+        assertThat(ramAccounting.totalBytes()).isEqualTo(64L);
 
-        Object values = aggregationFunction.terminatePartial(RAM_ACCOUNTING, state);
+        Object values = aggregationFunction.terminatePartial(ramAccounting, state);
+        assertThat(ramAccounting.totalBytes()).isEqualTo(104L);
         assertThat((List<Object>) values).isEmpty();
     }
 

--- a/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
@@ -236,7 +236,7 @@ public class CommonQueryBuilderTest extends LuceneQueryBuilderTest {
     }
 
     @Test
-    public void test_regex_query_prce_without_index() throws Exception {
+    public void test_regex_query_pcre_without_index() throws Exception {
         Query query = convert("text_no_index ~ '\\D'");
         assertThat(query).isExactlyInstanceOf(GenericFunctionQuery.class);
         query = convert("text_no_index ~* '\\D'");


### PR DESCRIPTION
- `collect_set`'s `terminatePartial` didn't account for the new ArrayList
    created, and returned.

- Simplify ramaccounting for ArrayAgg by using a static number to avoid calls to RamUsageEstimator.
   Follows: #20005

- tests: fix typo in test name
   Follows: #20010

