### PR TITLE
Ignore SET pkfield=excluded.pkfield in INSERT ON CONFLICT

### DIFF
--- a/server/src/main/java/io/crate/analyze/InsertAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/InsertAnalyzer.java
@@ -319,6 +319,10 @@ class InsertAnalyzer {
             f -> f.signature().isDeterministic());
         Map<Reference, Symbol> updateAssignments = HashMap.newHashMap(duplicateKeyContext.getAssignments().size());
         for (Assignment<Expression> assignment : duplicateKeyContext.getAssignments()) {
+            if (duplicateKeyContext.getType() == Insert.DuplicateKeyContext.Type.ON_CONFLICT_DO_UPDATE_SET
+                && isNoopPrimaryKeyAssignment(assignment, targetTable)) {
+                continue;
+            }
             Reference targetCol = (Reference) exprAnalyzer.convert(assignment.columnName(), exprCtx);
             Symbol valueSymbol = ValueNormalizer.normalizeInputForReference(
                 normalizer.normalize(expressionAnalyzer.convert(assignment.expression(), exprCtx), txnCtx),
@@ -352,5 +356,23 @@ class InsertAnalyzer {
             paramTypeHints,
             duplicateKeyContext
         );
+    }
+
+    private static boolean isNoopPrimaryKeyAssignment(Assignment<Expression> assignment, DocTableRelation targetTable) {
+
+        if (!(assignment.columnName() instanceof QualifiedNameReference targetRef)
+            || !(assignment.expression() instanceof QualifiedNameReference valueRef)) {
+            return false;
+        }
+
+        List<String> targetParts = targetRef.getName().getParts();
+        List<String> valueParts = valueRef.getName().getParts();
+        if (targetParts.size() != 1 || valueParts.size() != 2 || !"excluded".equals(valueParts.get(0))) {
+            return false;
+        }
+        ColumnIdent targetColumn = ColumnIdent.of(targetParts.get(0));
+        ColumnIdent excludedColumn = ColumnIdent.of(valueParts.get(1));
+
+        return targetColumn.equals(excludedColumn) && targetTable.tableInfo().primaryKey().contains(targetColumn);
     }
 }

--- a/server/src/test/java/io/crate/analyze/InsertAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/InsertAnalyzerTest.java
@@ -610,4 +610,48 @@ public class InsertAnalyzerTest extends CrateDummyClusterServiceUnitTest {
             .hasMessage(
                 "Cannot convert VALUES element in row 2 of type `text_array` to `text` for `name`");
     }
+
+    @Test
+    public void testOnConflictDoUpdateCanAssignPrimaryKeyToExcludedPrimaryKey() {
+        e.analyze("""
+            insert into users (id, name)
+            values (1, 'Varun')
+            on conflict (id)
+            do update set id = excluded.id
+            """);
+    }
+
+    @Test
+    public void testOnConflictDoUpdateCanAssignPrimaryKeyToExcludedPrimaryKeyWithAnotherField() {
+        e.analyze("""
+            insert into users (id, name)
+            values (1, 'Virat')
+            on conflict (id)
+            do update set id = excluded.id, name = excluded.name
+            """);
+    }
+
+    @Test
+    public void testOnConflictDoUpdateCannotChangePrimaryKeyWithAnotherField() {
+        assertThatThrownBy(() -> e.analyze("""
+            insert into users (id, name)
+            values (1, 'Varun')
+            on conflict (id)
+            do update set id = 2, name = excluded.name
+            """))
+                .isInstanceOf(ColumnValidationException.class)
+                .hasMessageContaining("Updating a primary key is not supported");
+    }
+
+    @Test
+    public void testOnConflictDoUpdateCannotChangePrimaryKey() {
+        assertThatThrownBy(() -> e.analyze("""
+            insert into users (id, name)
+            values (1, 'Varun')
+            on conflict (id)
+            do update set id = 2
+            """))
+                .isInstanceOf(ColumnValidationException.class)
+                .hasMessageContaining("Updating a primary key is not supported");
+    }
 }


### PR DESCRIPTION
Closes #17834 

## Summary of the changes / Why this improves CrateDB

Allow `ON CONFLICT DO UPDATE` to assign a primary key column from its corresponding `excluded` value, while continuing to reject attempts to assign a different value to a primary key.

### Changes

Allow assignments such as:

ON CONFLICT (id) DO UPDATE SET id = excluded.id

Continue rejecting assignments that modify the primary key to a different value:

ON CONFLICT (id) DO UPDATE SET id = 2

### Testing

Added test coverage for both cases in InsertAnalyzerTest (reused tables already created in prepare() method)


## Checklist

 - [ ] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes.
       If you're an external contributor you can give yourself attribution and include your name and Github handle.
       e.g.:
       ```
       `John Doe <https://github.com/John_Doe>`_ added support for ...
       ```
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
