### PR TITLE
Fix QuerySplitter dropping bare outer column filters

### DIFF
--- a/docs/appendices/release-notes/6.4.4.rst
+++ b/docs/appendices/release-notes/6.4.4.rst
@@ -82,3 +82,16 @@ Fixes
 
     SELECT * FROM t JOIN t AS t2 ON t.c = (select 1)
 
+
+- Fixed an issue that could cause a correlated subquery inside a join, to
+  ignore a filter on a bare boolean column of the outer relation. As a
+  consequence, it could return rows that should have been filtered out. e.g.::
+
+    SELECT (
+        SELECT count(*)
+        FROM t t1 CROSS JOIN t t2
+        WHERE t1.col = t2.col AND q.flag
+    )
+    FROM t q;
+
+  In this example, the ``q.flag`` filter was dropped.

--- a/server/src/main/java/io/crate/analyze/relations/QuerySplitter.java
+++ b/server/src/main/java/io/crate/analyze/relations/QuerySplitter.java
@@ -33,6 +33,7 @@ import io.crate.expression.symbol.AliasSymbol;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.MatchPredicate;
+import io.crate.expression.symbol.OuterColumn;
 import io.crate.expression.symbol.ScopedSymbol;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolVisitor;
@@ -152,6 +153,13 @@ public class QuerySplitter {
         public Void visitAlias(AliasSymbol aliasSymbol, Context ctx) {
             Set<RelationName> qualifiedNames = RelationNames.getShallow(aliasSymbol);
             ctx.parts.merge(qualifiedNames, aliasSymbol, AndOperator::of);
+            return null;
+        }
+
+        @Override
+        public Void visitOuterColumn(OuterColumn outerColumn, Context ctx) {
+            Set<RelationName> qualifiedNames = RelationNames.getShallow(outerColumn.symbol());
+            ctx.parts.merge(qualifiedNames, outerColumn, AndOperator::of);
             return null;
         }
     }

--- a/server/src/test/java/io/crate/analyze/relations/QuerySplitterTest.java
+++ b/server/src/test/java/io/crate/analyze/relations/QuerySplitterTest.java
@@ -33,6 +33,7 @@ import org.junit.Test;
 
 import io.crate.expression.operator.AndOperator;
 import io.crate.expression.symbol.AliasSymbol;
+import io.crate.expression.symbol.OuterColumn;
 import io.crate.expression.symbol.ScopedSymbol;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.ColumnIdent;
