### PR TITLE
Extend logical replication targets from RelationName to TableOrPartition

### DIFF
--- a/server/src/main/java/io/crate/replication/logical/LogicalReplicationService.java
+++ b/server/src/main/java/io/crate/replication/logical/LogicalReplicationService.java
@@ -37,7 +37,6 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -259,21 +258,21 @@ public class LogicalReplicationService implements ClusterStateListener, Closeabl
     }
 
     /**
-     * Restore new subscribed relations using the {@link RestoreService} and update the
-     * {@link Subscription.RelationState} of each given {@link RelationName} based on the result.
+     * Restore new subscribed targets using the {@link RestoreService} and update the
+     * {@link Subscription.RelationState} of each given {@link TableOrPartition} based on the result.
      *
      * @param subscriptionName      The name of the subscription relations will be restored for
      * @param restoreSettings       The restore settings needed by the {@link RestoreService}
-     * @param tablesToRestore       List of {@link TableOrPartition}'s to update their {@link Subscription.RelationState}
+     * @param targetsToRestore      List of {@link TableOrPartition}'s to update their {@link Subscription.RelationState}
      */
     public CompletableFuture<Boolean> restore(String subscriptionName,
                                               Settings restoreSettings,
-                                              List<TableOrPartition> tablesToRestore) {
+                                              List<TableOrPartition> targetsToRestore) {
         var publisherClusterRepoName = LogicalReplicationRepository.REMOTE_REPOSITORY_PREFIX + subscriptionName;
         final var restoreRequest = new RestoreSnapshotRequest(
             publisherClusterRepoName,
             LogicalReplicationRepository.LATEST,
-            tablesToRestore,
+            targetsToRestore,
             restoreSettings,
             true,
             false,
@@ -285,25 +284,26 @@ public class LogicalReplicationService implements ClusterStateListener, Closeabl
 
         FutureActionListener<RestoreService.RestoreCompletionResponse> restoreListener = new FutureActionListener<>();
         activeOperations.incrementAndGet();
-        Set<RelationName> relationNames = tablesToRestore.stream()
-            .map(TableOrPartition::table)
-            .collect(Collectors.toUnmodifiableSet());
         var restoreFuture = restoreListener
             .whenComplete((_, _) -> activeOperations.decrementAndGet())
             // Update subscription state, we want to wait until this update is done before proceeding
-            .thenCompose(_ -> updateSubscriptionState(
+            .thenCompose(_ -> updateSubscriptionTargetsState(
                 subscriptionName,
-                relationNames,
+                targetsToRestore,
                 Subscription.State.RESTORING,
                 null
             ))
-            .thenCompose(_ -> afterReplicationStarted(subscriptionName, restoreListener.join(), relationNames));
+            .thenCompose(_ -> afterReplicationStarted(
+                subscriptionName,
+                restoreListener.join(),
+                targetsToRestore
+            ));
 
         try {
             threadPool.executor(ThreadPool.Names.SNAPSHOT).execute(
                 () -> {
                     try {
-                        restoreService.restoreSnapshot(restoreRequest, tablesToRestore, restoreListener);
+                        restoreService.restoreSnapshot(restoreRequest, targetsToRestore, restoreListener);
                     } catch (Exception e) {
                         restoreListener.onFailure(e);
                     }
@@ -318,13 +318,13 @@ public class LogicalReplicationService implements ClusterStateListener, Closeabl
 
     private CompletableFuture<Boolean> afterReplicationStarted(String subscriptionName,
                                                                RestoreService.RestoreCompletionResponse response,
-                                                               Collection<RelationName> relationNames) {
+                                                               Collection<TableOrPartition> targets) {
         Function<RestoreInfo, CompletableFuture<Boolean>> onRestoreInfo = restoreInfo -> {
             if (restoreInfo == null || restoreInfo.failedShards() == 0) {
                 LOGGER.debug("Restore success, following will start once shards are active");
-                return updateSubscriptionState(
+                return updateSubscriptionTargetsState(
                     subscriptionName,
-                    relationNames,
+                    targets,
                     Subscription.State.MONITORING,
                     null
                 );
@@ -352,17 +352,17 @@ public class LogicalReplicationService implements ClusterStateListener, Closeabl
         }
     }
 
-    public CompletableFuture<Boolean> updateSubscriptionState(String subscriptionName,
-                                                              Collection<RelationName> relationNames,
-                                                              Subscription.State newState,
-                                                              @Nullable String failureReason) {
+    public CompletableFuture<Boolean> updateSubscriptionTargetsState(String subscriptionName,
+                                                                     Collection<TableOrPartition> targets,
+                                                                     Subscription.State newState,
+                                                                     @Nullable String failureReason) {
         var oldSubscription = subscriptions().get(subscriptionName);
         if (oldSubscription == null) {
             return CompletableFuture.completedFuture(false);
         }
-        HashMap<RelationName, Subscription.RelationState> relations = new HashMap<>(oldSubscription.relations());
-        for (var relationName : relationNames) {
-            relations.put(relationName, new Subscription.RelationState(newState, failureReason));
+        HashMap<TableOrPartition, Subscription.RelationState> relations = new HashMap<>(oldSubscription.relations());
+        for (var target : targets) {
+            relations.put(target, new Subscription.RelationState(newState, failureReason));
         }
         return updateSubscriptionState(subscriptionName, oldSubscription, relations);
     }
@@ -374,7 +374,7 @@ public class LogicalReplicationService implements ClusterStateListener, Closeabl
         if (oldSubscription == null) {
             return CompletableFuture.completedFuture(false);
         }
-        HashMap<RelationName, Subscription.RelationState> relations = new HashMap<>();
+        HashMap<TableOrPartition, Subscription.RelationState> relations = new HashMap<>();
         for (var entry : oldSubscription.relations().entrySet()) {
             relations.put(entry.getKey(), new Subscription.RelationState(newState, failureReason));
         }
@@ -383,7 +383,7 @@ public class LogicalReplicationService implements ClusterStateListener, Closeabl
 
     private CompletableFuture<Boolean> updateSubscriptionState(String subscriptionName,
                                                                Subscription subscription,
-                                                               Map<RelationName, Subscription.RelationState> relations) {
+                                                               Map<TableOrPartition, Subscription.RelationState> relations) {
         var newSubscription = new Subscription(
             subscription.owner(),
             subscription.connectionInfo(),

--- a/server/src/main/java/io/crate/replication/logical/MetadataTracker.java
+++ b/server/src/main/java/io/crate/replication/logical/MetadataTracker.java
@@ -237,9 +237,9 @@ public final class MetadataTracker implements Closeable {
                     subscriptionName
                 );
                 LOGGER.error(msg);
-                return replicationService.updateSubscriptionState(
+                return replicationService.updateSubscriptionTargetsState(
                     subscriptionName,
-                    existingTables,
+                    existingTables.stream().map(table -> new TableOrPartition(table, null)).toList(),
                     Subscription.State.FAILED,
                     // Table name is not included, as this message included for every row of pg_subscriptions_rel which already has table name.
                     "Relation already exists"
@@ -264,11 +264,11 @@ public final class MetadataTracker implements Closeable {
                 return CompletableFuture.completedFuture(true);
             }
 
-            CompletableFuture<Boolean> updateState = restoreDiff.relationsForStateUpdate.isEmpty()
+            CompletableFuture<Boolean> updateState = restoreDiff.targetsForStateUpdate.isEmpty()
                 ? CompletableFuture.completedFuture(true)
-                : replicationService.updateSubscriptionState(
+                : replicationService.updateSubscriptionTargetsState(
                     subscriptionName,
-                    restoreDiff.relationsForStateUpdate,
+                    restoreDiff.targetsForStateUpdate,
                     Subscription.State.INITIALIZING,
                     null
                 );
@@ -353,7 +353,8 @@ public final class MetadataTracker implements Closeable {
         var updateClusterState = false;
         Metadata subscriberMetadata = subscriberClusterState.metadata();
         Metadata publisherMetadata = publicationsState.metadata();
-        for (var followedTable : subscription.relations().keySet()) {
+        for (var followedTarget : subscription.relations().keySet()) {
+            RelationName followedTable = followedTarget.table();
             RelationMetadata.Table publisherTable = publisherMetadata.getRelation(followedTable);
             if (publisherTable == null) {
                 // Dropped relations are handled separately, see processDroppedTablesOrPartitions(...)
@@ -439,7 +440,10 @@ public final class MetadataTracker implements Closeable {
         // Table existence check is done on a subscription creation but
         // there are cases when attempt to subscribe to existing table happens later during the replication.
         var metadata = subscriberClusterState.metadata();
-        Set<RelationName> currentlyReplicatedTables = subscription.relations().keySet();
+        Set<RelationName> currentlyReplicatedTables = subscription.relations().keySet()
+            .stream()
+            .map(TableOrPartition::table)
+            .collect(Collectors.toSet());
 
         return publisherStateResponse.metadata().relations(RelationMetadata.Table.class).stream()
             .map(RelationMetadata.Table::name)
@@ -449,7 +453,7 @@ public final class MetadataTracker implements Closeable {
     }
 
     record RestoreDiff(List<TableOrPartition> toRestore,
-                       Set<RelationName> relationsForStateUpdate) {
+                       Set<TableOrPartition> targetsForStateUpdate) {
 
         public boolean isEmpty() {
             return toRestore.isEmpty();
@@ -460,8 +464,8 @@ public final class MetadataTracker implements Closeable {
     static RestoreDiff getRestoreDiff(Subscription subscription,
                                       ClusterState subscriberState,
                                       PublicationsStateAction.Response stateResponse) {
-        Map<RelationName, RelationState> subscribedRelations = subscription.relations();
-        HashSet<RelationName> relationNamesForStateUpdate = new HashSet<>();
+        Map<TableOrPartition, RelationState> subscribedRelations = subscription.relations();
+        HashSet<TableOrPartition> targetsForStateUpdate = new HashSet<>();
         HashSet<TableOrPartition> toRestore = new HashSet<>();
         Metadata subscriberMetadata = subscriberState.metadata();
         Metadata publisherMetadata = stateResponse.metadata();
@@ -469,8 +473,12 @@ public final class MetadataTracker implements Closeable {
             RelationName relationName = table.name();
             for (IndexMetadata indexMetadata : publisherMetadata.getIndices(relationName, List.of(), false, x -> x)) {
                 String indexName = indexMetadata.getIndex().name();
-                if (subscribedRelations.get(relationName) == null) {
-                    relationNamesForStateUpdate.add(relationName);
+                String partitionIdent = indexMetadata.partitionValues().isEmpty()
+                    ? null
+                    : PartitionName.encodeIdent(indexMetadata.partitionValues());
+                var target = new TableOrPartition(relationName, partitionIdent);
+                if (subscribedRelations.get(target) == null) {
+                    targetsForStateUpdate.add(target);
                 }
                 if (REPLICATION_INDEX_ROUTING_ACTIVE.get(indexMetadata.getSettings()) == false) {
                     // If the index is not active, we cannot restore it
@@ -481,23 +489,23 @@ public final class MetadataTracker implements Closeable {
                 }
                 String indexUUID = subscriberMetadata.getIndex(relationName, indexMetadata.partitionValues(), false, IndexMetadata::getIndexUUID);
                 if (indexUUID == null) {
-                    String partitionIdent = PartitionName.encodeIdent(indexMetadata.partitionValues());
-                    toRestore.add(new TableOrPartition(relationName, partitionIdent));
-                    relationNamesForStateUpdate.add(relationName);
+                    toRestore.add(target);
+                    targetsForStateUpdate.add(target);
                 }
             }
             if (table.indexUUIDs().isEmpty() && table.partitionedBy().isEmpty() == false) {
                 // If the table is partitioned, we need to restore the table itself
                 if (subscriberMetadata.getRelation(relationName) == null) {
-                    toRestore.add(new TableOrPartition(relationName, null));
-                    relationNamesForStateUpdate.add(relationName);
+                    var target = new TableOrPartition(relationName, null);
+                    toRestore.add(target);
+                    targetsForStateUpdate.add(target);
                 }
             }
         }
         if (toRestore.isEmpty()) {
-            relationNamesForStateUpdate.clear();
+            targetsForStateUpdate.clear();
         }
-        return new RestoreDiff(toRestore.stream().toList(), relationNamesForStateUpdate);
+        return new RestoreDiff(toRestore.stream().toList(), targetsForStateUpdate);
     }
 
     private ClusterState processDroppedTablesOrPartitions(String subscriptionName,
@@ -508,7 +516,8 @@ public final class MetadataTracker implements Closeable {
         HashSet<Index> partitionsToRemove = new HashSet<>();
         Metadata subscriberMetadata = subscriberClusterState.metadata();
         Metadata.Builder updatedMetadataBuilder = Metadata.builder(subscriberMetadata);
-        for (var relationName : subscription.relations().keySet()) {
+        for (var target : subscription.relations().keySet()) {
+            RelationName relationName = target.table();
             RelationMetadata.Table publisherTable = publisherMetadata.getRelation(relationName);
             if (publisherTable == null) {
                 changedRelations.add(relationName);
@@ -543,12 +552,12 @@ public final class MetadataTracker implements Closeable {
 
         }
         if (changedRelations.isEmpty() == false) {
-            HashMap<RelationName, Subscription.RelationState> relations = new HashMap<>();
+            HashMap<TableOrPartition, Subscription.RelationState> relations = new HashMap<>();
             for (var entry : subscription.relations().entrySet()) {
-                var relationName = entry.getKey();
+                var relationName = entry.getKey().table();
                 if (changedRelations.contains(relationName) == false) {
                     RelationState state = entry.getValue();
-                    relations.put(relationName, state);
+                    relations.put(entry.getKey(), state);
                 }
             }
             updatedClusterState = DropSubscriptionAction.removeSubscriptionSetting(

--- a/server/src/main/java/io/crate/replication/logical/action/CreatePublicationRequest.java
+++ b/server/src/main/java/io/crate/replication/logical/action/CreatePublicationRequest.java
@@ -21,7 +21,8 @@
 
 package io.crate.replication.logical.action;
 
-import io.crate.metadata.RelationName;
+import org.elasticsearch.Version;
+import org.elasticsearch.action.admin.cluster.snapshots.restore.TableOrPartition;
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -30,18 +31,20 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import io.crate.metadata.RelationName;
+
 public class CreatePublicationRequest extends AcknowledgedRequest<CreatePublicationRequest> {
 
     private final String owner;
     private final String name;
     private final boolean forAllTables;
-    private final List<RelationName> tables;
+    private final List<TableOrPartition> targets;
 
-    public CreatePublicationRequest(String owner, String name, boolean forAllTables, List<RelationName> tables) {
+    public CreatePublicationRequest(String owner, String name, boolean forAllTables, List<TableOrPartition> targets) {
         this.owner = owner;
         this.name = name;
         this.forAllTables = forAllTables;
-        this.tables = tables;
+        this.targets = targets;
     }
 
     public CreatePublicationRequest(StreamInput in) throws IOException {
@@ -50,11 +53,15 @@ public class CreatePublicationRequest extends AcknowledgedRequest<CreatePublicat
         this.name = in.readString();
         this.forAllTables = in.readBoolean();
         int size = in.readVInt();
-        var t = new ArrayList<RelationName>(size);
+        var t = new ArrayList<TableOrPartition>(size);
         for (var i = 0; i < size; i++) {
-            t.add(new RelationName(in));
+            if (in.getVersion().before(Version.V_6_5_0)) {
+                t.add(new TableOrPartition(new RelationName(in), null));
+            } else {
+                t.add(new TableOrPartition(in));
+            }
         }
-        this.tables = List.copyOf(t);
+        this.targets = List.copyOf(t);
     }
 
     public String owner() {
@@ -69,8 +76,8 @@ public class CreatePublicationRequest extends AcknowledgedRequest<CreatePublicat
         return forAllTables;
     }
 
-    public List<RelationName> tables() {
-        return tables;
+    public List<TableOrPartition> targets() {
+        return targets;
     }
 
     @Override
@@ -79,9 +86,20 @@ public class CreatePublicationRequest extends AcknowledgedRequest<CreatePublicat
         out.writeString(owner);
         out.writeString(name);
         out.writeBoolean(forAllTables);
-        out.writeVInt(tables.size());
-        for (var table : tables) {
-            table.writeTo(out);
+        if (out.getVersion().before(Version.V_6_5_0)) {
+            for (var target : targets) {
+                if (target.partitionIdent() != null) {
+                    throw new IllegalStateException("Cannot write partition publication target to a node before " + Version.V_6_5_0);
+                }
+            }
+        }
+        out.writeVInt(targets.size());
+        for (var target : targets) {
+            if (out.getVersion().before(Version.V_6_5_0)) {
+                target.table().writeTo(out);
+            } else {
+                target.writeTo(out);
+            }
         }
     }
 }

--- a/server/src/main/java/io/crate/replication/logical/action/DropSubscriptionAction.java
+++ b/server/src/main/java/io/crate/replication/logical/action/DropSubscriptionAction.java
@@ -25,6 +25,7 @@ import static io.crate.replication.logical.LogicalReplicationSettings.REPLICATIO
 
 import java.util.Collection;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
@@ -150,7 +151,13 @@ public class DropSubscriptionAction extends ActionType<AcknowledgedResponse> {
                         assert !newMetadata.equals(oldMetadata) : "must not be equal to guarantee the cluster change action";
                         mdBuilder.putCustom(SubscriptionsMetadata.TYPE, newMetadata);
 
-                        return removeSubscriptionSetting(subscription.relations().keySet(), currentState, mdBuilder);
+                        return removeSubscriptionSetting(
+                            subscription.relations().keySet().stream()
+                                .map(target -> target.table())
+                                .collect(Collectors.toSet()),
+                            currentState,
+                            mdBuilder
+                        );
                     } else if (request.ifExists() == false) {
                         throw new SubscriptionUnknownException(request.name());
                     }

--- a/server/src/main/java/io/crate/replication/logical/action/TransportAlterPublication.java
+++ b/server/src/main/java/io/crate/replication/logical/action/TransportAlterPublication.java
@@ -28,8 +28,10 @@ import java.util.List;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.admin.cluster.snapshots.restore.TableOrPartition;
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.action.support.master.TransportMasterNodeAction;
@@ -144,47 +146,52 @@ public class TransportAlterPublication extends TransportMasterNodeAction<Transpo
     @VisibleForTesting
     static Publication updatePublication(Request request, Metadata currentMetadata, Publication oldPublication) {
         // Ensure tables exists
-        for (var relation : request.tables) {
+        for (var target : request.targets) {
+            var relation = target.table();
             if (currentMetadata.getRelation(relation) == null) {
                 throw new RelationUnknown(relation);
             }
         }
 
-        HashSet<RelationName> tables = new HashSet<>();
+        HashSet<TableOrPartition> targets = new HashSet<>();
         switch (request.operation) {
-            case SET -> tables = new HashSet<>(request.tables);
+            case SET -> targets = new HashSet<>(request.targets);
             case ADD -> {
-                tables.addAll(oldPublication.tables());
-                tables.addAll(request.tables);
+                targets.addAll(oldPublication.targets());
+                targets.addAll(request.targets);
             }
-            case DROP -> oldPublication.tables().stream()
-                .filter(relationName -> request.tables.contains(relationName) == false)
-                .forEach(tables::add);
+            case DROP -> oldPublication.targets().stream()
+                .filter(target -> request.targets.contains(target) == false)
+                .forEach(targets::add);
             default ->
                 throw new UnsupportedOperationException(
                     "Alter publication operation '" + request.operation + "' is not supported"
                 );
         }
-        return new Publication(oldPublication.owner(), oldPublication.isForAllTables(), new ArrayList<>(tables));
+        return new Publication(oldPublication.owner(), oldPublication.isForAllTables(), new ArrayList<>(targets));
     }
 
     public static class Request extends AcknowledgedRequest<Request> {
 
         private final String name;
         private final AlterPublication.Operation operation;
-        private final List<RelationName> tables;
+        private final List<TableOrPartition> targets;
 
-        public Request(String name, AlterPublication.Operation operation, List<RelationName> tables) {
+        public Request(String name, AlterPublication.Operation operation, List<TableOrPartition> targets) {
             this.name = name;
             this.operation = operation;
-            this.tables = tables;
+            this.targets = targets;
         }
 
         public Request(StreamInput in) throws IOException {
             super(in);
             name = in.readString();
             operation = AlterPublication.Operation.VALUES[in.readVInt()];
-            tables = in.readList(RelationName::new);
+            if (in.getVersion().before(Version.V_6_5_0)) {
+                targets = in.readList(stream -> new TableOrPartition(new RelationName(stream), null));
+            } else {
+                targets = in.readList(TableOrPartition::new);
+            }
         }
 
         @Override
@@ -192,7 +199,18 @@ public class TransportAlterPublication extends TransportMasterNodeAction<Transpo
             super.writeTo(out);
             out.writeString(name);
             out.writeVInt(operation.ordinal());
-            out.writeList(tables);
+            if (out.getVersion().before(Version.V_6_5_0)) {
+                for (var target : targets) {
+                    if (target.partitionIdent() != null) {
+                        throw new IllegalStateException("Cannot write partition publication target to a node before " + Version.V_6_5_0);
+                    }
+                }
+                out.writeCollection(targets, (stream, target) -> {
+                    target.table().writeTo(stream);
+                });
+            } else {
+                out.writeList(targets);
+            }
         }
     }
 }

--- a/server/src/main/java/io/crate/replication/logical/action/TransportCreatePublication.java
+++ b/server/src/main/java/io/crate/replication/logical/action/TransportCreatePublication.java
@@ -99,7 +99,8 @@ public class TransportCreatePublication extends AbstractDDLTransportAction<Creat
                 }
 
                 // Ensure tables exists
-                for (var relation : request.tables()) {
+                for (var target : request.targets()) {
+                    var relation = target.table();
                     RelationMetadata.Table table = currentMetadata.getRelation(relation);
                     if (table == null) {
                         throw new RelationUnknown(relation);
@@ -110,7 +111,7 @@ public class TransportCreatePublication extends AbstractDDLTransportAction<Creat
                 var newMetadata = PublicationsMetadata.newInstance(oldMetadata);
                 newMetadata.publications().put(
                     request.name(),
-                    new Publication(request.owner(), request.isForAllTables(), request.tables())
+                    new Publication(request.owner(), request.isForAllTables(), request.targets())
                 );
                 assert !newMetadata.equals(oldMetadata) : "must not be equal to guarantee the cluster change action";
                 mdBuilder.putCustom(PublicationsMetadata.TYPE, newMetadata);

--- a/server/src/main/java/io/crate/replication/logical/action/TransportCreateSubscription.java
+++ b/server/src/main/java/io/crate/replication/logical/action/TransportCreateSubscription.java
@@ -30,6 +30,7 @@ import java.util.concurrent.CompletableFuture;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.admin.cluster.snapshots.restore.TableOrPartition;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.cluster.AckedClusterStateUpdateTask;
@@ -48,7 +49,6 @@ import org.elasticsearch.transport.TransportService;
 
 import io.crate.common.exceptions.Exceptions;
 import io.crate.exceptions.RelationAlreadyExists;
-import io.crate.metadata.RelationName;
 import io.crate.replication.logical.LogicalReplicationService;
 import io.crate.replication.logical.exceptions.PublicationUnknownException;
 import io.crate.replication.logical.exceptions.SubscriptionAlreadyExistsException;
@@ -199,11 +199,11 @@ public class TransportCreateSubscription extends TransportMasterNodeAction<Creat
                     throw new SubscriptionAlreadyExistsException(request.name());
                 }
 
-                HashMap<RelationName, Subscription.RelationState> relations = new HashMap<>();
+                HashMap<TableOrPartition, Subscription.RelationState> relations = new HashMap<>();
                 Metadata publisherMetadata = publicationsStateResponse.metadata();
                 for (RelationMetadata.Table table : publisherMetadata.relations(RelationMetadata.Table.class)) {
                     relations.put(
-                        table.name(),
+                        new TableOrPartition(table.name(), null),
                         new Subscription.RelationState(Subscription.State.INITIALIZING, null)
                     );
                 }

--- a/server/src/main/java/io/crate/replication/logical/action/UpdateSubscriptionAction.java
+++ b/server/src/main/java/io/crate/replication/logical/action/UpdateSubscriptionAction.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.admin.cluster.snapshots.restore.TableOrPartition;
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.action.support.master.TransportMasterNodeAction;
@@ -44,7 +45,6 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
 import io.crate.common.annotations.VisibleForTesting;
-import io.crate.metadata.RelationName;
 import io.crate.replication.logical.exceptions.SubscriptionUnknownException;
 import io.crate.replication.logical.metadata.Subscription;
 import io.crate.replication.logical.metadata.SubscriptionsMetadata;
@@ -65,13 +65,13 @@ public class UpdateSubscriptionAction extends ActionType<AcknowledgedResponse> {
 
     @VisibleForTesting
     static Subscription updateSubscription(Subscription oldSubscription, Subscription newSubscription) {
-        HashMap<RelationName, Subscription.RelationState> relations = new HashMap<>();
+        HashMap<TableOrPartition, Subscription.RelationState> relations = new HashMap<>();
         for (var entry : newSubscription.relations().entrySet()) {
-            var relationName = entry.getKey();
+            var target = entry.getKey();
             relations.put(
-                relationName,
+                target,
                 Subscription.updateRelationState(
-                    oldSubscription.relations().get(relationName),
+                    oldSubscription.relations().get(target),
                     entry.getValue()
                 )
             );

--- a/server/src/main/java/io/crate/replication/logical/metadata/Publication.java
+++ b/server/src/main/java/io/crate/replication/logical/metadata/Publication.java
@@ -29,8 +29,10 @@ import java.util.List;
 import java.util.Objects;
 import java.util.function.Predicate;
 
+import org.elasticsearch.action.admin.cluster.snapshots.restore.TableOrPartition;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
@@ -41,6 +43,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.Index;
 
 import io.crate.metadata.RelationName;
+import io.crate.metadata.PartitionName;
 import io.crate.role.Permission;
 import io.crate.role.Role;
 import io.crate.role.Roles;
@@ -51,22 +54,26 @@ public class Publication implements Writeable {
     private static final Logger LOGGER = LogManager.getLogger(Publication.class);
     private final String owner;
     private final boolean forAllTables;
-    private final List<RelationName> tables;
+    private final List<TableOrPartition> targets;
 
-    public Publication(String owner, boolean forAllTables, List<RelationName> tables) {
-        assert !forAllTables || (forAllTables && tables.isEmpty()) : "If forAllTables is true, tables must be empty";
+    public Publication(String owner, boolean forAllTables, List<TableOrPartition> targets) {
+        assert !forAllTables || (forAllTables && targets.isEmpty()) : "If forAllTables is true, targets must be empty";
         this.owner = owner;
         this.forAllTables = forAllTables;
-        this.tables = tables;
+        this.targets = targets;
     }
 
     Publication(StreamInput in) throws IOException {
         owner = in.readString();
         forAllTables = in.readBoolean();
         int size = in.readVInt();
-        tables = new ArrayList<>(size);
+        targets = new ArrayList<>(size);
         for (int i = 0; i < size; i++) {
-            tables.add(RelationName.fromIndexName(in.readString()));
+            if (in.getVersion().before(Version.V_6_5_0)) {
+                targets.add(new TableOrPartition(RelationName.fromIndexName(in.readString()), null));
+            } else {
+                targets.add(new TableOrPartition(in));
+            }
         }
     }
 
@@ -78,17 +85,32 @@ public class Publication implements Writeable {
         return forAllTables;
     }
 
+    public List<TableOrPartition> targets() {
+        return targets;
+    }
+
     public List<RelationName> tables() {
-        return tables;
+        return targets.stream().map(TableOrPartition::table).toList();
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(owner);
         out.writeBoolean(forAllTables);
-        out.writeVInt(tables.size());
-        for (var table : tables) {
-            out.writeString(table.indexNameOrAlias());
+        if (out.getVersion().before(Version.V_6_5_0)) {
+            for (var target : targets) {
+                if (target.partitionIdent() != null) {
+                    throw new IllegalStateException("Cannot write partition publication target to a node before " + Version.V_6_5_0);
+                }
+            }
+        }
+        out.writeVInt(targets.size());
+        for (var target : targets) {
+            if (out.getVersion().before(Version.V_6_5_0)) {
+                out.writeString(target.table().indexNameOrAlias());
+            } else {
+                target.writeTo(out);
+            }
         }
     }
 
@@ -101,17 +123,17 @@ public class Publication implements Writeable {
             return false;
         }
         Publication that = (Publication) o;
-        return forAllTables == that.forAllTables && owner.equals(that.owner) && tables.equals(that.tables);
+        return forAllTables == that.forAllTables && owner.equals(that.owner) && targets.equals(that.targets);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(owner, tables, forAllTables);
+        return Objects.hash(owner, targets, forAllTables);
     }
 
     @Override
     public String toString() {
-        return "Publication{forAllTables=" + forAllTables + ", owner=" + owner + ", tables=" + tables + "}";
+        return "Publication{forAllTables=" + forAllTables + ", owner=" + owner + ", targets=" + targets + "}";
     }
 
     public Metadata.Builder resolveCurrentRelations(ClusterState state,
@@ -147,7 +169,8 @@ public class Publication implements Writeable {
                 addRelation(metadata, metadataBuilder, table, indexFilter);
             }
         } else {
-            for (RelationName relationName : tables) {
+            for (TableOrPartition target : targets) {
+                RelationName relationName = target.table();
                 if (relationFilter.test(relationName) == false) {
                     continue;
                 }
@@ -158,11 +181,38 @@ public class Publication implements Writeable {
                     }
                     continue;
                 }
-                addRelation(metadata, metadataBuilder, table, indexFilter);
+                addTarget(metadata, metadataBuilder, table, target, indexFilter);
             }
         }
 
         return metadataBuilder;
+    }
+
+    private static void addTarget(Metadata currentMetadata,
+                                  Metadata.Builder metadataBuilder,
+                                  org.elasticsearch.cluster.metadata.RelationMetadata.Table table,
+                                  TableOrPartition target,
+                                  Predicate<Index> indexFilter) {
+        if (target.partitionIdent() == null) {
+            addRelation(currentMetadata, metadataBuilder, table, indexFilter);
+            return;
+        }
+
+        List<String> partitionValues = PartitionName.decodeIdent(target.partitionIdent());
+        List<IndexMetadata> indices = currentMetadata.getIndices(table.name(), partitionValues, false, im -> im);
+        if (indices.isEmpty()) {
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("Partition {} of table {} not found in metadata, skipping publication resolution for it.",
+                    target.partitionIdent(),
+                    table.name());
+            }
+            return;
+        }
+
+        metadataBuilder.setRelation(table.withIndexUUIDs(indices.stream().map(IndexMetadata::getIndexUUID).toList()));
+        for (IndexMetadata indexMetadata : indices) {
+            addIndex(metadataBuilder, indexMetadata, indexFilter);
+        }
     }
 
     private static void addRelation(Metadata currentMetadata,
@@ -171,19 +221,25 @@ public class Publication implements Writeable {
                                     Predicate<Index> indexFilter) {
         metadataBuilder.setRelation(table);
         for (IndexMetadata indexMetadata : currentMetadata.getIndices(table.name(), List.of(), true, im -> im)) {
-            var publishedIndexMetadata = IndexMetadata.builder(indexMetadata);
-            if (indexFilter.test(indexMetadata.getIndex()) == false) {
-                publishedIndexMetadata.settings(
-                    Settings.builder()
-                        .put(indexMetadata.getSettings())
-                        .put(REPLICATION_INDEX_ROUTING_ACTIVE.getKey(), false)
-                );
-            }
-            // Add empty dummy mapping given that we're faking responses from
-            // old nodes which would have some mapping
-            publishedIndexMetadata.putMapping("{}");
-            metadataBuilder.put(publishedIndexMetadata);
+            addIndex(metadataBuilder, indexMetadata, indexFilter);
         }
+    }
+
+    private static void addIndex(Metadata.Builder metadataBuilder,
+                                 IndexMetadata indexMetadata,
+                                 Predicate<Index> indexFilter) {
+        var publishedIndexMetadata = IndexMetadata.builder(indexMetadata);
+        if (indexFilter.test(indexMetadata.getIndex()) == false) {
+            publishedIndexMetadata.settings(
+                Settings.builder()
+                    .put(indexMetadata.getSettings())
+                    .put(REPLICATION_INDEX_ROUTING_ACTIVE.getKey(), false)
+            );
+        }
+        // Add empty dummy mapping given that we're faking responses from
+        // old nodes which would have some mapping
+        publishedIndexMetadata.putMapping("{}");
+        metadataBuilder.put(publishedIndexMetadata);
     }
 
     private static boolean subscriberCanRead(Roles roles, RelationName relationName, Role subscriber, String publicationName) {

--- a/server/src/main/java/io/crate/replication/logical/metadata/PublicationsMetadata.java
+++ b/server/src/main/java/io/crate/replication/logical/metadata/PublicationsMetadata.java
@@ -30,6 +30,7 @@ import java.util.Objects;
 
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.Version;
+import org.elasticsearch.action.admin.cluster.snapshots.restore.TableOrPartition;
 import org.elasticsearch.cluster.AbstractNamedDiffable;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -124,7 +125,7 @@ public class PublicationsMetadata extends AbstractNamedDiffable<Metadata.Custom>
                     if (parser.nextToken() == XContentParser.Token.START_OBJECT) {
                         String owner = null;
                         boolean forAllTables = false;
-                        var tables = new ArrayList<RelationName>();
+                        var targets = new ArrayList<TableOrPartition>();
                         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
                             if ("owner".equals(parser.currentName())) {
                                 parser.nextToken();
@@ -137,14 +138,14 @@ public class PublicationsMetadata extends AbstractNamedDiffable<Metadata.Custom>
                             if ("tables".equals(parser.currentName())) {
                                 parser.nextToken();
                                 while ((parser.nextToken()) != XContentParser.Token.END_ARRAY) {
-                                    tables.add(RelationName.fromIndexName(parser.text()));
+                                    targets.add(new TableOrPartition(RelationName.fromIndexName(parser.text()), null));
                                 }
                             }
                         }
                         if (owner == null) {
                             throw new ElasticsearchParseException("failed to parse publication, expected field 'owner' in object");
                         }
-                        publications.put(name, new Publication(owner, forAllTables, tables));
+                        publications.put(name, new Publication(owner, forAllTables, targets));
                     }
                 }
             }
@@ -185,7 +186,7 @@ public class PublicationsMetadata extends AbstractNamedDiffable<Metadata.Custom>
 
     public boolean isPublished(RelationName relation) {
         for (Publication publication : publications().values()) {
-            if (publication.isForAllTables() || publication.tables().contains(relation)) {
+            if (publication.isForAllTables() || publication.targets().contains(new TableOrPartition(relation, null))) {
                 return true;
             }
         }

--- a/server/src/main/java/io/crate/replication/logical/metadata/Subscription.java
+++ b/server/src/main/java/io/crate/replication/logical/metadata/Subscription.java
@@ -21,7 +21,8 @@
 
 package io.crate.replication.logical.metadata;
 
-import io.crate.metadata.RelationName;
+import org.elasticsearch.Version;
+import org.elasticsearch.action.admin.cluster.snapshots.restore.TableOrPartition;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -34,6 +35,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+
+import io.crate.metadata.RelationName;
 
 public class Subscription implements Writeable {
 
@@ -87,13 +90,13 @@ public class Subscription implements Writeable {
     private final ConnectionInfo connectionInfo;
     private final List<String> publications;
     private final Settings settings;
-    private final Map<RelationName, RelationState> relations;
+    private final Map<TableOrPartition, RelationState> relations;
 
     public Subscription(String owner,
                         ConnectionInfo connectionInfo,
                         List<String> publications,
                         Settings settings,
-                        Map<RelationName, RelationState> relations) {
+                        Map<TableOrPartition, RelationState> relations) {
         this.owner = owner;
         this.connectionInfo = connectionInfo;
         this.publications = publications;
@@ -107,9 +110,14 @@ public class Subscription implements Writeable {
         publications = Arrays.stream(in.readStringArray()).toList();
         settings = Settings.readSettingsFromStream(in);
         int relSize = in.readVInt();
-        HashMap<RelationName, RelationState> relations = new HashMap<>();
+        HashMap<TableOrPartition, RelationState> relations = new HashMap<>();
         for (int i = 0; i < relSize; i++) {
-            RelationName relationName = new RelationName(in);
+            TableOrPartition relationName;
+            if (in.getVersion().before(Version.V_6_5_0)) {
+                relationName = new TableOrPartition(new RelationName(in), null);
+            } else {
+                relationName = new TableOrPartition(in);
+            }
             RelationState relationState = RelationState.readFrom(in);
             relations.put(relationName, relationState);
         }
@@ -132,7 +140,7 @@ public class Subscription implements Writeable {
         return settings;
     }
 
-    public Map<RelationName, RelationState> relations() {
+    public Map<TableOrPartition, RelationState> relations() {
         return relations;
     }
 
@@ -142,9 +150,21 @@ public class Subscription implements Writeable {
         connectionInfo.writeTo(out);
         out.writeStringArray(publications.toArray(new String[0]));
         Settings.writeSettingsToStream(out, settings);
+        if (out.getVersion().before(Version.V_6_5_0)) {
+            for (var target : relations.keySet()) {
+                if (target.partitionIdent() != null) {
+                    throw new IllegalStateException("Cannot write partition subscription target to a node before " + Version.V_6_5_0);
+                }
+            }
+        }
         out.writeVInt(relations.size());
         for (var entry : relations.entrySet()) {
-            entry.getKey().writeTo(out);
+            var target = entry.getKey();
+            if (out.getVersion().before(Version.V_6_5_0)) {
+                target.table().writeTo(out);
+            } else {
+                target.writeTo(out);
+            }
             RelationState.writeTo(out, entry.getValue());
         }
     }

--- a/server/src/main/java/io/crate/replication/logical/metadata/SubscriptionsMetadata.java
+++ b/server/src/main/java/io/crate/replication/logical/metadata/SubscriptionsMetadata.java
@@ -31,6 +31,7 @@ import java.util.Objects;
 
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.Version;
+import org.elasticsearch.action.admin.cluster.snapshots.restore.TableOrPartition;
 import org.elasticsearch.cluster.AbstractNamedDiffable;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -140,7 +141,7 @@ public class SubscriptionsMetadata extends AbstractNamedDiffable<Metadata.Custom
                         ConnectionInfo connectionInfo = null;
                         Settings settings = null;
                         var publications = new ArrayList<String>();
-                        HashMap<RelationName, Subscription.RelationState> relations = new HashMap<>();
+                        HashMap<TableOrPartition, Subscription.RelationState> relations = new HashMap<>();
                         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
                             if ("owner".equals(parser.currentName())) {
                                 parser.nextToken();
@@ -193,7 +194,10 @@ public class SubscriptionsMetadata extends AbstractNamedDiffable<Metadata.Custom
                                     if (state == null) {
                                         throw new ElasticsearchParseException("failed to parse subscription relation, expected field 'state' in object");
                                     }
-                                    relations.put(relationName, new Subscription.RelationState(state, stateReason));
+                                    relations.put(
+                                        new TableOrPartition(relationName, null),
+                                        new Subscription.RelationState(state, stateReason)
+                                    );
                                 }
 
                             }

--- a/server/src/main/java/io/crate/replication/logical/metadata/pgcatalog/PgSubscriptionRelTable.java
+++ b/server/src/main/java/io/crate/replication/logical/metadata/pgcatalog/PgSubscriptionRelTable.java
@@ -55,15 +55,18 @@ public class PgSubscriptionRelTable {
                     (e, c) -> {
                         var sub = e.getValue();
                         sub.relations().forEach(
-                            (r, rs) -> c.accept(
-                                new PgSubscriptionRelRow(
-                                    OidHash.subscriptionOid(e.getKey(), sub),
-                                    new Regclass(logicalReplicationService.getsubscriberTableOid(r), r.fqn()),
-                                    sub.owner(),
-                                    rs.state().pg_state(),
-                                    rs.reason()
-                                )
-                            )
+                            (target, rs) -> {
+                                var relationName = target.table();
+                                c.accept(
+                                    new PgSubscriptionRelRow(
+                                        OidHash.subscriptionOid(e.getKey(), sub),
+                                        new Regclass(logicalReplicationService.getsubscriberTableOid(relationName), relationName.fqn()),
+                                        sub.owner(),
+                                        rs.state().pg_state(),
+                                        rs.reason()
+                                    )
+                                );
+                            }
                         );
                     }
                 );

--- a/server/src/main/java/io/crate/replication/logical/plan/AlterPublicationPlan.java
+++ b/server/src/main/java/io/crate/replication/logical/plan/AlterPublicationPlan.java
@@ -21,6 +21,8 @@
 
 package io.crate.replication.logical.plan;
 
+import org.elasticsearch.action.admin.cluster.snapshots.restore.TableOrPartition;
+
 import io.crate.data.Row;
 import io.crate.data.Row1;
 import io.crate.data.RowConsumer;
@@ -54,7 +56,9 @@ public class AlterPublicationPlan implements Plan {
         var request = new TransportAlterPublication.Request(
             alterPublication.name(),
             alterPublication.operation(),
-            alterPublication.tables()
+            alterPublication.tables().stream()
+                .map(table -> new TableOrPartition(table, null))
+                .toList()
         );
         dependencies.client().execute(TransportAlterPublication.ACTION, request)
             .whenComplete(new OneRowActionListener<>(consumer, rCount -> new Row1(rCount == null ? -1L : 1L)));

--- a/server/src/main/java/io/crate/replication/logical/plan/CreatePublicationPlan.java
+++ b/server/src/main/java/io/crate/replication/logical/plan/CreatePublicationPlan.java
@@ -21,6 +21,8 @@
 
 package io.crate.replication.logical.plan;
 
+import org.elasticsearch.action.admin.cluster.snapshots.restore.TableOrPartition;
+
 import io.crate.data.Row;
 import io.crate.data.Row1;
 import io.crate.data.RowConsumer;
@@ -55,7 +57,9 @@ public class CreatePublicationPlan implements Plan {
             plannerContext.transactionContext().sessionSettings().sessionUser().name(),
             analyzedCreatePublication.name(),
             analyzedCreatePublication.isForAllTables(),
-            analyzedCreatePublication.tables()
+            analyzedCreatePublication.tables().stream()
+                .map(table -> new TableOrPartition(table, null))
+                .toList()
         );
 
         dependencies.client().execute(TransportCreatePublication.ACTION, request)

--- a/server/src/test/java/io/crate/analyze/AlterTableRenameTableAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/AlterTableRenameTableAnalyzerTest.java
@@ -27,6 +27,7 @@ import java.util.Arrays;
 import java.util.Map;
 
 import org.elasticsearch.Version;
+import org.elasticsearch.action.admin.cluster.snapshots.restore.TableOrPartition;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.indices.InvalidRelationName;
@@ -91,7 +92,14 @@ public class AlterTableRenameTableAnalyzerTest extends CrateDummyClusterServiceU
     }
 
     private ClusterService clusterServiceWithPublicationMetadata(boolean allTablesPublished, RelationName... tables) {
-        var publications = Map.of("pub1", new Publication("user1", allTablesPublished, Arrays.asList(tables)));
+        var publications = Map.of(
+            "pub1",
+            new Publication(
+                "user1",
+                allTablesPublished,
+                Arrays.stream(tables).map(table -> new TableOrPartition(table, null)).toList()
+            )
+        );
         var publicationsMetadata = new PublicationsMetadata(publications);
         var metadata = new Metadata.Builder(Metadata.OID_UNASSIGNED).putCustom(PublicationsMetadata.TYPE, publicationsMetadata).build();
         return createClusterService(additionalClusterSettings(), metadata, Version.CURRENT);

--- a/server/src/test/java/io/crate/execution/ddl/tables/AlterTableOperationTest.java
+++ b/server/src/test/java/io/crate/execution/ddl/tables/AlterTableOperationTest.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.elasticsearch.Version;
+import org.elasticsearch.action.admin.cluster.snapshots.restore.TableOrPartition;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESTestCase;
@@ -73,7 +74,7 @@ public class AlterTableOperationTest extends ESTestCase {
             .build();
 
         RelationName t1 = new RelationName("doc", "t1");
-        var oneTablePublished = Map.of("pub1", new Publication("owner", false, List.of(t1)));
+        var oneTablePublished = Map.of("pub1", new Publication("owner", false, List.of(new TableOrPartition(t1, null))));
 
         assertThatThrownBy(() -> AlterTableClient.validateSettingsForPublishedTables(t1, settings, oneTablePublished, DEFAULT_SCOPED_SETTINGS))
             .isExactlyInstanceOf(IllegalArgumentException.class)

--- a/server/src/test/java/io/crate/integrationtests/LogicalReplicationITest.java
+++ b/server/src/test/java/io/crate/integrationtests/LogicalReplicationITest.java
@@ -32,6 +32,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
+import org.elasticsearch.action.admin.cluster.snapshots.restore.TableOrPartition;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -559,7 +560,9 @@ public class LogicalReplicationITest extends LogicalReplicationITestCase {
                 var metadata = SubscriptionsMetadata.get(currentMetadata);
                 var subscription = metadata.subscription().get(subscriptionName);
                 if (subscription != null) {
-                    var currentState = subscription.relations().get(RelationName.fromIndexName("doc.t1")).state();
+                    var currentState = subscription.relations()
+                        .get(new TableOrPartition(RelationName.fromIndexName("doc.t1"), null))
+                        .state();
                     synchronized (subscriptionStates) {
                         var size = subscriptionStates.size();
                         if (size == 0 || subscriptionStates.get(size - 1).equals(currentState) == false) {

--- a/server/src/test/java/io/crate/metadata/doc/DocSchemaInfoTest.java
+++ b/server/src/test/java/io/crate/metadata/doc/DocSchemaInfoTest.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.elasticsearch.Version;
+import org.elasticsearch.action.admin.cluster.snapshots.restore.TableOrPartition;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
@@ -193,8 +194,8 @@ public class DocSchemaInfoTest extends CrateDummyClusterServiceUnitTest {
     }
 
     private PublicationsMetadata publicationsMetadata(String name, boolean allTables, List<String> tables) {
-        var relationNames = Lists.map(tables, x -> new RelationName(DocSchemaInfo.NAME, x));
-        var publications = Map.of(name, new Publication("user1", allTables, relationNames));
+        var targets = Lists.map(tables, x -> new TableOrPartition(new RelationName(DocSchemaInfo.NAME, x), null));
+        var publications = Map.of(name, new Publication("user1", allTables, targets));
         return new PublicationsMetadata(publications);
     }
 

--- a/server/src/test/java/io/crate/replication/logical/MetadataTrackerTest.java
+++ b/server/src/test/java/io/crate/replication/logical/MetadataTrackerTest.java
@@ -284,7 +284,10 @@ public class MetadataTrackerTest extends ESTestCase {
                 publications,
                 Settings.EMPTY,
                 replicatingRelations.stream().map(RelationName::fromIndexName)
-                    .collect(Collectors.toMap(rn -> rn, _ -> new Subscription.RelationState(Subscription.State.MONITORING, null)))
+                    .collect(Collectors.toMap(
+                        rn -> new TableOrPartition(rn, null),
+                        _ -> new Subscription.RelationState(Subscription.State.MONITORING, null)
+                    ))
             );
             var subscriptionsMetadata = SubscriptionsMetadata.newInstance(
                 clusterState.metadata().custom(SubscriptionsMetadata.TYPE));
@@ -303,7 +306,9 @@ public class MetadataTrackerTest extends ESTestCase {
             var publication = new Publication(
                 "user",
                 relations.isEmpty(),
-                relations.stream().map(RelationName::fromIndexName).toList()
+                relations.stream()
+                    .map(relation -> new TableOrPartition(RelationName.fromIndexName(relation), null))
+                    .toList()
             );
             var publicationsMetadata = PublicationsMetadata.newInstance(
                 clusterState.metadata().custom(PublicationsMetadata.TYPE));
@@ -541,7 +546,7 @@ public class MetadataTrackerTest extends ESTestCase {
             subscriberClusterState,
             publisherStateResponse
         );
-        assertThat(restoreDiff.relationsForStateUpdate()).containsExactly(newRelation);
+        assertThat(restoreDiff.targetsForStateUpdate()).containsExactly(new TableOrPartition(newRelation, null));
         assertThat(restoreDiff.toRestore()).containsExactly(new TableOrPartition(p1, null));
     }
 
@@ -566,7 +571,7 @@ public class MetadataTrackerTest extends ESTestCase {
             publisherStateResponse
         );
 
-        assertThat(restoreDiff.relationsForStateUpdate()).containsExactly(newRelation);
+        assertThat(restoreDiff.targetsForStateUpdate()).containsExactly(new TableOrPartition(newRelation, newPartitionName.ident()));
         assertThat(restoreDiff.toRestore()).containsExactly(new TableOrPartition(newRelation, newPartitionName.ident()));
     }
 
@@ -592,7 +597,7 @@ public class MetadataTrackerTest extends ESTestCase {
             publisherStateResponse
         );
 
-        assertThat(restoreDiff.relationsForStateUpdate()).containsExactly(relationName);
+        assertThat(restoreDiff.targetsForStateUpdate()).containsExactly(new TableOrPartition(relationName, newPartitionName.ident()));
         assertThat(restoreDiff.toRestore()).containsExactly(new TableOrPartition(relationName, newPartitionName.ident()));
     }
 
@@ -642,7 +647,7 @@ public class MetadataTrackerTest extends ESTestCase {
             subscriberClusterState,
             publisherStateResponse
         );
-        assertThat(restoreDiff.relationsForStateUpdate()).isEmpty();
+        assertThat(restoreDiff.targetsForStateUpdate()).isEmpty();
         assertThat(restoreDiff.toRestore()).isEmpty();
     }
 }

--- a/server/src/test/java/io/crate/replication/logical/action/CreatePublicationRequestTest.java
+++ b/server/src/test/java/io/crate/replication/logical/action/CreatePublicationRequestTest.java
@@ -19,71 +19,40 @@
  * software solely pursuant to the terms of the relevant commercial agreement.
  */
 
-package io.crate.replication.logical.metadata;
+package io.crate.replication.logical.action;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Map;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.cluster.snapshots.restore.TableOrPartition;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
-import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Test;
 
 import io.crate.metadata.RelationName;
 
-public class PublicationsMetadataTest extends ESTestCase {
-
-    private static TableOrPartition target(String schema, String table) {
-        return new TableOrPartition(new RelationName(schema, table), null);
-    }
-
-    public static PublicationsMetadata createMetadata() {
-        Map<String, Publication> map = Map.of(
-            "pub1",
-            new Publication(
-                "user1",
-                false,
-                List.of(target("s1", "t1"), target("s1", "t2"))
-            ),
-            "myPub2",
-            new Publication("user2", true, List.of())
-        );
-        return new PublicationsMetadata(map);
-    }
-
-    @Test
-    public void testStreaming() throws IOException {
-        PublicationsMetadata pubs = createMetadata();
-        BytesStreamOutput out = new BytesStreamOutput();
-        pubs.writeTo(out);
-
-        StreamInput in = out.bytes().streamInput();
-        PublicationsMetadata pubs2 = new PublicationsMetadata(in);
-        assertThat(pubs2).isEqualTo(pubs);
-
-    }
+public class CreatePublicationRequestTest extends ESTestCase {
 
     @Test
     public void test_streaming_partition_targets() throws IOException {
         var target = new TableOrPartition(new RelationName("doc", "t1"), "04132");
-        var publication = new Publication(
-            "user1",
+        var request = new CreatePublicationRequest(
+            "owner",
+            "pub1",
             false,
             List.of(target)
         );
         var out = new BytesStreamOutput();
         out.setVersion(Version.V_6_5_0);
-        publication.writeTo(out);
+        request.writeTo(out);
 
         var in = out.bytes().streamInput();
         in.setVersion(Version.V_6_5_0);
-        var streamed = new Publication(in);
+        var streamed = new CreatePublicationRequest(in);
 
         assertThat(streamed.targets()).containsExactly(target);
     }
@@ -91,33 +60,35 @@ public class PublicationsMetadataTest extends ESTestCase {
     @Test
     public void test_streaming_table_targets_to_older_version() throws IOException {
         var target = new TableOrPartition(new RelationName("doc", "t1"), null);
-        var publication = new Publication(
-            "user1",
+        var request = new CreatePublicationRequest(
+            "owner",
+            "pub1",
             false,
             List.of(target)
         );
         var out = new BytesStreamOutput();
         out.setVersion(Version.V_6_4_0);
-        publication.writeTo(out);
+        request.writeTo(out);
 
         var in = out.bytes().streamInput();
         in.setVersion(Version.V_6_4_0);
-        var streamed = new Publication(in);
+        var streamed = new CreatePublicationRequest(in);
 
         assertThat(streamed.targets()).containsExactly(target);
     }
 
     @Test
     public void test_cannot_stream_partition_targets_to_older_version() {
-        var publication = new Publication(
-            "user1",
+        var request = new CreatePublicationRequest(
+            "owner",
+            "pub1",
             false,
             List.of(new TableOrPartition(new RelationName("doc", "t1"), "04132"))
         );
         var out = new BytesStreamOutput();
         out.setVersion(Version.V_6_4_0);
 
-        assertThatThrownBy(() -> publication.writeTo(out))
+        assertThatThrownBy(() -> request.writeTo(out))
             .isExactlyInstanceOf(IllegalStateException.class)
             .hasMessageContaining("Cannot write partition publication target to a node before");
     }

--- a/server/src/test/java/io/crate/replication/logical/action/PublicationsStateActionTest.java
+++ b/server/src/test/java/io/crate/replication/logical/action/PublicationsStateActionTest.java
@@ -34,6 +34,7 @@ import java.util.Map;
 
 import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.Version;
+import org.elasticsearch.action.admin.cluster.snapshots.restore.TableOrPartition;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.metadata.MetadataUpgradeService;
@@ -66,6 +67,19 @@ import io.crate.testing.SQLExecutor;
 public class PublicationsStateActionTest extends CrateDummyClusterServiceUnitTest {
 
     private MockLogAppender appender;
+
+    private static TableOrPartition target(RelationName relationName) {
+        return new TableOrPartition(relationName, null);
+    }
+
+    private static TableOrPartition target(String relationName) {
+        return target(RelationName.fromIndexName(relationName));
+    }
+
+    private static TableOrPartition target(String relationName, List<String> partitionValues) {
+        RelationName table = RelationName.fromIndexName(relationName);
+        return new TableOrPartition(table, new PartitionName(table, partitionValues).ident());
+    }
 
     @Before
     public void appendLogger() throws Exception {
@@ -197,8 +211,8 @@ public class PublicationsStateActionTest extends CrateDummyClusterServiceUnitTes
             .startShards("doc.t1", "doc.t2");
         var publication = new Publication("publisher", false,
             List.of(
-                RelationName.of(QualifiedName.of("t1"), DocSchemaInfo.NAME),
-                RelationName.of(QualifiedName.of("t2"), DocSchemaInfo.NAME)
+                target(RelationName.of(QualifiedName.of("t1"), DocSchemaInfo.NAME)),
+                target(RelationName.of(QualifiedName.of("t2"), DocSchemaInfo.NAME))
             )
         );
 
@@ -280,7 +294,7 @@ public class PublicationsStateActionTest extends CrateDummyClusterServiceUnitTes
         var publication = new Publication(
             "some_user",
             false,
-            List.of(RelationName.fromIndexName("t1"), RelationName.fromIndexName("doc.t2"))
+            List.of(target("t1"), target("doc.t2"))
         );
 
         Metadata.Builder metadataBuilder = Metadata.builder(clusterService.state().metadata().currentMaxTableOid());
@@ -364,7 +378,7 @@ public class PublicationsStateActionTest extends CrateDummyClusterServiceUnitTes
         var publication = new Publication(
             "some_user",
             false,
-            List.of(RelationName.fromIndexName("p1"))
+            List.of(target("p1"))
         );
 
         Metadata.Builder metadataBuilder = Metadata.builder(clusterService.state().metadata().currentMaxTableOid());

--- a/server/src/test/java/io/crate/replication/logical/action/TransportAlterPublicationTest.java
+++ b/server/src/test/java/io/crate/replication/logical/action/TransportAlterPublicationTest.java
@@ -26,6 +26,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
 
+import org.elasticsearch.action.admin.cluster.snapshots.restore.TableOrPartition;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.junit.Test;
 
@@ -38,6 +39,10 @@ import io.crate.testing.SQLExecutor;
 
 public class TransportAlterPublicationTest extends CrateDummyClusterServiceUnitTest {
 
+    private static TableOrPartition target(String table) {
+        return new TableOrPartition(RelationName.fromIndexName(table), null);
+    }
+
     @Test
     public void test_unknown_table_raises_exception() {
         var pub = new Publication("owner", false, List.of());
@@ -45,7 +50,7 @@ public class TransportAlterPublicationTest extends CrateDummyClusterServiceUnitT
         var request = new TransportAlterPublication.Request(
             "pub1",
             AlterPublication.Operation.SET,
-            List.of(RelationName.fromIndexName("t1"))
+            List.of(target("t1"))
         );
 
         assertThatThrownBy(() -> TransportAlterPublication.updatePublication(request, metadata, pub))
@@ -54,7 +59,7 @@ public class TransportAlterPublicationTest extends CrateDummyClusterServiceUnitT
 
     @Test
     public void test_set_tables_on_existing_publication() throws Exception {
-        var oldPublication = new Publication("owner", false, List.of(RelationName.fromIndexName("t1")));
+        var oldPublication = new Publication("owner", false, List.of(target("t1")));
 
         SQLExecutor.of(clusterService)
             .addTable("create table t2 (x int)");
@@ -63,7 +68,7 @@ public class TransportAlterPublicationTest extends CrateDummyClusterServiceUnitT
         var request = new TransportAlterPublication.Request(
             "pub1",
             AlterPublication.Operation.SET,
-            List.of(RelationName.fromIndexName("t2"))
+            List.of(target("t2"))
         );
 
         var newPublication = TransportAlterPublication.updatePublication(request, metadata, oldPublication);
@@ -73,14 +78,14 @@ public class TransportAlterPublicationTest extends CrateDummyClusterServiceUnitT
 
     @Test
     public void test_add_table_on_existing_publication() throws Exception {
-        var oldPublication = new Publication("owner", false, List.of(RelationName.fromIndexName("t1")));
+        var oldPublication = new Publication("owner", false, List.of(target("t1")));
         SQLExecutor.of(clusterService)
             .addTable("create table t2 (x int)");
         Metadata metadata = clusterService.state().metadata();
         var request = new TransportAlterPublication.Request(
             "pub1",
             AlterPublication.Operation.ADD,
-            List.of(RelationName.fromIndexName("t2"))
+            List.of(target("t2"))
         );
 
         var newPublication = TransportAlterPublication.updatePublication(request, metadata, oldPublication);
@@ -94,7 +99,7 @@ public class TransportAlterPublicationTest extends CrateDummyClusterServiceUnitT
         var oldPublication = new Publication(
             "owner",
             false,
-            List.of(RelationName.fromIndexName("t1"), RelationName.fromIndexName("t2"))
+            List.of(target("t1"), target("t2"))
         );
         SQLExecutor.of(clusterService)
             .addTable("create table t1 (x int)")
@@ -103,7 +108,7 @@ public class TransportAlterPublicationTest extends CrateDummyClusterServiceUnitT
         var request = new TransportAlterPublication.Request(
             "pub1",
             AlterPublication.Operation.DROP,
-            List.of(RelationName.fromIndexName("t2"))
+            List.of(target("t2"))
         );
 
         var newPublication = TransportAlterPublication.updatePublication(request, metadata, oldPublication);

--- a/server/src/test/java/io/crate/replication/logical/action/TransportAlterPublicationTest.java
+++ b/server/src/test/java/io/crate/replication/logical/action/TransportAlterPublicationTest.java
@@ -24,10 +24,13 @@ package io.crate.replication.logical.action;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.io.IOException;
 import java.util.List;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.cluster.snapshots.restore.TableOrPartition;
 import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.junit.Test;
 
 import io.crate.exceptions.RelationUnknown;
@@ -114,5 +117,58 @@ public class TransportAlterPublicationTest extends CrateDummyClusterServiceUnitT
         var newPublication = TransportAlterPublication.updatePublication(request, metadata, oldPublication);
         assertThat(newPublication).isNotEqualTo(oldPublication);
         assertThat(newPublication.tables()).containsExactly(RelationName.fromIndexName("t1"));
+    }
+
+    @Test
+    public void test_streaming_partition_targets() throws IOException {
+        var target = new TableOrPartition(new RelationName("doc", "t1"), "04132");
+        var request = new TransportAlterPublication.Request(
+            "pub1",
+            AlterPublication.Operation.ADD,
+            List.of(target)
+        );
+        var out = new BytesStreamOutput();
+        out.setVersion(Version.V_6_5_0);
+        request.writeTo(out);
+
+        var in = out.bytes().streamInput();
+        in.setVersion(Version.V_6_5_0);
+        var streamed = new TransportAlterPublication.Request(in);
+
+        assertThat(streamed).usingRecursiveComparison().isEqualTo(request);
+    }
+
+    @Test
+    public void test_streaming_table_targets_to_older_version() throws IOException {
+        var target = new TableOrPartition(new RelationName("doc", "t1"), null);
+        var request = new TransportAlterPublication.Request(
+            "pub1",
+            AlterPublication.Operation.ADD,
+            List.of(target)
+        );
+        var out = new BytesStreamOutput();
+        out.setVersion(Version.V_6_4_0);
+        request.writeTo(out);
+
+        var in = out.bytes().streamInput();
+        in.setVersion(Version.V_6_4_0);
+        var streamed = new TransportAlterPublication.Request(in);
+
+        assertThat(streamed).usingRecursiveComparison().isEqualTo(request);
+    }
+
+    @Test
+    public void test_cannot_stream_partition_targets_to_older_version() {
+        var request = new TransportAlterPublication.Request(
+            "pub1",
+            AlterPublication.Operation.ADD,
+            List.of(new TableOrPartition(new RelationName("doc", "t1"), "04132"))
+        );
+        var out = new BytesStreamOutput();
+        out.setVersion(Version.V_6_4_0);
+
+        assertThatThrownBy(() -> request.writeTo(out))
+            .isExactlyInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("Cannot write partition publication target to a node before");
     }
 }

--- a/server/src/test/java/io/crate/replication/logical/action/UpdateSubscriptionActionTest.java
+++ b/server/src/test/java/io/crate/replication/logical/action/UpdateSubscriptionActionTest.java
@@ -26,6 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.List;
 import java.util.Map;
 
+import org.elasticsearch.action.admin.cluster.snapshots.restore.TableOrPartition;
 import org.elasticsearch.common.settings.Settings;
 import org.junit.Test;
 
@@ -35,6 +36,10 @@ import io.crate.replication.logical.metadata.Subscription;
 
 public class UpdateSubscriptionActionTest {
 
+    private static TableOrPartition target(String table) {
+        return new TableOrPartition(RelationName.fromIndexName(table), null);
+    }
+
     @Test
     public void test_existing_same_state_is_not_overridden() throws Exception {
         var oldSubscription = new Subscription(
@@ -43,7 +48,7 @@ public class UpdateSubscriptionActionTest {
             List.of("some_publication", "another_publication"),
             Settings.builder().put("enable", "true").build(),
             Map.of(
-                RelationName.fromIndexName("doc.t1"),
+                target("doc.t1"),
                 new Subscription.RelationState(Subscription.State.FAILED, "Subscription failed on restore")
             )
         );
@@ -53,7 +58,7 @@ public class UpdateSubscriptionActionTest {
             oldSubscription.publications(),
             oldSubscription.settings(),
             Map.of(
-                RelationName.fromIndexName("doc.t1"),
+                target("doc.t1"),
                 new Subscription.RelationState(Subscription.State.FAILED, "Some other reason")
             )
         );

--- a/server/src/test/java/io/crate/replication/logical/metadata/PublicationsMetadataTest.java
+++ b/server/src/test/java/io/crate/replication/logical/metadata/PublicationsMetadataTest.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
+import org.elasticsearch.action.admin.cluster.snapshots.restore.TableOrPartition;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.test.ESTestCase;
@@ -36,13 +37,17 @@ import io.crate.metadata.RelationName;
 
 public class PublicationsMetadataTest extends ESTestCase {
 
+    private static TableOrPartition target(String schema, String table) {
+        return new TableOrPartition(new RelationName(schema, table), null);
+    }
+
     public static PublicationsMetadata createMetadata() {
         Map<String, Publication> map = Map.of(
             "pub1",
             new Publication(
                 "user1",
                 false,
-                List.of(new RelationName("s1", "t1"), new RelationName("s1", "t2"))
+                List.of(target("s1", "t1"), target("s1", "t2"))
             ),
             "myPub2",
             new Publication("user2", true, List.of())

--- a/server/src/test/java/io/crate/replication/logical/metadata/SubscriptionsMetadataTest.java
+++ b/server/src/test/java/io/crate/replication/logical/metadata/SubscriptionsMetadataTest.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
+import org.elasticsearch.action.admin.cluster.snapshots.restore.TableOrPartition;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.Settings;
@@ -37,6 +38,10 @@ import io.crate.metadata.RelationName;
 
 public class SubscriptionsMetadataTest extends ESTestCase {
 
+    private static TableOrPartition target(String table) {
+        return new TableOrPartition(RelationName.fromIndexName(table), null);
+    }
+
     public static SubscriptionsMetadata createMetadata() {
         Map<String, Subscription> map = Map.of(
             "sub1",
@@ -46,7 +51,7 @@ public class SubscriptionsMetadataTest extends ESTestCase {
                 List.of("pub1"),
                 Settings.EMPTY,
                 Map.of(
-                    RelationName.fromIndexName("doc.t1"),
+                    target("doc.t1"),
                     new Subscription.RelationState(Subscription.State.INITIALIZING, null)
                 )
             ),
@@ -57,7 +62,7 @@ public class SubscriptionsMetadataTest extends ESTestCase {
                 List.of("some_publication", "another_publication"),
                 Settings.builder().put("enable", "true").build(),
                 Map.of(
-                    RelationName.fromIndexName("doc.t1"),
+                    target("doc.t1"),
                     new Subscription.RelationState(Subscription.State.FAILED, "Subscription failed on restore")
                 )
             )

--- a/server/src/test/java/io/crate/replication/logical/metadata/SubscriptionsMetadataTest.java
+++ b/server/src/test/java/io/crate/replication/logical/metadata/SubscriptionsMetadataTest.java
@@ -22,11 +22,13 @@
 package io.crate.replication.logical.metadata;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.cluster.snapshots.restore.TableOrPartition;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -80,5 +82,65 @@ public class SubscriptionsMetadataTest extends ESTestCase {
         var subs2 = new SubscriptionsMetadata(in);
         assertThat(subs2).isEqualTo(subs);
 
+    }
+
+    @Test
+    public void test_streaming_partition_targets() throws IOException {
+        var target = new TableOrPartition(new RelationName("doc", "t1"), "04132");
+        var subscription = new Subscription(
+            "user1",
+            ConnectionInfo.fromURL("crate://example.com:4310"),
+            List.of("pub1"),
+            Settings.EMPTY,
+            Map.of(target, new Subscription.RelationState(Subscription.State.INITIALIZING, null))
+        );
+        var out = new BytesStreamOutput();
+        out.setVersion(Version.V_6_5_0);
+        subscription.writeTo(out);
+
+        var in = out.bytes().streamInput();
+        in.setVersion(Version.V_6_5_0);
+        var streamed = new Subscription(in);
+
+        assertThat(streamed.relations()).containsOnlyKeys(target);
+    }
+
+    @Test
+    public void test_streaming_table_targets_to_older_version() throws IOException {
+        var target = new TableOrPartition(new RelationName("doc", "t1"), null);
+        var subscription = new Subscription(
+            "user1",
+            ConnectionInfo.fromURL("crate://example.com:4310"),
+            List.of("pub1"),
+            Settings.EMPTY,
+            Map.of(target, new Subscription.RelationState(Subscription.State.INITIALIZING, null))
+        );
+        var out = new BytesStreamOutput();
+        out.setVersion(Version.V_6_4_0);
+        subscription.writeTo(out);
+
+        var in = out.bytes().streamInput();
+        in.setVersion(Version.V_6_4_0);
+        var streamed = new Subscription(in);
+
+        assertThat(streamed.relations()).containsOnlyKeys(target);
+    }
+
+    @Test
+    public void test_cannot_stream_partition_targets_to_older_version() {
+        var target = new TableOrPartition(new RelationName("doc", "t1"), "04132");
+        var subscription = new Subscription(
+            "user1",
+            ConnectionInfo.fromURL("crate://example.com:4310"),
+            List.of("pub1"),
+            Settings.EMPTY,
+            Map.of(target, new Subscription.RelationState(Subscription.State.INITIALIZING, null))
+        );
+        var out = new BytesStreamOutput();
+        out.setVersion(Version.V_6_4_0);
+
+        assertThatThrownBy(() -> subscription.writeTo(out))
+            .isExactlyInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("Cannot write partition subscription target to a node before");
     }
 }

--- a/server/src/testFixtures/java/io/crate/testing/SQLExecutor.java
+++ b/server/src/testFixtures/java/io/crate/testing/SQLExecutor.java
@@ -52,6 +52,7 @@ import java.util.function.LongSupplier;
 import java.util.function.UnaryOperator;
 
 import org.elasticsearch.Version;
+import org.elasticsearch.action.admin.cluster.snapshots.restore.TableOrPartition;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterState;
@@ -905,7 +906,11 @@ public class SQLExecutor {
 
     public SQLExecutor addPublication(String name, boolean forAllTables, RelationName... tables) {
         ClusterState prevState = clusterService.state();
-        var publication = new Publication(user.name(), forAllTables, Arrays.asList(tables));
+        var publication = new Publication(
+            user.name(),
+            forAllTables,
+            Arrays.stream(tables).map(table -> new TableOrPartition(table, null)).toList()
+        );
         var publicationsMetadata = new PublicationsMetadata(Map.of(name, publication));
 
         Metadata newMetadata = Metadata.builder(prevState.metadata())


### PR DESCRIPTION
This is a preparatory change towards supporting logical replication for individual table partitions.

- Replace table-only logical replication targets with `TableOrPartition`
- Keep existing table-level behavior unchanged
- Preserve backwards compatibility when reading metadata/request streams from older versions
- Reject writing partition targets to nodes older than `6.5.0`