### PR TITLE
Fix string_agg with dynamic delimeter

### DIFF
--- a/docs/appendices/release-notes/6.4.4.rst
+++ b/docs/appendices/release-notes/6.4.4.rst
@@ -110,3 +110,11 @@ Fixes
 
 - Fixed an issue that caused wrong accounting of memory usage for queries using
   :ref:`string_agg() <aggregation-string-agg>` aggregation function.
+
+- Fixed an issue that caused wrong results when
+  :ref:`string_agg() <aggregation-string-agg>` aggregation function was used with
+  :ref:`window functions <window-functions>` with a dynamic ``delimeter`` and an
+  explicit window frame, e.g.::
+
+    SELECT string_agg(value, delimiter) OVER(
+      ORDER BY value ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) FROM tbl

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/StringAgg.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/StringAgg.java
@@ -23,7 +23,9 @@ package io.crate.execution.engine.aggregation.impl;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 
 import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.Version;
@@ -75,26 +77,59 @@ public final class StringAgg extends AggregationFunction<StringAgg.StringAggStat
         );
     }
 
-    public static class StringAggState implements Writeable {
+    public record StringAggState(List<String> values, List<String> delimiters) implements Writeable {
 
-        private final List<String> values;
-        private String firstDelimiter;
+        private static final long SHALLOW_SIZE = 2 * ArrayType.ARRAY_LIST_SHALLOW_SIZE;
 
-        public static final long SHALLOW_SIZE = ArrayType.ARRAY_LIST_SHALLOW_SIZE;
-
-        private StringAggState() {
-            values = new ArrayList<>();
+        StringAggState() {
+            this(new ArrayList<>(), new ArrayList<>());
         }
 
         private StringAggState(StreamInput in) throws IOException {
-            values = in.readList(StreamInput::readString);
-            firstDelimiter = in.readOptionalString();
+            List<String> values;
+            List<String> delimiters;
+            if (in.getVersion().onOrAfter(Version.V_6_4_4)) {
+                values = in.readStringList();
+                int size = in.readVInt();
+                delimiters = new ArrayList<>(size);
+                for (int i = 0; i < size; i++) {
+                    delimiters.add(in.readOptionalString());
+                }
+            } else {
+                List<String> list = in.readStringList();
+                values = new ArrayList<>(list.size() / 2);
+                delimiters = new ArrayList<>(list.size() / 2);
+
+                String firstDelimiter = in.readOptionalString();
+                delimiters.add(firstDelimiter);
+
+                Iterator<String> iterator = list.iterator();
+                while (iterator.hasNext()) {
+                    values.add(iterator.next());
+                    delimiters.add(iterator.next());
+                }
+            }
+            this(values, delimiters);
         }
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeStringCollection(values);
-            out.writeOptionalString(firstDelimiter);
+            if (out.getVersion().onOrAfter(Version.V_6_4_4)) {
+                out.writeStringCollection(values);
+                out.writeVInt(delimiters.size());
+                for (String delimiter : delimiters) {
+                    out.writeOptionalString(delimiter);
+                }
+            } else {
+                out.writeVInt(values.size() + delimiters.size());
+                for (int i = 0; i < values.size(); i++) {
+                    out.writeString(values.get(i));
+                    if (i < values().size() - 1) {
+                        out.writeString(delimiters.get(i + 1));
+                    }
+                }
+                out.writeOptionalString(delimiters.isEmpty() ? null : delimiters.getFirst());
+            }
         }
     }
 
@@ -114,7 +149,7 @@ public final class StringAgg extends AggregationFunction<StringAgg.StringAggStat
 
         @Override
         public String getName() {
-            return "string_list";
+            return "string_lists";
         }
 
         @Override
@@ -176,14 +211,10 @@ public final class StringAgg extends AggregationFunction<StringAgg.StringAggStat
         ramAccounting.addBytes(LIST_ENTRY_OVERHEAD + RamUsageEstimator.sizeOf(expression));
         String delimiter = (String) args[1].value();
         if (delimiter != null) {
-            if (state.firstDelimiter == null && state.values.isEmpty()) {
-                state.firstDelimiter = delimiter;
-            } else {
-                ramAccounting.addBytes(LIST_ENTRY_OVERHEAD + RamUsageEstimator.sizeOf(delimiter));
-                state.values.add(delimiter);
-            }
+            ramAccounting.addBytes(LIST_ENTRY_OVERHEAD + RamUsageEstimator.sizeOf(delimiter));
         }
         state.values.add(expression);
+        state.delimiters.add(delimiter);
         return state;
     }
 
