### PR TITLE
Ensure that GroupHashAggregate provides outputsToKeep according to its source outputs order

### DIFF
--- a/server/src/main/java/io/crate/planner/operators/GroupHashAggregate.java
+++ b/server/src/main/java/io/crate/planner/operators/GroupHashAggregate.java
@@ -259,18 +259,24 @@ public class GroupHashAggregate extends ForwardingLogicalPlan {
 
     @Override
     public LogicalPlan pruneOutputsExcept(SequencedCollection<Symbol> outputsToKeep) {
-        // Keep the same order and avoid introducing an Eval
-        ArrayList<Symbol> toKeep = new ArrayList<>();
+        HashSet<Symbol> required = new HashSet<>();
         // We cannot prune groupKeys, even if they are not used in the outputs, because it would change the result semantically
         for (Symbol groupKey : groupKeys) {
-            Symbols.intersection(groupKey, source.outputs(), toKeep::add);
+            Symbols.intersection(groupKey, source.outputs(), required::add);
         }
         ArrayList<Function> newAggregates = new ArrayList<>();
         for (Symbol outputToKeep : outputsToKeep) {
             Symbols.intersection(outputToKeep, aggregates, newAggregates::add);
         }
         for (Function newAggregate : newAggregates) {
-            Symbols.intersection(newAggregate, source.outputs(), toKeep::add);
+            Symbols.intersection(newAggregate, source.outputs(), required::add);
+        }
+        // Keep the same order of source outputs to follow method's contract.
+        ArrayList<Symbol> toKeep = new ArrayList<>();
+        for (Symbol sourceOutput : source.outputs()) {
+            if (required.contains(sourceOutput)) {
+                toKeep.add(sourceOutput);
+            }
         }
         LogicalPlan newSource = source.pruneOutputsExcept(toKeep);
         if (newSource == source && aggregates.size() == newAggregates.size()) {

--- a/server/src/test/java/io/crate/planner/consumer/GroupByPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/consumer/GroupByPlannerTest.java
@@ -24,7 +24,6 @@ package io.crate.planner.consumer;
 import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.Asserts.isReference;
 import static java.util.Collections.singletonList;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.util.List;
@@ -54,6 +53,7 @@ import io.crate.planner.ExecutionPlan;
 import io.crate.planner.Merge;
 import io.crate.planner.PositionalOrderBy;
 import io.crate.planner.node.dql.Collect;
+import io.crate.planner.operators.LogicalPlan;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.Asserts;
 import io.crate.testing.SQLExecutor;
@@ -708,6 +708,27 @@ public class GroupByPlannerTest extends CrateDummyClusterServiceUnitTest {
         ExecutionPlan executionPlan = e.plan("select count(*), city from clustered_parted where date=1395874800000 or date=1395961200000 group by city");
         assertThat(executionPlan).isExactlyInstanceOf(Merge.class);
         assertThat(((Merge) executionPlan).subPlan()).isExactlyInstanceOf(Merge.class);
+    }
+
+    @Test
+    public void test_group_by_columns_reversed_order_pruning_keeps_source_column_order() throws Exception {
+        var e = SQLExecutor.builder(clusterService)
+            .setNumNodes(2)
+            .build()
+            .addTable("create table doc.t (c0 int, c1 int, c2 int, c3 int)");
+
+        LogicalPlan logicalPlan = e.logicalPlan(
+            """
+            SELECT c0, c1, min(c2) FROM (SELECT c0, c1, c2, c3 FROM doc.t) s GROUP BY c1, c0
+            """);
+        String expectedPlan =
+            """
+            Eval[c0, c1, min(c2)]
+              └ GroupHashAggregate[c1, c0 | min(c2)]
+                └ Rename[c0, c1, c2] AS s
+                  └ Collect[doc.t | [c0, c1, c2] | true]
+            """;
+        assertThat(logicalPlan).isEqualTo(expectedPlan);
     }
 
     @Test

--- a/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
@@ -698,13 +698,13 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
             "    │  └ Union[ai, \"avg(x)\", \"cast(i AS BIGINT)\"]",
             "    │    ├ Eval[cast(a AS INTEGER) AS ai, avg(x), cast(i AS BIGINT)]",
             "    │    │  └ GroupHashAggregate[cast(a AS INTEGER) AS ai, cast(i AS BIGINT) | avg(x)]",
-            "    │    │    └ Collect[doc.t1 | [cast(a AS INTEGER) AS ai, cast(i AS BIGINT), x] | (a = '1')]",
+            "    │    │    └ Collect[doc.t1 | [x, cast(a AS INTEGER) AS ai, cast(i AS BIGINT)] | (a = '1')]",
             "    │    └ Eval[cast(a AS INTEGER) AS ai, avg(x), cast(i AS BIGINT)]",
             "    │      └ GroupHashAggregate[cast(a AS INTEGER) AS ai, cast(i AS BIGINT) | avg(x)]",
-            "    │        └ Collect[doc.t1 | [cast(a AS INTEGER) AS ai, cast(i AS BIGINT), x] | (a = '2')]",
+            "    │        └ Collect[doc.t1 | [x, cast(a AS INTEGER) AS ai, cast(i AS BIGINT)] | (a = '2')]",
             "    └ Eval[cast(a AS INTEGER) AS ai, avg(x), cast(i AS BIGINT)]",
             "      └ GroupHashAggregate[cast(a AS INTEGER) AS ai, cast(i AS BIGINT) | avg(x)]",
-            "        └ Collect[doc.t1 | [cast(a AS INTEGER) AS ai, cast(i AS BIGINT), x] | (a = '3')]"
+            "        └ Collect[doc.t1 | [x, cast(a AS INTEGER) AS ai, cast(i AS BIGINT)] | (a = '3')]"
         );
     }
 
@@ -726,13 +726,13 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
             "    │  └ Union[ai, \"avg(x)\", \"cast(i AS BIGINT)\"]",
             "    │    ├ Eval[cast(a AS INTEGER) AS ai, avg(x), cast(i AS BIGINT)]",
             "    │    │  └ GroupHashAggregate[cast(a AS INTEGER) AS ai, cast(i AS BIGINT) | avg(x)]",
-            "    │    │    └ Collect[doc.t1 | [cast(a AS INTEGER) AS ai, cast(i AS BIGINT), x] | (a = '1')]",
+            "    │    │    └ Collect[doc.t1 | [x, cast(a AS INTEGER) AS ai, cast(i AS BIGINT)] | (a = '1')]",
             "    │    └ Eval[cast(a AS INTEGER) AS ai, avg(x), cast(i AS BIGINT)]",
             "    │      └ GroupHashAggregate[cast(a AS INTEGER) AS ai, cast(i AS BIGINT) | avg(x)]",
-            "    │        └ Collect[doc.t1 | [cast(a AS INTEGER) AS ai, cast(i AS BIGINT), x] | (a = '2')]",
+            "    │        └ Collect[doc.t1 | [x, cast(a AS INTEGER) AS ai, cast(i AS BIGINT)] | (a = '2')]",
             "    └ Eval[cast(a AS INTEGER) AS ai, avg(x), cast(i AS BIGINT)]",
             "      └ GroupHashAggregate[cast(a AS INTEGER) AS ai, cast(i AS BIGINT) | avg(x)]",
-            "        └ Collect[doc.t1 | [cast(a AS INTEGER) AS ai, cast(i AS BIGINT), x] | (a = '3')]"
+            "        └ Collect[doc.t1 | [x, cast(a AS INTEGER) AS ai, cast(i AS BIGINT)] | (a = '3')]"
         );
     }
 


### PR DESCRIPTION
I confirmed that this fixes https://github.com/crate/crate/issues/19856 even with state before https://github.com/crate/crate/commit/c5f8cccf1adf734976e07d8651b3000c99111f35

No change entry as issue was resolved already with https://github.com/crate/crate/commit/c5f8cccf1adf734976e07d8651b3000c99111f35, 
this is a general improvement. 

It might address other possible issues, hence backporting to 6.4.


