### PR TITLE
Add optimizer rule MergeEvalIntoFetch

### DIFF
--- a/server/src/main/java/io/crate/planner/operators/AbstractJoinPlan.java
+++ b/server/src/main/java/io/crate/planner/operators/AbstractJoinPlan.java
@@ -25,6 +25,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import org.jspecify.annotations.Nullable;
@@ -92,6 +93,28 @@ public abstract class AbstractJoinPlan implements LogicalPlan {
             return lhs.outputs();
         } else {
             return Lists.concat(lhs.outputs(), rhs.outputs());
+        }
+    }
+
+    protected final void validateOutputsOrder(List<Symbol> outputsAfterPruning) {
+        boolean isSubsequence = Lists.isSubsequence(outputsAfterPruning, outputs());
+        if (!isSubsequence) {
+            String error = String.format(
+                """
+                Column pruning reshuffled outputs in %s:
+                outputs = %s
+                outputsAfterPruning = %s
+                lhs.outputs() = %s
+                rhs.outputs() = %s
+                """,
+                getClass().getSimpleName(),
+                outputs(),
+                outputsAfterPruning,
+                lhs.outputs(),
+                rhs.outputs(),
+                Locale.ENGLISH
+            );
+            throw new IllegalStateException(error);
         }
     }
 

--- a/server/src/main/java/io/crate/planner/operators/Eval.java
+++ b/server/src/main/java/io/crate/planner/operators/Eval.java
@@ -40,6 +40,7 @@ import io.crate.execution.dsl.projection.builder.InputColumns;
 import io.crate.execution.dsl.projection.builder.ProjectionBuilder;
 import io.crate.expression.symbol.FetchMarker;
 import io.crate.expression.symbol.Symbol;
+import io.crate.expression.symbol.Symbols;
 import io.crate.planner.DependencyCarrier;
 import io.crate.planner.ExecutionPlan;
 import io.crate.planner.Merge;
