### PR TITLE
Support bit string concatenation with || operator

### DIFF
--- a/docs/appendices/release-notes/6.5.0.rst
+++ b/docs/appendices/release-notes/6.5.0.rst
@@ -199,3 +199,7 @@ SQL Standard and PostgreSQL Compatibility
 - `Somil Jain <https://github.com/somiljain2006>`_ added the
   ``information_schema.constraint_column_usage`` view to improve PostgreSQL
   compatibility with tools that introspect database metadata.
+
+- `Somil Jain <https://github.com/somiljain2006>`_ added support for
+  concatenating :ref:`bitstrings <data-types-bit-strings>` using the
+  :ref:`concat function <scalar-concat>` or the ``||`` operator.

--- a/docs/general/builtins/scalar-functions.rst
+++ b/docs/general/builtins/scalar-functions.rst
@@ -23,9 +23,10 @@ String functions
 --------------------------------------------------------
 
 Concatenates a variable number of arguments into a single string. It ignores
-``NULL`` values.
+``NULL`` values. The ``concat`` function also supports concatenating
+:ref:`bit strings <data-types-bit-strings>`.
 
-Returns: ``text``
+Returns: ``text`` or ``bit string``
 
 ::
 
@@ -37,7 +38,18 @@ Returns: ``text``
     +--------+
     SELECT 1 row in set (... sec)
 
-You can also use the ``||`` :ref:`operator <gloss-operator>`::
+::
+
+    cr> select concat(B'101', B'0101') AS col;
+    +------------+
+    | col        |
+    +------------+
+    | B'1010101' |
+    +------------+
+    SELECT 1 row in set (... sec)
+
+You can also use the ``||`` :ref:`operator <gloss-operator>` to concatenate
+strings and bit strings::
 
     cr> select 'foo' || 'bar' AS col;
     +--------+

--- a/server/src/main/java/io/crate/expression/scalar/ConcatFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ConcatFunction.java
@@ -21,6 +21,8 @@
 
 package io.crate.expression.scalar;
 
+import java.util.BitSet;
+
 import io.crate.data.Input;
 import io.crate.expression.operator.Operator;
 import io.crate.expression.scalar.object.ObjectMergeFunction;
@@ -35,6 +37,8 @@ import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
 import io.crate.metadata.functions.TypeVariableConstraint;
+import io.crate.sql.tree.BitString;
+import io.crate.types.BitStringType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import io.crate.types.TypeSignature;
@@ -155,12 +159,46 @@ public abstract class ConcatFunction extends Scalar<String, String> {
                 return new ObjectMergeFunction(signature, boundSignature.withReturnType(returnType));
             }
         );
+        module.add(
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(BitStringType.INSTANCE_ONE.getTypeSignature(),
+                    BitStringType.INSTANCE_ONE.getTypeSignature())
+                .returnType(BitStringType.INSTANCE_ONE.getTypeSignature())
+                .features(Feature.DETERMINISTIC)
+                .bindActualTypes()
+                .build(),
+            (signature, boundSignature) -> createBitStringConcatFunction(signature, boundSignature, false)
+        );
+        module.add(
+            Signature.builder(OPERATOR_NAME, FunctionType.SCALAR)
+                .argumentTypes(BitStringType.INSTANCE_ONE.getTypeSignature(),
+                    BitStringType.INSTANCE_ONE.getTypeSignature())
+                .returnType(BitStringType.INSTANCE_ONE.getTypeSignature())
+                .features(Feature.DETERMINISTIC, Feature.STRICTNULL)
+                .bindActualTypes()
+                .build(),
+            (signature, boundSignature) -> createBitStringConcatFunction(signature, boundSignature, true)
+        );
+    }
+
+    private static BitStringConcatFunction createBitStringConcatFunction(
+        Signature signature, BoundSignature boundSignature, boolean strictNull) {
+
+        DataType<?> arg0 = boundSignature.argTypes().get(0);
+        DataType<?> arg1 = boundSignature.argTypes().get(1);
+
+        int len1 = arg0 instanceof BitStringType bs ? bs.length() : 0;
+        int len2 = arg1 instanceof BitStringType bs ? bs.length() : 0;
+
+        DataType<?> returnType = new BitStringType(len1 + len2);
+        return new BitStringConcatFunction(signature, boundSignature.withReturnType(returnType), strictNull);
     }
 
     ConcatFunction(Signature signature, BoundSignature boundSignature) {
         super(signature, boundSignature);
     }
 
