### PR TITLE
Support table partitions in CREATE PUBLICATION

### DIFF
--- a/libs/sql-parser/src/main/antlr/io/crate/sql/parser/antlr/SqlBaseParser.g4
+++ b/libs/sql-parser/src/main/antlr/io/crate/sql/parser/antlr/SqlBaseParser.g4
@@ -631,7 +631,8 @@ createStmt
         OPEN_ROUND_BRACKET? options=spaceSeparatedIdents CLOSE_ROUND_BRACKET?))?     #createRole
     | CREATE ( OR REPLACE )? VIEW name=qname AS queryOptParens                       #createView
     | CREATE PUBLICATION name=ident
-        (FOR ALL TABLES | FOR TABLE qname ASTERISK?  (COMMA qname ASTERISK? )*)?     #createPublication
+        (FOR ALL TABLES | FOR TABLE tableWithPartition ASTERISK?
+            (COMMA tableWithPartition ASTERISK? )*)?                                 #createPublication
     | CREATE SUBSCRIPTION name=ident CONNECTION conninfo=expr
           PUBLICATION publications=idents
           withProperties?                                                            #createSubscription

--- a/libs/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
@@ -743,11 +743,9 @@ public final class SqlFormatter {
             builder.append(formatQualifiedName(node.getName()));
             if (!node.partitionProperties().isEmpty()) {
                 builder.append(" PARTITION (");
-                for (var assignment : node.partitionProperties()) {
-                    builder.append(assignment.columnName().toString());
-                    builder.append("=");
-                    builder.append(assignment.expression().toString());
-                }
+                builder.append(node.partitionProperties().stream()
+                    .map(assignment -> assignment.columnName().toString() + "=" + assignment.expression().toString())
+                    .collect(COMMA_JOINER));
                 builder.append(")");
             }
             return null;
@@ -1469,11 +1467,19 @@ public final class SqlFormatter {
                 builder.append(" FOR ALL TABLES");
             } else if (createPublication.tables().isEmpty() == false) {
                 builder.append(" FOR TABLE ");
-                builder.append(
-                    createPublication.tables().stream()
-                        .map(Formatter::formatQualifiedName)
-                        .collect(COMMA_JOINER)
-                );
+                builder.append(createPublication.tables().stream()
+                    .map(table -> {
+                        var formattedTable = new StringBuilder(formatQualifiedName(table.getName()));
+                        if (!table.partitionProperties().isEmpty()) {
+                            formattedTable.append(" PARTITION (")
+                                .append(table.partitionProperties().stream()
+                                    .map(assignment -> assignment.columnName().toString() + "=" + assignment.expression().toString())
+                                    .collect(COMMA_JOINER))
+                                .append(")");
+                        }
+                        return formattedTable;
+                    })
+                    .collect(COMMA_JOINER));
             }
             return null;
         }

--- a/libs/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -1219,10 +1219,9 @@ class AstBuilder extends SqlBaseParserBaseVisitor<Node> {
     }
 
     @Override
