### PR TITLE
Load fdw wrapper implementations via service loader

### DIFF
--- a/server/src/main/java/io/crate/fdw/FdwProvider.java
+++ b/server/src/main/java/io/crate/fdw/FdwProvider.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.fdw;
+
+import java.util.concurrent.Executor;
+
+import org.elasticsearch.common.settings.Settings;
+
+import io.crate.expression.InputFactory;
+
+public interface FdwProvider {
+
+    String name();
+
+    ForeignDataWrapper create(Settings settings, InputFactory inputFactory, Executor executor);
+}

--- a/server/src/main/java/io/crate/fdw/ForeignDataWrappers.java
+++ b/server/src/main/java/io/crate/fdw/ForeignDataWrappers.java
@@ -23,9 +23,12 @@ package io.crate.fdw;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
+import java.util.ServiceLoader;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.cluster.metadata.Metadata;
@@ -73,9 +76,12 @@ public class ForeignDataWrappers implements CollectSource {
                                ThreadPool threadPool) {
         this.clusterService = clusterService;
         this.inputFactory = new InputFactory(nodeContext);
-        this.wrappers = Map.of(
-            "jdbc", new JdbcForeignDataWrapper(settings, inputFactory, threadPool.executor(ThreadPool.Names.SEARCH))
-        );
+        this.wrappers = new HashMap<>();
+        Executor executor = threadPool.executor(ThreadPool.Names.SEARCH);
+        for (var fdwProvider : ServiceLoader.load(FdwProvider.class)) {
+            ForeignDataWrapper wrapper = fdwProvider.create(settings, inputFactory, executor);
+            wrappers.put(fdwProvider.name(), wrapper);
+        }
         this.roles = nodeContext.roles();
     }
 

--- a/server/src/main/java/io/crate/fdw/JdbcFdwProvider.java
+++ b/server/src/main/java/io/crate/fdw/JdbcFdwProvider.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.fdw;
+
+import java.util.concurrent.Executor;
+
+import org.elasticsearch.common.settings.Settings;
+
+import io.crate.expression.InputFactory;
+
+public class JdbcFdwProvider implements FdwProvider {
+
+    @Override
+    public String name() {
+        return "jdbc";
+    }
+
+    @Override
+    public ForeignDataWrapper create(Settings settings, InputFactory inputFactory, Executor executor) {
+        return new JdbcForeignDataWrapper(settings, inputFactory, executor);
+    }
+}

--- a/server/src/main/resources/META-INF/services/io.crate.fdw.FdwProvider
+++ b/server/src/main/resources/META-INF/services/io.crate.fdw.FdwProvider
@@ -1,0 +1,1 @@
+io.crate.fdw.JdbcFdwProvider


### PR DESCRIPTION
To allow us to add additional implementations outside of the `server`
module.
