### PR TITLE
Fix handling of some pg style interval formats sent via pgwire in text format

### DIFF
--- a/docs/appendices/release-notes/6.4.5.rst
+++ b/docs/appendices/release-notes/6.4.5.rst
@@ -46,5 +46,8 @@ series.
 Fixes
 =====
 
+- Fixed decoding of ``interval`` values sent from PostgreSQL wire protocol
+  clients using text format in the ``x hours y minutes ...`` style.
+
 - Fixed an issue that could lead to out of memory errors if using the
   ``percentile`` aggregation.

--- a/server/src/main/java/io/crate/protocols/postgres/types/IntervalType.java
+++ b/server/src/main/java/io/crate/protocols/postgres/types/IntervalType.java
@@ -26,6 +26,7 @@ import java.nio.charset.StandardCharsets;
 import org.joda.time.Period;
 import org.joda.time.ReadablePeriod;
 
+import io.crate.interval.IntervalParser;
 import io.crate.metadata.RelationLookup;
 import io.crate.types.Regproc;
 import io.netty.buffer.ByteBuf;
@@ -123,6 +124,7 @@ public class IntervalType extends PGType<Period> {
 
     @Override
     Period decodeUTF8Text(byte[] bytes, RelationLookup relationLookup) {
-        return io.crate.types.IntervalType.PERIOD_FORMATTER.parsePeriod(new String(bytes, StandardCharsets.UTF_8));
+        String text = new String(bytes, StandardCharsets.UTF_8);
+        return IntervalParser.apply(text);
     }
 }

--- a/server/src/main/java/io/crate/types/DataTypes.java
+++ b/server/src/main/java/io/crate/types/DataTypes.java
@@ -44,6 +44,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.io.stream.Writeable.Reader;
+import org.joda.time.Period;
 import org.jspecify.annotations.Nullable;
 import org.locationtech.spatial4j.shape.impl.PointImpl;
 import org.locationtech.spatial4j.shape.jts.JtsPoint;
@@ -306,7 +307,8 @@ public final class DataTypes {
         entry(Character.class, STRING),
         entry(BitString.class, BitStringType.INSTANCE_ONE),
         entry(TimeTZ.class, TimeTZType.INSTANCE),
-        entry(UUID.class, UUIDType.INSTANCE)
+        entry(UUID.class, UUIDType.INSTANCE),
+        entry(Period.class, IntervalType.INSTANCE)
     );
 
     public static DataType<?> guessType(Object value) {

--- a/server/src/main/java/io/crate/types/IntervalType.java
+++ b/server/src/main/java/io/crate/types/IntervalType.java
@@ -97,6 +97,8 @@ public class IntervalType extends DataType<Period> implements FixedWidthType, St
             return null;
         } else if (value instanceof String strValue) {
             return IntervalParser.apply(strValue);
+        } else if (value instanceof Period period) {
+            return period;
         } else {
             throw new ClassCastException("Can't cast '" + value + "' to " + getName());
         }

--- a/server/src/main/java/io/crate/types/ResultSetParser.java
+++ b/server/src/main/java/io/crate/types/ResultSetParser.java
@@ -34,9 +34,11 @@ import org.elasticsearch.common.xcontent.DeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.joda.time.Period;
 import org.locationtech.spatial4j.context.jts.JtsSpatialContext;
 import org.locationtech.spatial4j.shape.impl.PointImpl;
 import org.postgresql.geometric.PGpoint;
+import org.postgresql.util.PGInterval;
 import org.postgresql.util.PGobject;
 
 import io.crate.protocols.postgres.types.PGArray;
@@ -117,6 +119,27 @@ public class ResultSetParser {
             case "bit":
                 value = BitString.ofRawBits(resultSet.getString(columnIndex));
                 break;
+
+            case "interval":
+                PGInterval interval = (PGInterval) resultSet.getObject(columnIndex);
+                if (interval == null) {
+                    value = null;
+                } else {
+                    int weeks = 0;
+                    int millis = interval.getMicroSeconds() / 1000;
+                    value = new Period(
+                        interval.getYears(),
+                        interval.getMonths(),
+                        weeks,
+                        interval.getDays(),
+                        interval.getHours(),
+                        interval.getMinutes(),
+                        interval.getWholeSeconds(),
+                        millis
+                    );
+                }
+                break;
+
 
             default:
                 value = resultSet.getObject(columnIndex);

--- a/server/src/test/java/io/crate/integrationtests/PostgresITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PostgresITest.java
@@ -56,6 +56,7 @@ import org.junit.Test;
 import org.postgresql.PGProperty;
 import org.postgresql.geometric.PGpoint;
 import org.postgresql.jdbc.PreferQueryMode;
+import org.postgresql.util.PGInterval;
 import org.postgresql.util.PGobject;
 import org.postgresql.util.PSQLException;
 import org.postgresql.util.PSQLState;
@@ -1362,6 +1363,20 @@ public class PostgresITest extends IntegTestCase {
                         rs.getString(2);
                     }
                 }