@@ -197,27 +228,15 @@ public final class StringAgg extends AggregationFunction<StringAgg.StringAggStat
                                                     StringAggState previousAggState,
                                                     Input<?>[] stateToRemove) {
         String expression = (String) stateToRemove[0].value();
-        if (expression == null) {
-            return previousAggState;
-        }
         String delimiter = (String) stateToRemove[1].value();
 
-        int indexOfExpression = previousAggState.values.indexOf(expression);
-        if (indexOfExpression > -1) {
-            ramAccounting.addBytes(-(LIST_ENTRY_OVERHEAD + RamUsageEstimator.sizeOf(expression)));
-            if (delimiter != null && indexOfExpression + 1 < previousAggState.values.size()) {
-                String elementNextToExpression = previousAggState.values.get(indexOfExpression + 1);
-                if (elementNextToExpression.equalsIgnoreCase(delimiter)) {
-                    previousAggState.values.remove(indexOfExpression + 1);
-                }
-            }
-            if (indexOfExpression == 0) {
-                // First element is removed, so next one will a new first.
-                // Reset state to avoid adding a delimiter before the "new first"
-                previousAggState.firstDelimiter = null;
-            }
-            previousAggState.values.remove(indexOfExpression);
-        }
+        String removed = previousAggState.values.removeFirst();
+        assert removed.equals(expression) : "AggregateToWindowFunctionAdapter should always remove the first state";
+        removed = previousAggState.delimiters.removeFirst();
+        assert Objects.equals(removed, delimiter) : "AggregateToWindowFunctionAdapter should always remove the first state";
+
+        ramAccounting.addBytes(-(LIST_ENTRY_OVERHEAD + RamUsageEstimator.sizeOf(expression)));
+        ramAccounting.addBytes(-(LIST_ENTRY_OVERHEAD + RamUsageEstimator.sizeOf(delimiter)));
         return previousAggState;
     }
 
@@ -229,22 +248,23 @@ public final class StringAgg extends AggregationFunction<StringAgg.StringAggStat
         if (state2.values.isEmpty()) {
             return state1;
         }
-        if (state2.firstDelimiter != null) {
-            state1.values.add(state2.firstDelimiter);
-        }
         state1.values.addAll(state2.values);
