### PR TITLE
[WIP] DocValuesGroupByOptimizedIterator with one thread per leaf

### DIFF
--- a/.idea/runConfigurations/CrateDB.xml
+++ b/.idea/runConfigurations/CrateDB.xml
@@ -3,8 +3,7 @@
     <option name="MAIN_CLASS_NAME" value="io.crate.bootstrap.CrateDB" />
     <module name="crate-app" />
     <option name="PROGRAM_PARAMETERS" value="-Cpath.home=$PROJECT_DIR$/sandbox/crate" />
-    <!-- Netty uses Unsafe, disable warning, continue to allow it (See also https://github.com/netty/netty/pull/14975) -->
-    <option name="VM_PARAMETERS" value="-Dlog4j.shutdownHookEnabled=false -Dlog4j.skipJansi=true --enable-native-access=ALL-UNNAMED --add-modules jdk.incubator.vector --sun-misc-unsafe-memory-access=allow -XX:+HeapDumpOnOutOfMemoryError" />
+    <option name="VM_PARAMETERS" value="-Xms8g -Dlog4j.shutdownHookEnabled=false -Dlog4j.skipJansi=true --enable-native-access=ALL-UNNAMED --add-modules jdk.incubator.vector --sun-misc-unsafe-memory-access=allow -XX:+HeapDumpOnOutOfMemoryError" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/app" />
     <RunnerSettings RunnerId="Debug">
       <option name="DEBUG_PORT" value="" />

--- a/server/src/main/java/io/crate/collections/TwoLevelHashMap.java
+++ b/server/src/main/java/io/crate/collections/TwoLevelHashMap.java
@@ -56,7 +56,8 @@ public class TwoLevelHashMap<K, V> implements Iterable<Map.Entry<K, V>> {
     /** Fibonacci hashing: spreads entropy into the high bits regardless of the input distribution. */
     private static final int MIX_CONSTANT = 0x9E3779B1;
 
-    private int bucketIndex(Object key) {
+    /** Exposed so callers can route entries into {@link #bucket(int)} directly, bypassing {@link #put}/{@link #get}. */
+    public int bucketIndex(Object key) {
         int mixed = key.hashCode() * MIX_CONSTANT;
         return mixed >>> (32 - bitsForBucket);
     }

--- a/server/src/main/java/io/crate/collections/TwoLevelHashMap.java
+++ b/server/src/main/java/io/crate/collections/TwoLevelHashMap.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.collections;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.NoSuchElementException;
+
+/**
+ * A hash map split into a fixed number of independent buckets, each a plain {@link java.util.HashMap}.
+ * The bucket is picked from the high bits of the (spread) key hash code, mirroring ClickHouse's
+ * TwoLevelHashTable. Splitting into buckets allows e.g. bucket-parallel merging of two instances.
+ */
+public class TwoLevelHashMap<K, V> implements Iterable<Map.Entry<K, V>> {
+
+    private static final int DEFAULT_BITS_FOR_BUCKET = 8;
+
+    private final int bitsForBucket;
+    private final int numBuckets;
+    private final HashMap<K, V>[] buckets;
+
+    public TwoLevelHashMap() {
+        this(DEFAULT_BITS_FOR_BUCKET);
+    }
+
+    @SuppressWarnings("unchecked")
+    public TwoLevelHashMap(int bitsForBucket) {
+        this.bitsForBucket = bitsForBucket;
+        this.numBuckets = 1 << bitsForBucket;
+        this.buckets = new HashMap[numBuckets];
+        for (int i = 0; i < numBuckets; i++) {
+            buckets[i] = new HashMap<>();
+        }
+    }
+
+    /** Fibonacci hashing: spreads entropy into the high bits regardless of the input distribution. */
+    private static final int MIX_CONSTANT = 0x9E3779B1;
+
+    private int bucketIndex(Object key) {
+        int mixed = key.hashCode() * MIX_CONSTANT;
+        return mixed >>> (32 - bitsForBucket);
+    }
+
+    public V put(K key, V value) {
+        return buckets[bucketIndex(key)].put(key, value);
+    }
+
+    public V get(Object key) {
+        return buckets[bucketIndex(key)].get(key);
+    }
+
+    public V remove(Object key) {
+        return buckets[bucketIndex(key)].remove(key);
+    }
+
+    public boolean containsKey(Object key) {
+        return buckets[bucketIndex(key)].containsKey(key);
+    }
+
+    public int size() {
+        int size = 0;
+        for (var bucket : buckets) {
+            size += bucket.size();
+        }
+        return size;
+    }
+
+    public boolean isEmpty() {
+        for (var bucket : buckets) {
+            if (!bucket.isEmpty()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public void clear() {
+        for (var bucket : buckets) {
+            bucket.clear();
+        }
+    }
+
+    public int numBuckets() {
+        return numBuckets;
+    }
+
+    public Map<K, V> bucket(int index) {
+        return buckets[index];
+    }
+
+    @Override
+    public Iterator<Map.Entry<K, V>> iterator() {
+        return new Iterator<>() {
+            int bucketIdx = 0;
+            Iterator<Map.Entry<K, V>> current = buckets[0].entrySet().iterator();
+
+            private void advance() {
+                while (!current.hasNext() && bucketIdx < numBuckets - 1) {
+                    bucketIdx++;
+                    current = buckets[bucketIdx].entrySet().iterator();
+                }
+            }
+
+            @Override
+            public boolean hasNext() {
+                advance();
+                return current.hasNext();
+            }
+
+            @Override
+            public Map.Entry<K, V> next() {
+                advance();
+                if (!current.hasNext()) {
+                    throw new NoSuchElementException();
+                }
+                return current.next();
+            }
+        };
+    }
+}

--- a/server/src/main/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIterator.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIterator.java
@@ -36,6 +36,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.stream.StreamSupport;
 
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.DocIdSetIterator;
@@ -51,6 +52,7 @@ import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.ShardId;
 import org.jspecify.annotations.Nullable;
 
+import io.crate.collections.TwoLevelHashMap;
 import io.crate.common.TriConsumer;
 import io.crate.common.annotations.VisibleForTesting;
 import io.crate.common.collections.Lists;
@@ -326,7 +328,7 @@ final class DocValuesGroupByOptimizedIterator {
             );
         }
 
-        private static <K> Iterable<Row> getRows(Map<K, Object[]> groupedPartialsByKey,
+        private static <K> Iterable<Row> getRows(TwoLevelHashMap<K, Object[]> groupedPartialsByKey,
                                                   int numberOfKeys,
                                                   BiConsumer<K, Object[]> applyKeyToCells,
                                                   int numberOfAggregates) {
@@ -340,7 +342,7 @@ final class DocValuesGroupByOptimizedIterator {
                     System.arraycopy(partials, 0, cells, numberOfKeys, partials.length);
                     return row;
                 };
-                return groupedPartialsByKey.entrySet().stream().map(mapper).iterator();
+                return StreamSupport.stream(groupedPartialsByKey.spliterator(), false).map(mapper).iterator();
             };
         }
 
@@ -350,7 +352,7 @@ final class DocValuesGroupByOptimizedIterator {
          * runs on, so blocking here on the joined result can't self-deadlock that pool.
          */
         @SuppressWarnings("rawtypes")
-        private static <K> Map<K, Object[]> collectGroupedByKey(
+        private static <K> TwoLevelHashMap<K, Object[]> collectGroupedByKey(
             Supplier<LeafState> leafStateFactory,
             Supplier<RamAccounting> ramAccountingFactory,
             List<AggregationFunction> reducers,
@@ -369,7 +371,7 @@ final class DocValuesGroupByOptimizedIterator {
                 1f
             );
             List<LeafReaderContext> leaves = indexSearcher.getTopReaderContext().leaves();
-            List<Supplier<Map<K, Object[]>>> tasks = new ArrayList<>(leaves.size());
+            List<Supplier<TwoLevelHashMap<K, Object[]>>> tasks = new ArrayList<>(leaves.size());
             for (var leaf : leaves) {
                 tasks.add(() -> {
                     try {
@@ -389,7 +391,7 @@ final class DocValuesGroupByOptimizedIterator {
                     }
                 });
             }
-            List<Map<K, Object[]>> leafResults;
+            List<TwoLevelHashMap<K, Object[]>> leafResults;
             try {
                 leafResults = ThreadPools.runWithAvailableThreads(
                     executor,
@@ -403,11 +405,11 @@ final class DocValuesGroupByOptimizedIterator {
                 }
                 throw re;
             }
-            return mergeLeafResults(leafResults, reducers, ramAccountingFactory.get());
+            return mergeLeafResults(leafResults, reducers, ramAccountingFactory, executor);
         }
 
         @SuppressWarnings("rawtypes")
-        private static <K> Map<K, Object[]> processLeaf(
+        private static <K> TwoLevelHashMap<K, Object[]> processLeaf(
             LeafState leafState,
             RamAccounting ramAccounting,
             Weight weight,
@@ -430,7 +432,7 @@ final class DocValuesGroupByOptimizedIterator {
 
             Scorer scorer = weight.scorer(leaf);
             if (scorer == null) {
-                return Map.of();
+                return new TwoLevelHashMap<>();
             }
 
             TriConsumer<ResizeAwareMap<K, Object[]>, K, Object[]> accountForNewKeyEntry =
@@ -479,7 +481,7 @@ final class DocValuesGroupByOptimizedIterator {
                 }
             }
 
-            Map<K, Object[]> partials = new HashMap<>();
+            TwoLevelHashMap<K, Object[]> partials = new TwoLevelHashMap<>();
             for (var entry : statesByKey.entrySet()) {
                 Object[] rawStates = entry.getValue();
                 Object[] partial = new Object[numberOfAggregates];
@@ -492,14 +494,52 @@ final class DocValuesGroupByOptimizedIterator {
             return partials;
         }
 
+        /**
+         * Bucket index depends only on the key's hash, so bucket N of every leaf result and of
+         * {@code result} all hold the exact same set of possible keys -- merging bucket N is
+         * independent of every other bucket and can run on its own thread.
+         */
         @SuppressWarnings("rawtypes")
-        private static <K> Map<K, Object[]> mergeLeafResults(List<Map<K, Object[]>> leafResults,
-                                                              List<AggregationFunction> reducers,
-                                                              RamAccounting ramAccounting) {
-            Map<K, Object[]> merged = new HashMap<>();
+        private static <K> TwoLevelHashMap<K, Object[]> mergeLeafResults(List<TwoLevelHashMap<K, Object[]>> leafResults,
+                                                                          List<AggregationFunction> reducers,
+                                                                          Supplier<RamAccounting> ramAccountingFactory,
+                                                                          ThreadPoolExecutor executor) {
+            if (leafResults.size() <= 1) {
+                return leafResults.isEmpty() ? new TwoLevelHashMap<>() : leafResults.get(0);
+            }
+            TwoLevelHashMap<K, Object[]> result = new TwoLevelHashMap<>();
+            int numBuckets = result.numBuckets();
+            List<Supplier<Void>> tasks = new ArrayList<>(numBuckets);
+            for (int b = 0; b < numBuckets; b++) {
+                int bucketIdx = b;
+                tasks.add(() -> {
+                    mergeBucket(bucketIdx, result, leafResults, reducers, ramAccountingFactory.get());
+                    return null;
+                });
+            }
+            try {
+                ThreadPools.runWithAvailableThreads(
+                    executor,
+                    ThreadPools.numIdleThreads(executor, Runtime.getRuntime().availableProcessors()),
+                    tasks
+                ).join();
+            } catch (CompletionException e) {
+                throw Exceptions.toRuntimeException(e);
+            }
+            return result;
+        }
+
+        @SuppressWarnings("rawtypes")
+        private static <K> void mergeBucket(int bucketIdx,
+                                            TwoLevelHashMap<K, Object[]> result,
+                                            List<TwoLevelHashMap<K, Object[]>> leafResults,
+                                            List<AggregationFunction> reducers,
+                                            RamAccounting ramAccounting) {
+            Map<K, Object[]> target = result.bucket(bucketIdx);
             for (var leafResult : leafResults) {
-                for (var entry : leafResult.entrySet()) {
-                    merged.merge(entry.getKey(), entry.getValue(), (a, b) -> {
+                Map<K, Object[]> source = leafResult.bucket(bucketIdx);
+                for (var entry : source.entrySet()) {
+                    target.merge(entry.getKey(), entry.getValue(), (a, b) -> {
                         Object[] out = new Object[reducers.size()];
                         for (int j = 0; j < reducers.size(); j++) {
                             //noinspection unchecked
@@ -509,7 +549,6 @@ final class DocValuesGroupByOptimizedIterator {
                     });
                 }
             }
-            return merged;
         }
 
         private static boolean docDeleted(@Nullable Bits liveDocs, int doc) {

--- a/server/src/main/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIterator.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIterator.java
@@ -28,7 +28,6 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletionException;
@@ -437,7 +436,15 @@ final class DocValuesGroupByOptimizedIterator {
 
             TriConsumer<ResizeAwareMap<K, Object[]>, K, Object[]> accountForNewKeyEntry =
                 accountForNewKeyEntryFactory.apply(ramAccounting);
-            ResizeAwareMap<K, Object[]> statesByKey = GroupByMaps.wrapperForJDKMap(new HashMap<>());
+            // Accumulate directly into the bucketed map (routing each key via its own bucket's
+            // ResizeAwareMap wrapper) instead of building a flat HashMap and copying it into a
+            // TwoLevelHashMap afterwards -- that copy would double the insert cost per leaf.
+            TwoLevelHashMap<K, Object[]> statesByKey = new TwoLevelHashMap<>();
+            @SuppressWarnings("unchecked")
+            ResizeAwareMap<K, Object[]>[] bucketWrappers = new ResizeAwareMap[statesByKey.numBuckets()];
+            for (int i = 0; i < bucketWrappers.length; i++) {
+                bucketWrappers[i] = GroupByMaps.wrapperForJDKMap(statesByKey.bucket(i));
+            }
 
             for (int i = 0; i < keyExpressions.size(); i++) {
                 keyExpressions.get(i).setNextReader(new ReaderContext(leaf));
@@ -458,8 +465,9 @@ final class DocValuesGroupByOptimizedIterator {
                     keyExpressions.get(i).setNextDocId(doc);
                 }
                 K key = keyExtractor.apply(keyExpressions);
+                ResizeAwareMap<K, Object[]> bucketMap = bucketWrappers[statesByKey.bucketIndex(key)];
 
-                Object[] states = statesByKey.get(key);
+                Object[] states = bucketMap.get(key);
                 if (states == null) {
                     states = new Object[aggregators.size()];
                     for (int i = 0; i < aggregators.size(); i++) {
@@ -471,8 +479,8 @@ final class DocValuesGroupByOptimizedIterator {
                         state = aggregator.apply(ramAccounting, doc, state);
                         states[i] = state;
                     }
-                    accountForNewKeyEntry.accept(statesByKey, key, states);
-                    statesByKey.put(key, states);
+                    accountForNewKeyEntry.accept(bucketMap, key, states);
+                    bucketMap.put(key, states);
                 } else {
                     for (int i = 0; i < aggregators.size(); i++) {
                         //noinspection unchecked
@@ -481,17 +489,16 @@ final class DocValuesGroupByOptimizedIterator {
                 }
             }
 
-            TwoLevelHashMap<K, Object[]> partials = new TwoLevelHashMap<>();
-            for (var entry : statesByKey.entrySet()) {
+            // Overwrite each entry's states array in place with its partial result -- same keys,
+            // same buckets, so this needs no re-insertion/rehashing, just a value-array mutation.
+            for (var entry : statesByKey) {
                 Object[] rawStates = entry.getValue();
-                Object[] partial = new Object[numberOfAggregates];
                 for (int i = 0; i < numberOfAggregates; i++) {
                     //noinspection unchecked
-                    partial[i] = aggregators.get(i).partialResult(ramAccounting, rawStates[i]);
+                    rawStates[i] = aggregators.get(i).partialResult(ramAccounting, rawStates[i]);
                 }
-                partials.put(entry.getKey(), partial);
             }
-            return partials;
+            return statesByKey;
         }
 
         /**

--- a/server/src/main/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIterator.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIterator.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletionException;
@@ -346,9 +347,15 @@ final class DocValuesGroupByOptimizedIterator {
         }
 
         /**
-         * Runs one task per leaf (segment) on {@code executor} -- a pool dedicated to this kind
-         * of fan-out, distinct from the SEARCH pool this whole batch-iterator pipeline already
-         * runs on, so blocking here on the joined result can't self-deadlock that pool.
+         * One map per THREAD, not per leaf -- mirrors ClickHouse's per-thread AggregatedDataVariants,
+         * which persists across every block (here: every leaf) that thread happens to process.
+         * Leaves are pre-partitioned into one group per available thread; each group's task builds
+         * a single map and accumulates every leaf in its group into it, so leaves that land on the
+         * same thread converge for free instead of each demanding their own merge input.
+         *
+         * Runs on {@code executor} -- a pool dedicated to this kind of fan-out, distinct from the
+         * SEARCH pool this whole batch-iterator pipeline already runs on, so blocking here on the
+         * joined result can't self-deadlock that pool.
          */
         @SuppressWarnings("rawtypes")
         private static <K> TwoLevelHashMap<K, Object[]> collectGroupedByKey(
@@ -364,21 +371,29 @@ final class DocValuesGroupByOptimizedIterator {
             Killable.Token killToken,
             ThreadPoolExecutor executor
         ) throws IOException {
+            List<LeafReaderContext> leaves = indexSearcher.getTopReaderContext().leaves();
+            if (leaves.isEmpty()) {
+                return new TwoLevelHashMap<>();
+            }
             Weight weight = indexSearcher.createWeight(
                 indexSearcher.rewrite(query),
                 ScoreMode.COMPLETE_NO_SCORES,
                 1f
             );
-            List<LeafReaderContext> leaves = indexSearcher.getTopReaderContext().leaves();
-            List<Supplier<TwoLevelHashMap<K, Object[]>>> tasks = new ArrayList<>(leaves.size());
-            for (var leaf : leaves) {
+            int idleThreads = ThreadPools.numIdleThreads(executor, Runtime.getRuntime().availableProcessors()).getAsInt();
+            int groupCount = Math.max(1, Math.min(idleThreads, leaves.size()));
+            int leavesPerGroup = (leaves.size() + groupCount - 1) / groupCount;
+            List<List<LeafReaderContext>> leafGroups = Lists.partition(leaves, leavesPerGroup);
+
+            List<Supplier<LeafGroupResult<K>>> tasks = new ArrayList<>(leafGroups.size());
+            for (var leafGroup : leafGroups) {
                 tasks.add(() -> {
                     try {
-                        return processLeaf(
+                        return processLeafGroup(
                             leafStateFactory.get(),
                             ramAccountingFactory.get(),
                             weight,
-                            leaf,
+                            leafGroup,
                             numberOfAggregates,
                             minNodeVersion,
                             accountForNewKeyEntryFactory,
@@ -390,13 +405,11 @@ final class DocValuesGroupByOptimizedIterator {
                     }
                 });
             }
-            List<TwoLevelHashMap<K, Object[]>> leafResults;
+            List<LeafGroupResult<K>> groupResults;
             try {
-                leafResults = ThreadPools.runWithAvailableThreads(
-                    executor,
-                    ThreadPools.numIdleThreads(executor, Runtime.getRuntime().availableProcessors()),
-                    tasks
-                ).join();
+                // groupCount was already sized to <= idleThreads, so this dispatches 1 task per
+                // thread directly instead of ThreadPools re-bundling multiple groups onto one.
+                groupResults = ThreadPools.runWithAvailableThreads(executor, () -> leafGroups.size(), tasks).join();
             } catch (CompletionException e) {
                 RuntimeException re = Exceptions.toRuntimeException(e);
                 if (re instanceof UncheckedIOException uio) {
@@ -404,23 +417,44 @@ final class DocValuesGroupByOptimizedIterator {
                 }
                 throw re;
             }
-            return mergeLeafResults(leafResults, reducers, ramAccountingFactory, executor);
+            return mergeGroupResults(groupResults, reducers, ramAccountingFactory, executor);
+        }
+
+        /**
+         * Below this many distinct keys, a thread's map stays flat -- cheap, no bucket-array/hash-mix
+         * overhead per op, no 256 up-front HashMap allocations. Only threads that actually accumulate
+         * past this get promoted to a {@link TwoLevelHashMap}, mid-scan, once. Mirrors ClickHouse's
+         * single-level -> two-level promotion instead of always paying the two-level cost.
+         */
+        private static final int TWO_LEVEL_PROMOTION_THRESHOLD = 10_000;
+
+        /** Either {@code twoLevel} or {@code flat} is set, never both -- see {@link #isTwoLevel()}. */
+        private record LeafGroupResult<K>(@Nullable TwoLevelHashMap<K, Object[]> twoLevel, @Nullable Map<K, Object[]> flat) {
+            static <K> LeafGroupResult<K> twoLevel(TwoLevelHashMap<K, Object[]> map) {
+                return new LeafGroupResult<>(map, null);
+            }
+
+            static <K> LeafGroupResult<K> flat(Map<K, Object[]> map) {
+                return new LeafGroupResult<>(null, map);
+            }
+
+            boolean isTwoLevel() {
+                return twoLevel != null;
+            }
         }
 
         @SuppressWarnings("rawtypes")
-        private static <K> TwoLevelHashMap<K, Object[]> processLeaf(
+        private static <K> LeafGroupResult<K> processLeafGroup(
             LeafState leafState,
             RamAccounting ramAccounting,
             Weight weight,
-            LeafReaderContext leaf,
+            List<LeafReaderContext> leafGroup,
             int numberOfAggregates,
             Version minNodeVersion,
             Function<RamAccounting, TriConsumer<ResizeAwareMap<K, Object[]>, K, Object[]>> accountForNewKeyEntryFactory,
             Function<List<? extends LuceneCollectorExpression<?>>, K> keyExtractor,
             Killable.Token killToken
         ) throws IOException {
-            killToken.raiseIfKilled();
-
             List<DocValueAggregator> aggregators = leafState.aggregators();
             List<LuceneCollectorExpression<?>> keyExpressions = leafState.keyExpressions();
             MemoryManager memoryManager = leafState.memoryManager();
@@ -429,90 +463,156 @@ final class DocValuesGroupByOptimizedIterator {
                 keyExpressions.get(i).startCollect(collectorContext);
             }
 
-            Scorer scorer = weight.scorer(leaf);
-            if (scorer == null) {
-                return new TwoLevelHashMap<>();
-            }
-
             TriConsumer<ResizeAwareMap<K, Object[]>, K, Object[]> accountForNewKeyEntry =
                 accountForNewKeyEntryFactory.apply(ramAccounting);
-            // Accumulate directly into the bucketed map (routing each key via its own bucket's
-            // ResizeAwareMap wrapper) instead of building a flat HashMap and copying it into a
-            // TwoLevelHashMap afterwards -- that copy would double the insert cost per leaf.
-            TwoLevelHashMap<K, Object[]> statesByKey = new TwoLevelHashMap<>();
-            @SuppressWarnings("unchecked")
-            ResizeAwareMap<K, Object[]>[] bucketWrappers = new ResizeAwareMap[statesByKey.numBuckets()];
-            for (int i = 0; i < bucketWrappers.length; i++) {
-                bucketWrappers[i] = GroupByMaps.wrapperForJDKMap(statesByKey.bucket(i));
-            }
 
-            for (int i = 0; i < keyExpressions.size(); i++) {
-                keyExpressions.get(i).setNextReader(new ReaderContext(leaf));
-            }
-            for (int i = 0; i < aggregators.size(); i++) {
-                aggregators.get(i).loadDocValues(leaf);
-            }
+            ResizeAwareMap<K, Object[]> flatStates = GroupByMaps.wrapperForJDKMap(new HashMap<>());
+            TwoLevelHashMap<K, Object[]> twoLevelStates = null;
+            ResizeAwareMap<K, Object[]>[] bucketWrappers = null;
 
-            DocIdSetIterator docs = scorer.iterator();
-            Bits liveDocs = leaf.reader().getLiveDocs();
-            for (int doc = docs.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = docs.nextDoc()) {
+            for (var leaf : leafGroup) {
                 killToken.raiseIfKilled();
-                if (docDeleted(liveDocs, doc)) {
+                Scorer scorer = weight.scorer(leaf);
+                if (scorer == null) {
                     continue;
                 }
 
                 for (int i = 0; i < keyExpressions.size(); i++) {
-                    keyExpressions.get(i).setNextDocId(doc);
+                    keyExpressions.get(i).setNextReader(new ReaderContext(leaf));
                 }
-                K key = keyExtractor.apply(keyExpressions);
-                ResizeAwareMap<K, Object[]> bucketMap = bucketWrappers[statesByKey.bucketIndex(key)];
+                for (int i = 0; i < aggregators.size(); i++) {
+                    aggregators.get(i).loadDocValues(leaf);
+                }
 
-                Object[] states = bucketMap.get(key);
-                if (states == null) {
-                    states = new Object[aggregators.size()];
-                    for (int i = 0; i < aggregators.size(); i++) {
-                        var aggregator = aggregators.get(i);
-
-                        Object state = aggregator.initialState(ramAccounting, memoryManager, minNodeVersion);
-
-                        //noinspection unchecked
-                        state = aggregator.apply(ramAccounting, doc, state);
-                        states[i] = state;
+                DocIdSetIterator docs = scorer.iterator();
+                Bits liveDocs = leaf.reader().getLiveDocs();
+                for (int doc = docs.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = docs.nextDoc()) {
+                    killToken.raiseIfKilled();
+                    if (docDeleted(liveDocs, doc)) {
+                        continue;
                     }
-                    accountForNewKeyEntry.accept(bucketMap, key, states);
-                    bucketMap.put(key, states);
-                } else {
-                    for (int i = 0; i < aggregators.size(); i++) {
-                        //noinspection unchecked
-                        states[i] = aggregators.get(i).apply(ramAccounting, doc, states[i]);
+
+                    for (int i = 0; i < keyExpressions.size(); i++) {
+                        keyExpressions.get(i).setNextDocId(doc);
+                    }
+                    K key = keyExtractor.apply(keyExpressions);
+                    ResizeAwareMap<K, Object[]> bucketMap = twoLevelStates == null
+                        ? flatStates
+                        : bucketWrappers[twoLevelStates.bucketIndex(key)];
+
+                    Object[] states = bucketMap.get(key);
+                    if (states == null) {
+                        states = new Object[aggregators.size()];
+                        for (int i = 0; i < aggregators.size(); i++) {
+                            var aggregator = aggregators.get(i);
+
+                            Object state = aggregator.initialState(ramAccounting, memoryManager, minNodeVersion);
+
+                            //noinspection unchecked
+                            state = aggregator.apply(ramAccounting, doc, state);
+                            states[i] = state;
+                        }
+                        accountForNewKeyEntry.accept(bucketMap, key, states);
+                        bucketMap.put(key, states);
+
+                        if (twoLevelStates == null && flatStates.size() >= TWO_LEVEL_PROMOTION_THRESHOLD) {
+                            twoLevelStates = toTwoLevel(flatStates);
+                            bucketWrappers = wrapBuckets(twoLevelStates);
+                            flatStates = null;
+                        }
+                    } else {
+                        for (int i = 0; i < aggregators.size(); i++) {
+                            //noinspection unchecked
+                            states[i] = aggregators.get(i).apply(ramAccounting, doc, states[i]);
+                        }
                     }
                 }
             }
 
+            Iterable<Map.Entry<K, Object[]>> finalEntries = twoLevelStates != null ? twoLevelStates : flatStates.entrySet();
             // Overwrite each entry's states array in place with its partial result -- same keys,
             // same buckets, so this needs no re-insertion/rehashing, just a value-array mutation.
-            for (var entry : statesByKey) {
+            for (var entry : finalEntries) {
                 Object[] rawStates = entry.getValue();
                 for (int i = 0; i < numberOfAggregates; i++) {
                     //noinspection unchecked
                     rawStates[i] = aggregators.get(i).partialResult(ramAccounting, rawStates[i]);
                 }
             }
-            return statesByKey;
+            return twoLevelStates != null ? LeafGroupResult.twoLevel(twoLevelStates) : LeafGroupResult.flat(flatStates);
+        }
+
+        private static <K> TwoLevelHashMap<K, Object[]> toTwoLevel(Map<K, Object[]> flat) {
+            TwoLevelHashMap<K, Object[]> result = new TwoLevelHashMap<>();
+            for (var entry : flat.entrySet()) {
+                result.put(entry.getKey(), entry.getValue());
+            }
+            return result;
+        }
+
+        @SuppressWarnings("unchecked")
+        private static <K> ResizeAwareMap<K, Object[]>[] wrapBuckets(TwoLevelHashMap<K, Object[]> map) {
+            ResizeAwareMap<K, Object[]>[] wrappers = new ResizeAwareMap[map.numBuckets()];
+            for (int i = 0; i < wrappers.length; i++) {
+                wrappers[i] = GroupByMaps.wrapperForJDKMap(map.bucket(i));
+            }
+            return wrappers;
         }
 
         /**
-         * Bucket index depends only on the key's hash, so bucket N of every leaf result and of
+         * If no thread's map ever promoted, merge the flat maps directly -- total size is bounded
+         * by threadCount * TWO_LEVEL_PROMOTION_THRESHOLD, too small for a parallel bucket-merge to
+         * pay for itself, and matches ClickHouse skipping the two-level path entirely in that case.
+         * Otherwise every group needs the same bucket shape to merge buckets independently in
+         * parallel, so any group that stayed flat gets cheaply promoted first (it's small, at most
+         * TWO_LEVEL_PROMOTION_THRESHOLD entries).
+         */
+        @SuppressWarnings("rawtypes")
+        private static <K> TwoLevelHashMap<K, Object[]> mergeGroupResults(List<LeafGroupResult<K>> groupResults,
+                                                                          List<AggregationFunction> reducers,
+                                                                          Supplier<RamAccounting> ramAccountingFactory,
+                                                                          ThreadPoolExecutor executor) {
+            if (groupResults.size() == 1) {
+                var only = groupResults.get(0);
+                return only.isTwoLevel() ? only.twoLevel() : toTwoLevel(only.flat());
+            }
+            boolean anyTwoLevel = false;
+            for (var groupResult : groupResults) {
+                if (groupResult.isTwoLevel()) {
+                    anyTwoLevel = true;
+                    break;
+                }
+            }
+            if (!anyTwoLevel) {
+                RamAccounting ramAccounting = ramAccountingFactory.get();
+                Map<K, Object[]> merged = new HashMap<>();
+                for (var groupResult : groupResults) {
+                    for (var entry : groupResult.flat().entrySet()) {
+                        merged.merge(entry.getKey(), entry.getValue(), (a, b) -> reduce(reducers, ramAccounting, a, b));
+                    }
+                }
+                return toTwoLevel(merged);
+            }
+
+            List<TwoLevelHashMap<K, Object[]>> bucketed = new ArrayList<>(groupResults.size());
+            for (var groupResult : groupResults) {
+                bucketed.add(groupResult.isTwoLevel() ? groupResult.twoLevel() : toTwoLevel(groupResult.flat()));
+            }
+            return mergeBucketedResults(bucketed, reducers, ramAccountingFactory, executor);
+        }
+
+        /**
+         * Bucket index depends only on the key's hash, so bucket N of every input and of
          * {@code result} all hold the exact same set of possible keys -- merging bucket N is
          * independent of every other bucket and can run on its own thread.
          */
         @SuppressWarnings("rawtypes")
-        private static <K> TwoLevelHashMap<K, Object[]> mergeLeafResults(List<TwoLevelHashMap<K, Object[]>> leafResults,
-                                                                          List<AggregationFunction> reducers,
-                                                                          Supplier<RamAccounting> ramAccountingFactory,
-                                                                          ThreadPoolExecutor executor) {
-            if (leafResults.size() <= 1) {
-                return leafResults.isEmpty() ? new TwoLevelHashMap<>() : leafResults.get(0);
+        private static <K> TwoLevelHashMap<K, Object[]> mergeBucketedResults(List<TwoLevelHashMap<K, Object[]>> bucketed,
+                                                                              List<AggregationFunction> reducers,
+                                                                              Supplier<RamAccounting> ramAccountingFactory,
+                                                                              ThreadPoolExecutor executor) {
+            if (bucketed.size() <= 1) {
+                return bucketed.isEmpty() ? new TwoLevelHashMap<>() : bucketed.get(0);
             }
             TwoLevelHashMap<K, Object[]> result = new TwoLevelHashMap<>();
             int numBuckets = result.numBuckets();
@@ -520,7 +620,7 @@ final class DocValuesGroupByOptimizedIterator {
             for (int b = 0; b < numBuckets; b++) {
                 int bucketIdx = b;
                 tasks.add(() -> {
-                    mergeBucket(bucketIdx, result, leafResults, reducers, ramAccountingFactory.get());
+                    mergeBucket(bucketIdx, result, bucketed, reducers, ramAccountingFactory.get());
                     return null;
                 });
             }
@@ -539,23 +639,26 @@ final class DocValuesGroupByOptimizedIterator {
         @SuppressWarnings("rawtypes")
         private static <K> void mergeBucket(int bucketIdx,
                                             TwoLevelHashMap<K, Object[]> result,
-                                            List<TwoLevelHashMap<K, Object[]>> leafResults,
+                                            List<TwoLevelHashMap<K, Object[]>> bucketed,
                                             List<AggregationFunction> reducers,
                                             RamAccounting ramAccounting) {
             Map<K, Object[]> target = result.bucket(bucketIdx);
-            for (var leafResult : leafResults) {
-                Map<K, Object[]> source = leafResult.bucket(bucketIdx);
+            for (var input : bucketed) {
+                Map<K, Object[]> source = input.bucket(bucketIdx);
                 for (var entry : source.entrySet()) {
-                    target.merge(entry.getKey(), entry.getValue(), (a, b) -> {
-                        Object[] out = new Object[reducers.size()];
-                        for (int j = 0; j < reducers.size(); j++) {
-                            //noinspection unchecked
-                            out[j] = reducers.get(j).reduce(ramAccounting, a[j], b[j]);
-                        }
-                        return out;
-                    });
+                    target.merge(entry.getKey(), entry.getValue(), (a, b) -> reduce(reducers, ramAccounting, a, b));
                 }
             }
+        }
+
+        @SuppressWarnings("rawtypes")
+        private static Object[] reduce(List<AggregationFunction> reducers, RamAccounting ramAccounting, Object[] a, Object[] b) {
+            Object[] out = new Object[reducers.size()];
+            for (int j = 0; j < reducers.size(); j++) {
+                //noinspection unchecked
+                out[j] = reducers.get(j).reduce(ramAccounting, a[j], b[j]);
+            }
+            return out;
         }
 
         private static boolean docDeleted(@Nullable Bits liveDocs, int doc) {

--- a/server/src/main/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIterator.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIterator.java
@@ -25,13 +25,17 @@ import static io.crate.execution.dsl.projection.Projections.shardProjections;
 import static io.crate.execution.engine.collect.LuceneShardCollectorProvider.formatSource;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.DocIdSetIterator;
@@ -51,6 +55,7 @@ import io.crate.common.TriConsumer;
 import io.crate.common.annotations.VisibleForTesting;
 import io.crate.common.collections.Lists;
 import io.crate.common.concurrent.Killable;
+import io.crate.common.exceptions.Exceptions;
 import io.crate.data.BatchIterator;
 import io.crate.data.CollectingBatchIterator;
 import io.crate.data.Row;
@@ -59,11 +64,13 @@ import io.crate.data.breaker.RamAccounting;
 import io.crate.execution.dsl.phases.RoutedCollectPhase;
 import io.crate.execution.dsl.projection.GroupProjection;
 import io.crate.execution.dsl.projection.Projection;
+import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.execution.engine.aggregation.DocValueAggregator;
 import io.crate.execution.engine.aggregation.GroupByMaps;
 import io.crate.execution.engine.aggregation.ResizeAwareMap;
 import io.crate.execution.engine.fetch.ReaderContext;
 import io.crate.execution.jobs.SharedShardContext;
+import io.crate.execution.support.ThreadPools;
 import io.crate.expression.InputFactory;
 import io.crate.expression.reference.doc.lucene.CollectorContext;
 import io.crate.expression.reference.doc.lucene.LuceneCollectorExpression;
@@ -84,7 +91,22 @@ import io.crate.types.DataType;
 
 final class DocValuesGroupByOptimizedIterator {
 
+    /**
+     * DocValueAggregator/LuceneCollectorExpression instances carry per-leaf mutable state
+     * (e.g. the current segment's docValues), so each concurrently processed leaf needs its
+     * own instances. This bundle is what {@link Supplier#get()} builds fresh, once per leaf.
+     */
+    @SuppressWarnings("rawtypes")
+    record LeafState(
+        List<DocValueAggregator> aggregators,
+        List<LuceneCollectorExpression<?>> keyExpressions,
+        MemoryManager memoryManager,
+        CollectorContext collectorContext
+    ) {
+    }
+
     @Nullable
+    @SuppressWarnings("rawtypes")
     static BatchIterator<Row> tryOptimize(Functions functions,
                                           LuceneReferenceResolver referenceResolver,
                                           IndexShard indexShard,
@@ -93,7 +115,8 @@ final class DocValuesGroupByOptimizedIterator {
                                           LuceneQueryBuilder luceneQueryBuilder,
                                           DocInputFactory docInputFactory,
                                           RoutedCollectPhase collectPhase,
-                                          CollectTask collectTask) {
+                                          CollectTask collectTask,
+                                          ThreadPoolExecutor executor) {
         if (Symbols.hasColumn(collectPhase.toCollect(), SysColumns.SCORE)
             || collectPhase.where().hasColumn(SysColumns.SCORE)) {
             return null;
@@ -121,7 +144,7 @@ final class DocValuesGroupByOptimizedIterator {
 
         Version shardCreatedVersion = indexShard.getVersionCreated();
 
-        List<DocValueAggregator> aggregators = DocValuesAggregates.createAggregators(
+        Supplier<List<DocValueAggregator>> aggregatorsFactory = () -> DocValuesAggregates.createAggregators(
             functions,
             referenceResolver,
             groupProjection.values(),
@@ -129,8 +152,15 @@ final class DocValuesGroupByOptimizedIterator {
             table,
             shardCreatedVersion
         );
+        List<DocValueAggregator> aggregators = aggregatorsFactory.get();
         if (aggregators == null) {
             return null;
+        }
+        // Safe to cast: createAggregators above already resolved each aggregation to an
+        // AggregationFunction (it throws otherwise), so re-resolving here cannot fail.
+        List<AggregationFunction> reducers = new ArrayList<>(groupProjection.values().size());
+        for (var aggregation : groupProjection.values()) {
+            reducers.add((AggregationFunction) functions.getQualified(aggregation));
         }
 
         ShardId shardId = indexShard.shardId();
@@ -139,12 +169,21 @@ final class DocValuesGroupByOptimizedIterator {
         collectTask.addSearcher(sharedShardContext.readerId(), searcher);
         IndexService indexService = sharedShardContext.indexService();
 
-        InputFactory.Context<? extends LuceneCollectorExpression<?>> docCtx
-            = docInputFactory.getCtx(collectTask.txnCtx());
-        List<LuceneCollectorExpression<?>> keyExpressions = new ArrayList<>();
-        for (var keyRef : columnKeyRefs) {
-            keyExpressions.add((LuceneCollectorExpression<?>) docCtx.add(keyRef));
-        }
+        Supplier<List<LuceneCollectorExpression<?>>> keyExpressionsFactory = () -> {
+            InputFactory.Context<? extends LuceneCollectorExpression<?>> ctx = docInputFactory.getCtx(collectTask.txnCtx());
+            List<LuceneCollectorExpression<?>> exprs = new ArrayList<>(columnKeyRefs.size());
+            for (var keyRef : columnKeyRefs) {
+                exprs.add((LuceneCollectorExpression<?>) ctx.add(keyRef));
+            }
+            return exprs;
+        };
+        Supplier<RamAccounting> ramAccountingFactory = collectTask::getRamAccounting;
+        Supplier<LeafState> leafStateFactory = () -> new LeafState(
+            aggregatorsFactory.get(),
+            keyExpressionsFactory.get(),
+            collectTask.memoryManager(),
+            new CollectorContext(sharedShardContext.readerId(), () -> StoredRowLookup.create(shardCreatedVersion, table, partitionValues))
+        );
 
         LuceneQueryBuilder.Context queryContext = luceneQueryBuilder.convert(
             collectPhase.where(),
@@ -159,27 +198,25 @@ final class DocValuesGroupByOptimizedIterator {
 
         if (columnKeyRefs.size() == 1) {
             return GroupByIterator.forSingleKey(
-                aggregators,
+                leafStateFactory,
+                ramAccountingFactory,
+                reducers,
                 searcher.item(),
                 columnKeyRefs.get(0),
-                keyExpressions,
-                collectTask.getRamAccounting(),
-                collectTask.memoryManager(),
                 collectTask.minNodeVersion(),
                 queryContext.query(),
-                new CollectorContext(sharedShardContext.readerId(), () -> StoredRowLookup.create(shardCreatedVersion, table, partitionValues))
+                executor
             );
         } else {
             return GroupByIterator.forManyKeys(
-                aggregators,
+                leafStateFactory,
+                ramAccountingFactory,
+                reducers,
                 searcher.item(),
                 columnKeyRefs,
-                keyExpressions,
-                collectTask.getRamAccounting(),
-                collectTask.memoryManager(),
                 collectTask.minNodeVersion(),
                 queryContext.query(),
-                new CollectorContext(sharedShardContext.readerId(), () -> StoredRowLookup.create(shardCreatedVersion, table, partitionValues))
+                executor
             );
         }
     }
@@ -190,54 +227,49 @@ final class DocValuesGroupByOptimizedIterator {
 
         @SuppressWarnings("rawtypes")
         @VisibleForTesting
-        static BatchIterator<Row> forSingleKey(List<DocValueAggregator> aggregators,
+        static BatchIterator<Row> forSingleKey(Supplier<LeafState> leafStateFactory,
+                                               Supplier<RamAccounting> ramAccountingFactory,
+                                               List<AggregationFunction> reducers,
                                                IndexSearcher indexSearcher,
                                                Reference keyReference,
-                                               List<? extends LuceneCollectorExpression<?>> keyExpressions,
-                                               RamAccounting ramAccounting,
-                                               MemoryManager memoryManager,
                                                Version minNodeVersion,
                                                Query query,
-                                               CollectorContext collectorContext) {
+                                               ThreadPoolExecutor executor) {
             //noinspection unchecked
             DataType<Object> valueType = (DataType<Object>) keyReference.valueType();
             return GroupByIterator.getIterator(
-                aggregators,
+                leafStateFactory,
+                ramAccountingFactory,
+                reducers,
                 indexSearcher,
-                keyExpressions,
-                ramAccounting,
-                memoryManager,
+                1,
                 minNodeVersion,
-                GroupByMaps.accountForNewEntry(ramAccounting, valueType),
+                ra -> GroupByMaps.accountForNewEntry(ra, valueType),
                 (expressions) -> expressions.get(0).value(),
                 (key, cells) -> cells[0] = key,
                 query,
-                collectorContext
+                executor
             );
         }
 
         @SuppressWarnings("rawtypes")
         @VisibleForTesting
-        static BatchIterator<Row> forManyKeys(List<DocValueAggregator> aggregators,
+        static BatchIterator<Row> forManyKeys(Supplier<LeafState> leafStateFactory,
+                                              Supplier<RamAccounting> ramAccountingFactory,
+                                              List<AggregationFunction> reducers,
                                               IndexSearcher indexSearcher,
                                               List<Reference> keyColumnRefs,
-                                              List<? extends LuceneCollectorExpression<?>> keyExpressions,
-                                              RamAccounting ramAccounting,
-                                              MemoryManager memoryManager,
                                               Version minNodeVersion,
                                               Query query,
-                                              CollectorContext collectorContext) {
+                                              ThreadPoolExecutor executor) {
             return GroupByIterator.getIterator(
-                aggregators,
+                leafStateFactory,
+                ramAccountingFactory,
+                reducers,
                 indexSearcher,
-                keyExpressions,
-                ramAccounting,
-                memoryManager,
+                keyColumnRefs.size(),
                 minNodeVersion,
-                GroupByMaps.accountForNewEntry(
-                    ramAccounting,
-                    Lists.map(keyColumnRefs, Reference::valueType)
-                ),
+                ra -> GroupByMaps.accountForNewEntry(ra, Lists.map(keyColumnRefs, Reference::valueType)),
                 (expressions) -> {
                     ArrayList<Object> key = new ArrayList<>(keyColumnRefs.size());
                     for (int i = 0; i < expressions.size(); i++) {
@@ -251,148 +283,233 @@ final class DocValuesGroupByOptimizedIterator {
                     }
                 },
                 query,
-                collectorContext
+                executor
             );
         }
 
         @SuppressWarnings("rawtypes")
         @VisibleForTesting
-        static <K> BatchIterator<Row> getIterator(List<DocValueAggregator> aggregators,
+        static <K> BatchIterator<Row> getIterator(Supplier<LeafState> leafStateFactory,
+                                                  Supplier<RamAccounting> ramAccountingFactory,
+                                                  List<AggregationFunction> reducers,
                                                   IndexSearcher indexSearcher,
-                                                  List<? extends LuceneCollectorExpression<?>> keyExpressions,
-                                                  RamAccounting ramAccounting,
-                                                  MemoryManager memoryManager,
+                                                  int numberOfKeys,
                                                   Version minNodeVersion,
-                                                  TriConsumer<ResizeAwareMap<K, Object[]>, K, Object[]> accountForNewKeyEntry,
+                                                  Function<RamAccounting, TriConsumer<ResizeAwareMap<K, Object[]>, K, Object[]>> accountForNewKeyEntryFactory,
                                                   Function<List<? extends LuceneCollectorExpression<?>>, K> keyExtractor,
                                                   BiConsumer<K, Object[]> applyKeyToCells,
                                                   Query query,
-                                                  CollectorContext collectorContext) {
-            for (int i = 0; i < keyExpressions.size(); i++) {
-                keyExpressions.get(i).startCollect(collectorContext);
-            }
-
+                                                  ThreadPoolExecutor executor) {
             Killable.Token killToken = new Killable.Token();
+            int numberOfAggregates = reducers.size();
             return CollectingBatchIterator.newInstance(
                 killToken,
                 () -> getRows(
-                    applyAggregatesGroupedByKey(
-                        aggregators,
+                    collectGroupedByKey(
+                        leafStateFactory,
+                        ramAccountingFactory,
+                        reducers,
                         indexSearcher,
-                        keyExpressions,
-                        accountForNewKeyEntry,
-                        keyExtractor,
-                        ramAccounting,
-                        memoryManager,
+                        numberOfAggregates,
                         minNodeVersion,
+                        accountForNewKeyEntryFactory,
+                        keyExtractor,
                         query,
-                        killToken
+                        killToken,
+                        executor
                     ),
-                    keyExpressions.size(),
+                    numberOfKeys,
                     applyKeyToCells,
-                    aggregators,
-                    ramAccounting
+                    numberOfAggregates
                 ),
                 true
             );
         }
 
-        @SuppressWarnings("rawtypes")
-        private static <K> Iterable<Row> getRows(Map<K, Object[]> groupedStates,
-                                                 int numberOfKeys,
-                                                 BiConsumer<K, Object[]> applyKeyToCells,
-                                                 List<DocValueAggregator> aggregators,
-                                                 RamAccounting ramAccounting) {
+        private static <K> Iterable<Row> getRows(Map<K, Object[]> groupedPartialsByKey,
+                                                  int numberOfKeys,
+                                                  BiConsumer<K, Object[]> applyKeyToCells,
+                                                  int numberOfAggregates) {
             return () -> {
-                Object[] cells = new Object[numberOfKeys + aggregators.size()];
+                Object[] cells = new Object[numberOfKeys + numberOfAggregates];
                 RowN row = new RowN(cells);
                 Function<Map.Entry<K, Object[]>, Row> mapper = entry -> {
                     K key = entry.getKey();
                     applyKeyToCells.accept(key, cells);
-
-                    Object[] states = entry.getValue();
-                    int c = numberOfKeys;
-                    for (int i = 0; i < states.length; i++) {
-                        //noinspection unchecked
-                        cells[c] = aggregators.get(i).partialResult(ramAccounting, states[i]);
-                        c++;
-                    }
+                    Object[] partials = entry.getValue();
+                    System.arraycopy(partials, 0, cells, numberOfKeys, partials.length);
                     return row;
                 };
-                return groupedStates.entrySet().stream().map(mapper).iterator();
+                return groupedPartialsByKey.entrySet().stream().map(mapper).iterator();
             };
         }
 
+        /**
+         * Runs one task per leaf (segment) on {@code executor} -- a pool dedicated to this kind
+         * of fan-out, distinct from the SEARCH pool this whole batch-iterator pipeline already
+         * runs on, so blocking here on the joined result can't self-deadlock that pool.
+         */
         @SuppressWarnings("rawtypes")
-        private static <K> Map<K, Object[]> applyAggregatesGroupedByKey(
-            List<DocValueAggregator> aggregators,
+        private static <K> Map<K, Object[]> collectGroupedByKey(
+            Supplier<LeafState> leafStateFactory,
+            Supplier<RamAccounting> ramAccountingFactory,
+            List<AggregationFunction> reducers,
             IndexSearcher indexSearcher,
-            List<? extends LuceneCollectorExpression<?>> keyExpressions,
-            TriConsumer<ResizeAwareMap<K, Object[]>, K, Object[]> accountForNewKeyEntry,
-            Function<List<? extends LuceneCollectorExpression<?>>, K> keyExtractor,
-            RamAccounting ramAccounting,
-            MemoryManager memoryManager,
+            int numberOfAggregates,
             Version minNodeVersion,
+            Function<RamAccounting, TriConsumer<ResizeAwareMap<K, Object[]>, K, Object[]>> accountForNewKeyEntryFactory,
+            Function<List<? extends LuceneCollectorExpression<?>>, K> keyExtractor,
             Query query,
-            Killable.Token killToken
+            Killable.Token killToken,
+            ThreadPoolExecutor executor
         ) throws IOException {
-
-            ResizeAwareMap<K, Object[]> statesByKey = GroupByMaps.wrapperForJDKMap(new HashMap<>());
             Weight weight = indexSearcher.createWeight(
                 indexSearcher.rewrite(query),
                 ScoreMode.COMPLETE_NO_SCORES,
                 1f
             );
             List<LeafReaderContext> leaves = indexSearcher.getTopReaderContext().leaves();
+            List<Supplier<Map<K, Object[]>>> tasks = new ArrayList<>(leaves.size());
             for (var leaf : leaves) {
+                tasks.add(() -> {
+                    try {
+                        return processLeaf(
+                            leafStateFactory.get(),
+                            ramAccountingFactory.get(),
+                            weight,
+                            leaf,
+                            numberOfAggregates,
+                            minNodeVersion,
+                            accountForNewKeyEntryFactory,
+                            keyExtractor,
+                            killToken
+                        );
+                    } catch (IOException e) {
+                        throw new UncheckedIOException(e);
+                    }
+                });
+            }
+            List<Map<K, Object[]>> leafResults;
+            try {
+                leafResults = ThreadPools.runWithAvailableThreads(
+                    executor,
+                    ThreadPools.numIdleThreads(executor, Runtime.getRuntime().availableProcessors()),
+                    tasks
+                ).join();
+            } catch (CompletionException e) {
+                RuntimeException re = Exceptions.toRuntimeException(e);
+                if (re instanceof UncheckedIOException uio) {
+                    throw uio.getCause();
+                }
+                throw re;
+            }
+            return mergeLeafResults(leafResults, reducers, ramAccountingFactory.get());
+        }
+
+        @SuppressWarnings("rawtypes")
+        private static <K> Map<K, Object[]> processLeaf(
+            LeafState leafState,
+            RamAccounting ramAccounting,
+            Weight weight,
+            LeafReaderContext leaf,
+            int numberOfAggregates,
+            Version minNodeVersion,
+            Function<RamAccounting, TriConsumer<ResizeAwareMap<K, Object[]>, K, Object[]>> accountForNewKeyEntryFactory,
+            Function<List<? extends LuceneCollectorExpression<?>>, K> keyExtractor,
+            Killable.Token killToken
+        ) throws IOException {
+            killToken.raiseIfKilled();
+
+            List<DocValueAggregator> aggregators = leafState.aggregators();
+            List<LuceneCollectorExpression<?>> keyExpressions = leafState.keyExpressions();
+            MemoryManager memoryManager = leafState.memoryManager();
+            CollectorContext collectorContext = leafState.collectorContext();
+            for (int i = 0; i < keyExpressions.size(); i++) {
+                keyExpressions.get(i).startCollect(collectorContext);
+            }
+
+            Scorer scorer = weight.scorer(leaf);
+            if (scorer == null) {
+                return Map.of();
+            }
+
+            TriConsumer<ResizeAwareMap<K, Object[]>, K, Object[]> accountForNewKeyEntry =
+                accountForNewKeyEntryFactory.apply(ramAccounting);
+            ResizeAwareMap<K, Object[]> statesByKey = GroupByMaps.wrapperForJDKMap(new HashMap<>());
+
+            for (int i = 0; i < keyExpressions.size(); i++) {
+                keyExpressions.get(i).setNextReader(new ReaderContext(leaf));
+            }
+            for (int i = 0; i < aggregators.size(); i++) {
+                aggregators.get(i).loadDocValues(leaf);
+            }
+
+            DocIdSetIterator docs = scorer.iterator();
+            Bits liveDocs = leaf.reader().getLiveDocs();
+            for (int doc = docs.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = docs.nextDoc()) {
                 killToken.raiseIfKilled();
-                Scorer scorer = weight.scorer(leaf);
-                if (scorer == null) {
+                if (docDeleted(liveDocs, doc)) {
                     continue;
                 }
+
                 for (int i = 0; i < keyExpressions.size(); i++) {
-                    keyExpressions.get(i).setNextReader(new ReaderContext(leaf));
+                    keyExpressions.get(i).setNextDocId(doc);
                 }
-                for (int i = 0; i < aggregators.size(); i++) {
-                    aggregators.get(i).loadDocValues(leaf);
-                }
+                K key = keyExtractor.apply(keyExpressions);
 
-                DocIdSetIterator docs = scorer.iterator();
-                Bits liveDocs = leaf.reader().getLiveDocs();
-                for (int doc = docs.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = docs.nextDoc()) {
-                    killToken.raiseIfKilled();
-                    if (docDeleted(liveDocs, doc)) {
-                        continue;
+                Object[] states = statesByKey.get(key);
+                if (states == null) {
+                    states = new Object[aggregators.size()];
+                    for (int i = 0; i < aggregators.size(); i++) {
+                        var aggregator = aggregators.get(i);
+
+                        Object state = aggregator.initialState(ramAccounting, memoryManager, minNodeVersion);
+
+                        //noinspection unchecked
+                        state = aggregator.apply(ramAccounting, doc, state);
+                        states[i] = state;
                     }
-
-                    for (int i = 0; i < keyExpressions.size(); i++) {
-                        keyExpressions.get(i).setNextDocId(doc);
-                    }
-                    K key = keyExtractor.apply(keyExpressions);
-
-                    Object[] states = statesByKey.get(key);
-                    if (states == null) {
-                        states = new Object[aggregators.size()];
-                        for (int i = 0; i < aggregators.size(); i++) {
-                            var aggregator = aggregators.get(i);
-
-                            Object state = aggregator.initialState(ramAccounting, memoryManager, minNodeVersion);
-
-                            //noinspection unchecked
-                            state = aggregator.apply(ramAccounting, doc, state);
-                            states[i] = state;
-                        }
-                        accountForNewKeyEntry.accept(statesByKey, key, states);
-                        statesByKey.put(key, states);
-                    } else {
-                        for (int i = 0; i < aggregators.size(); i++) {
-                            //noinspection unchecked
-                            states[i] = aggregators.get(i).apply(ramAccounting, doc, states[i]);
-                        }
+                    accountForNewKeyEntry.accept(statesByKey, key, states);
+                    statesByKey.put(key, states);
+                } else {
+                    for (int i = 0; i < aggregators.size(); i++) {
+                        //noinspection unchecked
+                        states[i] = aggregators.get(i).apply(ramAccounting, doc, states[i]);
                     }
                 }
             }
-            return statesByKey;
+
+            Map<K, Object[]> partials = new HashMap<>();
+            for (var entry : statesByKey.entrySet()) {
+                Object[] rawStates = entry.getValue();
+                Object[] partial = new Object[numberOfAggregates];
+                for (int i = 0; i < numberOfAggregates; i++) {
+                    //noinspection unchecked
+                    partial[i] = aggregators.get(i).partialResult(ramAccounting, rawStates[i]);
+                }
+                partials.put(entry.getKey(), partial);
+            }
+            return partials;
+        }
+
+        @SuppressWarnings("rawtypes")
+        private static <K> Map<K, Object[]> mergeLeafResults(List<Map<K, Object[]>> leafResults,
+                                                              List<AggregationFunction> reducers,
+                                                              RamAccounting ramAccounting) {
+            Map<K, Object[]> merged = new HashMap<>();
+            for (var leafResult : leafResults) {
+                for (var entry : leafResult.entrySet()) {
+                    merged.merge(entry.getKey(), entry.getValue(), (a, b) -> {
+                        Object[] out = new Object[reducers.size()];
+                        for (int j = 0; j < reducers.size(); j++) {
+                            //noinspection unchecked
+                            out[j] = reducers.get(j).reduce(ramAccounting, a[j], b[j]);
+                        }
+                        return out;
+                    });
+                }
+            }
+            return merged;
         }
 
         private static boolean docDeleted(@Nullable Bits liveDocs, int doc) {

--- a/server/src/main/java/io/crate/execution/engine/collect/LuceneShardCollectorProvider.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/LuceneShardCollectorProvider.java
@@ -22,6 +22,7 @@
 package io.crate.execution.engine.collect;
 
 import java.util.Map;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.function.Supplier;
 
 import org.apache.logging.log4j.LogManager;
@@ -74,6 +75,7 @@ public class LuceneShardCollectorProvider extends ShardCollectorProvider {
     private final DocInputFactory docInputFactory;
     private final BigArrays bigArrays;
     private final ClusterService clusterService;
+    private final ThreadPool threadPool;
 
     private final LuceneReferenceResolver referenceResolver;
 
@@ -117,6 +119,7 @@ public class LuceneShardCollectorProvider extends ShardCollectorProvider {
         this.docInputFactory = new DocInputFactory(nodeCtx, referenceResolver);
         this.bigArrays = bigArrays;
         this.clusterService = clusterService;
+        this.threadPool = threadPool;
     }
 
     @Override
@@ -206,7 +209,8 @@ public class LuceneShardCollectorProvider extends ShardCollectorProvider {
             luceneQueryBuilder,
             docInputFactory,
             normalizedPhase,
-            collectTask
+            collectTask,
+            (ThreadPoolExecutor) threadPool.executor(ThreadPool.Names.GROUP_BY)
         );
         if (it != null) {
             return it;

--- a/server/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
+++ b/server/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
@@ -72,6 +72,7 @@ public class ThreadPool implements Scheduler {
         public static final String FETCH_SHARD_STARTED = "fetch_shard_started";
         public static final String FETCH_SHARD_STORE = "fetch_shard_store";
         public static final String LOGICAL_REPLICATION = "logical_replication";
+        public static final String GROUP_BY = "group_by";
     }
 
     public enum ThreadPoolType {
@@ -147,7 +148,8 @@ public class ThreadPool implements Scheduler {
             new ScalingExecutorBuilder(Names.FETCH_SHARD_STARTED, 1, 2 * availableProcessors, TimeValue.timeValueMinutes(5)),
             new FixedExecutorBuilder(settings, Names.FORCE_MERGE, oneEightOfProcessors(availableProcessors), -1),
             new ScalingExecutorBuilder(Names.FETCH_SHARD_STORE, 1, 2 * availableProcessors, TimeValue.timeValueMinutes(5)),
-            new FixedExecutorBuilder(settings, Names.LOGICAL_REPLICATION, searchThreadPoolSize(availableProcessors), 100)
+            new FixedExecutorBuilder(settings, Names.LOGICAL_REPLICATION, searchThreadPoolSize(availableProcessors), 100),
+            new FixedExecutorBuilder(settings, Names.GROUP_BY, searchThreadPoolSize(availableProcessors), 100)
         );
         HashMap<String, ExecutorHolder> executors = HashMap.newHashMap(builders.size() + 1);
         for (ExecutorBuilder builder : builders) {

--- a/server/src/test/java/io/crate/collections/TwoLevelHashMapTest.java
+++ b/server/src/test/java/io/crate/collections/TwoLevelHashMapTest.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.Test;
+
+public class TwoLevelHashMapTest {
+
+    @Test
+    public void test_put_and_get_roundtrip_across_many_buckets() throws Exception {
+        var map = new TwoLevelHashMap<Integer, String>();
+        for (int i = 0; i < 10_000; i++) {
+            map.put(i, "v" + i);
+        }
+        assertThat(map.size()).isEqualTo(10_000);
+        for (int i = 0; i < 10_000; i++) {
+            assertThat(map.get(i)).isEqualTo("v" + i);
+        }
+    }
+
+    @Test
+    public void test_put_overwrites_existing_key_and_returns_previous_value() throws Exception {
+        var map = new TwoLevelHashMap<String, Integer>();
+        assertThat(map.put("a", 1)).isNull();
+        assertThat(map.put("a", 2)).isEqualTo(1);
+        assertThat(map.get("a")).isEqualTo(2);
+        assertThat(map.size()).isEqualTo(1);
+    }
+
+    @Test
+    public void test_get_and_contains_key_on_missing_key() throws Exception {
+        var map = new TwoLevelHashMap<String, Integer>();
+        map.put("a", 1);
+        assertThat(map.get("missing")).isNull();
+        assertThat(map.containsKey("missing")).isFalse();
+        assertThat(map.containsKey("a")).isTrue();
+    }
+
+    @Test
+    public void test_remove() throws Exception {
+        var map = new TwoLevelHashMap<String, Integer>();
+        map.put("a", 1);
+        assertThat(map.remove("a")).isEqualTo(1);
+        assertThat(map.containsKey("a")).isFalse();
+        assertThat(map.size()).isEqualTo(0);
+        assertThat(map.isEmpty()).isTrue();
+    }
+
+    @Test
+    public void test_clear() throws Exception {
+        var map = new TwoLevelHashMap<Integer, Integer>();
+        for (int i = 0; i < 100; i++) {
+            map.put(i, i);
+        }
+        map.clear();
+        assertThat(map.isEmpty()).isTrue();
+        assertThat(map.size()).isEqualTo(0);
+    }
+
+    @Test
+    public void test_iterator_visits_every_entry_exactly_once() throws Exception {
+        var map = new TwoLevelHashMap<Integer, String>();
+        Map<Integer, String> expected = new HashMap<>();
+        for (int i = 0; i < 1_000; i++) {
+            map.put(i, "v" + i);
+            expected.put(i, "v" + i);
+        }
+
+        Set<Integer> seenKeys = new HashSet<>();
+        int count = 0;
+        for (Map.Entry<Integer, String> entry : map) {
+            assertThat(seenKeys.add(entry.getKey())).isTrue();
+            assertThat(entry.getValue()).isEqualTo(expected.get(entry.getKey()));
+            count++;
+        }
+        assertThat(count).isEqualTo(expected.size());
+    }
+
+    @Test
+    public void test_empty_map_iterator_has_no_elements() throws Exception {
+        var map = new TwoLevelHashMap<Integer, String>();
+        assertThat(map.iterator().hasNext()).isFalse();
+    }
+
+    @Test
+    public void test_custom_bits_for_bucket_controls_bucket_count() throws Exception {
+        var map = new TwoLevelHashMap<Integer, Integer>(4);
+        assertThat(map.numBuckets()).isEqualTo(16);
+    }
+
+    @Test
+    public void test_entries_are_distributed_across_multiple_buckets() throws Exception {
+        var map = new TwoLevelHashMap<Integer, Integer>();
+        for (int i = 0; i < 10_000; i++) {
+            map.put(i, i);
+        }
+
+        long nonEmptyBuckets = 0;
+        for (int i = 0; i < map.numBuckets(); i++) {
+            if (!map.bucket(i).isEmpty()) {
+                nonEmptyBuckets++;
+            }
+        }
+        assertThat(nonEmptyBuckets).isGreaterThan(1);
+    }
+}

--- a/server/src/test/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIteratorTest.java
@@ -33,6 +33,7 @@ import static org.mockito.Mockito.mock;
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
@@ -49,6 +50,7 @@ import org.apache.lucene.store.ByteBuffersDirectory;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.index.shard.IndexShard;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -142,9 +144,15 @@ public class DocValuesGroupByOptimizedIteratorTest extends CrateDummyClusterServ
             Version.CURRENT,
             List.of()
         );
-        var keyExpressions = List.of(new LongColumnReference("y"));
         var it = DocValuesGroupByOptimizedIterator.GroupByIterator.forSingleKey(
-            List.of(sumDocValuesAggregator),
+            () -> new DocValuesGroupByOptimizedIterator.LeafState(
+                List.of(sumDocValuesAggregator),
+                List.of(new LongColumnReference("y")),
+                null,
+                new CollectorContext(() -> null)
+            ),
+            () -> RamAccounting.NO_ACCOUNTING,
+            List.of(sumAggregation),
             indexSearcher,
             new SimpleReference(
                 RelationName.fromIndexName("test"),
@@ -159,12 +167,9 @@ public class DocValuesGroupByOptimizedIteratorTest extends CrateDummyClusterServ
                 false,
                 null
             ),
-            keyExpressions,
-            RamAccounting.NO_ACCOUNTING,
-            null,
             null,
             MatchAllDocsQuery.INSTANCE,
-            new CollectorContext(() -> null)
+            (ThreadPoolExecutor) THREAD_POOL.executor(ThreadPool.Names.GROUP_BY)
         );
 
         var rowConsumer = new TestingRowConsumer();
@@ -203,7 +208,6 @@ public class DocValuesGroupByOptimizedIteratorTest extends CrateDummyClusterServ
             Version.CURRENT,
             List.of()
         );
-        var keyExpressions = List.of(new StringColumnReference("x"), new LongColumnReference("y"));
         var keyRefs = List.<Reference>of(
             new SimpleReference(
                 RelationName.fromIndexName("test"),
@@ -233,15 +237,19 @@ public class DocValuesGroupByOptimizedIteratorTest extends CrateDummyClusterServ
             )
         );
         var it = DocValuesGroupByOptimizedIterator.GroupByIterator.forManyKeys(
-            List.of(sumDocValuesAggregator),
+            () -> new DocValuesGroupByOptimizedIterator.LeafState(
+                List.of(sumDocValuesAggregator),
+                List.of(new StringColumnReference("x"), new LongColumnReference("y")),
+                null,
+                new CollectorContext(() -> null)
+            ),
+            () -> RamAccounting.NO_ACCOUNTING,
+            List.of(sumAggregation),
             indexSearcher,
             keyRefs,
-            keyExpressions,
-            RamAccounting.NO_ACCOUNTING,
-            null,
             null,
             MatchAllDocsQuery.INSTANCE,
-            new CollectorContext(() -> null)
+            (ThreadPoolExecutor) THREAD_POOL.executor(ThreadPool.Names.GROUP_BY)
         );
 
         var rowConsumer = new TestingRowConsumer();
@@ -295,7 +303,8 @@ public class DocValuesGroupByOptimizedIteratorTest extends CrateDummyClusterServ
                 referenceResolver
             ),
             collectPhase,
-            collectTask
+            collectTask,
+            (ThreadPoolExecutor) THREAD_POOL.executor(ThreadPool.Names.GROUP_BY)
         );
         assertThat(it).isNotNull();
 
@@ -351,29 +360,34 @@ public class DocValuesGroupByOptimizedIteratorTest extends CrateDummyClusterServ
 
     private BatchIterator<Row> createBatchIterator(Runnable onNextReader) {
         return DocValuesGroupByOptimizedIterator.GroupByIterator.getIterator(
+            () -> new DocValuesGroupByOptimizedIterator.LeafState(
+                List.of(),
+                List.of(new LuceneCollectorExpression<>() {
+
+                    @Override
+                    public void setNextReader(ReaderContext context) throws IOException {
+                        onNextReader.run();
+                    }
+
+                    @Override
+                    public Object value() {
+                        return null;
+                    }
+                }),
+                null,
+                new CollectorContext(() -> null)
+            ),
+            () -> null,
             List.of(),
             indexSearcher,
-            List.of(new LuceneCollectorExpression<>() {
-
-                @Override
-                public void setNextReader(ReaderContext context) throws IOException {
-                    onNextReader.run();
-                }
-
-                @Override
-                public Object value() {
-                    return null;
-                }
-            }),
+            1,
             null,
-            null,
-            null,
-            (_, states, key) -> {
+            ra -> (_, states, key) -> {
             },
             (expressions) -> expressions.get(0).value(),
             (key, cells) -> cells[0] = key,
             MatchAllDocsQuery.INSTANCE,
-            new CollectorContext(() -> null)
+            (ThreadPoolExecutor) THREAD_POOL.executor(ThreadPool.Names.GROUP_BY)
         );
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB


## Checklist

 - [ ] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes.
       If you're an external contributor you can give yourself attribution and include your name and Github handle.
       e.g.:
       ```
       `John Doe <https://github.com/John_Doe>`_ added support for ...
       ```
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
