### PR TITLE
Ensure that Eval preserves order of its outputs after pruning; validate outputs order after the pruning in joins

### DIFF
--- a/server/src/main/java/io/crate/planner/operators/AbstractJoinPlan.java
+++ b/server/src/main/java/io/crate/planner/operators/AbstractJoinPlan.java
@@ -25,6 +25,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import org.jspecify.annotations.Nullable;
@@ -92,6 +93,28 @@ public abstract class AbstractJoinPlan implements LogicalPlan {
             return lhs.outputs();
         } else {
             return Lists.concat(lhs.outputs(), rhs.outputs());
+        }
+    }
+
+    protected final void validateOutputsOrder(List<Symbol> outputsAfterPruning) {
+        boolean isSubsequence = Lists.isSubsequence(outputsAfterPruning, outputs());
+        if (!isSubsequence) {
+            String error = String.format(
+                """
+                Column pruning reshuffled outputs in %s:
+                outputs = %s
+                outputsAfterPruning = %s
+                lhs.outputs() = %s
+                rhs.outputs() = %s
+                """,
+                getClass().getSimpleName(),
+                outputs(),
+                outputsAfterPruning,
+                lhs.outputs(),
+                rhs.outputs(),
+                Locale.ENGLISH
+            );
+            throw new IllegalStateException(error);
         }
     }
 

--- a/server/src/main/java/io/crate/planner/operators/Eval.java
+++ b/server/src/main/java/io/crate/planner/operators/Eval.java
@@ -40,6 +40,7 @@ import io.crate.execution.dsl.projection.builder.InputColumns;
 import io.crate.execution.dsl.projection.builder.ProjectionBuilder;
 import io.crate.expression.symbol.FetchMarker;
 import io.crate.expression.symbol.Symbol;
+import io.crate.expression.symbol.Symbols;
 import io.crate.planner.DependencyCarrier;
 import io.crate.planner.ExecutionPlan;
 import io.crate.planner.Merge;
@@ -101,11 +102,18 @@ public final class Eval extends ForwardingLogicalPlan {
 
     @Override
     public LogicalPlan pruneOutputsExcept(SequencedCollection<Symbol> outputsToKeep) {
-        LogicalPlan newSource = source.pruneOutputsExcept(outputsToKeep);
+        ArrayList<Symbol> sourceOutputsToKeep = new ArrayList<>();
+        for (Symbol outputToKeep : outputsToKeep) {
+            Symbols.intersection(outputToKeep, outputs, sourceOutputsToKeep::add);
+        }
+        LogicalPlan newSource = source.pruneOutputsExcept(sourceOutputsToKeep);
         if (source == newSource && outputs.isEmpty()) {
             return this;
         }
-        return new Eval(newSource, List.copyOf(outputsToKeep));
+        List<Symbol> prunedOutputs = Lists.intersection(outputs, sourceOutputsToKeep);
+        boolean isSubsequence = Lists.isSubsequence(prunedOutputs, outputs);
+        assert isSubsequence : "pruneOutputsExcept must not shuffle the outputs, it can only remove some of them.";
+        return new Eval(newSource, prunedOutputs);
     }
 
     @Nullable

--- a/server/src/main/java/io/crate/planner/operators/HashJoin.java
+++ b/server/src/main/java/io/crate/planner/operators/HashJoin.java
@@ -218,13 +218,15 @@ public class HashJoin extends AbstractJoinPlan {
             if (newLhs == lhs && newRhs == rhs) {
                 return this;
             }
-            return new HashJoin(
+            HashJoin newHashJoin = new HashJoin(
                 newLhs,
                 newRhs,
                 joinCondition,
                 joinType,
                 lookupJoin
             );
+            validateOutputsOrder(newHashJoin.outputs());
+            return newHashJoin;
         }
     }
 

--- a/server/src/main/java/io/crate/planner/operators/NestedLoopJoin.java
+++ b/server/src/main/java/io/crate/planner/operators/NestedLoopJoin.java
@@ -252,7 +252,7 @@ public class NestedLoopJoin extends AbstractJoinPlan {
         if (newLhs == lhs && newRhs == rhs) {
             return this;
         }
-        return new NestedLoopJoin(
+        NestedLoopJoin newNestedLoopJoin = new NestedLoopJoin(
             newLhs,
             newRhs,
             joinType,
@@ -262,6 +262,8 @@ public class NestedLoopJoin extends AbstractJoinPlan {
             rewriteNestedLoopJoinToHashJoinDone,
             lookupJoin
         );
+        validateOutputsOrder(newNestedLoopJoin.outputs());
+        return newNestedLoopJoin;
     }
 
     @Nullable

--- a/server/src/test/java/io/crate/planner/SelectPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/SelectPlannerTest.java
@@ -702,6 +702,7 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(outerJoin.joinPhase().joinCondition()).isNull();
         assertThat(outerJoin.joinPhase().projections()).satisfiesExactly(
             p -> assertThat(p).isExactlyInstanceOf(EvalProjection.class),
+            p -> assertThat(p).isExactlyInstanceOf(EvalProjection.class),
             p -> assertThat(p).isExactlyInstanceOf(EvalProjection.class));
     }
 

--- a/server/src/test/java/io/crate/planner/operators/JoinTest.java
+++ b/server/src/test/java/io/crate/planner/operators/JoinTest.java
@@ -28,7 +28,6 @@ import static io.crate.analyze.TableDefinitions.USER_TABLE_IDENT;
 import static io.crate.testing.Asserts.assertList;
 import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.Asserts.isInputColumn;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
@@ -600,14 +599,16 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
         // This resulted in an `Can't handle Symbol [SimpleReference: event_time]` error because `event_time` is not an output of the Join, but is fetched
         assertThat(plan).hasOperators(
             "Rename[user_type, domain] AS doc.user_session_visitortype",
-            "  └ Fetch[CASE WHEN (event_time = first_event_time) THEN 'new_user' ELSE 'returning_user' END AS user_type, domain]",
-            "    └ Limit[1::bigint;0]",
-            "      └ HashJoin[INNER | (user_id = user_id)]",
-            "        ├ Rename[first_event_time, user_id] AS first_visit",
-            "        │  └ Eval[min(event_time) AS first_event_time, user_id]",
-            "        │    └ GroupHashAggregate[user_id | min(event_time)]",
-            "        │      └ Collect[doc.user_session | [event_time, user_id] | true]",
-            "        └ Collect[doc.user_session | [_fetchid, user_id] | (domain = 'example.com')]"
+            "  └ Eval[CASE WHEN (event_time = first_event_time) THEN 'new_user' ELSE 'returning_user' END AS user_type, domain]",
+            "    └ Fetch[event_time, domain, first_event_time]",
+            "      └ Limit[1::bigint;0]",
+            "        └ Eval[_fetchid, first_event_time]",
+            "          └ HashJoin[INNER | (user_id = user_id)]",
+            "            ├ Rename[user_id, first_event_time] AS first_visit",
+            "            │  └ Eval[user_id, min(event_time) AS first_event_time]",
+            "            │    └ GroupHashAggregate[user_id | min(event_time)]",
+            "            │      └ Collect[doc.user_session | [event_time, user_id] | true]",
+            "            └ Collect[doc.user_session | [_fetchid, user_id] | (domain = 'example.com')]"
         );
     }
 

--- a/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
@@ -772,11 +772,14 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
         LogicalPlan plan = sqlExecutor.logicalPlan("""
             SELECT i, avgx FROM (SELECT a, avg(x) OVER(ORDER BY i) as avgx, i FROM t1) as vt
             """);
+        // x comes first in the plan because window functions picked up first in SplitPointsBuilder.
+        // Then last Eval is added to re-order as user wants.
         assertThat(plan).hasOperators(
-            "Rename[i, avgx] AS vt",
-            "  └ Eval[i, avg(x) OVER (ORDER BY i ASC) AS avgx]",
-            "    └ WindowAgg[x, i] | [avg(x) OVER (ORDER BY i ASC)]",
-            "      └ Collect[doc.t1 | [x, i] | true]"
+            "Eval[i, avgx]",
+            "  └ Rename[avgx, i] AS vt",
+            "    └ Eval[avg(x) OVER (ORDER BY i ASC) AS avgx, i]",
+            "      └ WindowAgg[x, i] | [avg(x) OVER (ORDER BY i ASC)]",
+            "        └ Collect[doc.t1 | [x, i] | true]"
         );
     }
 
