### PR TITLE
Derive size for ArrayList to consider JVM settings

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/ArrayAgg.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/ArrayAgg.java
@@ -38,6 +38,7 @@ import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
 import io.crate.metadata.functions.TypeVariableConstraint;
+import io.crate.types.ArrayType;
 import io.crate.types.DataType;
 import io.crate.types.TypeSignature;
 
@@ -81,7 +82,7 @@ public class ArrayAgg extends AggregationFunction<List<Object>, List<Object>> {
     public List<Object> newState(RamAccounting ramAccounting,
                                  Version minNodeInCluster,
                                  MemoryManager memoryManager) {
-        ramAccounting.addBytes(RamUsageEstimator.alignObjectSize(40L)); // ArrayList overhead
+        ramAccounting.addBytes(RamUsageEstimator.alignObjectSize(ArrayType.ARRAY_LIST_SHALLOW_SIZE));
         return new ArrayList<>();
     }
 
@@ -125,7 +126,7 @@ public class ArrayAgg extends AggregationFunction<List<Object>, List<Object>> {
 
         @Override
         public List<Object> terminatePartial(RamAccounting ramAccounting, List<Object> state) {
-            ramAccounting.addBytes(RamUsageEstimator.alignObjectSize(40L)); // ArrayList overhead
+            ramAccounting.addBytes(RamUsageEstimator.alignObjectSize(ArrayType.ARRAY_LIST_SHALLOW_SIZE));
             return new ArrayList<>(state);
         }
 

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/CollectSetAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/CollectSetAggregation.java
@@ -147,7 +147,7 @@ public class CollectSetAggregation extends AggregationFunction<Map<Object, Objec
 
     @Override
     public List<Object> terminatePartial(RamAccounting ramAccounting, Map<Object, Object> state) {
-        ramAccounting.addBytes(RamUsageEstimator.alignObjectSize(40L)); // Overhead for ArrayList
+        ramAccounting.addBytes(RamUsageEstimator.alignObjectSize(ArrayType.ARRAY_LIST_SHALLOW_SIZE));
         return new ArrayList<>(state.keySet());
     }
 
@@ -266,7 +266,7 @@ public class CollectSetAggregation extends AggregationFunction<Map<Object, Objec
 
         @Override
         public List<Object> terminatePartial(RamAccounting ramAccounting, Map<Object, Long> state) {
-            ramAccounting.addBytes(RamUsageEstimator.alignObjectSize(40L)); // Overhead for ArrayList
+            ramAccounting.addBytes(RamUsageEstimator.alignObjectSize(ArrayType.ARRAY_LIST_SHALLOW_SIZE));
             return new ArrayList<>(state.keySet());
         }
 

--- a/server/src/main/java/io/crate/types/ArrayType.java
+++ b/server/src/main/java/io/crate/types/ArrayType.java
@@ -77,6 +77,7 @@ import io.crate.statistics.ColumnStatsSupport;
 public class ArrayType<T> extends DataType<List<T>> {
 
     public static final ArrayType<Object> ARRAY_OF_UNDEFINED = new ArrayType<>(UndefinedType.INSTANCE);
+    public static final long ARRAY_LIST_SHALLOW_SIZE = RamUsageEstimator.shallowSizeOfInstance(ArrayList.class);
 
     private static final long SHALLOW_SIZE = RamUsageEstimator.shallowSizeOfInstance(ArrayType.class);
 

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/ArrayAggTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/ArrayAggTest.java
@@ -90,12 +90,12 @@ public class ArrayAggTest extends AggregationTestCase {
         );
         RamAccounting ramAccounting = new PlainRamAccounting();
         Object state = impl.newState(ramAccounting, Version.CURRENT, memoryManager);
-        assertThat(ramAccounting.totalBytes()).isEqualTo(40L);
+        assertThat(ramAccounting.totalBytes()).isEqualTo(24L);
         impl.iterate(ramAccounting, memoryManager, state, Literal.of("trillian"));
         impl.iterate(ramAccounting, memoryManager, state, Literal.of("arthur"));
-        assertThat(ramAccounting.totalBytes()).isEqualTo(152L);
+        assertThat(ramAccounting.totalBytes()).isEqualTo(136L);
         impl.terminatePartial(ramAccounting, state);
-        assertThat(ramAccounting.totalBytes()).isEqualTo(152L);
+        assertThat(ramAccounting.totalBytes()).isEqualTo(136L);
     }
 
     @SuppressWarnings("unchecked")
@@ -114,16 +114,16 @@ public class ArrayAggTest extends AggregationTestCase {
         var impl = (AggregationFunction<Object, Object>) agg.optimizeForExecutionAsWindowFunction(Version.CURRENT);
         RamAccounting ramAccounting = new PlainRamAccounting();
         Object state = impl.newState(ramAccounting, Version.CURRENT, memoryManager);
-        assertThat(ramAccounting.totalBytes()).isEqualTo(40L);
+        assertThat(ramAccounting.totalBytes()).isEqualTo(24L);
         impl.iterate(ramAccounting, memoryManager, state, Literal.of("trillian"));
         impl.iterate(ramAccounting, memoryManager, state, Literal.of("arthur"));
         impl.iterate(ramAccounting, memoryManager, state, Literal.of("john"));
-        assertThat(ramAccounting.totalBytes()).isEqualTo(200L);
+        assertThat(ramAccounting.totalBytes()).isEqualTo(184L);
 
         impl.removeFromAggregatedState(ramAccounting, state, new Input[] { Literal.of("trillian") });
-        assertThat(ramAccounting.totalBytes()).isEqualTo(144L);
+        assertThat(ramAccounting.totalBytes()).isEqualTo(128L);
 
         impl.terminatePartial(ramAccounting, state);
-        assertThat(ramAccounting.totalBytes()).isEqualTo(184L);
+        assertThat(ramAccounting.totalBytes()).isEqualTo(152L);
     }
 }

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/CollectSetAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/CollectSetAggregationTest.java
@@ -21,7 +21,7 @@
 
 package io.crate.execution.engine.aggregation.impl;
 
-import static io.crate.testing.Asserts.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -118,7 +118,7 @@ public class CollectSetAggregationTest extends AggregationTestCase {
         assertThat(ramAccounting.totalBytes()).isEqualTo(256L);
 
         Object values = aggregationFunction.terminatePartial(ramAccounting, state);
-        assertThat(ramAccounting.totalBytes()).isEqualTo(296L);
+        assertThat(ramAccounting.totalBytes()).isEqualTo(280L);
         assertThat((List<Object>) values).containsExactlyInAnyOrder(10L, 20L);
     }
 
@@ -141,7 +141,7 @@ public class CollectSetAggregationTest extends AggregationTestCase {
         assertThat(ramAccounting.totalBytes()).isEqualTo(64L);
 
         Object values = aggregationFunction.terminatePartial(ramAccounting, state);
-        assertThat(ramAccounting.totalBytes()).isEqualTo(104L);
+        assertThat(ramAccounting.totalBytes()).isEqualTo(88L);
         assertThat((List<Object>) values).isEmpty();
     }
 


### PR DESCRIPTION
Follows https://github.com/crate/crate/pull/20014

Compressed refs and compressed classes settings influence the size of objects. For example:

    ***** Hotspot Layout Simulation (JDK 15, 64-bit model, compressed references, compressed classes, 8-byte aligned)
    java.util.ArrayList object internals:
    OFF  SZ                 TYPE DESCRIPTION               VALUE
      0   8                      (object header: mark)     N/A
      8   4                      (object header: class)    N/A
     12   4                  int AbstractList.modCount     N/A
     16   4                  int ArrayList.size            N/A
     20   4   java.lang.Object[] ArrayList.elementData     N/A
    Instance size: 24 bytes
    Space losses: 0 bytes internal + 0 bytes external = 0 bytes total

    ***** Hotspot Layout Simulation (JDK 15, 64-bit model, compressed references, compressed classes, 16-byte aligned)
    java.util.ArrayList object internals:
    OFF  SZ                 TYPE DESCRIPTION               VALUE
      0   8                      (object header: mark)     N/A
      8   4                      (object header: class)    N/A
     12   4                  int AbstractList.modCount     N/A
     16   4                  int ArrayList.size            N/A
     20   4   java.lang.Object[] ArrayList.elementData     N/A
     24   8                      (object alignment gap)
    Instance size: 32 bytes
    Space losses: 0 bytes internal + 8 bytes external = 8 bytes total

(cherry picked from commit 863ba8757051050ddac0a9825fac72d2ff532002)
