### PR TITLE
Fix handling of bitstring params when creating views

### DIFF
--- a/docs/appendices/release-notes/6.4.4.rst
+++ b/docs/appendices/release-notes/6.4.4.rst
@@ -46,6 +46,12 @@ series.
 Fixes
 =====
 
+- Fixed an issue that caused ``CREATE VIEW`` statements to fail if their query
+  contained a parameter placeholder (``?``) for a ``bit`` value with an error
+  like::
+
+    Cannot cast `'B''0101'''` of type `text` to type `bit(4)`
+
 - Fixed an issue that could cause inserts to be routed to the wrong shards if
   writing to a table with more than one shard and a primary key column that has
   a default clause and omitting that column in the INSERT INTO statement. Those

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/Literal.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/Literal.java
@@ -70,6 +70,7 @@ public sealed interface Literal extends Expression permits
                 }
                 yield new ObjectLiteral(map);
             }
+            case BitString val -> val;
             default -> new StringLiteral(value.toString());
         };
     }

--- a/libs/sql-parser/src/test/java/io/crate/sql/LiteralsTest.java
+++ b/libs/sql-parser/src/test/java/io/crate/sql/LiteralsTest.java
@@ -30,6 +30,7 @@ import java.math.BigDecimal;
 import org.junit.jupiter.api.Test;
 
 import io.crate.sql.parser.SqlParser;
+import io.crate.sql.tree.BitString;
 import io.crate.sql.tree.IntegerLiteral;
 import io.crate.sql.tree.Literal;
 import io.crate.sql.tree.NumericLiteral;
@@ -308,5 +309,13 @@ public class LiteralsTest {
         Literal literal = Literal.fromObject(v);
         assertThat(literal).isExactlyInstanceOf(NumericLiteral.class);
         assertThat(((NumericLiteral) literal).value()).isEqualTo(v);
+    }
+
+    @Test
+    public void test_literal_from_bitstring() throws Exception {
+        BitString value = BitString.ofRawBits("0101");
+        Literal literal = Literal.fromObject(value);
+        assertThat(literal).isExactlyInstanceOf(BitString.class);
+        assertThat(literal).isEqualTo(value);
     }
 }

--- a/server/src/main/java/io/crate/types/ResultSetParser.java
+++ b/server/src/main/java/io/crate/types/ResultSetParser.java
@@ -41,6 +41,7 @@ import org.postgresql.util.PGobject;
 
 import io.crate.protocols.postgres.types.PGArray;
 import io.crate.protocols.postgres.types.PgOidVectorType;
+import io.crate.sql.tree.BitString;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 
@@ -112,6 +113,9 @@ public class ResultSetParser {
                 ByteBuf buf = Unpooled.wrappedBuffer(bytes);
                 value = PGArray.BIT_ARRAY.readTextValue(buf, bytes.length, null);
                 buf.release();
+                break;
+            case "bit":
+                value = BitString.ofRawBits(resultSet.getString(columnIndex));
                 break;
 
             default:

--- a/server/src/test/java/io/crate/integrationtests/ViewsITest.java
+++ b/server/src/test/java/io/crate/integrationtests/ViewsITest.java
@@ -26,6 +26,7 @@ import static io.crate.protocols.postgres.PGErrorStatus.DUPLICATE_TABLE;
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
 import static io.crate.testing.Asserts.assertThat;
 import static io.netty.handler.codec.http.HttpResponseStatus.CONFLICT;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Locale;
@@ -41,6 +42,7 @@ import org.junit.Test;
 import io.crate.exceptions.RelationAlreadyExists;
 import io.crate.metadata.RelationName;
 import io.crate.protocols.postgres.PGErrorStatus;
+import io.crate.sql.tree.BitString;
 import io.crate.testing.Asserts;
 import io.netty.handler.codec.http.HttpResponseStatus;
 
@@ -80,6 +82,16 @@ public class ViewsITest extends IntegTestCase {
             RelationMetadata view = clusterService.state().metadata().getRelation(RelationName.fromIndexName(sqlExecutor.getCurrentSchema() + ".v1"));
             assertThat(view).isNull();
         }
+    }
+
+    @Test
+    public void test_can_use_bitstring_parameter_in_view_definition() throws Exception {
+        BitString value = BitString.ofRawBits("0001");
+        execute("create view v1 as select ?::bit(4)", $(value));
+        execute("select * from v1");
+        assertThat(response).hasRows(
+            "B'0001'"
+        );
     }
 
     @Test

--- a/server/src/testFixtures/java/io/crate/testing/SQLTransportExecutor.java
+++ b/server/src/testFixtures/java/io/crate/testing/SQLTransportExecutor.java
@@ -57,6 +57,7 @@ import org.elasticsearch.cluster.health.Health;
 import org.elasticsearch.common.util.concurrent.FutureUtils;
 import org.elasticsearch.test.ESTestCase;
 import org.jspecify.annotations.Nullable;
+import org.postgresql.util.PGobject;
 
 import com.carrotsearch.randomizedtesting.RandomizedContext;
 
@@ -83,6 +84,7 @@ import io.crate.session.DescribeResult;
 import io.crate.session.ResultReceiver;
 import io.crate.session.Session;
 import io.crate.session.Sessions;
+import io.crate.sql.tree.BitString;
 import io.crate.types.ArrayType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -419,6 +421,16 @@ public class SQLTransportExecutor {
     public static Object toJdbcCompatObject(Connection connection, Object arg) {
         if (arg == null) {
             return arg;
+        }
+        if (arg instanceof BitString bitString) {
+            PGobject pgObject = new PGobject();
+            try {
+                pgObject.setValue(bitString.asRawBitString());
+            } catch (SQLException e) {
+                throw Exceptions.toRuntimeException(e);
+            }
+            pgObject.setType("bit");
+            return pgObject;
         }
         if (arg instanceof Map) {
             return DataTypes.STRING.implicitCast(arg);


### PR DESCRIPTION
`Literal.fromObject` didn't handle `bitstring` values - creating a
`StringLiteral` with the bitstring value instead. For `CREATE VIEW`
statements containing parameter placeholders `Literal.fromObject` is
used to inline the values for the placeholders. Due to the missing
handling, that step failed.

`Literal.fromObject` is also used in a few other places (`show create
table` to convert setting values), but these are unproblematic as far as
I can tell.

With asyncpg this caused failures like:

    xs = asyncpg.BitString('0101')
    await conn.execute("create view v1 as select ?::bit(4)", xs)
    asyncpg.exceptions.InternalServerError: Cannot cast `'B''0101'''` of type `text` to type `bit(4)`


Noticed this due to https://github.com/crate/crate/pull/20117


(Will also have to check if the same type of error happens with interval/period values)
