### PR TITLE
Fix GroupByMaps new entry accounting for JDK Maps

### DIFF
--- a/docs/appendices/release-notes/6.4.4.rst
+++ b/docs/appendices/release-notes/6.4.4.rst
@@ -148,3 +148,6 @@ Fixes
       AND t1.x = t3.z
       AND t2.y = t3.z;
 
+- Fixed a regression introduced with :ref:`version_6.4.3`, causing queries
+  with aggregations to fail with false positive ``CircuitBreakerException``.
+

--- a/server/src/main/java/io/crate/execution/engine/aggregation/GroupByMaps.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/GroupByMaps.java
@@ -44,26 +44,10 @@ import io.netty.util.collection.ShortObjectHashMap;
 public final class GroupByMaps {
 
     public static <K, V> TriConsumer<ResizeAwareMap<K, V>, K, Object[]> accountForNewEntry(RamAccounting ramAccounting, DataType<K> type) {
-        long singleItemBytes = singleItemBytes(type);
         return (map, key, states) -> {
             long keyBytes = RamUsageEstimator.alignObjectSize(type.valueBytes(key) + 36);
             long statesShallowBytes = RamUsageEstimator.shallowSizeOf(states);
-            long capacityIncreaseBytes = singleItemBytes * map.expectedCapacityIncrease();
-            ramAccounting.addBytes(keyBytes + statesShallowBytes + capacityIncreaseBytes);
-        };
-    }
-
-    /**
-     * Netty maps keep a primitive key array alongside the  Object[] array.
-     */
-    private static long singleItemBytes(DataType<?> type) {
-        return switch (type.id()) {
-            case ByteType.ID -> Byte.BYTES + RamUsageEstimator.NUM_BYTES_OBJECT_REF;
-            case ShortType.ID -> Short.BYTES + RamUsageEstimator.NUM_BYTES_OBJECT_REF;
-            case IntegerType.ID -> Integer.BYTES + RamUsageEstimator.NUM_BYTES_OBJECT_REF;
-            case LongType.ID, TimestampType.ID_WITH_TZ, TimestampType.ID_WITHOUT_TZ ->
-                Long.BYTES + RamUsageEstimator.NUM_BYTES_OBJECT_REF;
-            default -> RamUsageEstimator.NUM_BYTES_OBJECT_REF;
+            ramAccounting.addBytes(keyBytes + statesShallowBytes + map.expectedCapacityIncreaseBytes());
         };
     }
 
@@ -80,8 +64,7 @@ public final class GroupByMaps {
             }
             long keyBytes = RamUsageEstimator.alignObjectSize(size + 36);
             long statesShallowBytes = RamUsageEstimator.shallowSizeOf(states);
-            long capacityIncreaseBytes = (long) RamUsageEstimator.NUM_BYTES_OBJECT_REF * map.expectedCapacityIncrease();
-            ramAccounting.addBytes(keyBytes + statesShallowBytes + capacityIncreaseBytes);
+            ramAccounting.addBytes(keyBytes + statesShallowBytes + map.expectedCapacityIncreaseBytes());
         };
     }
 
@@ -92,21 +75,24 @@ public final class GroupByMaps {
                 new PrimitiveMapWithNulls<>(new ByteObjectHashMap<>()),
                 ByteObjectHashMap.DEFAULT_CAPACITY,
                 ByteObjectHashMap.DEFAULT_LOAD_FACTOR,
-                true
+                true,
+                Byte.BYTES + RamUsageEstimator.NUM_BYTES_OBJECT_REF
             );
 
             case ShortType.ID -> () -> (ResizeAwareMap<K, V>) new ResizeAwareMap<>(
                 new PrimitiveMapWithNulls<>(new ShortObjectHashMap<>()),
                 ShortObjectHashMap.DEFAULT_CAPACITY,
                 ShortObjectHashMap.DEFAULT_LOAD_FACTOR,
-                true
+                true,
+                Short.BYTES + RamUsageEstimator.NUM_BYTES_OBJECT_REF
             );
 
             case IntegerType.ID -> () -> (ResizeAwareMap<K, V>) new ResizeAwareMap<>(
                 new PrimitiveMapWithNulls<>(new IntObjectHashMap<>()),
                 IntObjectHashMap.DEFAULT_CAPACITY,
                 IntObjectHashMap.DEFAULT_LOAD_FACTOR,
-                true
+                true,
+                Integer.BYTES + RamUsageEstimator.NUM_BYTES_OBJECT_REF
             );
 
             case LongType.ID, TimestampType.ID_WITH_TZ, TimestampType.ID_WITHOUT_TZ ->
@@ -114,7 +100,8 @@ public final class GroupByMaps {
                     new PrimitiveMapWithNulls<>(new LongObjectHashMap<>()),
                     LongObjectHashMap.DEFAULT_CAPACITY,
                     LongObjectHashMap.DEFAULT_LOAD_FACTOR,
-                    true
+                    true,
+                    Long.BYTES + RamUsageEstimator.NUM_BYTES_OBJECT_REF
                 );
 
             default -> () -> wrapperForJDKMap(new HashMap<>());
