### PR TITLE
Improve accounting of TDigestState

### DIFF
--- a/docs/appendices/release-notes/6.4.5.rst
+++ b/docs/appendices/release-notes/6.4.5.rst
@@ -46,4 +46,5 @@ series.
 Fixes
 =====
 
-None
+- Fixed an issue that could lead to out of memory errors if using the
+  ``percentile`` aggregation.

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/PercentileAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/PercentileAggregation.java
@@ -212,8 +212,9 @@ class PercentileAggregation<T> extends AggregationFunction<TDigestState, Object>
     public TDigestState newState(RamAccounting ramAccounting,
                                  Version minNodeInCluster,
                                  MemoryManager memoryManager) {
-        ramAccounting.addBytes(TDigestState.SHALLOW_SIZE);
-        return TDigestState.createEmptyState();
+        var state = TDigestState.createEmptyState();
+        ramAccounting.addBytes(state.initialSize());
+        return state;
     }
 
     @Override
@@ -225,16 +226,17 @@ class PercentileAggregation<T> extends AggregationFunction<TDigestState, Object>
             Object fractionValue = args[1].value();
             if (args.length > 2) {
                 Double compression = DataTypes.DOUBLE.sanitizeValue(args[2].value());
+                long previousInitialSize = state.initialSize();
                 state = new TDigestState(compression, new double[]{});
+                // reflect replacement of the default-compression state.
+                ramAccounting.addBytes(state.initialSize() - previousInitialSize);
             }
             initState(state, fractionValue, ramAccounting);
         }
         T value = valueType.sanitizeValue(args[0].value());
         if (value != null) {
-            int delta = state.addGetSizeDelta(valueToDouble.applyAsDouble(value));
-            if (delta > 0) {
-                ramAccounting.addBytes(delta);
-            }
+            state.add(valueToDouble.applyAsDouble(value));
+            state.compress();
         }
         return state;
     }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/TDigestState.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/TDigestState.java
@@ -21,6 +21,9 @@
 
 package io.crate.execution.engine.aggregation.impl;
 
+import static org.apache.lucene.util.RamUsageEstimator.NUM_BYTES_ARRAY_HEADER;
+import static org.apache.lucene.util.RamUsageEstimator.alignObjectSize;
+
 import java.io.IOException;
 import java.util.Collection;
 
