### PR TITLE
Fix null = ALL(<empty>) incorrect results

### DIFF
--- a/docs/appendices/release-notes/6.4.4.rst
+++ b/docs/appendices/release-notes/6.4.4.rst
@@ -104,3 +104,6 @@ Fixes
 
     SELECT array_agg(x) OVER(
       ORDER BY x ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) FROM tbl
+
+- Fixed an issue where :ref:`ALL <sql_all_subquery_expresion>` did not return
+  ``TRUE`` when comparing ``NULL`` values against an empty array.

--- a/docs/general/builtins/subquery-expressions.rst
+++ b/docs/general/builtins/subquery-expressions.rst
@@ -114,6 +114,8 @@ The operator returns ``NULL`` if:
       e.g. ``(x,y) = ANY (select x, y from t)``
 
 
+.. _sql_all_subquery_expresion:
+
 ``ALL (subquery)``
 ------------------
 

--- a/server/src/main/java/io/crate/expression/operator/Operator.java
+++ b/server/src/main/java/io/crate/expression/operator/Operator.java
@@ -44,8 +44,10 @@ public abstract class Operator<I> extends Scalar<Boolean, I> {
 
     @Override
     public Symbol normalizeSymbol(Function function, TransactionContext txnCtx, NodeContext nodeCtx) {
-        // all operators evaluates to NULL if one argument is NULL
+        // Many operators evaluates to NULL if one argument is NULL
         // let's handle this here to prevent unnecessary collect operations
+        // Some operators handle NULL arguments differently though. Override
+        // this if needed
         for (Symbol symbol : function.arguments()) {
             if (symbol instanceof Input && ((Input<?>) symbol).value() == null) {
                 return Literal.of(RETURN_TYPE, null);

--- a/server/src/main/java/io/crate/expression/operator/all/AllOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/all/AllOperator.java
@@ -105,12 +105,28 @@ public abstract sealed class AllOperator<T> extends Operator<T> permits AllEqOpe
     protected void validateRightArg(T arg) {
     }
 
+    @Override
+    public Symbol normalizeSymbol(Function function, TransactionContext txnCtx, NodeContext nodeCtx) {
+        try {
+            return evaluateIfLiterals(this, txnCtx, nodeCtx, function);
+        } catch (Throwable t) {
+            return function;
+        }
+    }
+
     @SuppressWarnings("unchecked")
     @SafeVarargs
     @Override
     public final Boolean evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<T>... args) {
         T leftValue = args[0].value();
         Collection<T> rightValues = (Collection<T>) args[1].value();
+
+        // ALL(<empty>) should return true no matter what the left value is.
+        // Therefore, check for rightValues being empty first
+        if (rightValues != null && rightValues.isEmpty()) {
+            return true;
+        }
+
         if (leftValue == null || rightValues == null) {
             return null;
         }

--- a/server/src/test/java/io/crate/expression/operator/AllOperatorTest.java
+++ b/server/src/test/java/io/crate/expression/operator/AllOperatorTest.java
@@ -24,6 +24,8 @@ package io.crate.expression.operator;
 import org.junit.Test;
 
 import io.crate.expression.scalar.ScalarTestCase;
+import io.crate.expression.symbol.Literal;
+import io.crate.types.DataTypes;
 
 public class AllOperatorTest extends ScalarTestCase {
 
@@ -58,6 +60,16 @@ public class AllOperatorTest extends ScalarTestCase {
     }
 
     @Test
+    public void test_null_eq_empty_array_is_true() {
+        assertEvaluate("id = ALL(ARRAY[]::array(INTEGER))", true, Literal.of(DataTypes.INTEGER, null));
+    }
+
+    @Test
+    public void test_literal_null_eq_empty_array_is_true() {
+        assertEvaluate("null = ALL(ARRAY[]::array(INTEGER))", true);
+    }
+
+    @Test
     public void test_automatically_levels_array_dimensions_to_left_arg() {
         assertEvaluate("1 = ALL([ [1] ])", true);
     }
@@ -85,5 +97,23 @@ public class AllOperatorTest extends ScalarTestCase {
         assertEvaluate("1 <= ALL(ARRAY[1, 1])", true);
         assertEvaluate("0 < ALL(ARRAY[1, 1])", true);
         assertEvaluate("3 <> ALL(ARRAY[1, 2])", true);
+    }
+
+    @Test
+    public void test_all_with_basic_cmp_operators_and_empty_array() {
+        assertEvaluate("id > ALL(ARRAY[]::array(INTEGER))", true, Literal.of(DataTypes.INTEGER, null));
+        assertEvaluate("id >= ALL(ARRAY[]::array(INTEGER))", true, Literal.of(DataTypes.INTEGER, null));
+        assertEvaluate("id < ALL(ARRAY[]::array(INTEGER))", true, Literal.of(DataTypes.INTEGER, null));
+        assertEvaluate("id <= ALL(ARRAY[]::array(INTEGER))", true, Literal.of(DataTypes.INTEGER, null));
+        assertEvaluate("id <> ALL(ARRAY[]::array(INTEGER))", true, Literal.of(DataTypes.INTEGER, null));
+    }
+
+    @Test
+    public void test_all_literal_null_with_basic_cmp_operators_and_empty_array() {
+        assertEvaluate("null > ALL(ARRAY[]::array(INTEGER))", true);
+        assertEvaluate("null >= ALL(ARRAY[]::array(INTEGER))", true);
+        assertEvaluate("null < ALL(ARRAY[]::array(INTEGER))", true);
+        assertEvaluate("null <= ALL(ARRAY[]::array(INTEGER))", true);
+        assertEvaluate("null <> ALL(ARRAY[]::array(INTEGER))", true);
     }
 }


### PR DESCRIPTION

## Summary of the changes / Why this improves CrateDB

Fixes https://github.com/crate/crate/issues/19922 and
Fixes https://github.com/crate/crate/issues/20013

The `ALL` operator should return true when the right value is
empty even if the left value is null[1]. This commit fixes a couple scenarios where the incorrect results were returned when `null = ALL(<empty>)`.

1. When the left value is a column that evaluates to null

There are different code paths that can be taken to evaluate the `ALL` operator depending on the table being queried.
From the reported issue, when the outer query is on a base table ("b"), the query plan is:

```
    cr> explain SELECT id FROM b WHERE id = ALL (SELECT id FROM t WHERE FALSE);
    +-------------------------------------------------------------------------------+
    | QUERY PLAN                                                                    |
    +-------------------------------------------------------------------------------+
    | MultiPhase (rows=unknown)                                                     |
    |   └ Collect[doc.b | [id] | (id = ALL((SELECT id FROM (s))))] (rows=unknown)   |
    |   └ Rename[id] AS doc.t (rows=unknown)                                        |
    |     └ Rename[id] AS s (rows=unknown)                                          |
    |       └ Eval[max(id) OVER (PARTITION BY x) AS id] (rows=unknown)              |
    |         └ OrderBy[max(id) OVER (PARTITION BY x) AS id ASC] (rows=unknown)     |
    |           └ WindowAgg[id, x] | [max(id) OVER (PARTITION BY x)] (rows=unknown) |
    |             └ Collect[doc.b | [id, x] | false] (rows=unknown)                 |
    +-------------------------------------------------------------------------------+
```
Note `Collect[doc.b | [id] | (id = ALL((SELECT id FROM (s))))] (rows=unknown)`

Here, we push the `ALL` evaluation down to lucene. That causes the `ALL` operator to be evaluated by `AllEqOperator`, (in the examples in the issue). This code path has a check for an empty
right value (the output of the subquery) and ultimately returns the correct data.

However, when the outer query is on a view that is on a window function, we do not push the
`ALL` evaluation to lucene.

Here is a query plan demonstrating this ("t" is a view built from a window function):

```
    cr> explain SELECT id FROM t WHERE id = ALL (SELECT id FROM b WHERE FALSE);
    +--------------------------------------------------------------------------------------------------+
    | QUERY PLAN                                                                                       |
    +--------------------------------------------------------------------------------------------------+
    | MultiPhase (rows=0)                                                                              |
    |   └ Rename[id] AS doc.t (rows=0)                                                                 |
    |     └ Rename[id] AS s (rows=0)                                                                   |
    |       └ Eval[max(id) OVER (PARTITION BY x) AS id] (rows=0)                                       |
    |         └ Filter[(max(id) OVER (PARTITION BY x) AS id = ALL((SELECT id FROM (doc.b))))] (rows=0) |
    |           └ WindowAgg[id, x] | [max(id) OVER (PARTITION BY x)] (rows=unknown)                    |
    |             └ Collect[doc.b | [id, x] | true] (rows=unknown)                                     |
    |   └ OrderBy[id ASC] (rows=unknown)                                                               |
    |     └ Collect[doc.b | [id] | false] (rows=unknown)                                               |
    +--------------------------------------------------------------------------------------------------+
```

Note the ALL operator is handled by the Filter and not the Collect in this plan.

This latter code path will go through `AllOperator::evaluate`.
The problem is that this would return early once it saw the leftValue == null.
We now prioritize the right value check for empty to fix this issue.

2. The other scenario where the wrong results were returned for the ALL operator is when the query has a null literal on the left value

The `Operator::normalizeSymbol` method returns early if there is an argument that evaluates to NULL.
That is relevant for most operators, but not for the ALL operator. We
now override `normalizeSymbol` in `AllOperator` so that the code falls
through to `AllOperator`

[1]: "The result of ALL is "true" if all rows yield true (including the case where the subquery returns no rows)."
    [postgres docs](https://www.postgresql.org/docs/9.0/functions-subquery.html#AEN16897:~:text=The%20result%20of%20ALL%20is%20%22true%22%20if%20all%20rows%20yield%20true%20(including%20the%20case%20where%20the%20subquery%20returns%20no%20rows).)
## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes.
       If you're an external contributor you can give yourself attribution and include your name and Github handle.
       e.g.:
       ```
       `John Doe <https://github.com/John_Doe>`_ added support for ...
       ```
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
