### PR TITLE
Fix string_agg() with dynamic delimiter in window functions

### DIFF
--- a/docs/appendices/release-notes/6.4.4.rst
+++ b/docs/appendices/release-notes/6.4.4.rst
@@ -110,3 +110,11 @@ Fixes
 
 - Fixed an issue that caused wrong accounting of memory usage for queries using
   :ref:`string_agg() <aggregation-string-agg>` aggregation function.
+
+- Fixed an issue that caused wrong results when
+  :ref:`string_agg() <aggregation-string-agg>` aggregation function was used with
+  :ref:`window functions <window-functions>` with a dynamic ``delimeter`` and an
+  explicit window frame, e.g.::
+
+    SELECT string_agg(value, delimiter) OVER(
+      ORDER BY value ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) FROM tbl

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/StringAgg.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/StringAgg.java
@@ -24,6 +24,7 @@ package io.crate.execution.engine.aggregation.impl;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.Version;
@@ -175,13 +176,18 @@ public final class StringAgg extends AggregationFunction<StringAgg.StringAggStat
         }
         ramAccounting.addBytes(LIST_ENTRY_OVERHEAD + RamUsageEstimator.sizeOf(expression));
         String delimiter = (String) args[1].value();
-        if (delimiter != null) {
-            if (state.firstDelimiter == null && state.values.isEmpty()) {
-                state.firstDelimiter = delimiter;
-            } else {
+        if (delimiter == null) {
+            delimiter = "";
+        }
+        if (state.firstDelimiter == null && state.values.isEmpty()) {
+            state.firstDelimiter = delimiter;
+        } else {
+            if (!delimiter.isEmpty()) {
                 ramAccounting.addBytes(LIST_ENTRY_OVERHEAD + RamUsageEstimator.sizeOf(delimiter));
-                state.values.add(delimiter);
+            } else {
+                ramAccounting.addBytes(LIST_ENTRY_OVERHEAD);
             }
+            state.values.add(delimiter);
         }
         state.values.add(expression);
         return state;
@@ -200,24 +206,23 @@ public final class StringAgg extends AggregationFunction<StringAgg.StringAggStat
         if (expression == null) {
             return previousAggState;
         }
-        String delimiter = (String) stateToRemove[1].value();
+        String removed = previousAggState.values.removeFirst();
+        assert removed.equals(expression) : "AggregateToWindowFunctionAdapter should always remove the first state";
+        ramAccounting.addBytes(-(LIST_ENTRY_OVERHEAD + RamUsageEstimator.sizeOf(expression)));
 
-        int indexOfExpression = previousAggState.values.indexOf(expression);
-        if (indexOfExpression > -1) {
-            ramAccounting.addBytes(-(LIST_ENTRY_OVERHEAD + RamUsageEstimator.sizeOf(expression)));
-            if (delimiter != null && indexOfExpression + 1 < previousAggState.values.size()) {
-                String elementNextToExpression = previousAggState.values.get(indexOfExpression + 1);
-                if (elementNextToExpression.equalsIgnoreCase(delimiter)) {
-                    previousAggState.values.remove(indexOfExpression + 1);
-                }
-            }
-            if (indexOfExpression == 0) {
-                // First element is removed, so next one will a new first.
-                // Reset state to avoid adding a delimiter before the "new first"
-                previousAggState.firstDelimiter = null;
-            }
-            previousAggState.values.remove(indexOfExpression);
+        String delimiter = (String) stateToRemove[1].value();
+        if (delimiter == null) {
+            delimiter = "";
         }
+        assert Objects.equals(previousAggState.firstDelimiter, delimiter) : "AggregateToWindowFunctionAdapter should always remove the first state";
+
+        if (previousAggState.values.isEmpty()) {
+            previousAggState.firstDelimiter = null;
+        } else {
+            previousAggState.firstDelimiter = previousAggState.values.removeFirst();
+            ramAccounting.addBytes(-(LIST_ENTRY_OVERHEAD + RamUsageEstimator.sizeOf(previousAggState.firstDelimiter)));
+        }
+
         return previousAggState;
     }
 

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/StringAggTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/StringAggTest.java
@@ -116,11 +116,12 @@ public class StringAggTest extends AggregationTestCase {
         assertThat(ramAccounting.totalBytes()).isEqualTo(24L);
         impl.iterate(ramAccounting, memoryManager, state, Literal.of("trillian"), Literal.of("delim"));
         impl.iterate(ramAccounting, memoryManager, state, Literal.of("arthur"), Literal.of("delimiter"));
-        assertThat(ramAccounting.totalBytes()).isEqualTo(296L);
+        impl.iterate(ramAccounting, memoryManager, state, Literal.of("john"), Literal.NULL);
+        assertThat(ramAccounting.totalBytes()).isEqualTo(408L);
         impl.removeFromAggregatedState(ramAccounting, state,
             new Input[] {Literal.of("trillian"), Literal.of("delim")});
-        assertThat(ramAccounting.totalBytes()).isEqualTo(208L);
+        assertThat(ramAccounting.totalBytes()).isEqualTo(224L);
         impl.terminatePartial(ramAccounting, state);
-        assertThat(ramAccounting.totalBytes()).isEqualTo(208L);
+        assertThat(ramAccounting.totalBytes()).isEqualTo(224L);
     }
 }

--- a/server/src/test/java/io/crate/execution/engine/window/AggregationWindowFunctionsTest.java
+++ b/server/src/test/java/io/crate/execution/engine/window/AggregationWindowFunctionsTest.java
@@ -523,6 +523,168 @@ public class AggregationWindowFunctionsTest extends AbstractWindowFunctionTest {
     }
 
     @Test
+    public void test_string_agg_with_per_row_delimiter_over_shrinking_frame() throws Throwable {
+        assertEvaluate(
+            """
+                string_agg(cast(x AS text), z) OVER(
+                   ORDER BY x ROWS BETWEEN 1 PRECEDING AND CURRENT ROW
+                )
+            """,
+            new Object[]{"1", "1;2", "2/3", "3~4"},
+            List.of(ColumnIdent.of("x"), ColumnIdent.of("z")),
+            new Object[]{1, "|"},
+            new Object[]{2, ";"},
+            new Object[]{3, "/"},
+            new Object[]{4, "~"});
+    }
+
+    @Test
+    public void test_string_agg_with_per_row_delimiter_over_frame_of_three_rows() throws Throwable {
+        assertEvaluate(
+            """
+                string_agg(cast(x AS text), z) OVER(
+                   ORDER BY x ROWS BETWEEN 2 PRECEDING AND CURRENT ROW
+                )
+            """,
+            new Object[]{"1", "1;2", "1;2/3", "2/3~4"},
+            List.of(ColumnIdent.of("x"), ColumnIdent.of("z")),
+            new Object[]{1, "|"},
+            new Object[]{2, ";"},
+            new Object[]{3, "/"},
+            new Object[]{4, "~"});
+    }
+
+    @Test
+    public void test_string_agg_with_per_row_delimiter_over_sliding_frame() throws Throwable {
+        assertEvaluate(
+            """
+                string_agg(cast(x AS text), z) OVER(
+                   ORDER BY x ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING
+                )
+            """,
+            new Object[]{"1;2", "1;2/3", "2/3~4", "3~4"},
+            List.of(ColumnIdent.of("x"), ColumnIdent.of("z")),
+            new Object[]{1, "|"},
+            new Object[]{2, ";"},
+            new Object[]{3, "/"},
+            new Object[]{4, "~"});
+    }
+
+    @Test
+    public void test_string_agg_with_null_delimiter_in_the_middle_over_shrinking_frame() throws Throwable {
+        assertEvaluate(
+            """
+                string_agg(cast(x AS text), z) OVER(
+                   ORDER BY x ROWS BETWEEN 1 PRECEDING AND CURRENT ROW
+                )
+            """,
+            new Object[]{"1", "1;2", "23", "3~4"},
+            List.of(ColumnIdent.of("x"), ColumnIdent.of("z")),
+            new Object[]{1, "|"},
+            new Object[]{2, ";"},
+            new Object[]{3, null},
+            new Object[]{4, "~"});
+    }
+
+    @Test
+    public void test_string_agg_with_null_delimiter_over_frame_of_three_rows() throws Throwable {
+        // the delimiter of x=2 is NULL, so that row contributes no separator to the state.
+        // Dropping x=1 from the frame must not consume x=2's value as if it were one.
+        assertEvaluate(
+            """
+                string_agg(cast(x AS text), z) OVER(
+                   ORDER BY x ROWS BETWEEN 2 PRECEDING AND CURRENT ROW
+                )
+            """,
+            new Object[]{"1", "12", "12~3", "2~3/4"},
+            List.of(ColumnIdent.of("x"), ColumnIdent.of("z")),
+            new Object[]{1, "|"},
+            new Object[]{2, null},
+            new Object[]{3, "~"},
+            new Object[]{4, "/"});
+    }
+
+    @Test
+    public void test_string_agg_with_only_null_delimiters_over_frame_of_three_rows() throws Throwable {
+        assertEvaluate(
+            """
+                string_agg(cast(x AS text), z) OVER(
+                   ORDER BY x ROWS BETWEEN 2 PRECEDING AND CURRENT ROW
+                )
+            """,
+            new Object[]{"1", "12", "123", "234"},
+            List.of(ColumnIdent.of("x"), ColumnIdent.of("z")),
+            new Object[]{1, null},
+            new Object[]{2, null},
+            new Object[]{3, null},
+            new Object[]{4, null});
+    }
+
+    @Test
+    public void test_string_agg_with_value_equal_to_a_delimiter_over_shrinking_frame() throws Throwable {
+        assertEvaluate(
+            """
+                string_agg(cast(x AS text), z) OVER(
+                   ORDER BY x ROWS BETWEEN 1 PRECEDING AND CURRENT ROW
+                )
+            """,
+            new Object[]{"1", "112", "2-3", "3-4"},
+            List.of(ColumnIdent.of("x"), ColumnIdent.of("z")),
+            new Object[]{1, "-"},
+            new Object[]{2, "1"},
+            new Object[]{3, "-"},
+            new Object[]{4, "-"});
+    }
+
+    @Test
+    public void test_string_agg_over_shrinking_frame_with_duplicate_text_values() throws Throwable {
+        assertEvaluate(
+            """
+                string_agg(z, cast(x AS text)) OVER(
+                   ORDER BY x ROWS BETWEEN 1 PRECEDING AND CURRENT ROW
+                )
+            """,
+            new Object[]{"a", "a2b", "b3a", "a4b"},
+            List.of(ColumnIdent.of("x"), ColumnIdent.of("z")),
+            new Object[]{1, "a"},
+            new Object[]{2, "b"},
+            new Object[]{3, "a"},
+            new Object[]{4, "b"});
+    }
+
+    @Test
+    public void test_string_agg_with_delimiters_differing_only_in_case_over_shrinking_frame() throws Throwable {
+        assertEvaluate(
+            """
+                string_agg(cast(x AS text), z) OVER(
+                   ORDER BY x ROWS BETWEEN 1 PRECEDING AND CURRENT ROW
+                )
+            """,
+            new Object[]{"1", "1a2", "2A3", "3a4"},
+            List.of(ColumnIdent.of("x"), ColumnIdent.of("z")),
+            new Object[]{1, "A"},
+            new Object[]{2, "a"},
+            new Object[]{3, "A"},
+            new Object[]{4, "a"});
+    }
+
+    @Test
+    public void test_string_agg_with_constant_delimiter_over_shrinking_frame() throws Throwable {
+        assertEvaluate(
+            """
+                string_agg(z, ',') OVER(
+                   ORDER BY x ROWS BETWEEN 1 PRECEDING AND CURRENT ROW
+                )
+            """,
+            new Object[]{"a", "a,b", "b,c", "c,d"},
+            List.of(ColumnIdent.of("x"), ColumnIdent.of("z")),
+            new Object[]{1, "a"},
+            new Object[]{2, "b"},
+            new Object[]{3, "c"},
+            new Object[]{4, "d"});
+    }
+
+    @Test
     public void test_array_agg_over_rows_unbounded_preceding_current_row_frame() throws Throwable {
         Object[] expected = new Object[]{
             List.of(10),


### PR DESCRIPTION
Fix the logic of `removeFromAggregatedState()` to correctly remove a delimiter from the string list and correctly set the new `firstDelimiter`

Fixes: #20021

