### PR TITLE
Provide descriptions of assertions in our custom Assert classes

### DIFF
--- a/server/src/testFixtures/java/io/crate/testing/DocKeyAssert.java
+++ b/server/src/testFixtures/java/io/crate/testing/DocKeyAssert.java
@@ -40,7 +40,7 @@ public final class DocKeyAssert extends AbstractAssert<DocKeyAssert, DocKeys.Doc
     public DocKeyAssert isDocKey(Object... expectedKeyValues) {
         isNotNull();
         List<Object> docKeyValues = Lists.map(actual.values(), s -> ((Literal<?>) s).value());
-        assertThat(docKeyValues).containsExactly(expectedKeyValues);
+        assertThat(docKeyValues).as(info.description()).containsExactly(expectedKeyValues);
         return this;
     }
 }

--- a/server/src/testFixtures/java/io/crate/testing/EngineSearcherAssert.java
+++ b/server/src/testFixtures/java/io/crate/testing/EngineSearcherAssert.java
@@ -45,7 +45,7 @@ public class EngineSearcherAssert extends AbstractAssert<EngineSearcherAssert, E
     public EngineSearcherAssert hasTotalHits(Query query, int totalHits) {
         describedAs("total hits of size " + totalHits + " with query " + query);
         try {
-            assertThat(actual.count(query)).isEqualTo(totalHits);
+            assertThat(actual.count(query)).as(info.description()).isEqualTo(totalHits);
         } catch (IOException e) {
             fail(e.getMessage());
         }

--- a/server/src/testFixtures/java/io/crate/testing/LogicalPlanAssert.java
+++ b/server/src/testFixtures/java/io/crate/testing/LogicalPlanAssert.java
@@ -52,22 +52,23 @@ public class LogicalPlanAssert extends AbstractAssert<LogicalPlanAssert, Logical
 
     public LogicalPlanAssert isEqualTo(String expectedPlan) {
         isNotNull();
-        assertThat(expectedPlan).isNotNull();
-        assertThat(printPlan(actual)).isEqualTo(expectedPlan.strip());
+        assertThat(expectedPlan).as(info.description()).isNotNull();
+        assertThat(printPlan(actual)).as(info.description()).isEqualTo(expectedPlan.strip());
         return this;
     }
 
     public LogicalPlanAssert hasOperators(String ... operator) {
         isNotNull();
         assertThat(printPlan(actual).split("\n"))
+            .as(info.description())
             .containsExactly(operator);
         return this;
     }
 
     public LogicalPlanAssert isEqualTo(LogicalPlan expectedPlan) {
         isNotNull();
-        assertThat(expectedPlan).isNotNull();
-        assertThat(printPlan(actual)).isEqualTo(printPlan(expectedPlan));
+        assertThat(expectedPlan).as(info.description()).isNotNull();
+        assertThat(printPlan(actual)).as(info.description()).isEqualTo(printPlan(expectedPlan));
         return this;
     }
 }