+            }
+        }
+    }
+
+    @Test
+    public void test_interval_decoding_encoding_roundtrip() throws Exception {
+        try (var conn = DriverManager.getConnection(url(RW), properties)) {
+            try (var stmt = conn.prepareStatement("select ?::interval")) {
+                PGInterval intervalIn = new PGInterval(0, 0, 1, 2, 3, 4);
+                stmt.setObject(1, intervalIn);
+                ResultSet result = stmt.executeQuery();
+                assertThat(result.next()).isTrue();
+                Object intervalOut = result.getObject(1);
+                assertThat(intervalOut).isEqualTo(intervalIn);
             }
         }
     }

--- a/server/src/test/java/io/crate/integrationtests/ViewsITest.java
+++ b/server/src/test/java/io/crate/integrationtests/ViewsITest.java
@@ -36,6 +36,7 @@ import java.util.stream.Stream;
 import org.elasticsearch.cluster.metadata.RelationMetadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.test.IntegTestCase;
+import org.joda.time.Period;
 import org.junit.After;
 import org.junit.Test;
 
@@ -91,6 +92,16 @@ public class ViewsITest extends IntegTestCase {
         execute("select * from v1");
         assertThat(response).hasRows(
             "B'0001'"
+        );
+    }
+
+    @Test
+    public void test_can_use_period_parameter_in_view_definition() throws Exception {
+        Period value = new Period(200);
+        execute("create view v1 as select ?::interval", $(value));
+        execute("select * from v1");
+        assertThat(response).hasRows(
+            "PT0.200S"
         );
     }
 

--- a/server/src/test/java/io/crate/protocols/postgres/types/PGTypesTest.java
+++ b/server/src/test/java/io/crate/protocols/postgres/types/PGTypesTest.java
@@ -38,6 +38,7 @@ import java.util.stream.StreamSupport;
 
 import org.elasticsearch.test.ESTestCase;
 import org.joda.time.Period;
+import org.joda.time.PeriodType;
 import org.junit.Test;
 
 import io.crate.data.Row1;
@@ -192,7 +193,8 @@ public class PGTypesTest extends ESTestCase {
 
     @Test
     public void test_period_text_round_trip_streaming() {
-        var entry = new Entry<>(DataTypes.INTERVAL, new Period(1, 2, 3, 4, 5, 6, 7, 8));
+        Period value = new Period(1, 2, 3, 4, 5, 6, 7, 8).normalizedStandard(PeriodType.yearMonthDayTime());
+        var entry = new Entry<>(DataTypes.INTERVAL, value);
         assertThat(writeAndReadAsText(entry, IntervalType.INSTANCE)).isEqualTo(entry.value);
     }
 

--- a/server/src/testFixtures/java/io/crate/testing/SQLTransportExecutor.java
+++ b/server/src/testFixtures/java/io/crate/testing/SQLTransportExecutor.java
@@ -56,7 +56,9 @@ import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.health.Health;
 import org.elasticsearch.common.util.concurrent.FutureUtils;
 import org.elasticsearch.test.ESTestCase;
+import org.joda.time.Period;
 import org.jspecify.annotations.Nullable;
+import org.postgresql.util.PGInterval;
 import org.postgresql.util.PGobject;
 
 import com.carrotsearch.randomizedtesting.RandomizedContext;
@@ -431,6 +433,14 @@ public class SQLTransportExecutor {
             }
             pgObject.setType("bit");
             return pgObject;
+        }
+        if (arg instanceof Period period) {
+            try {
+                var interval = new PGInterval(period.toString());
+                return interval;
+            } catch (SQLException e) {
+                throw Exceptions.toRuntimeException(e);
+            }
         }
         if (arg instanceof Map) {
             return DataTypes.STRING.implicitCast(arg);


### PR DESCRIPTION
Using `PGInterval` values with the PostgreSQL jdbc client could trigger
decoding failures because it uses the PostgreSQL style format (`x years
y months ...` and the used `PERIOD_FORMATTER` didn't handle all variants.
