### PR TITLE
Docs: Clarify read-only scope and DR behavior of logical replication

### DIFF
--- a/docs/admin/logical-replication.rst
+++ b/docs/admin/logical-replication.rst
@@ -13,7 +13,13 @@ clusters and thus chaining subscriptions is possible.
 
 .. NOTE::
 
-    A replicated index on a subscriber is read-only.
+    Tables replicated by a subscription are read-only on the subscriber.
+    While a table is subscribed, only ``SELECT``, ``SHOW CREATE``,
+    ``REFRESH``, ``OPTIMIZE``, ``COPY TO`` and some ``ALTER TABLE`` variants
+    are supported. ``INSERT``, ``UPDATE``, ``DELETE``, ``DROP`` and other
+    ``ALTER TABLE`` variants are rejected, and subscribed tables cannot be
+    included in snapshots. See :ref:`read-only behavior
+    <logical-replication-read-only>`.
 
 Logical replication is useful for the following use cases:
 
@@ -22,7 +28,10 @@ Logical replication is useful for the following use cases:
 - Consolidating data from multiple clusters into a single one for aggregated
   reports.
 
-- Ensure high availability if one cluster becomes unavailable.
+- Ensure read availability if one cluster becomes unavailable. The subscriber
+  can continue to serve queries while the publisher is down. Write access on
+  the subscriber is not failed over automatically, see
+  :ref:`logical-replication-disaster-recovery`.
 
 - Replicating between different compatible versions of CrateDB.
   Replicating tables created on a cluster with higher major/minor version to a
@@ -102,6 +111,64 @@ The tables are matched between the publisher and the subscriber using the fully
 qualified table name. Replication to differently-named tables on the subscriber
 is not supported.
 
+.. _logical-replication-read-only:
+
+Read-only behavior
+------------------
+
+The read-only restriction is tied to the table on the subscriber, not to the
+health of the publisher. It stays in effect even when the publisher cluster is
+unreachable or when the subscription is in the ``e`` (failed) state visible in
+:ref:`pg_subscription_rel`.
+
+There is no automatic failover of write access. A subscribed table becomes a
+regular writable table only when:
+
+.. rst-class:: open
+
+- The subscription is removed with ``DROP SUBSCRIPTION``. This is a local
+  operation on the subscriber cluster and does not require the publisher to
+  be reachable.
+
+- The table is dropped on the publisher, which causes the subscriber to stop
+  tracking it.
+
+After a subscription is removed, replication cannot be re-established over
+the same tables without dropping them first.
+
+.. _logical-replication-disaster-recovery:
+
+Disaster recovery
+-----------------
+
+Logical replication provides a warm stand-by with continuous read access, but
+it does not provide automatic failover, and switching back is not supported:
+
+.. rst-class:: open
+
+- **Publisher outage:** The subscriber keeps retrying and resumes replicating
+  automatically once the publisher is reachable again. No manual action is
+  needed, and subscribed tables remain read-only during the outage.
+
+- **Total loss of the publisher:** The subscriber can be promoted by running
+  ``DROP SUBSCRIPTION``. The tables turn into
+  regular writable tables. This is a one-way decision: the promoted cluster
+  becomes the new source of truth, and it diverges permanently from any
+  future publisher. Data written on the subscriber after the last
+  successfully replicated operation is retained, so the replication lag at
+  the time of failure determines the number of lost writes.
+
+- **Switching back:** Returning to the original cluster requires re-seeding
+  it. A subscription cannot be created over tables that already exist on the
+  subscriber, not even over empty tables with a matching schema. There is no
+  incremental way to switch back.
+
+- **Snapshots:** A snapshot restore cannot be combined with a subscription.
+  Subscribed tables cannot be included in snapshots, and a subscription
+  cannot be created over tables restored from a snapshot. Snapshots for
+  backup purposes must therefore be taken on the publisher, or on a cluster
+  that is not a subscription target.
+
 Security
 --------
 
@@ -140,3 +207,10 @@ All subscriptions are listed in the :ref:`pg_subscription` table.
 More details for a subscription are available in the :ref:`pg_subscription_rel`
 table. The table contains detailed information about the replication state per
 table, including error messages if there was an error.
+
+A per-table state of ``e`` indicates the subscription failed for that table;
+the reason is shown in ``srsubstate_reason``. A failed subscription is not
+removed automatically and its tables remain read-only; it must be removed
+explicitly with ``DROP SUBSCRIPTION``. Transient
+publisher outages do not change the state, the metadata tracker retries until
+the publisher is reachable again.

--- a/docs/sql/statements/create-subscription.rst
+++ b/docs/sql/statements/create-subscription.rst
@@ -36,6 +36,12 @@ in the cluster. The subscription represents a replication connection to the
 publisher. A logical replication will be started on a publisher once
 the subscription is enabled, which is by default on creation.
 
+None of the tables in the publications may already exist on the subscriber
+cluster, not even as empty tables with a matching schema. The initial data is
+transferred as a physical copy from the publisher, after which changes are
+replicated continuously. There is no option to skip the initial copy and
+attach the subscription to pre-existing data.
+
 .. _sql-create-subscription-params:
 
 Parameters

--- a/docs/sql/statements/drop-subscription.rst
+++ b/docs/sql/statements/drop-subscription.rst
@@ -27,6 +27,10 @@ Removes an existing subscription from the cluster and stops the replication.
 Existing tables will turn into regular writable tables. It's not possible to
 resume dropped subscription.
 
+The subscription is removed locally on the subscriber cluster; the publisher
+does not need to be reachable. Replication cannot be resumed afterwards, and
+the replicated tables cannot be subscribed to again without dropping them.
+
 .. _sql-drop-subscription-params:
 
 Parameters


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Follow-up to a discussion on using logical replication for disaster
recovery, which surfaced that the admin page covers the happy path only.

- **`admin/logical-replication.rst`**:
  - the single "read-only" note now states which operations are affected and
    links to a new *Read-only behavior* section (restriction is tied to the
    table, survives publisher outages and failed subscriptions; lifted only by
    `DROP SUBSCRIPTION` or a publisher-side drop)
  - the "high availability" use case is qualified as *read* availability with
    manual, one-way write promotion
  - new "Disaster recovery" section: automatic resume after publisher outages,
    one-way promotion, no failback without re-seeding, snapshot/subscription
    non-composability
  - Monitoring: meaning of the `e` (failed) per-table state, which does not
    unlock tables
- **`create-subscription.rst`**: published tables must not exist on the
  subscriber, not even empty; no option to skip the initial copy
- **`drop-subscription.rst`**: local-only operation (publisher reachability
  not required); tables cannot be re-subscribed without dropping them

All statements are derived from the current implementation and its existing
integration tests.

## AI assistance disclosure

Per CONTRIBUTING.rst / AGENTS.rst, this branch was prepared with disclosed AI
assistance. The **code analysis** (tracing the enforcement paths and failure
behavior of the logical replication implementation) was performed by
**glm-5.3-flash** via the pi coding agent; the documentation changes were
drafted by the same model and are being **reviewed and adapted by the PR
author**, who takes full responsibility for the content.

## Notes for review

- [x] RST builds locally (`./blackbox/bin/sphinx`); no new warnings (3
      pre-existing, from untracked local scratch files)
- [ ] Please double-check wording of the DR section (promotion / failback) -
      happy to adjust tone and scope
- [ ] Release-notes entry: can add to the 6.5.0 notes if this counts as
      user-facing