@@ -39,11 +42,71 @@ class TDigestState extends MergingDigest {
 
     private double[] fractions;
 
-    private int lastByteSize = 0;
+    private long mergingDigestState = 0;
 
     TDigestState(double compression, double[] fractions) {
+        // mergingDigestState relies on the fact that only single argument ctor of the parent class is used.
+        // If we change it, we need to update its implementation.
         super(compression);
+        mergingDigestState = mergingDigestState(compression, -1, -1);
         this.fractions = fractions;
+    }
+
+    /**
+     * Accounts for arrays of the parent class MergingDigest.
+     * As stated in its javadocs, no allocation is required after initialization,
+     * so we can mirror sizes of arrays allocated for the given compression in the ctor.
+     * Note, that data and tempData are always null, as we don't use recordAllData().
+     */
+    private static long mergingDigestState(double compression, int bufferSize, int size) {
+        if (compression < 10) {
+            compression = 10;
+        }
+
+        double sizeFudge = 0;
+        // Reference code has if (useWeightLimit) check that is always true here.
+        sizeFudge = 10;
+        if (compression < 30) {
+            sizeFudge += 20;
+        }
+
+        size = (int) Math.max(2 * compression + sizeFudge, size);
+
+        // Reference code has if (bufferSize == -1) check that is always true here.
+        bufferSize = 5 * size;
+
+        if (bufferSize <= 2 * size) {
+            bufferSize = 2 * size;
+        }
+
+        // Reference code resets scale to 1 if (!useTwoLevelCompression), but can't happen here.
+        double scale = Math.max(1, bufferSize / size - 1);
+
+        double publicCompression = compression;
+        compression = Math.sqrt(scale) * publicCompression;
+
+        // changing the compression could cause buffers to be too small, readjust if so
+        if (size < compression + sizeFudge) {
+            size = (int) Math.ceil(compression + sizeFudge);
+        }
+
+        if (bufferSize <= 2 * size) {
+            bufferSize = 2 * size;
+        }
+
+        /**
+        weight = new double[size];
+        mean = new double[size];
+
+        tempWeight = new double[bufferSize];
+        tempMean = new double[bufferSize];
+        order = new int[bufferSize];
+        **/
+
+        long weightAndMeanSize = 2 * (NUM_BYTES_ARRAY_HEADER + (long) Double.BYTES * size);
+        long tempArraysSize = 2 * (NUM_BYTES_ARRAY_HEADER + (long) Double.BYTES * bufferSize);
+        long orderSize = NUM_BYTES_ARRAY_HEADER + (long) Integer.BYTES * bufferSize;
+        return alignObjectSize(weightAndMeanSize + tempArraysSize + orderSize);
     }
 
     static TDigestState createEmptyState() {
@@ -61,15 +124,6 @@ class TDigestState extends MergingDigest {
     void fractions(double[] fractions) {
         this.fractions = fractions;
     }
-
-    int addGetSizeDelta(double value) {
-        add(value);
-        int newByteSize = byteSize();
-        int delta = newByteSize - lastByteSize;
-        lastByteSize = newByteSize;
-        return delta;
-    }
-
 
     public static void write(TDigestState state, StreamOutput out) throws IOException {
         out.writeDouble(state.compression());
@@ -91,5 +145,12 @@ class TDigestState extends MergingDigest {
             state.add(in.readDouble(), in.readVInt());
         }
         return state;
+    }
+
+    /**
+     * Must be accounted only once per state.
+     */
+    public long initialSize() {
+        return SHALLOW_SIZE + RamUsageEstimator.sizeOf(fractions) + mergingDigestState;
     }
 }

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/IntervalPercentileAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/IntervalPercentileAggregationTest.java
@@ -418,12 +418,15 @@ public class IntervalPercentileAggregationTest extends AggregationTestCase {
         );
         io.crate.testing.PlainRamAccounting ramAccounting = new io.crate.testing.PlainRamAccounting();
         TDigestState state = impl.newState(ramAccounting, Version.CURRENT, memoryManager);
-        assertThat(ramAccounting.totalBytes()).isEqualTo(120L);
+        long newStateBytes = state.initialSize();
+        assertThat(ramAccounting.totalBytes()).isEqualTo(newStateBytes);
         Literal<List<Double>> fractions = Literal.of(Collections.singletonList(0.95D), DataTypes.DOUBLE_ARRAY);
         impl.iterate(ramAccounting, memoryManager, state,
             Literal.of(DataTypes.INTERVAL, Period.hours(10)), fractions);
         impl.iterate(ramAccounting, memoryManager, state,
             Literal.of(DataTypes.INTERVAL, Period.hours(20)), fractions);
-        assertThat(ramAccounting.totalBytes()).isEqualTo(192L);
+        // + 47776 bytes for the initial state
+        // + 8 bytes for the single fraction value
+        assertThat(ramAccounting.totalBytes()).isEqualTo(47776 + 8);
     }
 }

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/PercentileAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/PercentileAggregationTest.java
@@ -278,11 +278,51 @@ public class PercentileAggregationTest extends AggregationTestCase {
         );
         RamAccounting ramAccounting = new PlainRamAccounting();
         Object state = impl.newState(ramAccounting, Version.CURRENT, memoryManager);
-        assertThat(ramAccounting.totalBytes()).isEqualTo(120L);
+        long newStateBytes = ((TDigestState ) state).initialSize();
+        assertThat(ramAccounting.totalBytes()).isEqualTo(newStateBytes);
         Literal<List<Double>> fractions = Literal.of(Collections.singletonList(0.95D), DataTypes.DOUBLE_ARRAY);
         impl.iterate(ramAccounting, memoryManager, state, Literal.of(10L), fractions);
         impl.iterate(ramAccounting, memoryManager, state, Literal.of(20L), fractions);
