### PR TITLE
Fix union filter pushdown cast issue

### DIFF
--- a/docs/appendices/release-notes/6.4.4.rst
+++ b/docs/appendices/release-notes/6.4.4.rst
@@ -121,3 +121,14 @@ Fixes
 
 - Fixed an issue where :ref:`ANY <sql_any_subquery_expression>` did not return
   ``FALSE`` when comparing ``NULL`` against an empty array.
+
+- Fixed an issue when using :ref:`UNION ALL <sql-union>` where types were not
+  cast properly when the different union branches had different types, e.g::
+
+    SELECT count(*) AS cnt
+    FROM (
+        SELECT 1::integer AS x
+        UNION ALL
+        SELECT 2147483648::bigint AS x
+    ) AS u
+    WHERE x > 2147483647;

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathUnion.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathUnion.java
@@ -26,6 +26,7 @@ import static io.crate.planner.optimizer.matcher.Patterns.source;
 
 import java.util.List;
 
+import io.crate.expression.scalar.cast.CastMode;
 import io.crate.expression.symbol.FieldReplacer;
 import io.crate.expression.symbol.Symbol;
 import io.crate.planner.operators.Filter;
@@ -35,6 +36,8 @@ import io.crate.planner.optimizer.Rule;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
+import io.crate.types.DataType;
+import io.crate.types.DataTypes;
 
 public final class MoveFilterBeneathUnion implements Rule<Filter> {
 
@@ -73,7 +76,12 @@ public final class MoveFilterBeneathUnion implements Rule<Filter> {
                     "Field used in filter must be present in its source outputs." +
                     f + " missing in " + filter.source().outputs());
             }
-            return newSource.outputs().get(idx);
+            Symbol newField = newSource.outputs().get(idx);
+            if (!f.valueType().equals(newField.valueType())) {
+                DataType<?> commonType = DataTypes.merge(f.valueType(), newField.valueType());
+                newField = newField.cast(commonType, CastMode.IMPLICIT);
+            }
+            return newField;
         });
         return new Filter(newSource, newQuery);
     }

--- a/server/src/test/java/io/crate/integrationtests/UnionIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/UnionIntegrationTest.java
@@ -21,6 +21,7 @@
 
 package io.crate.integrationtests;
 
+import static io.crate.testing.Asserts.assertSQLError;
 import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.TestingHelpers.printedTable;
 
@@ -29,6 +30,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import io.crate.testing.UseJdbc;
+import io.crate.testing.UseRandomizedOptimizerRules;
 
 @IntegTestCase.ClusterScope(minNumDataNodes = 1)
 public class UnionIntegrationTest extends IntegTestCase {
@@ -331,5 +333,36 @@ public class UnionIntegrationTest extends IntegTestCase {
     public void test_null_literal_union_null_literal() {
         execute("select null from unnest([1, 2]) union select null from unnest([1])");
         assertThat(response).hasRows("NULL");
+    }
+
+    /**
+     * https://github.com/crate/crate/issues/20022
+     */
+    @UseRandomizedOptimizerRules(0)
+    @Test
+    public void test_union_filter_pushdown_cast_different_branch_types() throws Exception {
+        String query = "SELECT count(*) AS cnt FROM ( SELECT 1::integer AS x UNION ALL SELECT 2147483648::bigint AS x) AS u WHERE x > 2147483647";
+        // The left branch has the row as integer and the right branch has the row as bigint. Should cast the int up to bigint
+        execute("EXPLAIN (costs false) " + query);
+        assertThat(response).hasRows("""
+                Eval[count(*) AS cnt]
+                  └ HashAggregate[count(*)]
+                    └ Rename[] AS u
+                      └ Union[]
+                        ├ Filter[(1 AS x > 2147483647::bigint)]
+                        │  └ TableFunction[empty_row | [] | true]
+                        └ Filter[(2147483648::bigint AS x > 2147483647::bigint)]
+                          └ TableFunction[empty_row | [] | true]""");
+        execute(query);
+        assertThat(response).hasRows("1");
+    }
+
+    @UseRandomizedOptimizerRules(0)
+    @UseJdbc(0)
+    @Test
+    public void test_raises_if_cannot_cast_different_branch_types() throws Exception {
+        assertSQLError(() -> execute(
+                "SELECT count(*) AS cnt FROM ( SELECT 1::integer AS x UNION ALL SELECT 'cratedb' AS x) AS u WHERE x > 2147483647"))
+                .hasMessage("Cannot cast value `cratedb` to type `integer`");
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Fixes https://github.com/crate/crate/issues/20022

When pushing a filter beneath a UNION ALL with branches of different numeric types, we now cast according to allowed conversions (e.g., INTEGER → BIGINT). Otherwise, during execution, Java would try to cast Long to Integer and that would result in a ClassCastException at runtime.


## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes.
       If you're an external contributor you can give yourself attribution and include your name and Github handle.
       e.g.:
       ```
       `John Doe <https://github.com/John_Doe>`_ added support for ...
       ```
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