--- a/server/src/testFixtures/java/io/crate/testing/NodeAssert.java
+++ b/server/src/testFixtures/java/io/crate/testing/NodeAssert.java
@@ -43,14 +43,14 @@ public final class NodeAssert extends AbstractAssert<NodeAssert, Node> {
     public NodeAssert isColumnType(String expectedTypeName) {
         assertColumnType(expectedTypeName);
         isExactlyInstanceOf(ColumnType.class);
-        assertThat(((ColumnType<?>) actual).parameters()).isEmpty();
+        assertThat(((ColumnType<?>) actual).parameters()).as(info.description()).isEmpty();
         return this;
     }
 
     public NodeAssert isColumnType(String expectedTypeName, Integer... expectedParams) {
         assertColumnType(expectedTypeName);
         isExactlyInstanceOf(ColumnType.class);
-        assertThat(((ColumnType<?>) actual).parameters()).containsExactly(expectedParams);
+        assertThat(((ColumnType<?>) actual).parameters()).as(info.description()).containsExactly(expectedParams);
         return this;
     }
 
@@ -59,8 +59,8 @@ public final class NodeAssert extends AbstractAssert<NodeAssert, Node> {
         isExactlyInstanceOf(CollectionColumnType.class);
         CollectionColumnType<?> collectionColumnType = (CollectionColumnType<?>) actual;
 
-        assertThat(collectionColumnType.parameters()).isEmpty();
-        assertThat(collectionColumnType.innerType()).satisfies(innerTypeMatcher);
+        assertThat(collectionColumnType.parameters()).as(info.description()).isEmpty();
+        assertThat(collectionColumnType.innerType()).as(info.description()).satisfies(innerTypeMatcher);
         return this;
     }
 
@@ -69,9 +69,9 @@ public final class NodeAssert extends AbstractAssert<NodeAssert, Node> {
         isExactlyInstanceOf(ObjectColumnType.class);
         ObjectColumnType<?> objectColumnType = (ObjectColumnType<?>) actual;
 
-        assertThat(objectColumnType.parameters()).isEmpty();
-        assertThat(objectColumnType.nestedColumns()).isEmpty();
-        assertThat(objectColumnType.columnPolicy()).isNotEmpty()
+        assertThat(objectColumnType.parameters()).as(info.description()).isEmpty();
+        assertThat(objectColumnType.nestedColumns()).as(info.description()).isEmpty();
+        assertThat(objectColumnType.columnPolicy()).as(info.description()).isNotEmpty()
             .get().as("columnPolicy").satisfies(columnPolicyMatcher);
         return this;
     }
@@ -83,9 +83,9 @@ public final class NodeAssert extends AbstractAssert<NodeAssert, Node> {
         isExactlyInstanceOf(ObjectColumnType.class);
         ObjectColumnType<?> objectColumnType = (ObjectColumnType<?>) actual;
 
-        assertThat(objectColumnType.parameters()).isEmpty();
-        assertThat(objectColumnType.nestedColumns()).satisfies(nestedColumnsMatcher);
-        assertThat(objectColumnType.columnPolicy()).isNotEmpty()
+        assertThat(objectColumnType.parameters()).as(info.description()).isEmpty();
+        assertThat(objectColumnType.nestedColumns()).as(info.description()).satisfies(nestedColumnsMatcher);
+        assertThat(objectColumnType.columnPolicy()).as(info.description()).isNotEmpty()
             .get().as("columnPolicy").satisfies(columnPolicyMatcher);
         return this;
     }
@@ -95,8 +95,8 @@ public final class NodeAssert extends AbstractAssert<NodeAssert, Node> {
         isExactlyInstanceOf(ColumnDefinition.class);
         ColumnDefinition<?> columnDefinition = (ColumnDefinition<?>) actual;
 
-        assertThat(columnDefinition.ident()).isEqualTo(expectedIdent);
-        assertThat(columnDefinition.constraints()).isEmpty();
+        assertThat(columnDefinition.ident()).as(info.description()).isEqualTo(expectedIdent);
+        assertThat(columnDefinition.constraints()).as(info.description()).isEmpty();
         assertThat(columnDefinition.type()).as("columnType").satisfies(columnTypeMatcher);
         return this;
     }

--- a/server/src/testFixtures/java/io/crate/testing/ParsedDocumentAssert.java
+++ b/server/src/testFixtures/java/io/crate/testing/ParsedDocumentAssert.java
@@ -41,7 +41,7 @@ public class ParsedDocumentAssert extends AbstractAssert<ParsedDocumentAssert, P
     public void hasSameResolvedFields(Document expected, String fieldName) {
         IndexableField[] expectedFields = expected.getFields(fieldName);
         IndexableField[] actualFields = actual.doc().getFields(fieldName);
-        assertThat(actualFields).hasSize(expectedFields.length);
+        assertThat(actualFields).as(info.description()).hasSize(expectedFields.length);
         for (int i = 0; i < expectedFields.length; i++) {
             var field1 = actualFields[i];
             var field2 = expectedFields[i];

--- a/server/src/testFixtures/java/io/crate/testing/ProjectionAssert.java
+++ b/server/src/testFixtures/java/io/crate/testing/ProjectionAssert.java
@@ -39,8 +39,8 @@ public final class ProjectionAssert extends AbstractAssert<ProjectionAssert, Pro
     public ProjectionAssert isLimitAndOffset(int expectedLimit, int expectedOffset) {
         isNotNull();
         isExactlyInstanceOf(LimitAndOffsetProjection.class);
-        assertThat(((LimitAndOffsetProjection) actual).limit()).isEqualTo(expectedLimit);
-        assertThat(((LimitAndOffsetProjection) actual).offset()).isEqualTo(expectedOffset);
+        assertThat(((LimitAndOffsetProjection) actual).limit()).as(info.description()).isEqualTo(expectedLimit);
+        assertThat(((LimitAndOffsetProjection) actual).offset()).as(info.description()).isEqualTo(expectedOffset);
         return this;
     }
 

--- a/server/src/testFixtures/java/io/crate/testing/SQLResponseAssert.java
+++ b/server/src/testFixtures/java/io/crate/testing/SQLResponseAssert.java
@@ -35,7 +35,7 @@ public final class SQLResponseAssert extends AbstractAssert<SQLResponseAssert, S
 
     public SQLResponseAssert hasRowCount(long expectedRowCount) {
         isNotNull();
-        assertThat(actual.rowCount()).isEqualTo(expectedRowCount);
+        assertThat(actual.rowCount()).as(info.description()).isEqualTo(expectedRowCount);
         return this;
     }
 
@@ -45,7 +45,7 @@ public final class SQLResponseAssert extends AbstractAssert<SQLResponseAssert, S
     public SQLResponseAssert hasLines(String ... lines) {
         String result = TestingHelpers.printedTable(actual.rows());
         String[] resultRows = result.split("\n");
-        assertThat(resultRows).containsExactly(lines);
+        assertThat(resultRows).as(info.description()).containsExactly(lines);
         return this;
     }
 
@@ -62,7 +62,7 @@ public final class SQLResponseAssert extends AbstractAssert<SQLResponseAssert, S
             Object[] row = actual.rows()[i];
             resultRows[i] = TestingHelpers.printRow(row);
         }
-        assertThat(resultRows).containsExactly(rows);
+        assertThat(resultRows).as(info.description()).containsExactly(rows);
         return this;
     }
 
@@ -72,27 +72,27 @@ public final class SQLResponseAssert extends AbstractAssert<SQLResponseAssert, S
             Object[] row = actual.rows()[i];
             resultRows[i] = TestingHelpers.printRow(row);
         }