@@ -101,11 +102,18 @@ public final class Eval extends ForwardingLogicalPlan {
 
     @Override
     public LogicalPlan pruneOutputsExcept(SequencedCollection<Symbol> outputsToKeep) {
-        LogicalPlan newSource = source.pruneOutputsExcept(outputsToKeep);
+        ArrayList<Symbol> sourceOutputsToKeep = new ArrayList<>();
+        for (Symbol outputToKeep : outputsToKeep) {
+            Symbols.intersection(outputToKeep, outputs, sourceOutputsToKeep::add);
+        }
+        LogicalPlan newSource = source.pruneOutputsExcept(sourceOutputsToKeep);
         if (source == newSource && outputs.isEmpty()) {
             return this;
         }
-        return new Eval(newSource, List.copyOf(outputsToKeep));
+        List<Symbol> prunedOutputs = Lists.intersection(outputs, sourceOutputsToKeep);
+        boolean isSubsequence = Lists.isSubsequence(prunedOutputs, outputs);
+        assert isSubsequence : "pruneOutputsExcept must not shuffle the outputs, it can only remove some of them.";
+        return new Eval(newSource, prunedOutputs);
     }
 
     @Nullable

--- a/server/src/main/java/io/crate/planner/operators/Fetch.java
+++ b/server/src/main/java/io/crate/planner/operators/Fetch.java
@@ -102,6 +102,18 @@ public final class Fetch extends ForwardingLogicalPlan {
         return outputs;
     }
 
+    public Map<Symbol, Symbol> replacedOutputs() {
+        return replacedOutputs;
+    }
+
+    public List<Reference> fetchRefs() {
+        return fetchRefs;
+    }
+
+    public Map<RelationName, FetchSource> fetchSourceByRelation() {
+        return fetchSourceByRelation;
+    }
+
     @Override
     public LogicalPlan pruneOutputsExcept(SequencedCollection<Symbol> outputsToKeep) {
         return this;

--- a/server/src/main/java/io/crate/planner/operators/HashJoin.java
+++ b/server/src/main/java/io/crate/planner/operators/HashJoin.java
@@ -218,13 +218,15 @@ public class HashJoin extends AbstractJoinPlan {
             if (newLhs == lhs && newRhs == rhs) {
                 return this;
             }
-            return new HashJoin(
+            HashJoin newHashJoin = new HashJoin(
                 newLhs,
                 newRhs,
                 joinCondition,
                 joinType,
                 lookupJoin
             );
+            validateOutputsOrder(newHashJoin.outputs());
+            return newHashJoin;
         }
     }
 

--- a/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -103,6 +103,7 @@ import io.crate.planner.optimizer.rule.MergeAggregateAndCollectToCount;
 import io.crate.planner.optimizer.rule.MergeAggregateRenameAndCollectToCount;
 import io.crate.planner.optimizer.rule.MergeFilterAndCollect;
 import io.crate.planner.optimizer.rule.MergeFilterAndForeignCollect;
+import io.crate.planner.optimizer.rule.MergeEvalIntoFetch;
 import io.crate.planner.optimizer.rule.MergeFilters;
 import io.crate.planner.optimizer.rule.MoveConstantJoinConditionsBeneathJoin;
 import io.crate.planner.optimizer.rule.MoveEquiJoinFilterIntoInnerJoin;
@@ -201,7 +202,8 @@ public class LogicalPlanner {
     public static final List<Rule<?>> FETCH_OPTIMIZER_RULES = List.of(
         new RemoveRedundantEval(),
         new MergeFilterAndCollect(),
-        new RewriteToQueryThenFetch()
+        new RewriteToQueryThenFetch(),
+        new MergeEvalIntoFetch()
     );
 
     public static final List<Rule<?>> WRITE_OPTIMIZER_RULES = List.of(

--- a/server/src/main/java/io/crate/planner/operators/NestedLoopJoin.java
+++ b/server/src/main/java/io/crate/planner/operators/NestedLoopJoin.java
@@ -252,7 +252,7 @@ public class NestedLoopJoin extends AbstractJoinPlan {
         if (newLhs == lhs && newRhs == rhs) {
             return this;
         }
-        return new NestedLoopJoin(
+        NestedLoopJoin newNestedLoopJoin = new NestedLoopJoin(
             newLhs,
             newRhs,
             joinType,
@@ -262,6 +262,8 @@ public class NestedLoopJoin extends AbstractJoinPlan {
             rewriteNestedLoopJoinToHashJoinDone,
             lookupJoin
         );
+        validateOutputsOrder(newNestedLoopJoin.outputs());
+        return newNestedLoopJoin;
     }
 
     @Nullable

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MergeEvalIntoFetch.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MergeEvalIntoFetch.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.rule;
+
+import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
+import static io.crate.planner.optimizer.matcher.Patterns.source;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import io.crate.expression.symbol.Symbol;
+import io.crate.planner.operators.Eval;
+import io.crate.planner.operators.Fetch;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.operators.MapBackedSymbolReplacer;
+import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.matcher.Captures;
+import io.crate.planner.optimizer.matcher.Pattern;
+
+public final class MergeEvalIntoFetch implements Rule<Eval> {
+
+    private final Pattern<Eval> pattern = typeOf(Eval.class).with(source(), typeOf(Fetch.class));
+
+    @Override
+    public Pattern<Eval> pattern() {
+        return pattern;
+    }
+
+    @Override
+    public LogicalPlan apply(Eval eval, Captures captures, Rule.Context context) {
+        Fetch fetch = (Fetch) eval.source();
+        Map<Symbol, Symbol> fetchReplacedOutputs = fetch.replacedOutputs();
+        LinkedHashMap<Symbol, Symbol> newReplacedOutputs = new LinkedHashMap<>();
+        // Eval's source is Fetch, so each Eval output is a part of Fetch outputs,
+        // it just some extra computation on top if it.
+        // Hence, it's safe to lookup each Eval output in Fetch's replacedOutputs.
+        for (Symbol output : eval.outputs()) {
+            newReplacedOutputs.put(output, MapBackedSymbolReplacer.convert(output, fetchReplacedOutputs));
+        }
+        return new Fetch(
+            newReplacedOutputs,
+            fetch.fetchRefs(),
+            fetch.fetchSourceByRelation(),
+            fetch.sources().get(0)
+        );
+    }
+}

--- a/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
@@ -271,6 +271,7 @@ public class PgCatalogITest extends IntegTestCase {
             "optimizer_equi_join_to_lookup_join| false| Indicates if the optimizer rule EquiJoinToLookupJoin is activated.| NULL| NULL",
             "optimizer_merge_aggregate_and_collect_to_count| true| Indicates if the optimizer rule MergeAggregateAndCollectToCount is activated.| NULL| NULL",
             "optimizer_merge_aggregate_rename_and_collect_to_count| true| Indicates if the optimizer rule MergeAggregateRenameAndCollectToCount is activated.| NULL| NULL",
+            "optimizer_merge_eval_into_fetch| true| Indicates if the optimizer rule MergeEvalIntoFetch is activated.| NULL| NULL",
             "optimizer_merge_filter_and_collect| true| Indicates if the optimizer rule MergeFilterAndCollect is activated.| NULL| NULL",
             "optimizer_merge_filter_and_foreign_collect| true| Indicates if the optimizer rule MergeFilterAndForeignCollect is activated.| NULL| NULL",
             "optimizer_merge_filters| true| Indicates if the optimizer rule MergeFilters is activated.| NULL| NULL",

--- a/server/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
@@ -416,6 +416,7 @@ public class ShowIntegrationTest extends IntegTestCase {
             "optimizer_equi_join_to_lookup_join| false| Indicates if the optimizer rule EquiJoinToLookupJoin is activated.",
             "optimizer_merge_aggregate_and_collect_to_count| true| Indicates if the optimizer rule MergeAggregateAndCollectToCount is activated.",
             "optimizer_merge_aggregate_rename_and_collect_to_count| true| Indicates if the optimizer rule MergeAggregateRenameAndCollectToCount is activated.",
+            "optimizer_merge_eval_into_fetch| true| Indicates if the optimizer rule MergeEvalIntoFetch is activated.",
             "optimizer_merge_filter_and_collect| true| Indicates if the optimizer rule MergeFilterAndCollect is activated.",
             "optimizer_merge_filter_and_foreign_collect| true| Indicates if the optimizer rule MergeFilterAndForeignCollect is activated.",
             "optimizer_merge_filters| true| Indicates if the optimizer rule MergeFilters is activated.",

--- a/server/src/test/java/io/crate/planner/SelectPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/SelectPlannerTest.java
@@ -702,6 +702,7 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(outerJoin.joinPhase().joinCondition()).isNull();
         assertThat(outerJoin.joinPhase().projections()).satisfiesExactly(
             p -> assertThat(p).isExactlyInstanceOf(EvalProjection.class),
+            p -> assertThat(p).isExactlyInstanceOf(EvalProjection.class),
             p -> assertThat(p).isExactlyInstanceOf(EvalProjection.class));
     }
 

--- a/server/src/test/java/io/crate/planner/SubQueryPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/SubQueryPlannerTest.java
@@ -143,8 +143,7 @@ public class SubQueryPlannerTest extends CrateDummyClusterServiceUnitTest {
         assertSQL(((RoutedCollectPhase) right.collectPhase()).orderBy(), "doc.t2.b");
         assertThat(right.collectPhase().projections()).satisfiesExactly(
             isLimitAndOffset(5, 5),
-            exactlyInstanceOf(FetchProjection.class),
-            exactlyInstanceOf(EvalProjection.class)); // strips `b` used in order by from the outputs
+            exactlyInstanceOf(FetchProjection.class)); // FetchProjection itself strips `b` used in order by from the outputs
     }
 
     @Test

--- a/server/src/test/java/io/crate/planner/ViewPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/ViewPlannerTest.java
@@ -118,15 +118,14 @@ public class ViewPlannerTest extends CrateDummyClusterServiceUnitTest {
 
         assertThat(logicalPlan).hasOperators(
             "Rename[new_name, ts, val] AS doc.v",
-            "  └ Eval[name AS new_name, ts, val]",
-            "    └ Fetch[ts, val, id, name, id]",
-            "      └ Limit[100::bigint;0]",
-            "        └ OrderBy[ts ASC name AS new_name ASC]",
-            "          └ HashJoin[INNER | (id = id)]",
-            "            ├ Rename[x._fetchid, ts, id] AS x",
-            "            │  └ Collect[doc.tbl1 | [_fetchid, ts, id] | true]",
-            "            └ Rename[name, id] AS y",
-            "              └ Collect[doc.tbl2 | [name, id] | true]"
+            "  └ Fetch[name AS new_name, ts, val]",
+            "    └ Limit[100::bigint;0]",
+            "      └ OrderBy[ts ASC name AS new_name ASC]",
+            "        └ HashJoin[INNER | (id = id)]",
+            "          ├ Rename[x._fetchid, ts, id] AS x",
+            "          │  └ Collect[doc.tbl1 | [_fetchid, ts, id] | true]",
+            "          └ Rename[name, id] AS y",
+            "            └ Collect[doc.tbl2 | [name, id] | true]"
         );
     }
 }

--- a/server/src/test/java/io/crate/planner/operators/JoinTest.java
+++ b/server/src/test/java/io/crate/planner/operators/JoinTest.java
@@ -597,18 +597,18 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
         // This used to have an Eval with a `CASE WHEN (event_time = first_event_time)` beneath
         // the Limit because the ReorderHashJoin rule adds a `Eval` node to retain output order
         // This resulted in an `Can't handle Symbol [SimpleReference: event_time]` error because `event_time` is not an output of the Join, but is fetched
+        // The Eval on top of the Fetch is folded into the Fetch itself by MergeEvalIntoFetch.
         assertThat(plan).hasOperators(
             "Rename[user_type, domain] AS doc.user_session_visitortype",
-            "  └ Eval[CASE WHEN (event_time = first_event_time) THEN 'new_user' ELSE 'returning_user' END AS user_type, domain]",
-            "    └ Fetch[event_time, domain, first_event_time]",
-            "      └ Limit[1::bigint;0]",
-            "        └ Eval[_fetchid, first_event_time]",
-            "          └ HashJoin[INNER | (user_id = user_id)]",
-            "            ├ Rename[user_id, first_event_time] AS first_visit",
-            "            │  └ Eval[user_id, min(event_time) AS first_event_time]",
-            "            │    └ GroupHashAggregate[user_id | min(event_time)]",
-            "            │      └ Collect[doc.user_session | [event_time, user_id] | true]",
-            "            └ Collect[doc.user_session | [_fetchid, user_id] | (domain = 'example.com')]"
+            "  └ Fetch[CASE WHEN (event_time = first_event_time) THEN 'new_user' ELSE 'returning_user' END AS user_type, domain]",
+            "    └ Limit[1::bigint;0]",
+            "      └ Eval[_fetchid, first_event_time]",
+            "        └ HashJoin[INNER | (user_id = user_id)]",
+            "          ├ Rename[user_id, first_event_time] AS first_visit",
+            "          │  └ Eval[user_id, min(event_time) AS first_event_time]",
+            "          │    └ GroupHashAggregate[user_id | min(event_time)]",
+            "          │      └ Collect[doc.user_session | [event_time, user_id] | true]",
+            "          └ Collect[doc.user_session | [_fetchid, user_id] | (domain = 'example.com')]"
         );
     }
 

--- a/server/src/test/java/io/crate/planner/operators/JoinTest.java
+++ b/server/src/test/java/io/crate/planner/operators/JoinTest.java
@@ -28,7 +28,6 @@ import static io.crate.analyze.TableDefinitions.USER_TABLE_IDENT;
 import static io.crate.testing.Asserts.assertList;
 import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.Asserts.isInputColumn;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
@@ -600,14 +599,16 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
         // This resulted in an `Can't handle Symbol [SimpleReference: event_time]` error because `event_time` is not an output of the Join, but is fetched
         assertThat(plan).hasOperators(
             "Rename[user_type, domain] AS doc.user_session_visitortype",
-            "  └ Fetch[CASE WHEN (event_time = first_event_time) THEN 'new_user' ELSE 'returning_user' END AS user_type, domain]",
-            "    └ Limit[1::bigint;0]",
-            "      └ HashJoin[INNER | (user_id = user_id)]",
-            "        ├ Rename[first_event_time, user_id] AS first_visit",
-            "        │  └ Eval[min(event_time) AS first_event_time, user_id]",
-            "        │    └ GroupHashAggregate[user_id | min(event_time)]",
-            "        │      └ Collect[doc.user_session | [event_time, user_id] | true]",
-            "        └ Collect[doc.user_session | [_fetchid, user_id] | (domain = 'example.com')]"
+            "  └ Eval[CASE WHEN (event_time = first_event_time) THEN 'new_user' ELSE 'returning_user' END AS user_type, domain]",
+            "    └ Fetch[event_time, domain, first_event_time]",
+            "      └ Limit[1::bigint;0]",
+            "        └ Eval[_fetchid, first_event_time]",
+            "          └ HashJoin[INNER | (user_id = user_id)]",
+            "            ├ Rename[user_id, first_event_time] AS first_visit",
+            "            │  └ Eval[user_id, min(event_time) AS first_event_time]",
+            "            │    └ GroupHashAggregate[user_id | min(event_time)]",
+            "            │      └ Collect[doc.user_session | [event_time, user_id] | true]",
+            "            └ Collect[doc.user_session | [_fetchid, user_id] | (domain = 'example.com')]"
         );
     }
 

--- a/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
@@ -476,15 +476,14 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
 
         assertThat(plan).isEqualTo(
             """
-            Eval[i, a, i]
-              └ Fetch[i, a, x, i, y]
-                └ Limit[5::bigint;0]
-                  └ Filter[(x > y)]
-                    └ HashJoin[INNER | (i = i)]
-                      ├ MultiPhase
-                      │  └ Collect[doc.t1 | [_fetchid, i, x] | (i = ANY((doc.t2)))]
-                      │  └ Collect[doc.t2 | [i] | true]
-                      └ Collect[doc.t2 | [i, y] | true]
+            Fetch[i, a, i]
+              └ Limit[5::bigint;0]
+                └ Filter[(x > y)]
+                  └ HashJoin[INNER | (i = i)]
+                    ├ MultiPhase
+                    │  └ Collect[doc.t1 | [_fetchid, i, x] | (i = ANY((doc.t2)))]
+                    │  └ Collect[doc.t2 | [i] | true]
+                    └ Collect[doc.t2 | [i, y] | true]
             """
         );
     }
@@ -673,11 +672,10 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(plan.dependencies().entrySet()).hasSize(1);
         LogicalPlan subPlan = plan.dependencies().keySet().iterator().next();
         assertThat(subPlan).hasOperators(
-            "Eval[x]",
-            "  └ Fetch[x, a]",
-            "    └ Limit[10::bigint;0]",
-            "      └ OrderBy[a DESC]",
-            "        └ Collect[doc.t1 | [_fetchid, a] | true]"
+            "Fetch[x]",
+            "  └ Limit[10::bigint;0]",
+            "    └ OrderBy[a DESC]",
+            "      └ Collect[doc.t1 | [_fetchid, a] | true]"
         );
     }
 

--- a/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
@@ -772,11 +772,14 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
         LogicalPlan plan = sqlExecutor.logicalPlan("""
             SELECT i, avgx FROM (SELECT a, avg(x) OVER(ORDER BY i) as avgx, i FROM t1) as vt
             """);
+        // x comes first in the plan because window functions picked up first in SplitPointsBuilder.
+        // Then last Eval is added to re-order as user wants.
         assertThat(plan).hasOperators(
-            "Rename[i, avgx] AS vt",
-            "  └ Eval[i, avg(x) OVER (ORDER BY i ASC) AS avgx]",
-            "    └ WindowAgg[x, i] | [avg(x) OVER (ORDER BY i ASC)]",
-            "      └ Collect[doc.t1 | [x, i] | true]"
+            "Eval[i, avgx]",
+            "  └ Rename[avgx, i] AS vt",
+            "    └ Eval[avg(x) OVER (ORDER BY i ASC) AS avgx, i]",
+            "      └ WindowAgg[x, i] | [avg(x) OVER (ORDER BY i ASC)]",
+            "        └ Collect[doc.t1 | [x, i] | true]"
         );
     }
 
