### PR TITLE
Add dedicated HTTPFileInput & http access control settings for copy from

### DIFF
--- a/docs/admin/system-information.rst
+++ b/docs/admin/system-information.rst
@@ -140,6 +140,9 @@ information about the currently applied cluster settings.
     | settings['cluster']['routing']['allocation']['total_shards_per_node']             | integer      |
     | settings['cluster']['routing']['rebalance']                                       | object       |
     | settings['cluster']['routing']['rebalance']['enable']                             | text         |
+    | settings['copy_from']                                                             | object       |
+    | settings['copy_from']['http']                                                     | object       |
+    | settings['copy_from']['http']['redirects']                                        | text         |
     | settings['fdw']                                                                   | object       |
     | settings['fdw']['allow_local']                                                    | boolean      |
     | settings['gateway']                                                               | object       |

--- a/docs/admin/system-information.rst
+++ b/docs/admin/system-information.rst
@@ -142,6 +142,7 @@ information about the currently applied cluster settings.
     | settings['cluster']['routing']['rebalance']['enable']                             | text         |
     | settings['copy_from']                                                             | object       |
     | settings['copy_from']['http']                                                     | object       |
+    | settings['copy_from']['http']['blocked_hosts']                                    | text_array   |
     | settings['copy_from']['http']['redirects']                                        | text         |
     | settings['fdw']                                                                   | object       |
     | settings['fdw']['allow_local']                                                    | boolean      |

--- a/docs/appendices/release-notes/6.5.0.rst
+++ b/docs/appendices/release-notes/6.5.0.rst
@@ -181,7 +181,10 @@ Performance and Resilience Improvements
 Administration and Operations
 -----------------------------
 
-None
+- Added :ref:`copy_from.http.redirects` and :ref:`copy_from.http.blocked_hosts`
+  settings to allow CrateDB administrators to prevent users from accessing HTTP
+  resources from hosts reachable on an internal network or other arbitrary hosts
+  using :ref:`COPY FROM <sql-copy-from>`.
 
 Client interfaces
 -----------------

--- a/docs/config/cluster.rst
+++ b/docs/config/cluster.rst
@@ -1518,4 +1518,25 @@ clusters during the recovery.
    cr> RESET GLOBAL "memory.operation_limit"
    RESET OK, 1 row affected (... sec)
 
+
+Copy From
+---------
+
+Copy from operations can be configured with the following settings.
+
+
+.. _copy_from.http.redirects:
+
+**copy_from.http.redirects**
+  | *Default:* ``normal``
+  | *Runtime:* ``yes``
+
+Configures if the HTTP client used for COPY FROM on HTTPS or HTTP urls should
+follow redirects. The supported values are:
+
+- ``normal``: Always follow redirects, except from HTTPS URLs to HTTP URLs
+- ``always``: Always follow redirects with no restriction
+- ``never`` Never follow redirects
+
+
 .. _bootstrap checks: https://cratedb.com/docs/crate/howtos/en/latest/admin/bootstrap-checks.html

--- a/docs/config/cluster.rst
+++ b/docs/config/cluster.rst
@@ -1539,4 +1539,29 @@ follow redirects. The supported values are:
 - ``never`` Never follow redirects
 
 
+.. _copy_from.http.blocked_hosts:
+
+**copy_from.http.blocked_hosts**
+  | *Default:* ``[]``
+  | *Runtime:* ``yes``
+
+Sets a list of blocked hosts. By default no hosts are blocked.
+Supports the following special wildcards:
+
+- ``_link_``: Blocks any link local address like ``169.254.169.254``
+- ``_site_``: Blocks any site local address
+- ``_local_``: Blocks any local or loopback addresses
+
+For any literal host, both the hostname and all resolved host addresses are
+verified.
+
+This can be useful to prevent CrateDB users from accessing data from other hosts
+reachable on an internal network.
+
+Note that the blocked hosts are only checked against the initial host in a given
+URI. If an URI redirects to another host, that host name is **not** checked
+against the blocked hosts. Set ``copy_from.http.redirects`` to ``never`` to
+account for that.
+
+
 .. _bootstrap checks: https://cratedb.com/docs/crate/howtos/en/latest/admin/bootstrap-checks.html