-        assertThat(resultRows).containsExactlyInAnyOrder(rows);
+        assertThat(resultRows).as(info.description()).containsExactlyInAnyOrder(rows);
         return this;
     }
 
     public SQLResponseAssert hasRows(Object[] ... rows) {
-        assertThat(List.of(actual.rows())).containsExactly(rows);
+        assertThat(List.of(actual.rows())).as(info.description()).containsExactly(rows);
         return this;
     }
 
     public SQLResponseAssert hasRowsInAnyOrder(Object[] ... rows) {
-        assertThat(List.of(actual.rows())).containsExactlyInAnyOrder(rows);
+        assertThat(List.of(actual.rows())).as(info.description()).containsExactlyInAnyOrder(rows);
         return this;
     }
 
     public SQLResponseAssert hasColumns(String ... names) {
-        assertThat(actual.cols()).containsExactly(names);
+        assertThat(actual.cols()).as(info.description()).containsExactly(names);
         return this;
     }
 
     public SQLResponseAssert isEmpty() {
-        assertThat(actual.rows()).isEmpty();
+        assertThat(actual.rows()).as(info.description()).isEmpty();
         return this;
     }
 }

--- a/server/src/testFixtures/java/io/crate/testing/SymbolAssert.java
+++ b/server/src/testFixtures/java/io/crate/testing/SymbolAssert.java
@@ -62,9 +62,9 @@ public final class SymbolAssert extends AbstractAssert<SymbolAssert, Symbol> {
     public SymbolAssert hasValue(Object expectedValue) {
         Object value = ((Input<?>) actual).value();
         if (expectedValue == null) {
-            assertThat(value).isNull();
+            assertThat(value).as(info.description()).isNull();
         } else {
-            assertThat(value).isEqualTo(expectedValue);
+            assertThat(value).as(info.description()).isEqualTo(expectedValue);
         }
         return this;
     }
@@ -191,7 +191,7 @@ public final class SymbolAssert extends AbstractAssert<SymbolAssert, Symbol> {
             .isEqualTo(expectedName);
 
         if (expectedArgumentTypes != null) {
-            assertThat(f.arguments()).hasSize(expectedArgumentTypes.size());
+            assertThat(f.arguments()).as(info.description()).hasSize(expectedArgumentTypes.size());
             for (int i = 0; i < expectedArgumentTypes.size(); i++) {
                 assertThat(f.arguments().get(i).valueType())
                     .as("Argument pos: " + i)
@@ -205,7 +205,7 @@ public final class SymbolAssert extends AbstractAssert<SymbolAssert, Symbol> {
     public final SymbolAssert isFunction(final String name, Consumer<Symbol>... argMatchers) {
         isFunction(name);
         if (argMatchers != null) {
-            assertThat(((Function) actual).arguments()).satisfiesExactly(argMatchers);
+            assertThat(((Function) actual).arguments()).as(info.description()).satisfiesExactly(argMatchers);
         }
         return this;
     }
@@ -244,14 +244,14 @@ public final class SymbolAssert extends AbstractAssert<SymbolAssert, Symbol> {
     public final SymbolAssert isAggregation(final String name, Consumer<Symbol>... argMatchers) {
         isAggregation(name);
         if (argMatchers != null) {
-            assertThat(((Aggregation) actual).inputs()).satisfiesExactly(argMatchers);
+            assertThat(((Aggregation) actual).inputs()).as(info.description()).satisfiesExactly(argMatchers);
         }
         return this;
     }
 
     public SymbolAssert isSQL(final String expectedStmt) {
         isNotNull();
-        assertThat(SQLPrinter.print(actual)).isEqualTo(expectedStmt);
+        assertThat(SQLPrinter.print(actual)).as(info.description()).isEqualTo(expectedStmt);
         return this;
     }
 

--- a/server/src/testFixtures/java/io/crate/testing/TableInfoAssert.java
+++ b/server/src/testFixtures/java/io/crate/testing/TableInfoAssert.java
@@ -41,7 +41,7 @@ public class TableInfoAssert extends AbstractAssert<TableInfoAssert, TableInfo> 
     }
 
     public TableInfoAssert hasSize(int size) {
-        Assertions.assertThat(actual).hasSize(size);
+        Assertions.assertThat(actual).as(info.description()).hasSize(size);
         return this;
     }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

`SQLResponseAssert.as("custom message")` doesn't work in the sense that:

```java
assertThat(sqlResponse).as("my message").hasRows(expectedRows);
```

doesn't show `my message` if the expected rows are missing. Same is true for `SQLResponseAssert.withFailMessage()`.

This is because methods in `SQLResponseAssert` actually construct new assertions and they don't get the custom description. 

This PR fixes that by forwarding the custom description to the new assertions. I searched for all of custom asserts that we have, and I think this is all that needs to be fixed. The custom assert classes that _don't_ forward assertions aren't affected, e.g. [`SettingsAssert.hasKey`](https://github.com/crate/crate/blob/master/server/src/testFixtures/java/io/crate/testing/SettingsAssert.java#L46-L52). 

The PR doesn't fix `withFailMessage` because it's a bit more verbose (adds a few lines per method), so I'll try to find something simpler.

## Checklist

 - [ ] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes.
       If you're an external contributor you can give yourself attribution and include your name and Github handle.
       e.g.:
       ```
       `John Doe <https://github.com/John_Doe>`_ added support for ...
       ```
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
