### PR TITLE
Ensure that ProjectSet preserves order of its outputs after pruning

### DIFF
--- a/server/src/main/java/io/crate/planner/operators/Order.java
+++ b/server/src/main/java/io/crate/planner/operators/Order.java
@@ -102,7 +102,13 @@ public class Order extends ForwardingLogicalPlan {
         if (newSource == source) {
             return this;
         }
-        return replaceSources(List.of(newSource));
+        LogicalPlan newPlan = replaceSources(List.of(newSource));
+        // Order doesn't create a new instance based on some f(outputsToKeep),
+        // it only calls source pruning.
+        // Hence, we can validate outputs after the pruning,
+        // but don't have to normalize own outputs.
+        validateOutputsOrder(newPlan.outputs());
+        return newPlan;
     }
 
     @Nullable

--- a/server/src/main/java/io/crate/planner/operators/ProjectSet.java
+++ b/server/src/main/java/io/crate/planner/operators/ProjectSet.java
@@ -157,11 +157,14 @@ public class ProjectSet extends ForwardingLogicalPlan {
             Symbols.intersection(tableFunction, source.outputs(), toKeep::add);
         }
         toKeep.addAll(newStandalone);
+        List<Symbol> prunedOutputs = Lists.intersection(standalone, newStandalone);
         LogicalPlan newSource = source.pruneOutputsExcept(toKeep);
         if (newSource == source) {
             return this;
         }
-        return new ProjectSet(newSource, tableFunctions, List.copyOf(newStandalone));
+        ProjectSet newPlan = new ProjectSet(newSource, tableFunctions, prunedOutputs);
+        validateOutputsOrder(newPlan.outputs());
+        return newPlan;
     }
 
     @Override

--- a/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
@@ -795,7 +795,7 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
                 Eval[sumx, umaxx, minx, uavgx]
                   └ Rename[minx, umaxx, uavgx, sumx] AS vt
                     └ Eval[min(x) AS minx, unnest([max(x)]) AS umaxx, unnest([avg(x)]) AS uavgx, sum(x) AS sumx]
-                      └ ProjectSet[unnest([min(x)]), unnest([max(x)]), unnest([avg(x)]), unnest([sum(x)]), sum(x), max(x), min(x), avg(x)]
+                      └ ProjectSet[unnest([min(x)]), unnest([max(x)]), unnest([avg(x)]), unnest([sum(x)]), min(x), max(x), avg(x), sum(x)]
                         └ HashAggregate[min(x), max(x), avg(x), sum(x)]
                           └ Collect[doc.t1 | [x] | true]""");
     }


### PR DESCRIPTION
Relates to https://jenkins.crate.io/blue/organizations/jenkins/CrateDB%2Fqa%2Fcrate_qa/detail/crate_qa/1749/pipeline/47/

```
   Where: io.crate.planner.operators.LogicalPlan.validateOutputsOrder(LogicalPlan.java:236)

    io.crate.planner.operators.Filter.pruneOutputsExcept(Filter.java:112)
```

Filter's source was ProjectSet which violates the contract.

getPrimaryKeys query now passes locally.
Didn't add tests as we apparently had a unit test affected by this (had to update an assertion) + we have crate-qa tests