@@ -789,11 +792,12 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
             """);
         assertThat(plan).isEqualTo(
             """
-                Rename[sumx, umaxx, minx, uavgx] AS vt
-                  └ Eval[sum(x) AS sumx, unnest([max(x)]) AS umaxx, min(x) AS minx, unnest([avg(x)]) AS uavgx]
-                    └ ProjectSet[unnest([min(x)]), unnest([max(x)]), unnest([avg(x)]), unnest([sum(x)]), sum(x), max(x), min(x), avg(x)]
-                      └ HashAggregate[min(x), max(x), avg(x), sum(x)]
-                        └ Collect[doc.t1 | [x] | true]""");
+                Eval[sumx, umaxx, minx, uavgx]
+                  └ Rename[minx, umaxx, uavgx, sumx] AS vt
+                    └ Eval[min(x) AS minx, unnest([max(x)]) AS umaxx, unnest([avg(x)]) AS uavgx, sum(x) AS sumx]
+                      └ ProjectSet[unnest([min(x)]), unnest([max(x)]), unnest([avg(x)]), unnest([sum(x)]), sum(x), max(x), min(x), avg(x)]
+                        └ HashAggregate[min(x), max(x), avg(x), sum(x)]
+                          └ Collect[doc.t1 | [x] | true]""");
     }
 
     @Test


### PR DESCRIPTION
First commit - assertion, to be moved as the last commit to make each commit green. 
Maybe it's time to replace assert with throwing an error? At least for joins in this scope.


Second commit - relates to assertion failures, for example https://jenkins.crate.io/job/CrateDB/job/crate_on_pr/6552/testReport/junit/io.crate.planner.operators/JoinTest/test_extra_eval_operator_from_hash_join_reorder_works_with_fetch/

```
outputs()       =       [user_id, first_event_time, event_time, domain, user_id] 
outputsAfterPruning =   [first_event_time, user_id, event_time, domain, user_id] 
```
just enforcing the contract and fixing assertions.

Third commit - follow up to second commit, where we can end up with empty(!) outputs See https://jenkins.crate.io/job/CrateDB/job/crate_on_pr/6556/testReport/
`Couldn't find id in SourceSymbols{inputs={}, nonDeterministicFunctions={}}`

Reason - `outputsToKeep` has aliases and intersection doesn't dig into symbols. 
We need to compute intersection of output/outputsToKeep before normalizing order with Lists.intersection, similar to other operators.