@@ -172,5 +173,37 @@ public class QuerySplitterTest extends CrateDummyClusterServiceUnitTest {
         assertThat(split).hasSize(2);
         assertThat(split.get(Set.of(tr1))).isEqualTo(alias);
         assertThat(split.get(Set.of(tr2))).isEqualTo(rightQuery);
+    }
+
+    // tracks a bug: https://github.com/crate/crate/issues/20002
+    @Test
+    public void test_split_preserves_outer_column_boolean_predicates() {
+        Symbol firstFlag = new SimpleReference(
+            tr1,
+            ColumnIdent.of("first_flag"),
+            RowGranularity.DOC,
+            DataTypes.BOOLEAN,
+            0,
+            null
+        );
+        Symbol secondFlag = new SimpleReference(
+            tr1,
+            ColumnIdent.of("second_flag"),
+            RowGranularity.DOC,
+            DataTypes.BOOLEAN,
+            1,
+            null
+        );
+        var relation = T3.sources(List.of(T3.T1), clusterService).get(tr1);
+        Symbol firstOuterColumn = new OuterColumn(relation, firstFlag);
+        Symbol secondOuterColumn = new OuterColumn(relation, secondFlag);
+        Symbol normalQuery = asSymbol("t2.y = 1");
+        Symbol query = AndOperator.join(List.of(firstOuterColumn, secondOuterColumn, normalQuery));
+
+        Map<Set<RelationName>, Symbol> split = QuerySplitter.split(query);
+
+        assertThat(split).hasSize(2);
+        assertThat(split.get(Set.of(tr1))).isEqualTo(AndOperator.of(firstOuterColumn, secondOuterColumn));
+        assertThat(split.get(Set.of(tr2))).isEqualTo(normalQuery);
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes https://github.com/crate/crate/issues/20002.

The reported scenario can be reduced to:
```
CREATE TABLE b (name TEXT, w BOOLEAN);
INSERT INTO b VALUES ('abc', false);

SELECT (
  SELECT COUNT(*)
  FROM (
      SELECT l.name
      FROM b l CROSS JOIN b r
      WHERE l.name = r.name
  ) v
  WHERE q.w
)
FROM b q;
```
And below is `explain verbose` output:
```
+------------------------------------------------------+--------------------------------------------------------------------+
| STEP                                                 | QUERY PLAN                                                         |
+------------------------------------------------------+--------------------------------------------------------------------+
| Initial logical plan                                 | Limit[2::bigint;0::bigint] (rows=1)                                |
|                                                      |   └ HashAggregate[count(*)] (rows=1)                               |
|                                                      |     └ Filter[w] (rows=0)                                           |
|                                                      |       └ Rename[name] AS v (rows=0)                                 |
|                                                      |         └ Eval[name] (rows=0)                                      |
|                                                      |           └ Filter[(name = name)] (rows=0)                         |
|                                                      |             └ Join[CROSS] (rows=unknown)                           |
|                                                      |               ├ Rename[name] AS l (rows=unknown)                   |
|                                                      |               │  └ Collect[doc.b | [name] | true] (rows=unknown)   |
|                                                      |               └ Rename[name] AS r (rows=unknown)                   |
|                                                      |                 └ Collect[doc.b | [name] | true] (rows=unknown)    |
| optimizer_move_filter_beneath_rename                 | Limit[2::bigint;0::bigint] (rows=1)                                |
|                                                      |   └ HashAggregate[count(*)] (rows=1)                               |
|                                                      |     └ Rename[name] AS v (rows=0)                                   |
|                                                      |       └ Filter[w] (rows=0)                                         |
|                                                      |         └ Eval[name] (rows=0)                                      |
|                                                      |           └ Filter[(name = name)] (rows=0)                         |
|                                                      |             └ Join[CROSS] (rows=unknown)                           |
|                                                      |               ├ Rename[name] AS l (rows=unknown)                   |
|                                                      |               │  └ Collect[doc.b | [name] | true] (rows=unknown)   |
|                                                      |               └ Rename[name] AS r (rows=unknown)                   |
|                                                      |                 └ Collect[doc.b | [name] | true] (rows=unknown)    |
| optimizer_move_filter_beneath_eval                   | Limit[2::bigint;0::bigint] (rows=1)                                |
|                                                      |   └ HashAggregate[count(*)] (rows=1)                               |
|                                                      |     └ Rename[name] AS v (rows=0)                                   |
|                                                      |       └ Eval[name] (rows=0)                                        |
|                                                      |         └ Filter[w] (rows=0)                                       |
|                                                      |           └ Filter[(name = name)] (rows=0)                         |
|                                                      |             └ Join[CROSS] (rows=unknown)                           |
|                                                      |               ├ Rename[name] AS l (rows=unknown)                   |
|                                                      |               │  └ Collect[doc.b | [name] | true] (rows=unknown)   |
|                                                      |               └ Rename[name] AS r (rows=unknown)                   |
|                                                      |                 └ Collect[doc.b | [name] | true] (rows=unknown)    |
| optimizer_merge_filters                              | Limit[2::bigint;0::bigint] (rows=1)                                |
|                                                      |   └ HashAggregate[count(*)] (rows=1)                               |
|                                                      |     └ Rename[name] AS v (rows=0)                                   |
|                                                      |       └ Eval[name] (rows=0)                                        |
|                                                      |         └ Filter[(w AND (name = name))] (rows=0)                   |
|                                                      |           └ Join[CROSS] (rows=unknown)                             |
|                                                      |             ├ Rename[name] AS l (rows=unknown)                     |
|                                                      |             │  └ Collect[doc.b | [name] | true] (rows=unknown)     |
|                                                      |             └ Rename[name] AS r (rows=unknown)                     |
|                                                      |               └ Collect[doc.b | [name] | true] (rows=unknown)      |
| optimizer_rewrite_filter_on_cross_join_to_inner_join | Limit[2::bigint;0::bigint] (rows=1)                                |
|                                                      |   └ HashAggregate[count(*)] (rows=1)                               |
|                                                      |     └ Rename[name] AS v (rows=unknown)                             |
|                                                      |       └ Eval[name] (rows=unknown)                                  |
|                                                      |         └ Join[INNER | (name = name)] (rows=unknown)               |
|                                                      |           ├ Rename[name] AS l (rows=unknown)                       |
|                                                      |           │  └ Collect[doc.b | [name] | true] (rows=unknown)       |
|                                                      |           └ Rename[name] AS r (rows=unknown)                       |
|                                                      |             └ Collect[doc.b | [name] | true] (rows=unknown)        |
| optimizer_rewrite_join_plan                          | Limit[2::bigint;0::bigint] (rows=1)                                |
|                                                      |   └ HashAggregate[count(*)] (rows=1)                               |
|                                                      |     └ Rename[name] AS v (rows=unknown)                             |
|                                                      |       └ Eval[name] (rows=unknown)                                  |
|                                                      |         └ HashJoin[INNER | (name = name)] (rows=unknown)           |
|                                                      |           ├ Rename[name] AS l (rows=unknown)                       |
|                                                      |           │  └ Collect[doc.b | [name] | true] (rows=unknown)       |
|                                                      |           └ Rename[name] AS r (rows=unknown)                       |
|                                                      |             └ Collect[doc.b | [name] | true] (rows=unknown)        |
| Final logical plan                                   | Eval[(SELECT count(*) FROM (v))] (rows=unknown)                    |
|                                                      |   └ CorrelatedJoin[w, (SELECT count(*) FROM (v))] (rows=unknown)   |
|                                                      |     └ Rename[w] AS q (rows=unknown)                                |
|                                                      |       └ Collect[doc.b | [w] | true] (rows=unknown)                 |
|                                                      |     └ SubPlan                                                      |
|                                                      |       └ Limit[2::bigint;0::bigint] (rows=1)                        |
|                                                      |         └ HashAggregate[count(*)] (rows=1)                         |
|                                                      |           └ Rename[] AS v (rows=unknown)                           |
|                                                      |             └ Eval[] (rows=unknown)                                |
|                                                      |               └ HashJoin[INNER | (name = name)] (rows=unknown)     |
|                                                      |                 ├ Rename[name] AS l (rows=unknown)                 |
|                                                      |                 │  └ Collect[doc.b | [name] | true] (rows=unknown) |
|                                                      |                 └ Rename[name] AS r (rows=unknown)                 |
|                                                      |                   └ Collect[doc.b | [name] | true] (rows=unknown)  |
+------------------------------------------------------+--------------------------------------------------------------------+
EXPLAIN 7 rows in set (0.022 sec)
```

`optimizer_rewrite_filter_on_cross_join_to_inner_join` lost correlated boolean filters because `QuerySplitter` didn’t override `visitOuterColumn`, causing the filters to be dropped.

Relates: #19839

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes.
       If you're an external contributor you can give yourself attribution and include your name and Github handle.
       e.g.:
       ```
       `John Doe <https://github.com/John_Doe>`_ added support for ...
       ```
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