+        state1.delimiters.addAll(state2.delimiters);
         return state1;
     }
 
     @Override
     public String terminatePartial(RamAccounting ramAccounting, StringAggState state) {
-        List<String> values = state.values;
-        if (values.isEmpty()) {
+        if (state.values.isEmpty()) {
             return null;
         } else {
             var sb = new StringBuilder();
-            for (int i = 0; i < values.size(); i++) {
-                sb.append(values.get(i));
+            for (int i = 0; i < state.values.size(); i++) {
+                sb.append(state.values.get(i));
+                if (i < state.values.size() - 1) {
+                    int delimiterIndex = i + 1;
+                    sb.append(state.delimiters.get(delimiterIndex) == null ? "" : state.delimiters.get(delimiterIndex));
+                }
             }
             return sb.toString();
         }

--- a/server/src/main/java/org/elasticsearch/Version.java
+++ b/server/src/main/java/org/elasticsearch/Version.java
@@ -250,6 +250,7 @@ public class Version implements Comparable<Version> {
     public static final Version V_6_4_1 = new Version(9_04_01_99, false, org.apache.lucene.util.Version.LUCENE_10_4_0);
     public static final Version V_6_4_2 = new Version(9_04_02_99, false, org.apache.lucene.util.Version.LUCENE_10_4_0);
     public static final Version V_6_4_3 = new Version(9_04_03_99, false, org.apache.lucene.util.Version.LUCENE_10_4_0);
+    public static final Version V_6_4_4 = new Version(9_04_04_99, true, org.apache.lucene.util.Version.LUCENE_10_4_0);
 
     public static final Version V_6_5_0 = new Version(9_05_00_99, true, org.apache.lucene.util.Version.LUCENE_10_5_0);
 

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/StringAggStateTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/StringAggStateTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.execution.engine.aggregation.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.junit.Test;
+
+import io.crate.Streamer;
+
+public class StringAggStateTest {
+
+    @Test
+    public void testStreaming() throws Exception {
+        var state = new StringAgg.StringAggState();
+        state.values().addAll(List.of("a", "b", "c", "d"));
+        state.delimiters().addAll(Arrays.asList(new String[] {"|", ";", null, "~"}));
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        Streamer<StringAgg.StringAggState> streamer = StringAgg.StringAggStateType.INSTANCE.streamer();
+        streamer.writeValueTo(out, state);
+        StreamInput in = out.bytes().streamInput();
+        assertThat(streamer.readValueFrom(in)).isEqualTo(state);
+
+
+        out = new BytesStreamOutput();
+        out.setVersion(Version.V_6_4_4);
+        streamer.writeValueTo(out, state);
+        in = out.bytes().streamInput();
+        in.setVersion(Version.V_6_4_4);
+        assertThat(streamer.readValueFrom(in)).isEqualTo(state);
+    }
+}

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/StringAggTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/StringAggTest.java
@@ -113,14 +113,17 @@ public class StringAggTest extends AggregationTestCase {
         );
         RamAccounting ramAccounting = new PlainRamAccounting();
         Object state = impl.newState(ramAccounting, Version.CURRENT, memoryManager);
-        assertThat(ramAccounting.totalBytes()).isEqualTo(24L);
+        assertThat(ramAccounting.totalBytes()).isEqualTo(48L);
         impl.iterate(ramAccounting, memoryManager, state, Literal.of("trillian"), Literal.of("delim"));
-        impl.iterate(ramAccounting, memoryManager, state, Literal.of("arthur"), Literal.of("delimiter"));
-        assertThat(ramAccounting.totalBytes()).isEqualTo(296L);
-        impl.removeFromAggregatedState(ramAccounting, state,
+        impl.iterate(ramAccounting, memoryManager, state, Literal.of("arthur"), Literal.NULL);
+        impl.iterate(ramAccounting, memoryManager, state, Literal.of("john"), Literal.of("delimiter"));
+        assertThat(ramAccounting.totalBytes()).isEqualTo(488);
+        impl.removeFromAggregatedState(
+            ramAccounting,
+            state,
             new Input[] {Literal.of("trillian"), Literal.of("delim")});
-        assertThat(ramAccounting.totalBytes()).isEqualTo(208L);
+        assertThat(ramAccounting.totalBytes()).isEqualTo(312L);
         impl.terminatePartial(ramAccounting, state);
-        assertThat(ramAccounting.totalBytes()).isEqualTo(208L);
+        assertThat(ramAccounting.totalBytes()).isEqualTo(312L);
     }
 }

--- a/server/src/test/java/io/crate/execution/engine/window/AggregationWindowFunctionsTest.java
+++ b/server/src/test/java/io/crate/execution/engine/window/AggregationWindowFunctionsTest.java
@@ -522,6 +522,135 @@ public class AggregationWindowFunctionsTest extends AbstractWindowFunctionTest {
         );
     }
 
+
+    @Test
+    public void test_string_agg_with_per_row_delimiter_over_shrinking_frame() throws Throwable {
+        assertEvaluate(
+            """
+                string_agg(cast(x AS text), z) OVER(
+                   ORDER BY x ROWS BETWEEN 1 PRECEDING AND CURRENT ROW
+                )
+            """,
+            new Object[]{"1", "1;2", "2/3", "3~4"},
+            List.of(ColumnIdent.of("x"), ColumnIdent.of("z")),
+            new Object[]{1, "|"},
+            new Object[]{2, ";"},
+            new Object[]{3, "/"},
+            new Object[]{4, "~"});
+    }
+
+    @Test
+    public void test_string_agg_with_per_row_delimiter_over_frame_of_three_rows() throws Throwable {
+        assertEvaluate(
+            """
+                string_agg(cast(x AS text), z) OVER(
+                   ORDER BY x ROWS BETWEEN 2 PRECEDING AND CURRENT ROW
+                )
+            """,
+            new Object[]{"1", "1;2", "1;2/3", "2/3~4"},
+            List.of(ColumnIdent.of("x"), ColumnIdent.of("z")),
+            new Object[]{1, "|"},
+            new Object[]{2, ";"},
+            new Object[]{3, "/"},
+            new Object[]{4, "~"});
+    }
+
+    @Test
+    public void test_string_agg_with_per_row_delimiter_over_sliding_frame() throws Throwable {
+        assertEvaluate(
+            """
+                string_agg(cast(x AS text), z) OVER(
+                   ORDER BY x ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING
+                )
+            """,
+            new Object[]{"1;2", "1;2/3", "2/3~4", "3~4"},
+            List.of(ColumnIdent.of("x"), ColumnIdent.of("z")),
+            new Object[]{1, "|"},
+            new Object[]{2, ";"},
+            new Object[]{3, "/"},
+            new Object[]{4, "~"});
+    }
+
+    @Test
+    public void test_string_agg_with_null_delimiter_in_the_middle_over_shrinking_frame() throws Throwable {
+        assertEvaluate(
+            """
+                string_agg(cast(x AS text), z) OVER(
+                   ORDER BY x ROWS BETWEEN 1 PRECEDING AND CURRENT ROW
+                )
+            """,
+            new Object[]{"1", "1;2", "23", "3~4"},
+            List.of(ColumnIdent.of("x"), ColumnIdent.of("z")),
+            new Object[]{1, "|"},
+            new Object[]{2, ";"},
+            new Object[]{3, null},
+            new Object[]{4, "~"});
+    }
+
+    @Test
+    public void test_string_agg_with_value_equal_to_a_delimiter_over_shrinking_frame() throws Throwable {
+        assertEvaluate(
+            """
+                string_agg(cast(x AS text), z) OVER(
+                   ORDER BY x ROWS BETWEEN 1 PRECEDING AND CURRENT ROW
+                )
+            """,
+            new Object[]{"1", "112", "2-3", "3-4"},
+            List.of(ColumnIdent.of("x"), ColumnIdent.of("z")),
+            new Object[]{1, "-"},
+            new Object[]{2, "1"},
+            new Object[]{3, "-"},
+            new Object[]{4, "-"});
+    }
+
+    @Test
+    public void test_string_agg_over_shrinking_frame_with_duplicate_text_values() throws Throwable {
+        assertEvaluate(
+            """
+                string_agg(z, cast(x AS text)) OVER(
+                   ORDER BY x ROWS BETWEEN 1 PRECEDING AND CURRENT ROW
+                )
+            """,
+            new Object[]{"a", "a2b", "b3a", "a4b"},
+            List.of(ColumnIdent.of("x"), ColumnIdent.of("z")),
+            new Object[]{1, "a"},
+            new Object[]{2, "b"},
+            new Object[]{3, "a"},
+            new Object[]{4, "b"});
+    }
+
+    @Test
+    public void test_string_agg_with_delimiters_differing_only_in_case_over_shrinking_frame() throws Throwable {
+        assertEvaluate(
+            """
+                string_agg(cast(x AS text), z) OVER(
+                   ORDER BY x ROWS BETWEEN 1 PRECEDING AND CURRENT ROW
+                )
+            """,
+            new Object[]{"1", "1a2", "2A3", "3a4"},
+            List.of(ColumnIdent.of("x"), ColumnIdent.of("z")),
+            new Object[]{1, "A"},
+            new Object[]{2, "a"},
+            new Object[]{3, "A"},
+            new Object[]{4, "a"});
+    }
+
+    @Test
+    public void test_string_agg_with_constant_delimiter_over_shrinking_frame() throws Throwable {
+        assertEvaluate(
+            """
+                string_agg(z, ',') OVER(
+                   ORDER BY x ROWS BETWEEN 1 PRECEDING AND CURRENT ROW
+                )
+            """,
+            new Object[]{"a", "a,b", "b,c", "c,d"},
+            List.of(ColumnIdent.of("x"), ColumnIdent.of("z")),
+            new Object[]{1, "a"},
+            new Object[]{2, "b"},
+            new Object[]{3, "c"},
+            new Object[]{4, "d"});
+    }
+
     @Test
     public void test_array_agg_over_rows_unbounded_preceding_current_row_frame() throws Throwable {
         Object[] expected = new Object[]{


### PR DESCRIPTION
Previously, `StringAggState` was keeping one list with interleaved string values and delimeters, making it impossible to correctly remove values and delimiters in `removeFromAggregatedState()`, which is called when string_agg is used in window functions with moving frames. Keep values and delimiters separately to be able to handle `removeFromAggregatedState` correctly.

Fixes: #20021
