### PR TITLE
Fix `ANY` subquery expression operator returning incorrect result

### DIFF
--- a/docs/appendices/release-notes/6.4.4.rst
+++ b/docs/appendices/release-notes/6.4.4.rst
@@ -118,3 +118,6 @@ Fixes
 
     SELECT string_agg(value, delimiter) OVER(
       ORDER BY value ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) FROM tbl
+
+- Fixed an issue where :ref:`ANY <sql_any_subquery_expression>` did not return
+  ``FALSE`` when comparing ``NULL`` against an empty array.

--- a/server/src/main/java/io/crate/expression/operator/any/AnyOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/any/AnyOperator.java
@@ -21,6 +21,7 @@
 
 package io.crate.expression.operator.any;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.StreamSupport;
@@ -98,6 +99,16 @@ public abstract sealed class AnyOperator<T> extends Operator<T>
         );
     }
 
+    @Override
+    public Symbol normalizeSymbol(Function function, TransactionContext txnCtx, NodeContext nodeCtx) {
+        try {
+            return evaluateIfLiterals(this, txnCtx, nodeCtx, function);
+        } catch (Throwable t) {
+            return function;
+        }
+    }
+
+
     protected static List<?> filterNullValues(Literal<?> literal) {
         assert ArrayType.dimensions(literal.valueType()) == 1 : "The literal must be 1D array";
         return StreamSupport.stream(((Iterable<?>) literal.value()).spliterator(), false)
@@ -127,7 +138,11 @@ public abstract sealed class AnyOperator<T> extends Operator<T>
         assert args[0] != null : "1st argument must not be null";
 
         T item = args[0].value();
-        T items = args[1].value();
+        Collection<T> items = (Collection<T>) args[1].value();
+        if (items != null && items.isEmpty()) {
+            return false;
+        }
+
         if (items == null || item == null) {
             return null;
         }

--- a/server/src/test/java/io/crate/expression/operator/any/AnyEqOperatorTest.java
+++ b/server/src/test/java/io/crate/expression/operator/any/AnyEqOperatorTest.java
@@ -31,6 +31,8 @@ import org.apache.lucene.search.Query;
 import org.elasticsearch.Version;
 import org.junit.Test;
 
+import io.crate.types.DataTypes;
+import io.crate.expression.symbol.Literal;
 import io.crate.expression.scalar.ScalarTestCase;
 import io.crate.testing.QueryTester;
 
@@ -50,6 +52,14 @@ public class AnyEqOperatorTest extends ScalarTestCase {
         assertEvaluateNull("null = ANY(null)");
         assertEvaluateNull("42 = ANY(null)");
         assertEvaluateNull("null = ANY([1])");
+    }
+
+    @Test
+    public void testEmptySubquery() throws Exception {
+        assertEvaluate("null = ANY([])", false);
+        assertEvaluate("1 = ANY([])", false);
+        assertEvaluate("id = ANY([])", false, Literal.of(DataTypes.INTEGER, null));
+        assertEvaluate("['foo', 'bar'] = ANY([])", false);
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Previously, `SELECT null = ANY([])` query returned NULL. The ANY operator should return
false if the subquery is empty (no rows)

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes.
       If you're an external contributor you can give yourself attribution and include your name and Github handle.
       e.g.:
       ```
       `John Doe <https://github.com/John_Doe>`_ added support for ...
       ```
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