+    @SuppressWarnings("rawtypes")
     @Override
     public Symbol normalizeSymbol(Function function, TransactionContext txnCtx, NodeContext nodeCtx) {
         if (anyNonLiterals(function.arguments())) {
@@ -190,6 +228,7 @@ public abstract class ConcatFunction extends Scalar<String, String> {
             this.calledByOperator = calledByOperator;
         }
 
+        @SuppressWarnings("rawtypes")
         @Override
         public String evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input[] args) {
             String firstArg = (String) args[0].value();
@@ -230,6 +269,54 @@ public abstract class ConcatFunction extends Scalar<String, String> {
                 }
             }
             return sb.toString();
+        }
+    }
+
+    static class BitStringConcatFunction extends Scalar<BitString, BitString> {
+
+        private final boolean strictNull;
+
+        /**
+         * @param strictNull return null on any null input. If false returns the non-null arg if one is null
+         */
+        BitStringConcatFunction(Signature signature, BoundSignature boundSignature, boolean strictNull) {
+            super(signature, boundSignature);
+            this.strictNull = strictNull;
+        }
+
+        @Override
+        public BitString evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<BitString>[] args) {
+            BitString firstArg = args[0].value();
+            BitString secondArg = args[1].value();
+
+            if (strictNull && (firstArg == null || secondArg == null)) {
+                return null;
+            }
+            if (firstArg == null) {
+                return secondArg;
+            }
+            if (secondArg == null) {
+                return firstArg;
+            }
+
+            int newLength = firstArg.length() + secondArg.length();
+            BitSet newBitSet = new BitSet(newLength);
+
+            BitSet firstBits = firstArg.bitSet();
+            for (int i = 0; i < firstArg.length(); i++) {
+                if (firstBits.get(i)) {
+                    newBitSet.set(i);
+                }
+            }
+
+            BitSet secondBits = secondArg.bitSet();
+            for (int i = 0; i < secondArg.length(); i++) {
+                if (secondBits.get(i)) {
+                    newBitSet.set(firstArg.length() + i);
+                }
+            }
+
+            return new BitString(newBitSet, newLength);
         }
     }
 }

--- a/server/src/main/java/io/crate/types/BitStringType.java
+++ b/server/src/main/java/io/crate/types/BitStringType.java
@@ -181,6 +181,9 @@ public final class BitStringType extends DataType<BitString> implements Streamer
 
     @Override
     public BitString explicitCast(Object value, SessionSettings sessionSettings, RelationLookup relationLookup) throws IllegalArgumentException, ClassCastException {
+        if (value == null) {
+            return null;
+        }
         // explicit cast is allowed to trim or extend the bitstring
         if (value instanceof String str) {
             return BitString.ofRawBits(str, length);

--- a/server/src/test/java/io/crate/expression/scalar/ConcatFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ConcatFunctionTest.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import org.junit.Test;
 
 import io.crate.exceptions.UnsupportedFunctionException;
+import io.crate.sql.tree.BitString;
 import io.crate.types.DataTypes;
 
 public class ConcatFunctionTest extends ScalarTestCase {
@@ -149,5 +150,73 @@ public class ConcatFunctionTest extends ScalarTestCase {
     @Test
     public void test_concat_operator_with_element_and_array() {
         assertEvaluate("1 || [2]", List.of(1, 2));
+    }
+
+    @Test
+    public void test_concat_operator_with_bit_strings() {
+        assertNormalize(
+            "B'1001' || B'10001'",
+            isLiteral(BitString.ofRawBits("100110001"))
+        );
+    }
+
+    @Test
+    public void test_concat_operator_with_bit_strings_of_different_lengths() {
+        assertNormalize(
+            "B'101' || B'01010'",
+            isLiteral(BitString.ofRawBits("10101010"))
+        );
+    }
+
+    @Test
+    public void test_concat_operator_with_empty_bit_strings() {
+        assertNormalize(
+            "B'' || B'101'",
+            isLiteral(BitString.ofRawBits("101"))
+        );
+        assertNormalize(
+            "B'101' || B''",
+            isLiteral(BitString.ofRawBits("101"))
+        );
+    }
+
+    @Test
+    public void test_concat_operator_with_null_bit_strings() {
+        assertNormalize("NULL::bit(1) || B'101'", isLiteral(null));
+        assertNormalize("B'101' || NULL::bit(1)", isLiteral(null));
+    }
+
+    @Test
+    public void test_concat_function_with_bit_strings() {
+        assertNormalize(
+            "concat(B'1001', B'10001')",
+            isLiteral(BitString.ofRawBits("100110001"))
+        );
+    }
+
+    @Test
+    public void test_concat_function_with_bit_strings_of_different_lengths() {
+        assertNormalize(
+            "concat(B'101', B'01010')",
+            isLiteral(BitString.ofRawBits("10101010"))
+        );
+    }
+
+    @Test
+    public void test_concat_function_with_empty_bit_strings() {
+        assertNormalize(
+            "concat(B'', B'101')",
+            isLiteral(BitString.ofRawBits("101"))
+        );
+        assertNormalize(
+            "concat(B'101', B'')",
+            isLiteral(BitString.ofRawBits("101"))
+        );
+    }
+
+    @Test
+    public void test_concat_function_with_null_bit_strings() {
+        assertNormalize("concat(NULL::bit(1), B'101')", isLiteral(BitString.ofRawBits("101")));
+        assertNormalize("concat(B'101', NULL::bit(1))", isLiteral(BitString.ofRawBits("101")));
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Fixes #20029 

Fix bit string concatenation with the `||` operator by adding support for `bit` operands, preserving proper result lengths and NULL semantics, and adding regression tests for PostgreSQL-compatible behavior.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes.
       If you're an external contributor you can give yourself attribution and include your name and Github handle.
       e.g.:
       ```
       `John Doe <https://github.com/John_Doe>`_ added support for ...
       ```
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
