### PR TITLE
Bump Postgres Wire Protocol to 15

### DIFF
--- a/docs/appendices/release-notes/6.5.0.rst
+++ b/docs/appendices/release-notes/6.5.0.rst
@@ -182,7 +182,8 @@ None
 Client interfaces
 -----------------
 
-Increased PostgreSQL wire protocol to `15` since `14` is being deprecated in November.
+- Increased the PostgreSQL wire protocol version announced to clients from
+  ``14`` to ``15``, since ``14`` is being deprecated in November.
 
 
 SQL Standard and PostgreSQL Compatibility

--- a/docs/appendices/release-notes/6.5.0.rst
+++ b/docs/appendices/release-notes/6.5.0.rst
@@ -182,7 +182,8 @@ None
 Client interfaces
 -----------------
 
-None
+Increased PostgreSQL wire protocol to `15` since `14` is being deprecated in November.
+
 
 SQL Standard and PostgreSQL Compatibility
 -----------------------------------------

--- a/docs/interfaces/postgres.rst
+++ b/docs/interfaces/postgres.rst
@@ -34,7 +34,7 @@ which is why clients should generally enable ``autocommit``.
 Server compatibility
 ====================
 
-CrateDB emulates PostgreSQL server version ``14``.
+CrateDB emulates PostgreSQL server version ``15``.
 
 
 .. _postgres-start-up:

--- a/server/src/main/java/io/crate/protocols/postgres/PostgresWireProtocol.java
+++ b/server/src/main/java/io/crate/protocols/postgres/PostgresWireProtocol.java
@@ -198,8 +198,8 @@ public class PostgresWireProtocol {
     private static final String PASSWORD_AUTH_NAME = "password";
     private static final int AUTH_TIMEOUT_SEC = 30;
 
-    public static final int SERVER_VERSION_NUM = 140000;
-    public static final String PG_SERVER_VERSION = "14.0";
+    public static final int SERVER_VERSION_NUM = 150000;
+    public static final String PG_SERVER_VERSION = "15.0";
 
     public static final List<String> SUPPORTED_STARTUP_PROPERTIES = List.of(
         "user",

--- a/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
@@ -305,8 +305,8 @@ public class PgCatalogITest extends IntegTestCase {
             "optimizer_rewrite_right_outer_join_to_hash_join| true| Indicates if the optimizer rule RewriteRightOuterJoinToHashJoin is activated.| NULL| NULL",
             "optimizer_rewrite_to_query_then_fetch| true| Indicates if the optimizer rule RewriteToQueryThenFetch is activated.| NULL| NULL",
             "search_path| doc| Sets the schema search order.| NULL| NULL",
-            "server_version| 14.0| Reports the emulated PostgreSQL version number| NULL| NULL",
-            "server_version_num| 140000| Reports the emulated PostgreSQL version number| NULL| NULL",
+            "server_version| 15.0| Reports the emulated PostgreSQL version number| NULL| NULL",
+            "server_version_num| 150000| Reports the emulated PostgreSQL version number| NULL| NULL",
             "standard_conforming_strings| on| Causes '...' strings to treat backslashes literally.| NULL| NULL",
             "statement_timeout| 10s| The maximum duration of any statement before it gets killed. Infinite/disabled if 0| NULL| NULL"
         );

--- a/server/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
@@ -450,8 +450,8 @@ public class ShowIntegrationTest extends IntegTestCase {
             "optimizer_rewrite_right_outer_join_to_hash_join| true| Indicates if the optimizer rule RewriteRightOuterJoinToHashJoin is activated.",
             "optimizer_rewrite_to_query_then_fetch| true| Indicates if the optimizer rule RewriteToQueryThenFetch is activated.",
             "search_path| doc| Sets the schema search order.",
-            "server_version| 14.0| Reports the emulated PostgreSQL version number",
-            "server_version_num| 140000| Reports the emulated PostgreSQL version number",
+            "server_version| 15.0| Reports the emulated PostgreSQL version number",
+            "server_version_num| 150000| Reports the emulated PostgreSQL version number",
             "standard_conforming_strings| on| Causes '...' strings to treat backslashes literally.",
             "statement_timeout| 0s| The maximum duration of any statement before it gets killed. Infinite/disabled if 0"
         );


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Postgres is deprecating 14 in November. Client interfaces have already stopped connecting to 14 (Django 6.1)

## Checklist

 - [X] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes.
       If you're an external contributor you can give yourself attribution and include your name and Github handle.
       e.g.:
       ```
       `John Doe <https://github.com/John_Doe>`_ added support for ...
       ```
 - [X] Updated documentation & `sql_features` table for user facing changes
 - [X] Touched code is covered by tests
 - [X] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