@@ -126,7 +113,8 @@ public final class GroupByMaps {
             map,
             16, // HashMap.DEFAULT_INITIAL_CAPACITY
             0.75f, // HashMap.DEFAULT_LOAD_FACTOR
-            false
+            false,
+            RamUsageEstimator.NUM_BYTES_OBJECT_REF
         );
     }
 

--- a/server/src/main/java/io/crate/execution/engine/aggregation/ResizeAwareMap.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/ResizeAwareMap.java
@@ -25,6 +25,8 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 
+import io.crate.common.annotations.VisibleForTesting;
+
 /**
  * Wrapper for maps containing large number of elements.
  *
@@ -39,17 +41,27 @@ public class ResizeAwareMap<K, V> implements Map<K, V> {
     private final Map<K, V> delegate;
     private final float loadFactor;
     private final boolean openAddressing;
+    private final long singleItemBytes;
 
     private int currentCapacity;
 
+    /**
+     * @param openAddressing represents if it's a Netty map (true) or JDK map (false)
+     *
+     * @param singleItemBytes represents bytes per additional capacity slot on resize.
+     * JDK maps only store an object reference per slot, regardless of the key type.
+     * Netty maps additionally keep a primitive key array.
+     */
     public ResizeAwareMap(Map<K, V> delegate,
                           int initialCapacity,
                           float loadFactor,
-                          boolean openAddressing) {
+                          boolean openAddressing,
+                          long singleItemBytes) {
         this.delegate = delegate;
         this.currentCapacity = tableSizeFor(initialCapacity);
         this.loadFactor = loadFactor;
         this.openAddressing = openAddressing;
+        this.singleItemBytes = singleItemBytes;
     }
 
     @Override
