### PR TITLE
Revert "Fix filtered nested CROSS JOIN rewrite to nested INNER JOINs"

### DIFF
--- a/docs/appendices/release-notes/6.4.4.rst
+++ b/docs/appendices/release-notes/6.4.4.rst
@@ -148,21 +148,6 @@ Fixes
     ) AS u
     WHERE x > 2147483647;
 
-- Fixed an issue that caused queries with filtered nested ``CROSS JOIN``s to
-  return incorrect results when ``optimizer_eliminate_cross_join`` was set to
-  ``false`` and a filter above the join tree referenced only one side of the
-  current cross join, e.g.::
-
-    SET optimizer_eliminate_cross_join = false;
-
-    SELECT t1.x, t2.y, t3.z
-    FROM t1
-    CROSS JOIN t2
-    CROSS JOIN t3
-    WHERE t1.x = t2.y
-      AND t1.x = t3.z
-      AND t2.y = t3.z;
-
 - Fixed a regression introduced with :ref:`version_6.4.3`, causing queries
   with aggregations to fail with false positive ``CircuitBreakerException``.
 

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathJoin.java
@@ -120,7 +120,9 @@ public final class MoveFilterBeneathJoin implements Rule<Filter> {
         }
         var splitQueries = QuerySplitter.split(query);
         final int initialParts = splitQueries.size();
-
+        if (splitQueries.size() == 1 && splitQueries.keySet().iterator().next().size() > 1) {
+            return null;
+        }
         var lhs = join.lhs();
         var rhs = join.rhs();
 

--- a/server/src/main/java/io/crate/planner/optimizer/rule/RewriteFilterOnCrossJoinToInnerJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/RewriteFilterOnCrossJoinToInnerJoin.java
@@ -31,7 +31,6 @@ import java.util.Map;
 import java.util.Set;
 
 import io.crate.analyze.relations.QuerySplitter;
-import io.crate.common.collections.Sets;
 import io.crate.expression.operator.AndOperator;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.RelationName;