+    @SuppressWarnings({"unchecked", "rawtypes"})
     public Node visitCreatePublication(SqlBaseParser.CreatePublicationContext ctx) {
-        List<QualifiedName> tables = ctx.qname().stream()
-            .map(this::getQualifiedName)
-            .toList();
+        List<Table<Expression>> tables = (List) visitCollection(ctx.tableWithPartition(), Table.class);
         return new CreatePublication(getIdentText(ctx.name), ctx.ALL() != null, tables);
     }
 

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/CreatePublication.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/CreatePublication.java
@@ -25,7 +25,7 @@ import java.util.List;
 
 public record CreatePublication(String name,
                                 boolean forAllTables,
-                                List<QualifiedName> tables) implements Statement {
+                                List<Table<Expression>> tables) implements Statement {
 
     @Override
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) {

--- a/libs/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/libs/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -2175,6 +2175,9 @@ public class TestStatementBuilder {
         printStatement("CREATE PUBLICATION \"myPublication\" FOR TABLE t1");
         printStatement("CREATE PUBLICATION pub1 FOR TABLE s1.t1");
         printStatement("CREATE PUBLICATION pub1 FOR TABLE t1, s2.t2");
+        printStatement("CREATE PUBLICATION pub1 FOR TABLE t1 PARTITION (p = 1)");
+        printStatement("CREATE PUBLICATION pub1 FOR TABLE t1 PARTITION (p1 = 1, p2 = 2)");
+        printStatement("CREATE PUBLICATION pub1 FOR TABLE t1 PARTITION (p = 1), t1 PARTITION (p = 2), t2 PARTITION (p = 1)");
         printStatement("CREATE PUBLICATION pub1");
     }
 

--- a/server/src/main/java/io/crate/auth/AccessControlImpl.java
+++ b/server/src/main/java/io/crate/auth/AccessControlImpl.java
@@ -847,7 +847,8 @@ public final class AccessControlImpl implements AccessControl {
             hasALPrivileges(user);
             // All tables cannot be checked on publication creation - they are checked before actual replication starts
             // and a table gets published only if publication owner has DQL, DML and DDL privileges on that table.
-            for (RelationName relationName: createPublication.tables()) {
+            for (var table : createPublication.tables()) {
+                RelationName relationName = RelationName.of(table.getName(), null);
                 for (Permission permission : READ_WRITE_DEFINE) {
                     Privileges.ensureUserHasPrivilege(
                         relationVisitor.roles,

--- a/server/src/main/java/io/crate/replication/logical/analyze/AnalyzedCreatePublication.java
+++ b/server/src/main/java/io/crate/replication/logical/analyze/AnalyzedCreatePublication.java
@@ -21,21 +21,26 @@
 
 package io.crate.replication.logical.analyze;
 
+import java.util.List;
+import java.util.function.Consumer;
+
 import io.crate.analyze.AnalyzedStatementVisitor;
 import io.crate.analyze.DDLStatement;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.RelationName;
-
-import java.util.List;
-import java.util.function.Consumer;
+import io.crate.sql.tree.Assignment;
+import io.crate.sql.tree.Table;
 
 public class AnalyzedCreatePublication implements DDLStatement {
 
     private final String name;
     private final boolean forAllTables;
-    private final List<RelationName> tables;
+    private final List<Table<Symbol>> tables;
 
-    public AnalyzedCreatePublication(String name, boolean forAllTables, List<RelationName> tables) {
+    public AnalyzedCreatePublication(String name, boolean forAllTables, List<Table<Symbol>> tables) {
+        assert tables.stream()
+            .allMatch(table -> RelationName.of(table.getName(), null).schema() != null)
+            : "table names must include schema names";
         this.name = name;
         this.forAllTables = forAllTables;
         this.tables = tables;
@@ -49,12 +54,17 @@ public class AnalyzedCreatePublication implements DDLStatement {
         return forAllTables;
     }
 
-    public List<RelationName> tables() {
+    public List<Table<Symbol>> tables() {
         return tables;
     }
 
     @Override
     public void visitSymbols(Consumer<? super Symbol> consumer) {
+        for (var table : tables) {
+            for (Assignment<Symbol> partitionProperty : table.partitionProperties()) {
+                partitionProperty.expressions().forEach(consumer);
+            }
+        }
     }
 
     @Override

--- a/server/src/main/java/io/crate/replication/logical/analyze/LogicalReplicationAnalyzer.java
+++ b/server/src/main/java/io/crate/replication/logical/analyze/LogicalReplicationAnalyzer.java
@@ -21,6 +21,9 @@
 
 package io.crate.replication.logical.analyze;
 
+import java.util.HashSet;
+import java.util.List;
+
 import io.crate.analyze.ParamTypeHints;
 import io.crate.analyze.expressions.ExpressionAnalysisContext;
 import io.crate.analyze.expressions.ExpressionAnalyzer;
@@ -29,7 +32,9 @@ import io.crate.common.collections.Lists;
 import io.crate.exceptions.InvalidArgumentException;
 import io.crate.exceptions.RelationUnknown;
 import io.crate.exceptions.UnauthorizedException;
+import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.RelationName;
@@ -44,12 +49,14 @@ import io.crate.replication.logical.exceptions.SubscriptionAlreadyExistsExceptio
 import io.crate.replication.logical.exceptions.SubscriptionUnknownException;
 import io.crate.sql.tree.AlterPublication;
 import io.crate.sql.tree.AlterSubscription;
+import io.crate.sql.tree.Assignment;
 import io.crate.sql.tree.CreatePublication;
 import io.crate.sql.tree.CreateSubscription;
 import io.crate.sql.tree.DropPublication;
 import io.crate.sql.tree.DropSubscription;
 import io.crate.sql.tree.Expression;
 import io.crate.sql.tree.GenericProperties;
+import io.crate.sql.tree.Table;
 
 public class LogicalReplicationAnalyzer {
 
@@ -69,17 +76,47 @@ public class LogicalReplicationAnalyzer {
         if (logicalReplicationService.publications().containsKey(createPublication.name())) {
             throw new PublicationAlreadyExistsException(createPublication.name());
         }
-        var tables = Lists.map(
+        var sessionSettings = txnCtx.sessionSettings();
+        var exprCtx = new ExpressionAnalysisContext(sessionSettings);
+        var exprAnalyzerWithFieldsAsString = new ExpressionAnalyzer(
+            txnCtx, nodeCtx, ParamTypeHints.EMPTY, FieldProvider.TO_LITERAL_VALIDATE_NAME, null);
+        List<Table<Symbol>> tables = Lists.map(
             createPublication.tables(),
-            q -> {
-                CoordinatorSessionSettings sessionSettings = txnCtx.sessionSettings();
+            table -> {
                 DocTableInfo tableInfo = schemas.findRelation(
-                    q,
+                    table.getName(),
                     Operation.CREATE_PUBLICATION,
                     sessionSettings.sessionUser(),
                     sessionSettings.searchPath()
                 );
-                return tableInfo.ident();
+                Table<Symbol> analyzedTable = table
+                    // include schema names to AnalyzedCreatePublication
+                    .withName(tableInfo.ident().toQualifiedName())
+                    .map(x -> exprAnalyzerWithFieldsAsString.convert(x, exprCtx));
+                var partitionProperties = analyzedTable.partitionProperties();
+                if (partitionProperties.isEmpty() == false) {
+                    if (tableInfo.isPartitioned() == false) {
+                        throw new IllegalArgumentException("table '" + tableInfo.ident().fqn() + "' is not partitioned");
+                    }
+                    if (partitionProperties.size() != tableInfo.partitionedBy().size()) {
+                        throw new IllegalArgumentException(
+                            "The table \"" + tableInfo.ident().fqn() + "\" is partitioned by " +
+                                tableInfo.partitionedBy().size() + " columns but the PARTITION clause contains " +
+                                partitionProperties.size() + " columns"
+                        );
+                    }
+                    HashSet<ColumnIdent> seenPartitionColumns = new HashSet<>();
+                    for (Assignment<Symbol> assignment : partitionProperties) {
+                        ColumnIdent column = ColumnIdent.fromPath((String) ((Literal<?>) assignment.columnName()).value());
+                        if (seenPartitionColumns.add(column) == false) {
+                            throw new IllegalArgumentException("column \"" + column.sqlFqn() + "\" specified more than once");
+                        }
+                        if (tableInfo.partitionedBy().contains(column) == false) {
+                            throw new IllegalArgumentException("\"" + column.sqlFqn() + "\" is not a partition column");
+                        }
+                    }
+                }
+                return analyzedTable;
             }
         );
 

--- a/server/src/main/java/io/crate/replication/logical/plan/CreatePublicationPlan.java
+++ b/server/src/main/java/io/crate/replication/logical/plan/CreatePublicationPlan.java
@@ -21,12 +21,22 @@
 
 package io.crate.replication.logical.plan;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
 import org.elasticsearch.action.admin.cluster.snapshots.restore.TableOrPartition;
 
+import io.crate.analyze.SymbolEvaluator;
+import io.crate.common.collections.Lists;
 import io.crate.data.Row;
 import io.crate.data.Row1;
 import io.crate.data.RowConsumer;
 import io.crate.execution.support.OneRowActionListener;
+import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.PartitionName;
+import io.crate.metadata.doc.DocTableInfo;
+import io.crate.metadata.table.Operation;
 import io.crate.planner.DependencyCarrier;
 import io.crate.planner.Plan;
 import io.crate.planner.PlannerContext;
@@ -53,13 +63,38 @@ public class CreatePublicationPlan implements Plan {
                               PlannerContext plannerContext,
                               RowConsumer consumer,
                               Row params, SubQueryResults subQueryResults) throws Exception {
+        Function<? super Symbol, Object> eval = x -> SymbolEvaluator.evaluate(
+            plannerContext.transactionContext(),
+            dependencies.nodeContext(),
+            x,
+            params,
+            subQueryResults
+        );
+        List<TableOrPartition> targets = new ArrayList<>(analyzedCreatePublication.tables().size());
+        var sessionSettings = plannerContext.transactionContext().sessionSettings();
+        for (var table : analyzedCreatePublication.tables()) {
+            DocTableInfo tableInfo = dependencies.schemas().findRelation(
+                table.getName(),
+                Operation.CREATE_PUBLICATION,
+                sessionSettings.sessionUser(),
+                sessionSettings.searchPath()
+            );
+            String partitionIdent = null;
+            if (table.partitionProperties().isEmpty() == false) {
+                var partitionProperties = Lists.map(table.partitionProperties(), x -> x.map(eval));
+                partitionIdent = PartitionName.ofAssignments(
+                    tableInfo,
+                    partitionProperties,
+                    plannerContext.clusterState().metadata()
+                ).ident();
+            }
+            targets.add(new TableOrPartition(tableInfo.ident(), partitionIdent));
+        }
         var request = new CreatePublicationRequest(
-            plannerContext.transactionContext().sessionSettings().sessionUser().name(),
+            sessionSettings.sessionUser().name(),
             analyzedCreatePublication.name(),
             analyzedCreatePublication.isForAllTables(),
-            analyzedCreatePublication.tables().stream()
-                .map(table -> new TableOrPartition(table, null))
-                .toList()
+            targets
         );
 
         dependencies.client().execute(TransportCreatePublication.ACTION, request)

--- a/server/src/test/java/io/crate/integrationtests/LogicalReplicationITest.java
+++ b/server/src/test/java/io/crate/integrationtests/LogicalReplicationITest.java
@@ -41,10 +41,12 @@ import org.junit.Test;
 
 import io.crate.exceptions.OperationOnInaccessibleRelationException;
 import io.crate.exceptions.RelationAlreadyExists;
+import io.crate.metadata.PartitionName;
 import io.crate.metadata.RelationName;
 import io.crate.replication.logical.LogicalReplicationService;
 import io.crate.replication.logical.exceptions.CreateSubscriptionException;
 import io.crate.replication.logical.exceptions.PublicationUnknownException;
+import io.crate.replication.logical.metadata.PublicationsMetadata;
 import io.crate.replication.logical.metadata.Subscription;
 import io.crate.replication.logical.metadata.SubscriptionsMetadata;
 import io.crate.role.Role;
@@ -163,6 +165,46 @@ public class LogicalReplicationITest extends LogicalReplicationITestCase {
             " JOIN pg_publication_tables t ON p.pubname = t.pubname" +
             " ORDER BY p.pubname, schemaname, tablename");
         assertThat(response).hasRows("-119974068| pub1| -450373579| false| doc| t1| true| true| true");
+    }
+
+    @Test
+    public void test_create_publication_for_concrete_partition() {
+        executeOnPublisher(
+            "CREATE TABLE doc.parted (id INT, p INT) " +
+            "PARTITIONED BY (p) CLUSTERED INTO 1 SHARDS WITH (number_of_replicas = 0)");
+        executeOnPublisher("INSERT INTO doc.parted (id, p) VALUES (1, 1), (2, 2)");
+        executeOnPublisher("REFRESH TABLE doc.parted");
+        executeOnPublisher("CREATE PUBLICATION pub1 FOR TABLE doc.parted PARTITION (p = 1)");
+
+        PublicationsMetadata publicationsMetadata = publisherCluster.getInstance(ClusterService.class)
+            .state()
+            .metadata()
+            .custom(PublicationsMetadata.TYPE);
+        var publication = publicationsMetadata.publications().get("pub1");
+        var relationName = new RelationName("doc", "parted");
+        assertThat(publication.targets()).containsExactly(
+            new TableOrPartition(relationName, new PartitionName(relationName, List.of("1")).ident()));
+    }
+
+    @Test
+    public void test_create_publication_for_concrete_partition_with_parameter() {
+        executeOnPublisher(
+            "CREATE TABLE doc.parted (id INT, p INT) " +
+            "PARTITIONED BY (p) CLUSTERED INTO 1 SHARDS WITH (number_of_replicas = 0)");
+        executeOnPublisher("INSERT INTO doc.parted (id, p) VALUES (1, 1), (2, 2)");
+        executeOnPublisher("REFRESH TABLE doc.parted");
+        publisherSqlExecutor.exec(
+            "CREATE PUBLICATION pub1 FOR TABLE doc.parted PARTITION (p = ?)",
+            new Object[] { 1 });
+
+        PublicationsMetadata publicationsMetadata = publisherCluster.getInstance(ClusterService.class)
+            .state()
+            .metadata()
+            .custom(PublicationsMetadata.TYPE);
+        var publication = publicationsMetadata.publications().get("pub1");
+        var relationName = new RelationName("doc", "parted");
+        assertThat(publication.targets()).containsExactly(
+            new TableOrPartition(relationName, new PartitionName(relationName, List.of("1")).ident()));
     }
 
     @Test

--- a/server/src/test/java/io/crate/replication/logical/action/PublicationsStateActionTest.java
+++ b/server/src/test/java/io/crate/replication/logical/action/PublicationsStateActionTest.java
@@ -398,6 +398,51 @@ public class PublicationsStateActionTest extends CrateDummyClusterServiceUnitTes
     }
 
     @Test
+    public void test_resolve_relation_names_for_concrete_partition_includes_only_target_partition() throws Exception {
+        var user = userOf("dummy");
+        Roles roles = new Roles() {
+            @Override
+            public Collection<Role> roles() {
+                return List.of(user);
+            }
+
+            @Override
+            public boolean hasPrivilege(Role user, Permission permission, Securable securable, @Nullable String ident) {
+                return true; // This test case doesn't check privileges.
+            }
+        };
+
+        var relationName = new RelationName("doc", "p1");
+        var partitionName = new PartitionName(relationName, List.of("1"));
+        SQLExecutor.of(clusterService)
+            .addTable(
+                "CREATE TABLE doc.p1 (id int, p int) PARTITIONED BY (p)",
+                List.of("1"),
+                List.of("2")
+            )
+            .startShards("doc.p1");
+        var publication = new Publication(
+            "some_user",
+            false,
+            List.of(target("p1", List.of("1")))
+        );
+
+        Metadata.Builder metadataBuilder = Metadata.builder(clusterService.state().metadata().currentMaxTableOid());
+        publication.resolveCurrentRelations(
+            clusterService.state(),
+            roles,
+            user,
+            user,
+            "dummy",
+            metadataBuilder
+        );
+        Metadata metadata = metadataBuilder.build();
+
+        List<IndexMetadata> indices = metadata.getIndices(relationName, List.of(), true, im -> im);
+        assertThat(indices.stream().map(im -> im.getIndex().name()).toList()).containsExactly(partitionName.asIndexName());
+    }
+
+    @Test
     public void test_bwc_streaming_5() throws Exception {
         var publicationOwner = userOf("publisher");
         var subscriber = userOf("subscriber");

--- a/server/src/test/java/io/crate/replication/logical/analyze/LogicalReplicationAnalyzerTest.java
+++ b/server/src/test/java/io/crate/replication/logical/analyze/LogicalReplicationAnalyzerTest.java
@@ -21,8 +21,11 @@
 
 package io.crate.replication.logical.analyze;
 
+import static io.crate.testing.Asserts.isLiteral;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
 
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
@@ -60,6 +63,79 @@ public class LogicalReplicationAnalyzerTest extends CrateDummyClusterServiceUnit
 
         assertThatThrownBy(() -> e.analyze("CREATE PUBLICATION pub1 FOR TABLE doc.t1"))
             .isExactlyInstanceOf(PublicationAlreadyExistsException.class);
+    }
+
+    @Test
+    public void test_create_publication_accepts_multiple_partition_targets() throws Exception {
+        var e = SQLExecutor.of(clusterService)
+            .addTable("CREATE TABLE doc.t1 (id int, p int) PARTITIONED BY (p)", List.of("1"), List.of("2"))
+            .addTable("CREATE TABLE doc.t2 (id int, p int) PARTITIONED BY (p)", List.of("1"));
+
+        AnalyzedCreatePublication stmt = e.analyze(
+            "CREATE PUBLICATION pub1 " +
+            "FOR TABLE doc.t1 PARTITION (p = 1), " +
+            "doc.t1 PARTITION (p = 2), " +
+            "doc.t2 PARTITION (p = 1)");
+
+        assertThat(stmt.tables()).satisfiesExactly(
+            t -> {
+                assertThat(t.getName().toString()).isEqualTo("doc.t1");
+                assertThat(t.partitionProperties()).hasSize(1);
+                assertThat(t.partitionProperties().get(0).columnName()).satisfies(isLiteral("p"));
+                assertThat(t.partitionProperties().get(0).expressions()).satisfiesExactly(isLiteral(1));
+            },
+            t -> {
+                assertThat(t.getName().toString()).isEqualTo("doc.t1");
+                assertThat(t.partitionProperties()).hasSize(1);
+                assertThat(t.partitionProperties().get(0).columnName()).satisfies(isLiteral("p"));
+                assertThat(t.partitionProperties().get(0).expressions()).satisfiesExactly(isLiteral(2));
+            },
+            t -> {
+                assertThat(t.getName().toString()).isEqualTo("doc.t2");
+                assertThat(t.partitionProperties()).hasSize(1);
+                assertThat(t.partitionProperties().get(0).columnName()).satisfies(isLiteral("p"));
+                assertThat(t.partitionProperties().get(0).expressions()).satisfiesExactly(isLiteral(1));
+            });
+    }
+
+    @Test
+    public void test_create_publication_for_partition_on_non_partitioned_table_raises_error() throws Exception {
+        var e = SQLExecutor.of(clusterService)
+            .addTable("CREATE TABLE doc.t1 (id int, p int)");
+
+        assertThatThrownBy(() -> e.analyze("CREATE PUBLICATION pub1 FOR TABLE doc.t1 PARTITION (p = 1)"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("table 'doc.t1' is not partitioned");
+    }
+
+    @Test
+    public void test_create_publication_for_unknown_partition_column_raises_error() throws Exception {
+        var e = SQLExecutor.of(clusterService)
+            .addTable("CREATE TABLE doc.t1 (id int, p int) PARTITIONED BY (p)", List.of("1"));
+
+        assertThatThrownBy(() -> e.analyze("CREATE PUBLICATION pub1 FOR TABLE doc.t1 PARTITION (q = 1)"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("\"q\" is not a partition column");
+    }
+
+    @Test
+    public void test_create_publication_for_incomplete_partition_clause_raises_error() throws Exception {
+        var e = SQLExecutor.of(clusterService)
+            .addTable("CREATE TABLE doc.t1 (id int, p1 int, p2 int) PARTITIONED BY (p1, p2)", List.of("1", "2"));
+
+        assertThatThrownBy(() -> e.analyze("CREATE PUBLICATION pub1 FOR TABLE doc.t1 PARTITION (p1 = 1)"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("The table \"doc.t1\" is partitioned by 2 columns but the PARTITION clause contains 1 columns");
+    }
+
+    @Test
+    public void test_create_publication_for_partition_with_duplicate_partition_column_raises_error() throws Exception {
+        var e = SQLExecutor.of(clusterService)
+            .addTable("CREATE TABLE doc.t1 (id int, p1 int, p2 int) PARTITIONED BY (p1, p2)", List.of("1", "2"));
+
+        assertThatThrownBy(() -> e.analyze("CREATE PUBLICATION pub1 FOR TABLE doc.t1 PARTITION (p1 = 1, p1 = 1)"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("column \"p1\" specified more than once");
     }
 
     /**


### PR DESCRIPTION
This adds support for publishing individual table partitions.

Accepted:

```sql
-- Publish one concrete partition of a partitioned table
CREATE PUBLICATION pub1
FOR TABLE doc.t PARTITION (p = 1);
```

```sql
-- A partition clause must include all partition-by columns to identify one concrete partition
CREATE PUBLICATION pub1
FOR TABLE doc.t PARTITION (p1 = 1, p2 = 2);
```

```sql
-- Publish multiple partitions by listing multiple partition targets
CREATE PUBLICATION pub1
FOR TABLE doc.t PARTITION (p = 1),
          doc.t PARTITION (p = 2);
```

```sql
-- Publish partitions from different tables
CREATE PUBLICATION pub1
FOR TABLE doc.t1 PARTITION (p = 1),
          doc.t2 PARTITION (p = 1);
```

Rejected:

```sql
-- `doc.t` is not partitioned
CREATE PUBLICATION pub1
FOR TABLE doc.t PARTITION (p = 1);
```

```sql
-- `q` is not a partition-by column
CREATE PUBLICATION pub1
FOR TABLE doc.t PARTITION (q = 1);
```

```sql
-- The partition clause does not identify one concrete partition because `p2` is missing
CREATE PUBLICATION pub1
FOR TABLE doc.t PARTITION (p1 = 1);
```

```sql
-- The partition clause cannot specify the same partition-by column twice
CREATE PUBLICATION pub1
FOR TABLE doc.t PARTITION (p1 = 1, p1 = 1);
```


Publisher clusters' `PublicationsMetadata` now store `TableOrPartition` entries:

- `TableOrPartition(table, null)` for table publications
- `TableOrPartition(table, partitionIdent)` for partition publications

The metadata sent to subscriber clusters via `PublicationsStateAction.Response` is unchanged.