### PR TITLE
Ensure WindowAgg.pruneOutputsExcept() maintains order of outputs

### DIFF
--- a/server/src/main/java/io/crate/planner/operators/LogicalPlan.java
+++ b/server/src/main/java/io/crate/planner/operators/LogicalPlan.java
@@ -257,7 +257,7 @@ public interface LogicalPlan extends Plan {
      */
     default <T extends Symbol> List<T> normalizePrunedOutputs(Collection<T> originalOutputs, Collection<T> prunedOutputs) {
         List<T> normalizedOutputs = new ArrayList<>();
-        for (T output: originalOutputs) {
+        for (T output : originalOutputs) {
             if (prunedOutputs.contains(output)) {
                 normalizedOutputs.add(output);
             }

--- a/server/src/main/java/io/crate/planner/operators/WindowAgg.java
+++ b/server/src/main/java/io/crate/planner/operators/WindowAgg.java
@@ -24,6 +24,7 @@ package io.crate.planner.operators;
 import static io.crate.execution.dsl.phases.ExecutionPhases.executesOnHandler;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -115,23 +116,31 @@ public class WindowAgg extends ForwardingLogicalPlan {
     @Override
     public LogicalPlan pruneOutputsExcept(SequencedCollection<Symbol> outputsToKeep) {
         LinkedHashSet<Symbol> toKeep = new LinkedHashSet<>();
-        ArrayList<WindowFunction> newWindowFunctions = new ArrayList<>();
+        HashSet<WindowFunction> windowFuncsUnordered = new HashSet<>();
         for (Symbol outputToKeep : outputsToKeep) {
-            Symbols.intersection(outputToKeep, windowFunctions, newWindowFunctions::add);
+            Symbols.intersection(outputToKeep, windowFunctions, windowFuncsUnordered::add);
             Symbols.intersection(outputToKeep, standalone, toKeep::add);
         }
-        for (WindowFunction newWindowFunction : newWindowFunctions) {
+        for (WindowFunction newWindowFunction : windowFuncsUnordered) {
             Symbols.intersection(newWindowFunction, source.outputs(), toKeep::add);
         }
         LogicalPlan newSource = source.pruneOutputsExcept(toKeep);
         if (newSource == source) {
             return this;
         }
-        if (newWindowFunctions.isEmpty()) {
+        if (windowFuncsUnordered.isEmpty()) {
             return newSource;
-        } else {
-            return new WindowAgg(newSource, windowDefinition, List.copyOf(newWindowFunctions), newSource.outputs());
         }
+        // NB: this.outputs() = windowFunctions() + newSource.outputs()
+        WindowAgg newWindowAgg = new WindowAgg(newSource,
+            windowDefinition,
+            normalizePrunedOutputs(windowFunctions(), windowFuncsUnordered),
+            newSource.outputs()
+        );
+        boolean isSubsequence = Lists.isSubsequence(newWindowAgg.outputs(), outputs());
+        assert isSubsequence : "pruneOutputsExcept must not shuffle the outputs, it can only remove some of them.";
+
+        return newWindowAgg;
     }
 
     public List<WindowFunction> windowFunctions() {

--- a/server/src/test/java/io/crate/planner/operators/WindowAggTest.java
+++ b/server/src/test/java/io/crate/planner/operators/WindowAggTest.java
@@ -25,12 +25,12 @@ import static io.crate.execution.engine.pipeline.LimitAndOffset.NO_LIMIT;
 import static io.crate.execution.engine.pipeline.LimitAndOffset.NO_OFFSET;
 import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.Asserts.isReference;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
 import java.util.Set;
 
 import org.elasticsearch.Version;
@@ -42,6 +42,7 @@ import org.junit.Test;
 
 import io.crate.analyze.OrderBy;
 import io.crate.analyze.WindowDefinition;
+import io.crate.common.collections.Lists;
 import io.crate.data.Row;
 import io.crate.execution.dsl.projection.builder.ProjectionBuilder;
 import io.crate.expression.scalar.SubscriptObjectFunction;
@@ -107,6 +108,33 @@ public class WindowAggTest extends CrateDummyClusterServiceUnitTest {
                   └ Collect[doc.t1 | [x, y] | true]
             """;
         assertThat(plan).isEqualTo(expectedPlan);
+    }
+
+    @Test
+    public void test_prune_outputs_except_preserves_window_function_order() throws Exception {
+        e.addTable("CREATE TABLE t2 (a int, b int, c int)");
+        LogicalPlan plan = plan("SELECT avg(a) OVER (), min(b) OVER (), max(c) OVER () FROM t2");
+        while (!(plan instanceof WindowAgg windowAgg)) {
+            plan = plan.sources().get(0);
+        }
+
+        assertThat(windowAgg.windowFunctions()).hasSize(3);
+        WindowFunction avg = windowAgg.windowFunctions().get(0);
+        WindowFunction min = windowAgg.windowFunctions().get(1);
+
+        // Drop max(c) (forces the source to actually shrink) and request the
+        // remaining functions in the reverse of their original order.
+        List<Symbol> outputsToKeep = List.of(min, avg);
+        LogicalPlan pruned = windowAgg.pruneOutputsExcept(outputsToKeep);
+
+        assertThat(pruned).isNotSameAs(windowAgg);
+        assertThat(pruned).isExactlyInstanceOf(WindowAgg.class);
+        WindowAgg prunedWindowAgg = (WindowAgg) pruned;
+
+        // Result must follow the original definition order, not the order passed to pruneOutputsExcept.
+        assertThat(prunedWindowAgg.windowFunctions()).containsExactly(avg, min);
+        assertThat(prunedWindowAgg.outputs()).containsExactlyElementsOf(
+            Lists.concat(prunedWindowAgg.source().outputs(), List.of(avg, min)));
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB


## Checklist

 - [ ] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes.
       If you're an external contributor you can give yourself attribution and include your name and Github handle.
       e.g.:
       ```
       `John Doe <https://github.com/John_Doe>`_ added support for ...
       ```
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