@@ -789,11 +792,12 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
             """);
         assertThat(plan).isEqualTo(
             """
-                Rename[sumx, umaxx, minx, uavgx] AS vt
-                  └ Eval[sum(x) AS sumx, unnest([max(x)]) AS umaxx, min(x) AS minx, unnest([avg(x)]) AS uavgx]
-                    └ ProjectSet[unnest([min(x)]), unnest([max(x)]), unnest([avg(x)]), unnest([sum(x)]), sum(x), max(x), min(x), avg(x)]
-                      └ HashAggregate[min(x), max(x), avg(x), sum(x)]
-                        └ Collect[doc.t1 | [x] | true]""");
+                Eval[sumx, umaxx, minx, uavgx]
+                  └ Rename[minx, umaxx, uavgx, sumx] AS vt
+                    └ Eval[min(x) AS minx, unnest([max(x)]) AS umaxx, unnest([avg(x)]) AS uavgx, sum(x) AS sumx]
+                      └ ProjectSet[unnest([min(x)]), unnest([max(x)]), unnest([avg(x)]), unnest([sum(x)]), sum(x), max(x), min(x), avg(x)]
+                        └ HashAggregate[min(x), max(x), avg(x), sum(x)]
+                          └ Collect[doc.t1 | [x] | true]""");
     }
 
     @Test


### PR DESCRIPTION
Relates to https://github.com/crate/crate/pull/20067#discussion_r3864666304

I'm not sure we need it though - as discussed in the linked comment, computation of Eval is just baked in to the Fetch in this PR.

I think it actually makes plan less transparent while saving some fractions - not sure that overhead of Eval is bigger then doing something in the Fetch itself. 

To me having that Eval visible after https://github.com/crate/crate/pull/20067 was rather positive thing - but not 100% sure, would love to hear some opinions on this.