--- a/server/src/main/java/io/crate/execution/engine/collect/files/CopyModule.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/files/CopyModule.java
@@ -43,6 +43,9 @@ public class CopyModule extends AbstractModule {
         MapBinder<String, FileInputFactory> fileInputFactoryMapBinder = MapBinder.newMapBinder(binder(), String.class, FileInputFactory.class);
         MapBinder<String, FileOutputFactory> fileOutputFactoryMapBinder = MapBinder.newMapBinder(binder(), String.class, FileOutputFactory.class);
 
+        for (String scheme : HTTPFileInputFactory.NAMES) {
+            fileInputFactoryMapBinder.addBinding(scheme).to(HTTPFileInputFactory.class).asEagerSingleton();;
+        }
         fileInputFactoryMapBinder.addBinding(LocalFsFileInputFactory.NAME).to(LocalFsFileInputFactory.class).asEagerSingleton();
         fileOutputFactoryMapBinder.addBinding(LocalFsFileOutputFactory.NAME).to(LocalFsFileOutputFactory.class).asEagerSingleton();
 

--- a/server/src/main/java/io/crate/execution/engine/collect/files/HTTPFileInputFactory.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/files/HTTPFileInputFactory.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.execution.engine.collect.files;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpClient.Redirect;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.util.List;
+import java.util.concurrent.Executor;
+
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.threadpool.ThreadPool;
+
+import io.crate.common.exceptions.Exceptions;
+
+public class HTTPFileInputFactory implements FileInputFactory {
+
+    public static final List<String> NAMES = List.of("http", "https");
+    private final HttpClient client;
+
+    @Inject
+    public HTTPFileInputFactory(ThreadPool threadPool) {
+        Executor executor = threadPool.executor(ThreadPool.Names.SEARCH);
+        this.client = HttpClient.newBuilder()
+            .executor(executor)
+            .followRedirects(Redirect.NORMAL)
+            .build();
+    }
+
+    @Override
+    public FileInput create(URI uri, Settings withClauseOptions) throws IOException {
+        return new HTTPFileInput(client, uri);
+    }
+
+    static class HTTPFileInput implements FileInput {
+
+        private final URI uri;
+        private final HttpClient client;
+
+        public HTTPFileInput(HttpClient client, URI uri) {
+            this.client = client;
+            this.uri = uri;
+        }
+
+        @Override
+        public List<URI> expandUri() throws IOException {
+            return List.of(uri);
+        }
+
+        @Override
+        public InputStream getStream(URI uri) throws IOException {
+            HttpRequest request = HttpRequest.newBuilder(uri).build();
+            try {
+                return client.send(request, BodyHandlers.ofInputStream()).body();
+            } catch (InterruptedException e) {
+                throw Exceptions.toRuntimeException(e);
+            }
+        }
+
+        @Override
+        public boolean isGlobbed() {
+            return false;
+        }
+
+        @Override
+        public URI uri() {
+            return uri;
+        }
+
+        @Override
+        public boolean sharedStorageDefault() {
+            return true;
+        }
+    }
+}

--- a/server/src/main/java/io/crate/execution/engine/collect/files/HTTPFileInputFactory.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/files/HTTPFileInputFactory.java
@@ -23,13 +23,16 @@ package io.crate.execution.engine.collect.files;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.InetAddress;
 import java.net.URI;
+import java.net.UnknownHostException;
 import java.net.http.HttpClient;
 import java.net.http.HttpClient.Redirect;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 import java.util.concurrent.Executor;
 
 import org.elasticsearch.common.inject.Inject;
@@ -45,6 +48,9 @@ import io.crate.types.DataTypes;
 public class HTTPFileInputFactory implements FileInputFactory {
 
     public static final List<String> NAMES = List.of("http", "https");
+    public static final String LINK_LOCAL = "_link_";
+    public static final String SITE_LOCAL = "_site_";
+    public static final String LOCAL = "_local_";
     public static final Setting<Redirect> REDIRECT_SETTING = new Setting<>(
         "copy_from.http.redirects",
         "normal",
@@ -65,11 +71,24 @@ public class HTTPFileInputFactory implements FileInputFactory {
         Setting.Property.Exposed
     );
 
+    public static final Setting<List<String>> BLOCKED_HOSTS = Setting.listSetting(
+        "copy_from.http.blocked_hosts",
+        List.of(),
+        v -> v,
+        DataTypes.STRING_ARRAY,
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic,
+        Setting.Property.Exposed
+    );
+
+    private final ClusterSettings clusterSettings;
+
     @VisibleForTesting
     volatile HttpClient client;
 
     @Inject
     public HTTPFileInputFactory(ClusterSettings clusterSettings, ThreadPool threadPool) {
+        this.clusterSettings = clusterSettings;
         Executor executor = threadPool.executor(ThreadPool.Names.SEARCH);
         Redirect redirect = clusterSettings.get(REDIRECT_SETTING);
         this.client = HttpClient.newBuilder()
@@ -87,17 +106,19 @@ public class HTTPFileInputFactory implements FileInputFactory {
 
     @Override
     public FileInput create(URI uri, Settings withClauseOptions) throws IOException {
-        return new HTTPFileInput(client, uri);
+        return new HTTPFileInput(client, uri, clusterSettings.get(BLOCKED_HOSTS));
     }
 
     static class HTTPFileInput implements FileInput {
 
         private final URI uri;
         private final HttpClient client;
+        private final Set<String> blockedHosts;
 
-        public HTTPFileInput(HttpClient client, URI uri) {
+        public HTTPFileInput(HttpClient client, URI uri, List<String> blockedHosts) {
             this.client = client;
             this.uri = uri;
+            this.blockedHosts = Set.copyOf(blockedHosts);
         }
 
         @Override
@@ -107,12 +128,38 @@ public class HTTPFileInputFactory implements FileInputFactory {
 
         @Override
         public InputStream getStream(URI uri) throws IOException {
+            ensureNotBlocked(uri.getHost());
             HttpRequest request = HttpRequest.newBuilder(uri).build();
             try {
                 return client.send(request, BodyHandlers.ofInputStream()).body();
             } catch (InterruptedException e) {
                 throw Exceptions.toRuntimeException(e);
             }
+        }
+
+        private void ensureNotBlocked(String host) throws UnknownHostException {
+            if (blockedHosts.contains(host)) {
+                raiseBlocked(host);
+            }
+            for (var addr : InetAddress.getAllByName(host)) {
+                String hostAddr = addr.getHostAddress();
+                if (blockedHosts.contains(hostAddr)) {
+                    raiseBlocked(hostAddr);
+                }
+                if ((addr.isAnyLocalAddress() || addr.isLoopbackAddress()) && blockedHosts.contains(LOCAL)) {
+                    raiseBlocked(hostAddr);
+                }
+                if (addr.isSiteLocalAddress() && blockedHosts.contains(SITE_LOCAL)) {
+                    raiseBlocked(hostAddr);
+                }
+                if (addr.isLinkLocalAddress() && blockedHosts.contains(LINK_LOCAL)) {
+                    raiseBlocked(hostAddr);
+                }
+            }
+        }
+
+        private static void raiseBlocked(String host) {
+            throw new IllegalArgumentException("Host `" + host + "` is blocked");
         }
 
         @Override

--- a/server/src/main/java/io/crate/execution/engine/collect/files/HTTPFileInputFactory.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/files/HTTPFileInputFactory.java
@@ -29,26 +29,60 @@ import java.net.http.HttpClient.Redirect;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.Executor;
 
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.threadpool.ThreadPool;
 
+import io.crate.common.annotations.VisibleForTesting;
 import io.crate.common.exceptions.Exceptions;
+import io.crate.types.DataTypes;
 
 public class HTTPFileInputFactory implements FileInputFactory {
 
     public static final List<String> NAMES = List.of("http", "https");
-    private final HttpClient client;
+    public static final Setting<Redirect> REDIRECT_SETTING = new Setting<>(
+        "copy_from.http.redirects",
+        "normal",
+        value -> switch (value.toLowerCase(Locale.ENGLISH)) {
+            case "normal" -> Redirect.NORMAL;
+            case "always" -> Redirect.ALWAYS;
+            case "never" -> Redirect.NEVER;
+            default -> throw new IllegalArgumentException(
+                String.format(
+                    Locale.ENGLISH,
+                    "Invalid redirects value '%s'. Expected one of [normal, always, never]",
+                    value
+                ));
+        },
+        DataTypes.STRING,
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic,
+        Setting.Property.Exposed
+    );
+
+    @VisibleForTesting
+    volatile HttpClient client;
 
     @Inject
-    public HTTPFileInputFactory(ThreadPool threadPool) {
+    public HTTPFileInputFactory(ClusterSettings clusterSettings, ThreadPool threadPool) {
         Executor executor = threadPool.executor(ThreadPool.Names.SEARCH);
+        Redirect redirect = clusterSettings.get(REDIRECT_SETTING);
         this.client = HttpClient.newBuilder()
             .executor(executor)
-            .followRedirects(Redirect.NORMAL)
+            .followRedirects(redirect)
             .build();
+
+        clusterSettings.addSettingsUpdateConsumer(REDIRECT_SETTING, redirectValue -> {
+            this.client = HttpClient.newBuilder()
+                .executor(executor)
+                .followRedirects(redirectValue)
+                .build();
+        });
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -477,6 +477,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
         FsHealthService.REFRESH_INTERVAL_SETTING,
         FsHealthService.SLOW_PATH_LOGGING_THRESHOLD_SETTING,
         ForeignDataWrappers.ALLOW_LOCAL,
-        HTTPFileInputFactory.REDIRECT_SETTING
+        HTTPFileInputFactory.REDIRECT_SETTING,
+        HTTPFileInputFactory.BLOCKED_HOSTS
     );
 }

--- a/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -103,6 +103,7 @@ import org.elasticsearch.transport.netty4.Netty4Transport;
 import io.crate.auth.AuthSettings;
 import io.crate.blob.v2.BlobIndicesService;
 import io.crate.cluster.gracefulstop.DecommissioningService;
+import io.crate.execution.engine.collect.files.HTTPFileInputFactory;
 import io.crate.execution.engine.collect.stats.JobsLogService;
 import io.crate.execution.engine.indexing.ShardingUpsertExecutor;
 import io.crate.execution.jobs.NodeLimits;
@@ -475,6 +476,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
         FsHealthService.ENABLED_SETTING,
         FsHealthService.REFRESH_INTERVAL_SETTING,
         FsHealthService.SLOW_PATH_LOGGING_THRESHOLD_SETTING,
-        ForeignDataWrappers.ALLOW_LOCAL
+        ForeignDataWrappers.ALLOW_LOCAL,
+        HTTPFileInputFactory.REDIRECT_SETTING
     );
 }

--- a/server/src/test/java/io/crate/execution/engine/collect/files/HTTPFileInputFactoryTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/files/HTTPFileInputFactoryTest.java
@@ -24,6 +24,7 @@ package io.crate.execution.engine.collect.files;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.net.URI;
 import java.net.http.HttpClient.Redirect;
 
 import org.elasticsearch.common.settings.ClusterSettings;
@@ -63,6 +64,69 @@ public class HTTPFileInputFactoryTest {
             .build()
         );
         assertThat(httpFileInputFactory.client.followRedirects()).isEqualTo(Redirect.NEVER);
+    }
+
+    @Test
+    public void test_uri_with_blocked_hostname_raises_errors() throws Exception {
+        var settings = Settings.builder()
+            .put(HTTPFileInputFactory.BLOCKED_HOSTS.getKey(), "example.com,127.0.0.1")
+            .build();
+        var clusterSettings = new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        var httpFileInputFactory = new HTTPFileInputFactory(
+            clusterSettings,
+            Mockito.mock(ThreadPool.class, Answers.RETURNS_MOCKS)
+        );
+
+        URI uri = new URI("https://example.com");
+        FileInput fileInput = httpFileInputFactory.create(uri, Settings.EMPTY);
+        assertThatThrownBy(() -> fileInput.getStream(uri))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Host `example.com` is blocked");
+    }
+
+    @Test
+    public void test_uri_with_blocked_resolved_match_raises_error() throws Exception {
+        var settings = Settings.builder()
+            .put(HTTPFileInputFactory.BLOCKED_HOSTS.getKey(), "127.0.0.1")
+            .build();
+        var clusterSettings = new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        var httpFileInputFactory = new HTTPFileInputFactory(
+            clusterSettings,
+            Mockito.mock(ThreadPool.class, Answers.RETURNS_MOCKS)
+        );
+
+        URI uri = new URI("https://localhost");
+        FileInput fileInput = httpFileInputFactory.create(uri, Settings.EMPTY);
+        assertThatThrownBy(() -> fileInput.getStream(uri))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Host `127.0.0.1` is blocked");
+    }
+
+    @Test
+    public void test_uri_with_blocked_special_wildcard_match_raises_error() throws Exception {
+        var settings = Settings.builder()
+            .put(HTTPFileInputFactory.BLOCKED_HOSTS.getKey(), "_local_,_site_,_link_")
+            .build();
+        var clusterSettings = new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        var httpFileInputFactory = new HTTPFileInputFactory(
+            clusterSettings,
+            Mockito.mock(ThreadPool.class, Answers.RETURNS_MOCKS)
+        );
+
+        {
+            URI uri = new URI("https://localhost");
+            FileInput fileInput = httpFileInputFactory.create(uri, Settings.EMPTY);
+            assertThatThrownBy(() -> fileInput.getStream(uri))
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Host `127.0.0.1` is blocked");
+        }
+        {
+            URI uri = new URI("http://169.254.169.254/latest/");
+            FileInput fileInput = httpFileInputFactory.create(uri, Settings.EMPTY);
+            assertThatThrownBy(() -> fileInput.getStream(uri))
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Host `169.254.169.254` is blocked");
+        }
     }
 }
 

--- a/server/src/test/java/io/crate/execution/engine/collect/files/HTTPFileInputFactoryTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/files/HTTPFileInputFactoryTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.execution.engine.collect.files;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.net.http.HttpClient.Redirect;
+
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
+import org.mockito.Mockito;
+
+public class HTTPFileInputFactoryTest {
+
+    @Test
+    public void test_redirect_setting_value_validation() throws Exception {
+        var clusterSettings = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        Settings settings = Settings.builder()
+            .put(HTTPFileInputFactory.REDIRECT_SETTING.getKey(), "foo")
+            .build();
+        assertThatThrownBy(() -> clusterSettings.validate(settings, false))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Invalid redirects value 'foo'. Expected one of [normal, always, never]");
+    }
+
+    @Test
+    public void test_builds_http_client_with_redirect_based_on_setting() throws Exception {
+        var settings = Settings.builder()
+            .put(HTTPFileInputFactory.REDIRECT_SETTING.getKey(), "always")
+            .build();
+        var clusterSettings = new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        var httpFileInputFactory = new HTTPFileInputFactory(
+            clusterSettings,
+            Mockito.mock(ThreadPool.class, Answers.RETURNS_MOCKS)
+        );
+        assertThat(httpFileInputFactory.client.followRedirects()).isEqualTo(Redirect.ALWAYS);
+
+        clusterSettings.applySettings(Settings.builder()
+            .put(HTTPFileInputFactory.REDIRECT_SETTING.getKey(), "never")
+            .build()
+        );
+        assertThat(httpFileInputFactory.client.followRedirects()).isEqualTo(Redirect.NEVER);
+    }
+}
+

--- a/server/src/test/java/io/crate/integrationtests/CopyIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/CopyIntegrationTest.java
@@ -23,6 +23,7 @@ package io.crate.integrationtests;
 
 import static com.carrotsearch.randomizedtesting.RandomizedTest.newTempDir;
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
+import static io.crate.testing.Asserts.assertSQLError;
 import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.TestingHelpers.printedTable;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
@@ -607,6 +608,15 @@ public class CopyIntegrationTest extends SQLHttpIntegrationTest {
         execute("refresh table names");
         execute("select name from names order by id");
         assertThat(printedTable(response.rows())).isEqualTo("Marvin\nSlartibartfast\n");
+
+
+        execute("set global copy_from.http.blocked_hosts = '_local_'");
+        try {
+            assertSQLError(() -> execute("copy names from ?", new Object[]{urls}))
+                .hasMessageContaining("Host `127.0.0.1` is blocked");
+        } finally {
+            execute("reset global copy_from.http.blocked_hosts");
+        }
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/CopyIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/CopyIntegrationTest.java
@@ -626,7 +626,10 @@ public class CopyIntegrationTest extends SQLHttpIntegrationTest {
         assertThat(response).hasRowCount(2L);
         execute("refresh table names");
         execute("select name from names order by id");
-        assertThat(printedTable(response.rows())).isEqualTo("Arthur\nSlartibartfast\n");
+        assertThat(response).hasRows(
+            "Arthur",
+            "Slartibartfast"
+        );
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -590,7 +590,7 @@ public class InformationSchemaTest extends IntegTestCase {
     @Test
     public void testDefaultColumns() {
         execute("select * from information_schema.columns order by table_schema, table_name");
-        assertThat(response.rowCount()).isEqualTo(1120);
+        assertThat(response.rowCount()).isEqualTo(1121);
     }
 
     @Test
@@ -871,7 +871,7 @@ public class InformationSchemaTest extends IntegTestCase {
         execute("select max(ordinal_position) from information_schema.columns");
         assertThat(response.rowCount()).isEqualTo(1);
 
-        assertThat(response.rows()[0][0]).isEqualTo(133);
+        assertThat(response.rows()[0][0]).isEqualTo(134);
 
         execute("create table t1 (id integer, col1 string)");
         execute("select max(ordinal_position) from information_schema.columns where table_schema = ?",

--- a/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -24,6 +24,7 @@ package io.crate.integrationtests;
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
 import static io.crate.testing.Asserts.assertThat;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Collections;
 import java.util.List;
@@ -589,7 +590,7 @@ public class InformationSchemaTest extends IntegTestCase {
     @Test
     public void testDefaultColumns() {
         execute("select * from information_schema.columns order by table_schema, table_name");
-        assertThat(response.rowCount()).isEqualTo(1117);
+        assertThat(response.rowCount()).isEqualTo(1120);
     }
 
     @Test
@@ -870,7 +871,7 @@ public class InformationSchemaTest extends IntegTestCase {
         execute("select max(ordinal_position) from information_schema.columns");
         assertThat(response.rowCount()).isEqualTo(1);
 
-        assertThat(response.rows()[0][0]).isEqualTo(130);
+        assertThat(response.rows()[0][0]).isEqualTo(133);
 
         execute("create table t1 (id integer, col1 string)");
         execute("select max(ordinal_position) from information_schema.columns where table_schema = ?",


### PR DESCRIPTION
See commits.

- First one is adding a dedicated HTTPFileInput based on the HttpClient with no functional/user-facing change. Merely preperation for the 2 subsequent commits.
- Second adds a setting to control redirect handling
- Third adds a setting that allows to block hosts.