### PR TITLE
Validate outputs order after the pruning in Rename

### DIFF
--- a/server/src/main/java/io/crate/planner/operators/Rename.java
+++ b/server/src/main/java/io/crate/planner/operators/Rename.java
@@ -120,12 +120,14 @@ public final class Rename extends ForwardingLogicalPlan implements FieldResolver
         for (Symbol sourceOutput : newSource.outputs()) {
             newOutputs.add(childToParentMap.get(sourceOutput));
         }
-        return new Rename(
+        Rename newPlan = new Rename(
             newOutputs,
             name,
             fieldResolver,
             newSource
         );
+        validateOutputsOrder(newPlan.outputs());
+        return newPlan;
     }
 
     @Nullable


### PR DESCRIPTION
No intersection/enforcement as validation already passes tests

Also, `newOutputs` here is derived from source outputs - and source pruning must take care of ordering in its pruning, so validation is sufficient here