### PR TITLE
Fix filtered nested CROSS JOIN rewrite to nested INNER JOINs

### DIFF
--- a/docs/appendices/release-notes/6.4.4.rst
+++ b/docs/appendices/release-notes/6.4.4.rst
@@ -132,3 +132,19 @@ Fixes
         SELECT 2147483648::bigint AS x
     ) AS u
     WHERE x > 2147483647;
+
+- Fixed an issue that caused queries with filtered nested ``CROSS JOIN``s to
+  return incorrect results when ``optimizer_eliminate_cross_join`` was set to
+  ``false`` and a filter above the join tree referenced only one side of the
+  current cross join, e.g.::
+
+    SET optimizer_eliminate_cross_join = false;
+
+    SELECT t1.x, t2.y, t3.z
+    FROM t1
+    CROSS JOIN t2
+    CROSS JOIN t3
+    WHERE t1.x = t2.y
+      AND t1.x = t3.z
+      AND t2.y = t3.z;
+

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathJoin.java
@@ -120,9 +120,7 @@ public final class MoveFilterBeneathJoin implements Rule<Filter> {
         }
         var splitQueries = QuerySplitter.split(query);
         final int initialParts = splitQueries.size();
-        if (splitQueries.size() == 1 && splitQueries.keySet().iterator().next().size() > 1) {
-            return null;
-        }
+
         var lhs = join.lhs();
         var rhs = join.rhs();
 

--- a/server/src/main/java/io/crate/planner/optimizer/rule/RewriteFilterOnCrossJoinToInnerJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/RewriteFilterOnCrossJoinToInnerJoin.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.Set;
 
 import io.crate.analyze.relations.QuerySplitter;
+import io.crate.common.collections.Sets;
 import io.crate.expression.operator.AndOperator;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.RelationName;
