### PR TITLE
Move `normalizePrunedOutputs` to `Lists`

### DIFF
--- a/libs/shared/src/main/java/io/crate/common/collections/Lists.java
+++ b/libs/shared/src/main/java/io/crate/common/collections/Lists.java
@@ -32,6 +32,7 @@ import java.util.ListIterator;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.RandomAccess;
+import java.util.SequencedCollection;
 import java.util.SequencedSet;
 import java.util.StringJoiner;
 import java.util.function.Function;
@@ -75,6 +76,17 @@ public final class Lists {
         }
 
         return isSubsequence;
+    }
+
+    /// Return a new list with the intersection of `items` and `matches`, based on the iteration order of `items`.
+    public static <T> List<T> intersection(SequencedCollection<T> items, Collection<T> matches) {
+        ArrayList<T> result = new ArrayList<>(matches.size());
+        for (T item : items) {
+            if (matches.contains(item)) {
+                result.add(item);
+            }
+        }
+        return result;
     }
 
     @SuppressWarnings("unchecked")

--- a/server/src/main/java/io/crate/planner/operators/Collect.java
+++ b/server/src/main/java/io/crate/planner/operators/Collect.java
@@ -350,7 +350,7 @@ public class Collect implements LogicalPlan {
         for (Symbol outputToKeep : outputsToKeep) {
             Symbols.intersection(outputToKeep, outputs, required::add);
         }
-        List<Symbol> prunedOutputs = normalizePrunedOutputs(outputs, required);
+        List<Symbol> prunedOutputs = Lists.intersection(outputs, required);
         if (prunedOutputs.size() == outputs.size()) {
             return this;
         }

--- a/server/src/main/java/io/crate/planner/operators/HashAggregate.java
+++ b/server/src/main/java/io/crate/planner/operators/HashAggregate.java
@@ -221,7 +221,7 @@ public class HashAggregate extends ForwardingLogicalPlan {
         if (source == newSource && newAggregates == aggregates) {
             return this;
         }
-        List<Function> prunedOutputs = normalizePrunedOutputs(aggregates, newAggregates);
+        List<Function> prunedOutputs = Lists.intersection(aggregates, newAggregates);
         boolean isSubsequence = Lists.isSubsequence(prunedOutputs, aggregates);
         assert isSubsequence : "pruneOutputsExcept must not shuffle the outputs, it can only remove some of them.";
         return new HashAggregate(newSource, prunedOutputs, rewriteDistinct);

--- a/server/src/main/java/io/crate/planner/operators/LogicalPlan.java
+++ b/server/src/main/java/io/crate/planner/operators/LogicalPlan.java
@@ -21,7 +21,6 @@
 
 package io.crate.planner.operators;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -249,19 +248,5 @@ public interface LogicalPlan extends Plan {
                 printContext.text(" (rows=" + stats.numDocs() + ")");
             }
         }
-    }
-
-    /**
-     * Returns list of outputs ordered according to outputs of this plan.
-     * @param prunedOutputs is outputs in arbitrary order
-     */
-    default <T extends Symbol> List<T> normalizePrunedOutputs(Collection<T> originalOutputs, Collection<T> prunedOutputs) {
-        List<T> normalizedOutputs = new ArrayList<>();
-        for (T output : originalOutputs) {
-            if (prunedOutputs.contains(output)) {
-                normalizedOutputs.add(output);
-            }
-        }
-        return normalizedOutputs;
     }
 }

--- a/server/src/main/java/io/crate/planner/operators/WindowAgg.java
+++ b/server/src/main/java/io/crate/planner/operators/WindowAgg.java
@@ -36,10 +36,10 @@ import java.util.function.Function;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.UUIDs;
 import org.jspecify.annotations.Nullable;
-import io.crate.common.annotations.VisibleForTesting;
 
 import io.crate.analyze.OrderBy;
 import io.crate.analyze.WindowDefinition;
+import io.crate.common.annotations.VisibleForTesting;
 import io.crate.common.collections.Lists;
 import io.crate.data.Row;
 import io.crate.execution.dsl.phases.MergePhase;
@@ -134,7 +134,7 @@ public class WindowAgg extends ForwardingLogicalPlan {
         // NB: this.outputs() = windowFunctions() + newSource.outputs()
         WindowAgg newWindowAgg = new WindowAgg(newSource,
             windowDefinition,
-            normalizePrunedOutputs(windowFunctions(), windowFuncsUnordered),
+            Lists.intersection(windowFunctions(), windowFuncsUnordered),
             newSource.outputs()
         );
         boolean isSubsequence = Lists.isSubsequence(newWindowAgg.outputs(), outputs());


### PR DESCRIPTION
The method can be static and is fairly generic.
Also the `prunedOutputs` naming is a bit confusing, as it reads like
"outputs that have been pruned" but it's actually the outputs that are
required to keep.