@@ -72,8 +71,7 @@ public final class RewriteFilterOnCrossJoinToInnerJoin implements Rule<Filter> {
         JoinPlan crossJoin = captures.get(joinCapture);
 
         Map<Set<RelationName>, Symbol> filterQuery = QuerySplitter.split(equiJoinConditionFilter.query());
-        HashSet<RelationName> lhsRelations = new HashSet<>(crossJoin.lhs().relationNames());
-        HashSet<RelationName> rhsRelations = new HashSet<>(crossJoin.rhs().relationNames());
+        HashSet<RelationName> relationNamesInFilterQuery = new HashSet<>();
 
         ArrayList<Symbol> newJoinCondition = new ArrayList<>();
         ArrayList<Symbol> newFilterQuery = new ArrayList<>();
@@ -81,16 +79,19 @@ public final class RewriteFilterOnCrossJoinToInnerJoin implements Rule<Filter> {
         for (var entry : filterQuery.entrySet()) {
             Set<RelationName> key = entry.getKey();
             Symbol value = entry.getValue();
-            boolean referencesLhs = Sets.intersection(key, lhsRelations).isEmpty() == false;
-            boolean referencesRhs = Sets.intersection(key, rhsRelations).isEmpty() == false;
-            if (EquiJoinDetector.isEquiJoin(value) && referencesLhs && referencesRhs) {
+            if (EquiJoinDetector.isEquiJoin(value)) {
+                relationNamesInFilterQuery.addAll(key);
                 newJoinCondition.add(value);
             } else {
                 newFilterQuery.add(value);
             }
         }
 
-        if (newJoinCondition.isEmpty() == false) {
+        HashSet<RelationName> sources = new HashSet<>();
+        sources.addAll(crossJoin.lhs().relationNames());
+        sources.addAll(crossJoin.rhs().relationNames());
+
+        if (sources.containsAll(relationNamesInFilterQuery)) {
             return Filter.create(
                 new JoinPlan(
                     crossJoin.lhs(),

--- a/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
@@ -1618,12 +1618,11 @@ public class JoinIntegrationTest extends IntegTestCase {
         execute("explain (costs false) " + stmt);
 
         assertThat(response).hasLines(
-            "Eval[a, x, b, y, c]",
-            "  └ HashJoin[INNER | (((b = c) AND (a = b)) AND (x = y))]",
-            "    ├ HashJoin[INNER | (a = c)]",
-            "    │  ├ Collect[doc.t1 | [a, x] | true]",
-            "    │  └ Collect[doc.t3 | [c] | true]",
-            "    └ Collect[doc.t2 | [b, y] | true]"
+            "HashJoin[INNER | ((a = c) AND (b = c))]",
+            "  ├ HashJoin[INNER | ((a = b) AND (x = y))]",
+            "  │  ├ Collect[doc.t1 | [a, x] | true]",
+            "  │  └ Collect[doc.t2 | [b, y] | true]",
+            "  └ Collect[doc.t3 | [c] | true]"
         );
 
         execute(stmt);

--- a/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
@@ -66,7 +66,6 @@ import io.crate.planner.DependencyCarrier;
 import io.crate.planner.Plan;
 import io.crate.planner.node.dql.QueryThenFetch;
 import io.crate.planner.optimizer.rule.EquiJoinToLookupJoin;
-import io.crate.planner.optimizer.rule.EliminateCrossJoin;
 import io.crate.statistics.ColumnStats;
 import io.crate.statistics.MostCommonValues;
 import io.crate.statistics.Stats;
@@ -85,7 +84,6 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
             .addTable(TableDefinitions.USER_TABLE_DEFINITION)
             .addTable(T3.T1_DEFINITION)
             .addTable(T3.T2_DEFINITION)
-            .addTable(T3.T3_DEFINITION)
             .addView(new RelationName("doc", "v2"), "SELECT a, x FROM doc.t1")
             .addView(new RelationName("doc", "v3"), "SELECT a, x FROM doc.t1");
     }
@@ -566,35 +564,6 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
                 └ HashJoin[INNER | (a = b)]
                   ├ Collect[doc.t1 | [_fetchid, a] | true]
                   └ Collect[doc.t2 | [_fetchid, b] | true]
-            """
-        );
-    }
-
-    @Test
-    public void test_filter_on_nested_cross_join_to_nested_inner_joins() {
-        sqlExecutor.getSessionSettings().excludedOptimizerRules().add(EliminateCrossJoin.class);
-
-        LogicalPlan plan = plan("""
-            SELECT t1.x, t2.y, t3.z
-            FROM t1
-            CROSS JOIN t2
-            CROSS JOIN t3
-            WHERE t1.x = t2.y
-              AND t1.x = t3.z
-              AND t2.y = t3.z
-              AND t1.x > 1
-              AND t2.y > 2
-              AND t3.z > 3
-            """
-        );
-
-        assertThat(plan).isEqualTo(
-            """
-            HashJoin[INNER | ((x = z) AND (y = z))]
-              ├ HashJoin[INNER | (x = y)]
-              │  ├ Collect[doc.t1 | [x] | (x > 1)]
-              │  └ Collect[doc.t2 | [y] | (y > 2)]
-              └ Collect[doc.t3 | [z] | (z > 3)]
             """
         );
     }

--- a/server/src/test/java/io/crate/planner/optimizer/rule/MoveFilterBeneathJoinTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/rule/MoveFilterBeneathJoinTest.java
@@ -442,41 +442,6 @@ public class MoveFilterBeneathJoinTest extends CrateDummyClusterServiceUnitTest 
     }
 
     @Test
-    public void test_push_filter_referencing_multiple_relations_down_to_nested_join() {
-        var join1 = new JoinPlan(t1, t2, JoinType.CROSS, null);
-        var join2 = new JoinPlan(join1, t3, JoinType.INNER, e.asSymbol("doc.t2.b = doc.t3.c"));
-        var filter = new Filter(join2, e.asSymbol("doc.t1.a = doc.t2.b"));
-
-        assertThat(filter).hasOperators(
-            "Filter[(a = b)]",
-            "  └ Join[INNER | (b = c)]",
-            "    ├ Join[CROSS]",
-            "    │  ├ Collect[doc.t1 | [a] | true]",
-            "    │  └ Collect[doc.t2 | [b] | true]",
-            "    └ Collect[doc.t3 | [c] | true]"
-        );
-
-        var rule = new MoveFilterBeneathJoin();
-        var match = rule.pattern().accept(filter, Captures.empty());
-
-        assertThat(match.isPresent()).isTrue();
-        assertThat(match.value()).isEqualTo(filter);
-
-        var result = rule.apply(match.value(),
-            match.captures(),
-            e.ruleContext());
-
-        assertThat(result).hasOperators(
-            "Join[INNER | (b = c)]",
-            "  ├ Filter[(a = b)]",
-            "  │  └ Join[CROSS]",
-            "  │    ├ Collect[doc.t1 | [a] | true]",
-            "  │    └ Collect[doc.t2 | [b] | true]",
-            "  └ Collect[doc.t3 | [c] | true]"
-        );
-    }
-
-    @Test
     public void test_push_filter_down_to_preserved_side_of_left_nested_join() {
         var joinCondition1 = e.asSymbol("doc.t1.a = doc.t2.b");
         var join1 = new JoinPlan(t1, t2, JoinType.LEFT, joinCondition1);

--- a/server/src/test/java/io/crate/planner/optimizer/rule/RewriteFilterOnCrossJoinToInnerJoinTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/rule/RewriteFilterOnCrossJoinToInnerJoinTest.java
@@ -140,12 +140,11 @@ public class RewriteFilterOnCrossJoinToInnerJoinTest extends CrateDummyClusterSe
             e.ruleContext());
 
         assertThat(result).hasOperators(
-            "Filter[(a = b)]",
-            "  └ Join[INNER | (a = c)]",
-            "    ├ Collect[doc.t3 | [c] | true]",
-            "    └ Join[CROSS]",
-            "      ├ Collect[doc.t1 | [a] | true]",
-            "      └ Collect[doc.t2 | [b] | true]"
+            "Join[INNER | ((a = b) AND (a = c))]",
+            "  ├ Collect[doc.t3 | [c] | true]",
+            "  └ Join[CROSS]",
+            "    ├ Collect[doc.t1 | [a] | true]",
+            "    └ Collect[doc.t2 | [b] | true]"
         );
     }
 
@@ -175,8 +174,8 @@ public class RewriteFilterOnCrossJoinToInnerJoinTest extends CrateDummyClusterSe
             e.ruleContext());
 
         assertThat(result).hasOperators(
-            "Filter[((a = b) AND (a > 1))]",
-            "  └ Join[INNER | (a = c)]",
+            "Filter[(a > 1)]",
+            "  └ Join[INNER | ((a = b) AND (a = c))]",
             "    ├ Collect[doc.t3 | [c] | true]",
             "    └ Join[CROSS]",
             "      ├ Collect[doc.t1 | [a] | true]",


### PR DESCRIPTION
This reverts commit 106f9174737bc66bf9f71149526b5c94bd18b84b.

Because it generated worse join plan for joins with > 4 tables:

    EXPLAIN
    SELECT *
    FROM t1, t2, t3, t4
    WHERE t1.a1 = t3.a3
      AND t2.a2 = t4.a4
      AND t3.a3 = t4.a4;

+------------------------------------------------------------+
| QUERY PLAN                                                 |
+------------------------------------------------------------+
| HashJoin[INNER | ((a2 = a4) AND (a3 = a4))] (rows=unknown) |
|   ├ Eval[a1, a2, a3] (rows=unknown)                        |
|   │  └ NestedLoopJoin[CROSS] (rows=unknown)                |
|   │    ├ HashJoin[INNER | (a1 = a3)] (rows=unknown)        |
|   │    │  ├ Collect[doc.t1 | [a1] | true] (rows=unknown)   |
|   │    │  └ Collect[doc.t3 | [a3] | true] (rows=unknown)   |
|   │    └ Collect[doc.t2 | [a2] | true] (rows=unknown)      |
|   └ Collect[doc.t4 | [a4] | true] (rows=unknown)           |
+------------------------------------------------------------+