-        assertThat(ramAccounting.totalBytes()).isEqualTo(192L);
+        // + 47776 bytes for the initial state
+        // + 8 bytes for the single fraction value
+        assertThat(ramAccounting.totalBytes()).isEqualTo(47776 + 8);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void test_custom_compression_releases_discarded_default_state() throws Exception {
+        var signature = Signature.builder(PercentileAggregation.NAME, FunctionType.AGGREGATE)
+            .argumentTypes(
+                DataTypes.DOUBLE.getTypeSignature(),
+                DataTypes.DOUBLE.getTypeSignature(),
+                DataTypes.DOUBLE.getTypeSignature())
+            .returnType(DataTypes.DOUBLE.getTypeSignature())
+            .features(Scalar.Feature.DETERMINISTIC)
+            .build();
+        var impl = (AggregationFunction<Object, ?>) nodeCtx.functions().getQualified(
+            signature,
+            signature.getArgumentDataTypes(),
+            signature.getReturnType().createType()
+        );
+
+        RamAccounting ramAccounting = new PlainRamAccounting();
+        Object state = impl.newState(ramAccounting, Version.CURRENT, memoryManager);
+        assertThat(ramAccounting.totalBytes()).isEqualTo(47776L); // default compression
+
+        double customCompression = 300.0;
+        TDigestState stateAfterIterate = (TDigestState) impl.iterate(
+            ramAccounting,
+            memoryManager,
+            state,
+            Literal.of(1.0),
+            Literal.of(0.5),
+            Literal.of(customCompression)
+        );
+
+        // Replaced instance with default compression must have its bytes released
+        // to reflect re-creation of a new instance with a custom compression
+        assertThat(stateAfterIterate.initialSize()).isEqualTo(70984); // Custom compression. 47776L are subtracted
+        assertThat(ramAccounting.totalBytes()).isEqualTo(stateAfterIterate.initialSize());
     }
 
     @Test

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/TDigestStateTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/TDigestStateTest.java
@@ -23,9 +23,11 @@ package io.crate.execution.engine.aggregation.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.lang.reflect.Field;
 import java.util.Iterator;
 import java.util.stream.IntStream;
 
+import org.apache.lucene.util.RamUsageEstimator;
 import org.assertj.core.data.Offset;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
@@ -33,10 +35,39 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.junit.Test;
 
 import com.tdunning.math.stats.Centroid;
+import com.tdunning.math.stats.MergingDigest;
 
 import io.crate.Streamer;
 
 public class TDigestStateTest {
+
+    @Test
+    public void test_initial_size_different_compressions_matches_internal_size() throws Exception {
+        for (int compression = 0; compression <= TDigestState.DEFAULT_COMPRESSION; compression++) {
+            TDigestState state = new TDigestState(compression, new double[]{});
+
+            Field weightField = MergingDigest.class.getDeclaredField("weight");
+            weightField.setAccessible(true);
+            Field tempWeightField = MergingDigest.class.getDeclaredField("tempWeight");
+            tempWeightField.setAccessible(true);
+            Field orderField = MergingDigest.class.getDeclaredField("order");
+            orderField.setAccessible(true);
+
+            double[] weight = (double[]) weightField.get(state);
+            double[] tempWeight = (double[]) tempWeightField.get(state);
+            int[] order = (int[]) orderField.get(state);
+
+            long expected = TDigestState.SHALLOW_SIZE
+                + RamUsageEstimator.sizeOf(state.fractions())
+                + 2 * RamUsageEstimator.sizeOf(weight) // mean has the same size as weight.
+                + 2 * RamUsageEstimator.sizeOf(tempWeight) // tempMean has the same size as tempWeight.
+                + RamUsageEstimator.sizeOf(order);
+
+            assertThat(state.initialSize())
+                .as("mismatch on compression = %s", compression)
+                .isEqualTo(expected);
+        }
+    }
 
     @Test
     public void testStreaming() throws Exception {


### PR DESCRIPTION
Relates to https://github.com/crate/support/issues/921

Follows https://github.com/crate/crate/pull/13207

`SHALLOW_SIZE` doesn't account for arrays pre-allocated at the beginning.

`byteSize()` can't be used for memory accounting either. 
From its javadocs: Returns the number of bytes required to encode this TDigest using #asBytes(). 
However, `MergingDigest.asBytes` doesn't account for `order`, `tmpMean`, `tmpWeight` that are allocated at the very beginning. 

Also, even for `mean` and `weight` it accounts for `lastUsedCell` size, whereas all arrays are pre-allocated in ctor with a bigger size.

We have seen heap dumps with 22.000 states each taking 47K already at the creation time.

<img width="772" height="816" alt="Screenshot 2026-09-04 at 15 31 11 (2)" src="https://github.com/user-attachments/assets/28c26b8b-7478-4525-85bd-b61895ad11d0" />