@@ -71,7 +72,8 @@ public final class RewriteFilterOnCrossJoinToInnerJoin implements Rule<Filter> {
         JoinPlan crossJoin = captures.get(joinCapture);
 
         Map<Set<RelationName>, Symbol> filterQuery = QuerySplitter.split(equiJoinConditionFilter.query());
-        HashSet<RelationName> relationNamesInFilterQuery = new HashSet<>();
+        HashSet<RelationName> lhsRelations = new HashSet<>(crossJoin.lhs().relationNames());
+        HashSet<RelationName> rhsRelations = new HashSet<>(crossJoin.rhs().relationNames());
 
         ArrayList<Symbol> newJoinCondition = new ArrayList<>();
         ArrayList<Symbol> newFilterQuery = new ArrayList<>();
@@ -79,19 +81,16 @@ public final class RewriteFilterOnCrossJoinToInnerJoin implements Rule<Filter> {
         for (var entry : filterQuery.entrySet()) {
             Set<RelationName> key = entry.getKey();
             Symbol value = entry.getValue();
-            if (EquiJoinDetector.isEquiJoin(value)) {
-                relationNamesInFilterQuery.addAll(key);
+            boolean referencesLhs = Sets.intersection(key, lhsRelations).isEmpty() == false;
+            boolean referencesRhs = Sets.intersection(key, rhsRelations).isEmpty() == false;
+            if (EquiJoinDetector.isEquiJoin(value) && referencesLhs && referencesRhs) {
                 newJoinCondition.add(value);
             } else {
                 newFilterQuery.add(value);
             }
         }
 
-        HashSet<RelationName> sources = new HashSet<>();
-        sources.addAll(crossJoin.lhs().relationNames());
-        sources.addAll(crossJoin.rhs().relationNames());
-
-        if (sources.containsAll(relationNamesInFilterQuery)) {
+        if (newJoinCondition.isEmpty() == false) {
             return Filter.create(
                 new JoinPlan(
                     crossJoin.lhs(),

--- a/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
@@ -1618,11 +1618,12 @@ public class JoinIntegrationTest extends IntegTestCase {
         execute("explain (costs false) " + stmt);
 
         assertThat(response).hasLines(
-            "HashJoin[INNER | ((a = c) AND (b = c))]",
-            "  ├ HashJoin[INNER | ((a = b) AND (x = y))]",
-            "  │  ├ Collect[doc.t1 | [a, x] | true]",
-            "  │  └ Collect[doc.t2 | [b, y] | true]",
-            "  └ Collect[doc.t3 | [c] | true]"
+            "Eval[a, x, b, y, c]",
+            "  └ HashJoin[INNER | (((b = c) AND (a = b)) AND (x = y))]",
+            "    ├ HashJoin[INNER | (a = c)]",
+            "    │  ├ Collect[doc.t1 | [a, x] | true]",
+            "    │  └ Collect[doc.t3 | [c] | true]",
+            "    └ Collect[doc.t2 | [b, y] | true]"
         );
 
         execute(stmt);

--- a/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
@@ -66,6 +66,7 @@ import io.crate.planner.DependencyCarrier;
 import io.crate.planner.Plan;
 import io.crate.planner.node.dql.QueryThenFetch;
 import io.crate.planner.optimizer.rule.EquiJoinToLookupJoin;
+import io.crate.planner.optimizer.rule.EliminateCrossJoin;
 import io.crate.statistics.ColumnStats;
 import io.crate.statistics.MostCommonValues;
 import io.crate.statistics.Stats;
@@ -84,6 +85,7 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
             .addTable(TableDefinitions.USER_TABLE_DEFINITION)
             .addTable(T3.T1_DEFINITION)
             .addTable(T3.T2_DEFINITION)
+            .addTable(T3.T3_DEFINITION)
             .addView(new RelationName("doc", "v2"), "SELECT a, x FROM doc.t1")
             .addView(new RelationName("doc", "v3"), "SELECT a, x FROM doc.t1");
     }
@@ -564,6 +566,35 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
                 └ HashJoin[INNER | (a = b)]
                   ├ Collect[doc.t1 | [_fetchid, a] | true]
                   └ Collect[doc.t2 | [_fetchid, b] | true]
+            """
+        );
+    }
+
+    @Test
+    public void test_filter_on_nested_cross_join_to_nested_inner_joins() {
+        sqlExecutor.getSessionSettings().excludedOptimizerRules().add(EliminateCrossJoin.class);
+
+        LogicalPlan plan = plan("""
+            SELECT t1.x, t2.y, t3.z
+            FROM t1
+            CROSS JOIN t2
+            CROSS JOIN t3
+            WHERE t1.x = t2.y
+              AND t1.x = t3.z
+              AND t2.y = t3.z
+              AND t1.x > 1
+              AND t2.y > 2
+              AND t3.z > 3
+            """
+        );
+
+        assertThat(plan).isEqualTo(
+            """
+            HashJoin[INNER | ((x = z) AND (y = z))]
+              ├ HashJoin[INNER | (x = y)]
+              │  ├ Collect[doc.t1 | [x] | (x > 1)]
+              │  └ Collect[doc.t2 | [y] | (y > 2)]
+              └ Collect[doc.t3 | [z] | (z > 3)]
             """
         );
     }

--- a/server/src/test/java/io/crate/planner/optimizer/rule/MoveFilterBeneathJoinTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/rule/MoveFilterBeneathJoinTest.java
@@ -442,6 +442,41 @@ public class MoveFilterBeneathJoinTest extends CrateDummyClusterServiceUnitTest 
     }
 
     @Test
+    public void test_push_filter_referencing_multiple_relations_down_to_nested_join() {
+        var join1 = new JoinPlan(t1, t2, JoinType.CROSS, null);
+        var join2 = new JoinPlan(join1, t3, JoinType.INNER, e.asSymbol("doc.t2.b = doc.t3.c"));
+        var filter = new Filter(join2, e.asSymbol("doc.t1.a = doc.t2.b"));
+
+        assertThat(filter).hasOperators(
+            "Filter[(a = b)]",
+            "  └ Join[INNER | (b = c)]",
+            "    ├ Join[CROSS]",
+            "    │  ├ Collect[doc.t1 | [a] | true]",
+            "    │  └ Collect[doc.t2 | [b] | true]",
+            "    └ Collect[doc.t3 | [c] | true]"
+        );
+
+        var rule = new MoveFilterBeneathJoin();
+        var match = rule.pattern().accept(filter, Captures.empty());
+
+        assertThat(match.isPresent()).isTrue();
+        assertThat(match.value()).isEqualTo(filter);
+
+        var result = rule.apply(match.value(),
+            match.captures(),
+            e.ruleContext());
+
+        assertThat(result).hasOperators(
+            "Join[INNER | (b = c)]",
+            "  ├ Filter[(a = b)]",
+            "  │  └ Join[CROSS]",
+            "  │    ├ Collect[doc.t1 | [a] | true]",
+            "  │    └ Collect[doc.t2 | [b] | true]",
+            "  └ Collect[doc.t3 | [c] | true]"
+        );
+    }
+
+    @Test
     public void test_push_filter_down_to_preserved_side_of_left_nested_join() {
         var joinCondition1 = e.asSymbol("doc.t1.a = doc.t2.b");
         var join1 = new JoinPlan(t1, t2, JoinType.LEFT, joinCondition1);

--- a/server/src/test/java/io/crate/planner/optimizer/rule/RewriteFilterOnCrossJoinToInnerJoinTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/rule/RewriteFilterOnCrossJoinToInnerJoinTest.java
@@ -140,11 +140,12 @@ public class RewriteFilterOnCrossJoinToInnerJoinTest extends CrateDummyClusterSe
             e.ruleContext());
 
         assertThat(result).hasOperators(
-            "Join[INNER | ((a = b) AND (a = c))]",
-            "  ├ Collect[doc.t3 | [c] | true]",
-            "  └ Join[CROSS]",
-            "    ├ Collect[doc.t1 | [a] | true]",
-            "    └ Collect[doc.t2 | [b] | true]"
+            "Filter[(a = b)]",
+            "  └ Join[INNER | (a = c)]",
+            "    ├ Collect[doc.t3 | [c] | true]",
+            "    └ Join[CROSS]",
+            "      ├ Collect[doc.t1 | [a] | true]",
+            "      └ Collect[doc.t2 | [b] | true]"
         );
     }
 
@@ -174,8 +175,8 @@ public class RewriteFilterOnCrossJoinToInnerJoinTest extends CrateDummyClusterSe
             e.ruleContext());
 
         assertThat(result).hasOperators(
-            "Filter[(a > 1)]",
-            "  └ Join[INNER | ((a = b) AND (a = c))]",
+            "Filter[((a = b) AND (a > 1))]",
+            "  └ Join[INNER | (a = c)]",
             "    ├ Collect[doc.t3 | [c] | true]",
             "    └ Join[CROSS]",
             "      ├ Collect[doc.t1 | [a] | true]",


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Fixes https://github.com/crate/crate/issues/20023.

Please see the scenario below:
```
CREATE TABLE t1 (x int);
CREATE TABLE t2 (y int);
CREATE TABLE t3 (z int);

SET optimizer_eliminate_cross_join = false;

EXPLAIN SELECT t1.x, t2.y, t3.z
FROM t1
CROSS JOIN t2
CROSS JOIN t3
WHERE t1.x = t2.y
  AND t1.x = t3.z
  AND t2.y = t3.z;
```
Before this fix, the plan output is:
```
+--------------------------------------------------------------------------+
| QUERY PLAN                                                               |
+--------------------------------------------------------------------------+
| Eval[x, y, z] (rows=unknown)                                             |
|   └ HashJoin[INNER | (((x = y) AND (x = z)) AND (y = z))] (rows=unknown) |
|     ├ NestedLoopJoin[CROSS] (rows=unknown)                               |
|     │  ├ Collect[doc.t3 | [z] | true] (rows=unknown)                     |
|     │  └ Collect[doc.t2 | [y] | true] (rows=unknown)                     |
|     └ Collect[doc.t1 | [x] | true] (rows=unknown)                        |
+--------------------------------------------------------------------------+
```
The root cause is the top-level inner join, `HashJoin[INNER | (((x = y) AND (x = z)) AND (y = z))]`. It includes `y=z` which does not reference both LHS and RHS of the join. During the execution of the hash join, `y=z` affects the hash calculation for only one side causing hash mismatch and missing rows.

Ideally, `y = z` should be pushed down to the lower-level join. Once it is placed above the lower cross join, that cross join can also be rewritten to an inner join, resulting in:
```
+------------------------------------------------------------+
| QUERY PLAN                                                 |
+------------------------------------------------------------+
| Eval[x, y, z] (rows=unknown)                               |
|   └ HashJoin[INNER | ((x = y) AND (x = z))] (rows=unknown) |
|     ├ HashJoin[INNER | (y = z)] (rows=unknown)             |
|     │  ├ Collect[doc.t3 | [z] | true] (rows=unknown)       |
|     │  └ Collect[doc.t2 | [y] | true] (rows=unknown)       |
|     └ Collect[doc.t1 | [x] | true] (rows=unknown)          |
+------------------------------------------------------------+
```

For this to happen:
1. `RewriteFilterOnCrossJoinToInnerJoin` must preserve filters unrelated to the current cross join (`y = z` in this case).
2. `MoveFilterBeneathJoin` must be able to push down the filter preserved in step 1.
3. `RewriteFilterOnCrossJoinToInnerJoin` can then rewrite the lower-level cross join to an inner join.

Below is the `explain verbose` output after the fix:
```
+------------------------------------------------------+------------------------------------------------------------+
| STEP                                                 | QUERY PLAN                                                 |
+------------------------------------------------------+------------------------------------------------------------+
| Initial logical plan                                 | Eval[x, y, z] (rows=0)                                     |
|                                                      |   └ Filter[(((x = y) AND (x = z)) AND (y = z))] (rows=0)   |
|                                                      |     └ Join[CROSS] (rows=unknown)                           |
|                                                      |       ├ Join[CROSS] (rows=unknown)                         |
|                                                      |       │  ├ Collect[doc.t3 | [z] | true] (rows=unknown)     |
|                                                      |       │  └ Collect[doc.t2 | [y] | true] (rows=unknown)     |
|                                                      |       └ Collect[doc.t1 | [x] | true] (rows=unknown)        |
| optimizer_rewrite_filter_on_cross_join_to_inner_join | Eval[x, y, z] (rows=0)                                     |
|                                                      |   └ Filter[(y = z)] (rows=0)                               |
|                                                      |     └ Join[INNER | ((x = y) AND (x = z))] (rows=unknown)   |
|                                                      |       ├ Join[CROSS] (rows=unknown)                         |
|                                                      |       │  ├ Collect[doc.t3 | [z] | true] (rows=unknown)     |
|                                                      |       │  └ Collect[doc.t2 | [y] | true] (rows=unknown)     |
|                                                      |       └ Collect[doc.t1 | [x] | true] (rows=unknown)        |
| optimizer_move_filter_beneath_join                   | Eval[x, y, z] (rows=unknown)                               |
|                                                      |   └ Join[INNER | ((x = y) AND (x = z))] (rows=unknown)     |
|                                                      |     ├ Filter[(y = z)] (rows=0)                             |
|                                                      |     │  └ Join[CROSS] (rows=unknown)                        |
|                                                      |     │    ├ Collect[doc.t3 | [z] | true] (rows=unknown)     |
|                                                      |     │    └ Collect[doc.t2 | [y] | true] (rows=unknown)     |
|                                                      |     └ Collect[doc.t1 | [x] | true] (rows=unknown)          |
| optimizer_rewrite_join_plan                          | Eval[x, y, z] (rows=unknown)                               |
|                                                      |   └ HashJoin[INNER | ((x = y) AND (x = z))] (rows=unknown) |
|                                                      |     ├ Filter[(y = z)] (rows=0)                             |
|                                                      |     │  └ Join[CROSS] (rows=unknown)                        |
|                                                      |     │    ├ Collect[doc.t3 | [z] | true] (rows=unknown)     |
|                                                      |     │    └ Collect[doc.t2 | [y] | true] (rows=unknown)     |
|                                                      |     └ Collect[doc.t1 | [x] | true] (rows=unknown)          |
| optimizer_rewrite_filter_on_cross_join_to_inner_join | Eval[x, y, z] (rows=unknown)                               |
|                                                      |   └ HashJoin[INNER | ((x = y) AND (x = z))] (rows=unknown) |
|                                                      |     ├ Join[INNER | (y = z)] (rows=unknown)                 |
|                                                      |     │  ├ Collect[doc.t3 | [z] | true] (rows=unknown)       |
|                                                      |     │  └ Collect[doc.t2 | [y] | true] (rows=unknown)       |
|                                                      |     └ Collect[doc.t1 | [x] | true] (rows=unknown)          |
| optimizer_rewrite_join_plan                          | Eval[x, y, z] (rows=unknown)                               |
|                                                      |   └ HashJoin[INNER | ((x = y) AND (x = z))] (rows=unknown) |
|                                                      |     ├ HashJoin[INNER | (y = z)] (rows=unknown)             |
|                                                      |     │  ├ Collect[doc.t3 | [z] | true] (rows=unknown)       |
|                                                      |     │  └ Collect[doc.t2 | [y] | true] (rows=unknown)       |
|                                                      |     └ Collect[doc.t1 | [x] | true] (rows=unknown)          |
| Final logical plan                                   | Eval[x, y, z] (rows=unknown)                               |
|                                                      |   └ HashJoin[INNER | ((x = y) AND (x = z))] (rows=unknown) |
|                                                      |     ├ HashJoin[INNER | (y = z)] (rows=unknown)             |
|                                                      |     │  ├ Collect[doc.t3 | [z] | true] (rows=unknown)       |
|                                                      |     │  └ Collect[doc.t2 | [y] | true] (rows=unknown)       |
|                                                      |     └ Collect[doc.t1 | [x] | true] (rows=unknown)          |
+------------------------------------------------------+------------------------------------------------------------+

```

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes.
       If you're an external contributor you can give yourself attribution and include your name and Github handle.
       e.g.:
       ```
       `John Doe <https://github.com/John_Doe>`_ added support for ...
       ```
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
