### PR TITLE
Fix ram accounting for string_agg()

### DIFF
--- a/docs/appendices/release-notes/6.4.4.rst
+++ b/docs/appendices/release-notes/6.4.4.rst
@@ -107,3 +107,6 @@ Fixes
 
 - Fixed an issue where :ref:`ALL <sql_all_subquery_expresion>` did not return
   ``TRUE`` when comparing ``NULL`` values against an empty array.
+
+- Fixed an issue that caused wrong accounting of memory usage for queries using
+  :ref:`string_agg() <aggregation-string-agg>` aggregation function.

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/StringAgg.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/StringAgg.java
@@ -42,6 +42,7 @@ import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
+import io.crate.types.ArrayType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 
@@ -51,7 +52,7 @@ import io.crate.types.DataTypes;
  */
 public final class StringAgg extends AggregationFunction<StringAgg.StringAggState, String> {
 
-    private static final String NAME = "string_agg";
+    static final String NAME = "string_agg";
     public static final Signature SIGNATURE =
             Signature.builder(NAME, FunctionType.AGGREGATE)
                     .argumentTypes(DataTypes.STRING.getTypeSignature(),
@@ -74,16 +75,18 @@ public final class StringAgg extends AggregationFunction<StringAgg.StringAggStat
         );
     }
 
-    static class StringAggState implements Writeable {
+    public static class StringAggState implements Writeable {
 
         private final List<String> values;
         private String firstDelimiter;
 
-        public StringAggState() {
+        public static final long SHALLOW_SIZE = ArrayType.ARRAY_LIST_SHALLOW_SIZE;
+
+        private StringAggState() {
             values = new ArrayList<>();
         }
 
-        public StringAggState(StreamInput in) throws IOException {
+        private StringAggState(StreamInput in) throws IOException {
             values = in.readList(StreamInput::readString);
             firstDelimiter = in.readOptionalString();
         }
@@ -157,6 +160,7 @@ public final class StringAgg extends AggregationFunction<StringAgg.StringAggStat
     public StringAggState newState(RamAccounting ramAccounting,
                                    Version minNodeInCluster,
                                    MemoryManager memoryManager) {
+        ramAccounting.addBytes(StringAggState.SHALLOW_SIZE);
         return new StringAggState();
     }
 
@@ -200,7 +204,7 @@ public final class StringAgg extends AggregationFunction<StringAgg.StringAggStat
 
         int indexOfExpression = previousAggState.values.indexOf(expression);
         if (indexOfExpression > -1) {
-            ramAccounting.addBytes(-LIST_ENTRY_OVERHEAD + RamUsageEstimator.sizeOf(expression));
+            ramAccounting.addBytes(-(LIST_ENTRY_OVERHEAD + RamUsageEstimator.sizeOf(expression)));
             if (delimiter != null && indexOfExpression + 1 < previousAggState.values.size()) {
                 String elementNextToExpression = previousAggState.values.get(indexOfExpression + 1);
                 if (elementNextToExpression.equalsIgnoreCase(delimiter)) {

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/StringAggTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/StringAggTest.java
@@ -28,9 +28,17 @@ import java.util.List;
 import org.elasticsearch.Version;
 import org.junit.Test;
 
+import io.crate.data.Input;
+import io.crate.data.breaker.RamAccounting;
+import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.expression.symbol.Literal;
+import io.crate.metadata.FunctionType;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.BoundSignature;
+import io.crate.metadata.functions.Signature;
 import io.crate.operation.aggregation.AggregationTestCase;
+import io.crate.testing.PlainRamAccounting;
+import io.crate.types.DataTypes;
 
 public class StringAggTest extends AggregationTestCase {
 
@@ -88,5 +96,31 @@ public class StringAggTest extends AggregationTestCase {
         var result = stringAgg.terminatePartial(RAM_ACCOUNTING, mergedState);
 
         assertThat(result).isEqualTo("a;b,c;d");
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void test_array_agg_accounts_memory_for_state() throws Exception {
+        var impl = (AggregationFunction<Object, ?>) nodeCtx.functions().getQualified(
+            Signature.builder(StringAgg.NAME, FunctionType.AGGREGATE)
+                .argumentTypes(DataTypes.STRING.getTypeSignature(),
+                    DataTypes.STRING.getTypeSignature())
+                .returnType(DataTypes.STRING.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC)
+                .build(),
+            List.of(DataTypes.STRING),
+            DataTypes.STRING
+        );
+        RamAccounting ramAccounting = new PlainRamAccounting();
+        Object state = impl.newState(ramAccounting, Version.CURRENT, memoryManager);
+        assertThat(ramAccounting.totalBytes()).isEqualTo(24L);
+        impl.iterate(ramAccounting, memoryManager, state, Literal.of("trillian"), Literal.of("delim"));
+        impl.iterate(ramAccounting, memoryManager, state, Literal.of("arthur"), Literal.of("delimiter"));
+        assertThat(ramAccounting.totalBytes()).isEqualTo(296L);
+        impl.removeFromAggregatedState(ramAccounting, state,
+            new Input[] {Literal.of("trillian"), Literal.of("delim")});
+        assertThat(ramAccounting.totalBytes()).isEqualTo(208L);
+        impl.terminatePartial(ramAccounting, state);
+        assertThat(ramAccounting.totalBytes()).isEqualTo(208L);
     }
 }


### PR DESCRIPTION
Previously there was no size calculated for `newState()` and the `removeFromAggregatedState()` was not freeing all the memory reserved, because of missing parentheses in combinatio with the `-` symbol.