@@ -118,12 +130,17 @@ public class ResizeAwareMap<K, V> implements Map<K, V> {
      * @return internal capacity increase
      * after the next put() which will add a new unique key.
      */
-    public int expectedCapacityIncrease() {
+    @VisibleForTesting
+    int expectedCapacityIncrease() {
         int capacity = currentCapacity;
         while (capacity < MAXIMUM_CAPACITY && delegate.size() + 1 > resizeThreshold(capacity)) {
             capacity = capacity << 1;
         }
         return capacity - currentCapacity;
+    }
+
+    public long expectedCapacityIncreaseBytes() {
+        return singleItemBytes * expectedCapacityIncrease();
     }
 
     public int currentCapacity() {

--- a/server/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
@@ -273,10 +273,10 @@ final class GroupByOptimizedIterator {
                     String keyStr = sharedKey.utf8ToString();
                     countsByKey.compute(keyStr, (k, count) -> {
                         if (count == null) {
-                            long capacityIncreaseBytes =
-                                (long) RamUsageEstimator.NUM_BYTES_OBJECT_REF * countsByKey.expectedCapacityIncrease();
                             ramAccounting.addBytes(
-                                RamUsageEstimator.sizeOf(keyStr) + HASH_MAP_ENTRY_OVERHEAD + capacityIncreaseBytes);
+                                RamUsageEstimator.sizeOf(keyStr)
+                                    + HASH_MAP_ENTRY_OVERHEAD
+                                    + countsByKey.expectedCapacityIncreaseBytes());
                             return (long) numDocs;
                         }
                         return count + numDocs;

--- a/server/src/test/java/io/crate/execution/engine/aggregation/ResizeAwareMapTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/ResizeAwareMapTest.java
@@ -28,7 +28,11 @@ import static org.mockito.Mockito.when;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.lucene.util.RamUsageEstimator;
 import org.junit.Test;
+
+import io.crate.types.DataTypes;
+import io.netty.util.collection.IntObjectHashMap;
 
 public class ResizeAwareMapTest {
 
@@ -47,12 +51,53 @@ public class ResizeAwareMapTest {
     }
 
     @Test
+    public void test_jdk_map_accounts_only_object_ref_per_slot() {
+        Map<Integer, Integer> map = new HashMap<>();
+        ResizeAwareMap<Integer, Integer> resizeAwareMap = GroupByMaps.wrapperForJDKMap(map);
+        int defaultCapacity = 16; // HashMap.DEFAULT_INITIAL_CAPACITY
+        float defaultLoadFactor = 0.75f; // HashMap.DEFAULT_LOAD_FACTOR
+        int threshold = (int) (defaultCapacity * defaultLoadFactor);
+        int prevCapacity = resizeAwareMap.currentCapacity();
+        for (int i = 0; i < threshold ; i++) {
+            resizeAwareMap.put(i, i);
+        }
+
+        // Get prediction before put
+        long predictedBytes = resizeAwareMap.expectedCapacityIncreaseBytes();
+        resizeAwareMap.put(threshold, threshold); // trigger resize
+        int newCapacity = resizeAwareMap.currentCapacity();
+
+        long deltaInBytes = (long) (newCapacity - prevCapacity) * RamUsageEstimator.NUM_BYTES_OBJECT_REF;
+        assertThat(predictedBytes).isEqualTo(deltaInBytes);
+    }
+
+    @Test
+    public void test_netty_map_accounts_object_ref_and_primitive_per_slot() {
+        ResizeAwareMap<Integer, Object> resizeAwareMap = GroupByMaps.mapForType(DataTypes.INTEGER).get();
+        int defaultCapacity = IntObjectHashMap.DEFAULT_CAPACITY;
+        float defaultLoadFactor = IntObjectHashMap.DEFAULT_LOAD_FACTOR;
+        int threshold = (int) (defaultCapacity * defaultLoadFactor);
+        int prevCapacity = resizeAwareMap.currentCapacity();
+        for (int i = 0; i < threshold ; i++) {
+            resizeAwareMap.put(i, i);
+        }
+
+        // Get prediction before put
+        long predictedBytes = resizeAwareMap.expectedCapacityIncreaseBytes();
+        resizeAwareMap.put(threshold, threshold); // trigger resize
+        int newCapacity = resizeAwareMap.currentCapacity();
+
+        long deltaInBytes = (long) (newCapacity - prevCapacity) * (Integer.BYTES + RamUsageEstimator.NUM_BYTES_OBJECT_REF);
+        assertThat(predictedBytes).isEqualTo(deltaInBytes);
+    }
+
+    @Test
     public void test_put_initial_capacity_power_of_two() {
         Map<Integer, Integer> delegate = new HashMap<>();
         int capacity = 4;
         float loadFactor = 0.75f;
         int threshold = (int) (capacity * loadFactor);
-        ResizeAwareMap<Integer, Integer> map = new ResizeAwareMap<>(delegate, capacity, loadFactor, false);
+        ResizeAwareMap<Integer, Integer> map = new ResizeAwareMap<>(delegate, capacity, loadFactor, false, RamUsageEstimator.NUM_BYTES_OBJECT_REF);
 
         for (int i = 0; i < threshold; i++) {
             assertThat(map.expectedCapacityIncrease()).isEqualTo(0);
@@ -64,7 +109,7 @@ public class ResizeAwareMapTest {
     @Test
     public void test_put_initial_capacity_is_rounded_up_to_the_next_power_of_two() {
         Map<Integer, Integer> delegate = new HashMap<>();
-        ResizeAwareMap<Integer, Integer> map = new ResizeAwareMap<>(delegate, 5, 0.75f, false);
+        ResizeAwareMap<Integer, Integer> map = new ResizeAwareMap<>(delegate, 5, 0.75f, false, RamUsageEstimator.NUM_BYTES_OBJECT_REF);
         // 5 is rounded up to 8, hence threshold is 8*0.75 = 6
         for (int i = 0; i < 6; i++) {
             assertThat(map.expectedCapacityIncrease()).isEqualTo(0);
@@ -79,7 +124,7 @@ public class ResizeAwareMapTest {
         int capacity = 4;
         float loadFactor = 0.75f;
         int threshold = (int) (capacity * loadFactor);
-        ResizeAwareMap<Integer, Integer> map = new ResizeAwareMap<>(delegate, capacity, loadFactor, false);
+        ResizeAwareMap<Integer, Integer> map = new ResizeAwareMap<>(delegate, capacity, loadFactor, false, RamUsageEstimator.NUM_BYTES_OBJECT_REF);
 
         for (int i = 0; i < threshold + 1; i++) {
             map.expectedCapacityIncrease();
@@ -95,7 +140,7 @@ public class ResizeAwareMapTest {
         Map<Integer, Integer> delegate = mock(Map.class);
         when(delegate.size()).thenReturn(Integer.MAX_VALUE - 1);
 
-        ResizeAwareMap<Integer, Integer> map = new ResizeAwareMap<>(delegate, maximumCapacity, 0.75f, false);
+        ResizeAwareMap<Integer, Integer> map = new ResizeAwareMap<>(delegate, maximumCapacity, 0.75f, false, RamUsageEstimator.NUM_BYTES_OBJECT_REF);
         assertThat(map.expectedCapacityIncrease()).isEqualTo(0);
     }
 
@@ -105,7 +150,7 @@ public class ResizeAwareMapTest {
         int capacity = 4;
         float loadFactor = 0.75f;
         int threshold = (int) (capacity * loadFactor);
-        ResizeAwareMap<Integer, Integer> map = new ResizeAwareMap<>(delegate, capacity, loadFactor, false);
+        ResizeAwareMap<Integer, Integer> map = new ResizeAwareMap<>(delegate, capacity, loadFactor, false, RamUsageEstimator.NUM_BYTES_OBJECT_REF);
 
         // Bringing to the point where it's about to resize.
         for (int i = 0; i < threshold; i++) {


### PR DESCRIPTION
It added Netty overhead even for JDK Maps.
Also, it recomputed constant per put() call - changed to compute it once

