### PR TITLE
Ensure that Filter preserves order of its outputs after pruning

### DIFF
--- a/server/src/main/java/io/crate/planner/operators/AbstractJoinPlan.java
+++ b/server/src/main/java/io/crate/planner/operators/AbstractJoinPlan.java
@@ -25,7 +25,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 
 import org.jspecify.annotations.Nullable;
@@ -95,29 +94,6 @@ public abstract class AbstractJoinPlan implements LogicalPlan {
             return Lists.concat(lhs.outputs(), rhs.outputs());
         }
     }
-
-    protected final void validateOutputsOrder(List<Symbol> outputsAfterPruning) {
-        boolean isSubsequence = Lists.isSubsequence(outputsAfterPruning, outputs());
-        if (!isSubsequence) {
-            String error = String.format(
-                """
-                Column pruning reshuffled outputs in %s:
-                outputs = %s
-                outputsAfterPruning = %s
-                lhs.outputs() = %s
-                rhs.outputs() = %s
-                """,
-                getClass().getSimpleName(),
-                outputs(),
-                outputsAfterPruning,
-                lhs.outputs(),
-                rhs.outputs(),
-                Locale.ENGLISH
-            );
-            throw new IllegalStateException(error);
-        }
-    }
-
 
     @Override
     public Map<LogicalPlan, SelectSymbol> dependencies() {

--- a/server/src/main/java/io/crate/planner/operators/Filter.java
+++ b/server/src/main/java/io/crate/planner/operators/Filter.java
@@ -108,6 +108,8 @@ public final class Filter extends ForwardingLogicalPlan {
         if (newSource == source) {
             return this;
         }
+        // Filter's outputs is it's source's outputs.
+        validateOutputsOrder(newSource.outputs());
         return new Filter(newSource, query);
     }
 

--- a/server/src/main/java/io/crate/planner/operators/LogicalPlan.java
+++ b/server/src/main/java/io/crate/planner/operators/LogicalPlan.java
@@ -23,6 +23,7 @@ package io.crate.planner.operators;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.SequencedCollection;
 import java.util.Set;
@@ -217,6 +218,24 @@ public interface LogicalPlan extends Plan {
     }
 
     <C, R> R accept(LogicalPlanVisitor<C, R> visitor, C context);
+
+    default void validateOutputsOrder(List<Symbol> outputsAfterPruning) {
+        boolean isSubsequence = Lists.isSubsequence(outputsAfterPruning, outputs());
+        if (!isSubsequence) {
+            String error = String.format(
+                Locale.ENGLISH,
+                """
+                Column pruning reshuffled outputs in %s:
+                outputs = %s
+                outputsAfterPruning = %s
+                """,
+                getClass().getSimpleName(),
+                outputs(),
+                outputsAfterPruning
+            );
+            throw new IllegalStateException(error);
+        }
+    }
 
     default StatementType type() {
         return StatementType.SELECT;

--- a/server/src/main/java/io/crate/planner/operators/TableFunction.java
+++ b/server/src/main/java/io/crate/planner/operators/TableFunction.java
@@ -42,6 +42,7 @@ import io.crate.expression.eval.EvaluatingNormalizer;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.SelectSymbol;
 import io.crate.expression.symbol.Symbol;
+import io.crate.expression.symbol.Symbols;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.RowGranularity;
 import io.crate.planner.DependencyCarrier;
@@ -136,10 +137,16 @@ public final class TableFunction implements LogicalPlan {
 
     @Override
     public LogicalPlan pruneOutputsExcept(SequencedCollection<Symbol> outputsToKeep) {
-        if (toCollect.size() == outputsToKeep.size() && outputsToKeep.containsAll(toCollect)) {
+        ArrayList<Symbol> toKeep = new ArrayList<>();
+        for (Symbol outputToKeep : outputsToKeep) {
+            Symbols.intersection(outputToKeep, toCollect, toKeep::add);
+        }
+        List<Symbol> newToCollect = Lists.intersection(toCollect, toKeep);
+        if (newToCollect.size() == toCollect.size()) {
             return this;
         }
-        return new TableFunction(relation, List.copyOf(outputsToKeep), where);
+        validateOutputsOrder(newToCollect);
+        return new TableFunction(relation, newToCollect, where);
     }
 
     @Override

--- a/server/src/test/java/io/crate/integrationtests/CorrelatedSubqueryITest.java
+++ b/server/src/test/java/io/crate/integrationtests/CorrelatedSubqueryITest.java
@@ -67,8 +67,9 @@ public class CorrelatedSubqueryITest extends IntegTestCase {
             "    └ Rename[1, mountain] AS t\n" +
             "      └ Collect[sys.summits | [1, mountain] | true]\n" +
             "    └ SubPlan\n" +
-            "      └ Limit[2::bigint;0::bigint]\n" +
-            "        └ TableFunction[empty_row | [mountain] | true]\n"
+            "      └ Eval[mountain]\n" +
+            "        └ Limit[2::bigint;0::bigint]\n" +
+            "          └ TableFunction[empty_row | [] | true]\n"
         );
         execute("SELECT 1, (SELECT t.mountain) FROM sys.summits t");
         Comparator<Object[]> compareMountain = Comparator.comparing((Object[] row) -> (String) row[1]);
@@ -119,8 +120,9 @@ public class CorrelatedSubqueryITest extends IntegTestCase {
             "        └ Rename[1, mountain] AS t\n" +
             "          └ Collect[sys.summits | [1, mountain] | true]\n" +
             "        └ SubPlan\n" +
-            "          └ Limit[2::bigint;0::bigint]\n" +
-            "            └ TableFunction[empty_row | [mountain] | true]\n"
+            "          └ Eval[mountain]\n" +
+            "            └ Limit[2::bigint;0::bigint]\n" +
+            "              └ TableFunction[empty_row | [] | true]\n"
         );
         execute(statement);
         assertThat(TestingHelpers.printedTable(response.rows())).isEqualTo(
@@ -227,8 +229,9 @@ public class CorrelatedSubqueryITest extends IntegTestCase {
             "      └ Rename[x] AS t\n" +
             "        └ TableFunction[generate_series | [generate_series] | true]\n" +
             "      └ SubPlan\n" +
-            "        └ Limit[1;0]\n" +
-            "          └ TableFunction[empty_row | [x] | true]\n");
+            "        └ Eval[x]\n" +
+            "          └ Limit[1;0]\n" +
+            "            └ TableFunction[empty_row | [] | true]\n");
         execute(stmt);
         assertThat(TestingHelpers.printedTable(response.rows())).isEqualTo(
             "1\n" +
@@ -250,8 +253,9 @@ public class CorrelatedSubqueryITest extends IntegTestCase {
             "          └ Rename[mountain, region, height] AS t\n" +
             "            └ Collect[sys.summits | [mountain, region, height] | true]\n" +
             "          └ SubPlan\n" +
-            "            └ Limit[2::bigint;0::bigint]\n" +
-            "              └ TableFunction[empty_row | [mountain] | true]\n"
+            "            └ Eval[mountain]\n" +
+            "              └ Limit[2::bigint;0::bigint]\n" +
+            "                └ TableFunction[empty_row | [] | true]\n"
         );
         execute(stmt);
         assertThat(TestingHelpers.printedTable(response.rows())).isEqualTo(
@@ -376,8 +380,9 @@ public class CorrelatedSubqueryITest extends IntegTestCase {
             "                    ├ Collect[pg_catalog.pg_class | [oid, relnamespace] | (relname = table_name)]\n" +
             "                    └ Collect[pg_catalog.pg_namespace | [oid] | (nspname = table_schema)]\n" +
             "          └ SubPlan\n" +
-            "            └ Limit[2::bigint;0::bigint]\n" +
-            "              └ TableFunction[empty_row | [attrelid] | true]\n"
+            "            └ Eval[attrelid]\n" +
+            "              └ Limit[2::bigint;0::bigint]\n" +
+            "                └ TableFunction[empty_row | [] | true]\n"
         );
         execute(stmt);
         assertThat(TestingHelpers.printedTable(response.rows())).isEqualTo(

--- a/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
@@ -1822,7 +1822,8 @@ public class JoinIntegrationTest extends IntegTestCase {
             "  └ NestedLoopJoin[RIGHT | true] (rows=unknown)",
             "    ├ Collect[doc.t1 | [c0] | true] (rows=unknown)",
             "    └ Rename[\"1\"] AS sub0 (rows=unknown)",
-            "      └ TableFunction[empty_row | [1] | true] (rows=unknown)"
+            "      └ Eval[1] (rows=unknown)",
+            "        └ TableFunction[empty_row | [] | true] (rows=unknown)"
         );
 
         execute(query);

--- a/server/src/test/java/io/crate/planner/CorrelatedJoinPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/CorrelatedJoinPlannerTest.java
@@ -61,8 +61,9 @@ public class CorrelatedJoinPlannerTest extends CrateDummyClusterServiceUnitTest 
                       └ CorrelatedJoin[mountain, (SELECT mountain FROM (empty_row))]
                         └ Collect[sys.summits | [mountain] | true]
                         └ SubPlan
-                          └ Limit[2::bigint;0::bigint]
-                            └ TableFunction[empty_row | [mountain] | true]"""
+                          └ Eval[mountain]
+                            └ Limit[2::bigint;0::bigint]
+                              └ TableFunction[empty_row | [] | true]"""
         );
     }
 
@@ -78,8 +79,9 @@ public class CorrelatedJoinPlannerTest extends CrateDummyClusterServiceUnitTest 
                     └ Rename[mountain] AS t
                       └ Collect[sys.summits | [mountain] | true]
                     └ SubPlan
-                      └ Limit[2::bigint;0::bigint]
-                        └ TableFunction[empty_row | [mountain] | true]"""
+                      └ Eval[mountain]
+                        └ Limit[2::bigint;0::bigint]
+                          └ TableFunction[empty_row | [] | true]"""
         );
     }
 

--- a/server/src/test/java/io/crate/planner/SelectPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/SelectPlannerTest.java
@@ -1263,8 +1263,8 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
             Eval[unnest, sum(unnest) OVER (ORDER BY power(unnest, 2.0) ASC RANGE BETWEEN 3 PRECEDING AND CURRENT ROW)]
               └ WindowAgg[unnest, power(unnest, 2.0)] | [sum(unnest) OVER (ORDER BY power(unnest, 2.0) ASC RANGE BETWEEN 3 PRECEDING AND CURRENT ROW)]
                 └ Eval[unnest, power(unnest, 2.0)]
-                  └ Rename[unnest, unnest] AS t
-                    └ TableFunction[unnest | [unnest, unnest] | true]
+                  └ Rename[unnest] AS t
+                    └ TableFunction[unnest | [unnest] | true]
             """;
         assertThat(plan).isEqualTo(expectedPlan);
     }
@@ -1674,11 +1674,11 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
 
         // Used to hang in the value range validation in FloatType.implicitCast.
         LogicalPlan logicalPlan = e.logicalPlan("SELECT EXP(-1110102730.1852759636)::float");
-        assertThat(logicalPlan).hasOperators("TableFunction[empty_row | [0.0] | true]");
+        assertThat(logicalPlan).hasOperators("Eval[0.0]", "  └ TableFunction[empty_row | [] | true]");
 
         // Used to hang in the value range validation in DoubleType.implicitCast.
         logicalPlan = e.logicalPlan("SELECT EXP(-1110102730.1852759636)::double");
-        assertThat(logicalPlan).hasOperators("TableFunction[empty_row | [0.0] | true]");
+        assertThat(logicalPlan).hasOperators("Eval[0.0]", "  └ TableFunction[empty_row | [] | true]");
     }
 
     // tracks a bug: https://github.com/crate/crate/issues/17266

--- a/server/src/test/java/io/crate/planner/UnionPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/UnionPlannerTest.java
@@ -24,7 +24,6 @@ package io.crate.planner;
 import static io.crate.analyze.TableDefinitions.TEST_DOC_LOCATIONS_TABLE_IDENT;
 import static io.crate.analyze.TableDefinitions.USER_TABLE_IDENT;
 import static io.crate.testing.Asserts.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.HashMap;
 import java.util.List;
@@ -205,7 +204,8 @@ public class UnionPlannerTest extends CrateDummyClusterServiceUnitTest {
         UnionExecutionPlan union = e.plan("SELECT null UNION ALL SELECT id FROM users");
         Collect left = (Collect) union.left();
         assertThat(left.collectPhase().projections()).satisfiesExactly(
-            p -> assertThat(p).isExactlyInstanceOf(EvalProjection.class) // returns NULL
+            p -> assertThat(p).isExactlyInstanceOf(EvalProjection.class), // returns NULL
+            p -> assertThat(p).isExactlyInstanceOf(EvalProjection.class) // casts NULL to the union's output type
         );
         Collect right = (Collect) union.right();
         assertThat(left.streamOutputs()).isEqualTo(right.streamOutputs());
@@ -218,7 +218,8 @@ public class UnionPlannerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(left.streamOutputs()).isEqualTo(right.streamOutputs());
         assertThat(right.streamOutputs()).satisfiesExactly(o -> assertThat(o).isEqualTo(DataTypes.LONG));
         assertThat(right.collectPhase().projections()).satisfiesExactly(
-            p -> assertThat(p).isExactlyInstanceOf(EvalProjection.class) // returns NULL
+            p -> assertThat(p).isExactlyInstanceOf(EvalProjection.class), // returns NULL
+            p -> assertThat(p).isExactlyInstanceOf(EvalProjection.class) // casts NULL to the union's output type
         );
     }
 
@@ -264,7 +265,8 @@ public class UnionPlannerTest extends CrateDummyClusterServiceUnitTest {
                     │    │  └ Collect[doc.users | [id] | true]
                     │    └ Rename[id] AS y
                     │      └ Collect[doc.users | [id] | true]
-                    └ TableFunction[empty_row | [1, 1] | true]
+                    └ Eval[1, 1]
+                      └ TableFunction[empty_row | [] | true]
                 """
         );
     }

--- a/server/src/test/java/io/crate/planner/operators/JoinTest.java
+++ b/server/src/test/java/io/crate/planner/operators/JoinTest.java
@@ -907,9 +907,10 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
                   │  └ Collect[doc.c | [x] | true]
                   └ Collect[doc.d | [] | true]
                 └ SubPlan
-                  └ Limit[2::bigint;0::bigint]
-                    └ Filter[(((x = 1) AND (x = 1)) AND (x = 1))]
-                      └ TableFunction[empty_row | [1] | true]
+                  └ Eval[1]
+                    └ Limit[2::bigint;0::bigint]
+                      └ Filter[(((x = 1) AND (x = 1)) AND (x = 1))]
+                        └ TableFunction[empty_row | [] | true]
             """
         );
     }
@@ -951,7 +952,8 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
             "  │  ├ Collect[doc.t1 | [a, x, i] | true]",
             "  │  └ Collect[doc.t2 | [b, y, i] | true]",
             "  └ Rename[foo] AS temp",
-            "    └ TableFunction[empty_row | [1 AS foo] | true]"
+            "    └ Eval[1 AS foo]",
+            "      └ TableFunction[empty_row | [] | true]"
         );
     }
 
@@ -1015,8 +1017,10 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
             "    │    └ Collect[pg_catalog.pg_attrdef | [adbin, adrelid, adnum] | true]",
             "    └ Rename[oid, attnum] AS vals",
             "      └ Union[oid, attnum]",
-            "        ├ TableFunction[empty_row | [-2002935028 AS oid, 1 AS attnum] | true]",
-            "        └ TableFunction[empty_row | [-2002935028, 2] | true]"
+            "        ├ Eval[-2002935028 AS oid, 1 AS attnum]",
+            "        │  └ TableFunction[empty_row | [] | true]",
+            "        └ Eval[-2002935028, 2]",
+            "          └ TableFunction[empty_row | [] | true]"
         );
 
     }

--- a/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
@@ -1023,7 +1023,8 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
                 "    └ NestedLoopJoin[INNER | CASE WHEN (col0 = col0) THEN awesome ELSE false END]",
                 "      ├ Collect[doc.users | [awesome] | true]",
                 "      └ Rename[col0] AS sub0",
-                "        └ TableFunction[empty_row | [1 AS col0] | true]"
+                "        └ Eval[1 AS col0]",
+                "          └ TableFunction[empty_row | [] | true]"
             );
     }
 }

--- a/server/src/test/java/io/crate/planner/operators/StatementClassifierTest.java
+++ b/server/src/test/java/io/crate/planner/operators/StatementClassifierTest.java
@@ -56,7 +56,7 @@ public class StatementClassifierTest extends CrateDummyClusterServiceUnitTest {
         LogicalPlan plan = e.logicalPlan("SELECT 1");
         StatementClassifier.Classification classification = StatementClassifier.classify(plan);
         assertThat(classification.type()).isEqualTo(Plan.StatementType.SELECT);
-        assertThat(classification.labels()).containsExactly("TableFunction");
+        assertThat(classification.labels()).containsExactly("Eval", "TableFunction");
 
         plan = e.logicalPlan("SELECT * FROM users WHERE id = 1");
         classification = StatementClassifier.classify(plan);
@@ -96,7 +96,7 @@ public class StatementClassifierTest extends CrateDummyClusterServiceUnitTest {
         plan = e.logicalPlan("SELECT * FROM users WHERE id = (SELECT 1) OR name = (SELECT 'Arthur')");
         classification = StatementClassifier.classify(plan);
         assertThat(classification.type()).isEqualTo(Plan.StatementType.SELECT);
-        assertThat(classification.labels()).containsExactly("Collect", "Limit", "MultiPhase", "TableFunction");
+        assertThat(classification.labels()).containsExactly("Collect", "Eval", "Limit", "MultiPhase", "TableFunction");
     }
 
 

--- a/server/src/test/java/io/crate/planner/operators/TableFunctionTest.java
+++ b/server/src/test/java/io/crate/planner/operators/TableFunctionTest.java
@@ -44,10 +44,13 @@ public class TableFunctionTest extends CrateDummyClusterServiceUnitTest {
         Symbol a = e.asSymbol("a");
         Symbol b = e.asSymbol("b");
 
+        // `a` and `b` aren't outputs of this table function, so pruneOutputsExcept must not
+        // grow its outputs to contain them.
+        // Instead, pruning does normalization which gets back initial empty outputs.
         LogicalPlan tableFunction = TableFunction.create(mock(TableFunctionRelation.class), List.of(), WhereClause.MATCH_ALL);
         assertThat(tableFunction.outputs()).isEmpty();
         var prunedTableFunction = tableFunction.pruneOutputsExcept(List.of(a, b));
-        assertThat(prunedTableFunction.outputs()).containsExactly(a, b);
+        assertThat(prunedTableFunction.outputs()).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
First commit led to [2 failures](https://jenkins.crate.io/job/CrateDB/job/crate_on_pr/6591/).

`Filter`, similar to joins, doesn't have to normalize outputs, as it only calls source pruning and doesn't use `f(outputsToKeep)` to create a new instance. So adding only validation there.

Both failures happened due to `TableFunction` pruning expanding(!) from 0 original outputs to 1
 (Literal coming from outputsToKeep).

Solution: Normalize table with `Symbols.intersection` + `Lists.intersection(toCollect, toKeep)`, then those 2 failures will be gone. 

 I had 2 concerns with this solution:
 
 1. We got some extra `Evals` now, but it's fine, same reasons as in https://github.com/crate/crate/pull/20077, see description and comments
 2. We are basically reverting https://github.com/crate/crate/commit/c7ea2e0005c1c8ad583373e47ebb93f156c8b9f5 for 
    zero outputs case.
    It used to expand [] -> [1] after the pruning which violates the contract. 
    Pruning can only drop, can't reshuffle or add.

    I didn't check in details, but I got a test from its corresponding support [issue](https://github.com/crate/support/issues/437) and saw in debugger (on old version), 
    that `Eval` has id,name in one order and `outputsToKeep` in another and old version was argument order sensitive. 
    Also, UNION didn't have recent fixes obviously. 
    
    I confirmed that
    1.  test fail on old state before 
        https://github.com/crate/crate/commit/c7ea2e0005c1c8ad583373e47ebb93f156c8b9f5 - just a sanity check that test was good/bug catching.
    2.  test passes with old fix - also for sanity check. I think it fixed it by coincidence by NOT skipping pruning and such re-creating parent Eval.
    3.  test passes with modern version of Collect, Eval, Union + (TableFunction version from this PR)



