### PR TITLE
Support dropping multiple tables with DROP TABLE

### DIFF
--- a/docs/appendices/release-notes/6.5.0.rst
+++ b/docs/appendices/release-notes/6.5.0.rst
@@ -118,7 +118,9 @@ Changes
 SQL Statements
 --------------
 
-None
+- `Manish Singh <https://github.com/manish9363>`_ added support for dropping
+  multiple tables with a single :ref:`DROP TABLE <drop-table>` statement, e.g.
+  ``DROP TABLE t1, t2, t3``.
 
 SQL Standard and PostgreSQL Compatibility
 -----------------------------------------

--- a/docs/sql/statements/drop-table.rst
+++ b/docs/sql/statements/drop-table.rst
@@ -11,7 +11,7 @@ Synopsis
 
 .. code-block:: sql
 
-    DROP [BLOB] TABLE [IF EXISTS] table_ident
+    DROP [BLOB] TABLE [IF EXISTS] table_ident [, ...]
 
 Description
 ===========
@@ -29,3 +29,9 @@ Parameters
 
 :table_ident:
   The name (optionally schema-qualified) of the table to be removed.
+
+  Multiple tables can be removed with a single statement by providing a
+  comma-separated list of table names. Dropping multiple tables is not
+  atomic: if dropping one table fails, tables listed before it may already
+  have been dropped. ``DROP BLOB TABLE`` supports only a single table.
+

--- a/libs/sql-parser/src/main/antlr/io/crate/sql/parser/antlr/SqlBaseParser.g4
+++ b/libs/sql-parser/src/main/antlr/io/crate/sql/parser/antlr/SqlBaseParser.g4
@@ -768,7 +768,7 @@ objectTypeDefinition
 columnConstraint
     : primaryKeyContraint                                                            #columnConstraintPrimaryKey
     | NOT NULL                                                                       #columnConstraintNotNull
-    | NULL																			 #columnConstraintNull
+    | NULL                                                                           #columnConstraintNull
     | INDEX USING method=ident withProperties?                                       #columnIndexConstraint
     | INDEX OFF                                                                      #columnIndexOff
     | STORAGE withProperties                                                         #columnStorageDefinition

--- a/libs/sql-parser/src/main/antlr/io/crate/sql/parser/antlr/SqlBaseParser.g4
+++ b/libs/sql-parser/src/main/antlr/io/crate/sql/parser/antlr/SqlBaseParser.g4
@@ -99,7 +99,7 @@ statement
 
 dropStmt
     : DROP BLOB TABLE (IF EXISTS)? table                                             #dropBlobTable
-    | DROP TABLE (IF EXISTS)? table                                                  #dropTable
+    | DROP TABLE (IF EXISTS)? names=qnames                                                  #dropTable
     | DROP ALIAS qname                                                               #dropAlias
     | DROP REPOSITORY ident                                                          #dropRepository
     | DROP SNAPSHOT qname                                                            #dropSnapshot

--- a/libs/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
@@ -1399,12 +1399,14 @@ public final class SqlFormatter {
         }
 
         @Override
-        public Void visitDropTable(DropTable<?> node, Integer indent) {
+        public Void visitDropTable(DropTable node, Integer indent) {
             builder.append("DROP TABLE ");
             if (node.dropIfExists()) {
                 builder.append("IF EXISTS ");
             }
-            node.table().accept(this, indent);
+            builder.append(node.tables().stream()
+                .map(Formatter::formatQualifiedName)
+                .collect(COMMA_JOINER));
             return null;
         }
 

--- a/libs/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -854,7 +854,7 @@ class AstBuilder extends SqlBaseParserBaseVisitor<Node> {
 
     @Override
     public Node visitDropTable(SqlBaseParser.DropTableContext context) {
-        return new DropTable<>((Table<?>) visit(context.table()), context.EXISTS() != null);
+        return new DropTable(getQualifiedNames(context.qnames()), context.EXISTS() != null);
     }
 
     @Override

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
@@ -420,7 +420,7 @@ public abstract class AstVisitor<R, C> {
         return visitNode(node, context);
     }
 
-    public R visitDropTable(DropTable<?> node, C context) {
+    public R visitDropTable(DropTable node, C context) {
         return visitStatement(node, context);
     }
 

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/DefaultTraversalVisitor.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/DefaultTraversalVisitor.java
@@ -335,11 +335,6 @@ public abstract class DefaultTraversalVisitor<R, C> extends AstVisitor<R, C> {
         return null;
     }
 
-    @Override
-    public R visitDropTable(DropTable<?> node, C context) {
-        node.table().accept(this, context);
-        return super.visitDropTable(node, context);
-    }
 
     @Override
     public R visitCreateTable(CreateTable<?> node, C context) {

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/DropTable.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/DropTable.java
@@ -21,7 +21,10 @@
 
 package io.crate.sql.tree;
 
-public record DropTable<T>(Table<T> table, boolean dropIfExists) implements Statement {
+import java.util.List;
+
+
+public record DropTable(List<QualifiedName> tables, boolean dropIfExists) implements Statement {
 
     @Override
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
@@ -31,7 +34,7 @@ public record DropTable<T>(Table<T> table, boolean dropIfExists) implements Stat
     @Override
     public String toString() {
         return "DropTable{" +
-               "table=" + table +
+               "tables=" + tables +
                ", dropIfExists=" + dropIfExists +
                '}';
     }

--- a/server/src/main/java/io/crate/analyze/AnalyzedDropTable.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedDropTable.java
@@ -26,7 +26,6 @@ import java.util.function.Consumer;
 
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.RelationName;
-import io.crate.metadata.TableInfo;
 
 public final class AnalyzedDropTable implements DDLStatement {
 

--- a/server/src/main/java/io/crate/analyze/AnalyzedDropTable.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedDropTable.java
@@ -21,35 +21,31 @@
 
 package io.crate.analyze;
 
+import java.util.List;
 import java.util.function.Consumer;
 
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.TableInfo;
 
-public final class AnalyzedDropTable<T extends TableInfo> implements DDLStatement {
+public final class AnalyzedDropTable implements DDLStatement {
+
+    public record DropTableTarget(RelationName tableName, int tableOid) {}
 
     private final boolean dropIfExists;
-    private final RelationName tableName;
-    private final int tableOid;
+    private final List<DropTableTarget> tables;
 
-    AnalyzedDropTable(boolean dropIfExists, RelationName tableName, int tableOid) {
+    AnalyzedDropTable(boolean dropIfExists, List<DropTableTarget> tables) {
         this.dropIfExists = dropIfExists;
-        this.tableName = tableName;
-        this.tableOid = tableOid;
+        this.tables = tables;
     }
-
 
     public boolean dropIfExists() {
         return dropIfExists;
     }
 
-    public RelationName tableName() {
-        return tableName;
-    }
-
-    public int tableOid() {
-        return tableOid;
+    public List<DropTableTarget> tables() {
+        return tables;
     }
 
     @Override
@@ -61,3 +57,4 @@ public final class AnalyzedDropTable<T extends TableInfo> implements DDLStatemen
     public void visitSymbols(Consumer<? super Symbol> consumer) {
     }
 }
+

--- a/server/src/main/java/io/crate/analyze/AnalyzedStatementVisitor.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedStatementVisitor.java
@@ -236,7 +236,7 @@ public class AnalyzedStatementVisitor<C, R> {
         return visitDDLStatement(promoteReplicaStatement, context);
     }
 
-    public R visitDropTable(AnalyzedDropTable<?> dropTable, C context) {
+    public R visitDropTable(AnalyzedDropTable dropTable, C context) {
         return visitDDLStatement(dropTable, context);
     }
 

--- a/server/src/main/java/io/crate/analyze/Analyzer.java
+++ b/server/src/main/java/io/crate/analyze/Analyzer.java
@@ -549,7 +549,7 @@ public class Analyzer {
         }
 
         @Override
-        public AnalyzedDropTable<?> visitDropTable(DropTable<?> node, Analysis context) {
+        public AnalyzedDropTable visitDropTable(DropTable node, Analysis context) {
             return dropTableAnalyzer.analyze(node, context.sessionSettings());
         }
 

--- a/server/src/main/java/io/crate/analyze/DropTableAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/DropTableAnalyzer.java
@@ -24,6 +24,7 @@ package io.crate.analyze;
 import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
 
 import java.util.List;
+import java.util.ArrayList;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -56,24 +57,30 @@ class DropTableAnalyzer {
         this.schemas = schemas;
     }
 
-    public AnalyzedDropTable<DocTableInfo> analyze(DropTable<?> node, CoordinatorSessionSettings sessionSettings) {
-        return analyze(node.table().getName(), node.dropIfExists(), sessionSettings);
+    public AnalyzedDropTable analyze(DropTable node, CoordinatorSessionSettings sessionSettings) {
+        List<AnalyzedDropTable.DropTableTarget> targets = new ArrayList<>();
+        for (QualifiedName name : node.tables()) {
+            targets.add(resolve(name, node.dropIfExists(), sessionSettings));
+        }
+        return new AnalyzedDropTable(node.dropIfExists(), targets);
     }
 
-    public AnalyzedDropTable<BlobTableInfo> analyze(DropBlobTable<?> node, CoordinatorSessionSettings sessionSettings) {
+
+    public AnalyzedDropTable analyze(DropBlobTable<?> node, CoordinatorSessionSettings sessionSettings) {
         List<String> parts = node.table().getName().getParts();
         if (parts.size() != 1 && !parts.get(0).equals(BlobSchemaInfo.NAME)) {
             throw new IllegalArgumentException("No blob tables in schema `" + parts.get(0) + "`");
         } else {
             QualifiedName name = new QualifiedName(
                 List.of(BlobSchemaInfo.NAME, node.table().getName().getSuffix()));
-            return analyze(name, node.ignoreNonExistentTable(), sessionSettings);
+            var target = resolve(name, node.ignoreNonExistentTable(), sessionSettings);
+            return new AnalyzedDropTable(node.ignoreNonExistentTable(), List.of(target));
         }
     }
 
-    private <T extends TableInfo> AnalyzedDropTable<T> analyze(QualifiedName name,
-                                                               boolean dropIfExists,
-                                                               CoordinatorSessionSettings sessionSettings) {
+    private AnalyzedDropTable.DropTableTarget resolve(QualifiedName name,
+                                                      boolean dropIfExists,
+                                                      CoordinatorSessionSettings sessionSettings) {
         RelationName tableName;
         int tableOid = OID_UNASSIGNED;
         try {
@@ -105,6 +112,6 @@ class DropTableAnalyzer {
                 t
             );
         }
-        return new AnalyzedDropTable<>(dropIfExists, tableName, tableOid);
+        return new AnalyzedDropTable.DropTableTarget(tableName, tableOid);
     }
 }

--- a/server/src/main/java/io/crate/analyze/DropTableAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/DropTableAnalyzer.java
@@ -23,8 +23,8 @@ package io.crate.analyze;
 
 import static org.elasticsearch.cluster.metadata.Metadata.OID_UNASSIGNED;
 
-import java.util.List;
 import java.util.ArrayList;
+import java.util.List;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -33,8 +33,6 @@ import org.elasticsearch.cluster.service.ClusterService;
 import io.crate.exceptions.OperationOnInaccessibleRelationException;
 import io.crate.exceptions.RelationUnknown;
 import io.crate.exceptions.SchemaUnknownException;
-import io.crate.metadata.BlobTableInfo;
-import io.crate.metadata.DocTableInfo;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.Schemas;
 import io.crate.metadata.TableInfo;

--- a/server/src/main/java/io/crate/auth/AccessControlImpl.java
+++ b/server/src/main/java/io/crate/auth/AccessControlImpl.java
@@ -517,8 +517,10 @@ public final class AccessControlImpl implements AccessControl {
         }
 
         @Override
-        public Void visitDropTable(AnalyzedDropTable<?> dropTable, Role user) {
-            ensureDDLOnTable(user, dropTable.tableName().fqn());
+        public Void visitDropTable(AnalyzedDropTable analysis, Role user) {
+            for (AnalyzedDropTable.DropTableTarget target : analysis.tables()) {
+                ensureDDLOnTable(user, target.tableName().fqn());
+            }
             return null;
         }
 

--- a/server/src/main/java/io/crate/planner/Planner.java
+++ b/server/src/main/java/io/crate/planner/Planner.java
@@ -391,7 +391,7 @@ public class Planner extends AnalyzedStatementVisitor<PlannerContext, Plan> {
     }
 
     @Override
-    public Plan visitDropTable(AnalyzedDropTable<?> dropTable, PlannerContext context) {
+    public Plan visitDropTable(AnalyzedDropTable dropTable, PlannerContext context) {
         return new DropTablePlan(dropTable);
     }
 

--- a/server/src/main/java/io/crate/planner/node/ddl/DropTablePlan.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/DropTablePlan.java
@@ -28,6 +28,9 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.index.IndexNotFoundException;
 import io.crate.common.annotations.VisibleForTesting;
 
+import java.util.ArrayList;
+import java.util.concurrent.CompletableFuture;
+
 import io.crate.analyze.AnalyzedDropTable;
 import io.crate.data.InMemoryBatchIterator;
 import io.crate.data.Row;
@@ -45,17 +48,15 @@ import io.crate.planner.operators.SubQueryResults;
 public class DropTablePlan implements Plan {
 
     private static final Logger LOGGER = LogManager.getLogger(DropTablePlan.class);
-    private static final Row ROW_ZERO = new Row1(0L);
-    private static final Row ROW_ONE = new Row1(1L);
 
-    private final AnalyzedDropTable<?> dropTable;
+    private final AnalyzedDropTable dropTable;
 
-    public DropTablePlan(AnalyzedDropTable<?> dropTable) {
+    public DropTablePlan(AnalyzedDropTable dropTable) {
         this.dropTable = dropTable;
     }
 
     @VisibleForTesting
-    public AnalyzedDropTable<?> dropTable() {
+    public AnalyzedDropTable dropTable() {
         return dropTable;
     }
 
@@ -64,31 +65,47 @@ public class DropTablePlan implements Plan {
         return StatementType.DDL;
     }
 
-
     @Override
     public void executeOrFail(DependencyCarrier dependencies,
                               PlannerContext plannerContext,
                               RowConsumer consumer,
                               Row params,
                               SubQueryResults subQueryResults) {
-        var request = new DropTableRequest(dropTable.tableName(), dropTable.tableOid());
-        dependencies.client().execute(TransportDropTable.ACTION, request).whenComplete((response, err) -> {
-            if (err == null) {
-                if (!response.isAcknowledged() && LOGGER.isWarnEnabled()) {
-                    LOGGER.warn("Dropping table {} was not acknowledged. This could lead to inconsistent state.",
-                        dropTable.tableName());
-                }
-
-                consumer.accept(InMemoryBatchIterator.of(ROW_ONE, SENTINEL), null);
-            } else {
-                err = SQLExceptions.unwrap(err);
-                boolean doesntExist = err instanceof IndexNotFoundException || err instanceof RelationUnknown;
-                if (dropTable.dropIfExists() && doesntExist) {
-                    consumer.accept(InMemoryBatchIterator.of(ROW_ZERO, SENTINEL), null);
+        var targets = dropTable.tables();
+        ArrayList<CompletableFuture<Long>> futures = new ArrayList<>(targets.size());
+        for (var target : targets) {
+            var request = new DropTableRequest(target.tableName(), target.tableOid());
+            var future = dependencies.client().execute(TransportDropTable.ACTION, request)
+                .handle((response, err) -> {
+                    if (err == null) {
+                        if (!response.isAcknowledged() && LOGGER.isWarnEnabled()) {
+                            LOGGER.warn("Dropping table {} was not acknowledged. This could lead to inconsistent state.",
+                                target.tableName());
+                        }
+                        return 1L;
+                    }
+                    var unwrapped = SQLExceptions.unwrap(err);
+                    boolean doesntExist = unwrapped instanceof IndexNotFoundException
+                        || unwrapped instanceof RelationUnknown;
+                    if (dropTable.dropIfExists() && doesntExist) {
+                        return 0L;
+                    }
+                    throw new RuntimeException(unwrapped);
+                });
+            futures.add(future);
+        }
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
+            .whenComplete((ignored, err) -> {
+                if (err == null) {
+                    long count = 0;
+                    for (var f : futures) {
+                        count += f.join();
+                    }
+                    consumer.accept(InMemoryBatchIterator.of(new Row1(count), SENTINEL), null);
                 } else {
-                    consumer.accept(null, err);
+                    consumer.accept(null, SQLExceptions.unwrap(err));
                 }
-            }
-        });
+            });
     }
 }
+

--- a/server/src/test/java/io/crate/analyze/BlobTableAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/BlobTableAnalyzerTest.java
@@ -165,9 +165,9 @@ public class BlobTableAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testDropBlobTable() {
-        AnalyzedDropTable<BlobTableInfo> analysis = e.analyze("drop blob table blobs");
-        assertThat(analysis.tableName().name()).isEqualTo("blobs");
-        assertThat(analysis.tableName().schema()).isEqualTo(BlobSchemaInfo.NAME);
+        AnalyzedDropTable analysis = e.analyze("drop blob table blobs");
+        assertThat(analysis.tables().get(0).tableName().name()).isEqualTo("blobs");
+        assertThat(analysis.tables().get(0).tableName().schema()).isEqualTo(BlobSchemaInfo.NAME);
     }
 
     @Test
@@ -179,8 +179,8 @@ public class BlobTableAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testDropBlobTableWithValidSchema() {
-        AnalyzedDropTable<BlobTableInfo> analysis = e.analyze("drop blob table \"blob\".blobs");
-        assertThat(analysis.tableName().name()).isEqualTo("blobs");
+        AnalyzedDropTable analysis = e.analyze("drop blob table \"blob\".blobs");
+        assertThat(analysis.tables().get(0).tableName().name()).isEqualTo("blobs");
     }
 
     @Test
@@ -192,14 +192,14 @@ public class BlobTableAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testDropBlobTableIfExists() {
-        AnalyzedDropTable<BlobTableInfo> analysis = e.analyze("drop blob table if exists blobs");
+        AnalyzedDropTable analysis = e.analyze("drop blob table if exists blobs");
         assertThat(analysis.dropIfExists()).isTrue();
-        assertThat(analysis.tableName().fqn()).isEqualTo("blob.blobs");
+        assertThat(analysis.tables().get(0).tableName().fqn()).isEqualTo("blob.blobs");
     }
 
     @Test
     public void testDropNonExistentBlobTableIfExists() {
-        AnalyzedDropTable<BlobTableInfo> analysis = e.analyze("drop blob table if exists unknown");
+        AnalyzedDropTable analysis = e.analyze("drop blob table if exists unknown");
         assertThat(analysis.dropIfExists()).isTrue();
     }
 

--- a/server/src/test/java/io/crate/analyze/BlobTableAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/BlobTableAnalyzerTest.java
@@ -37,7 +37,6 @@ import io.crate.blob.v2.BlobIndicesService;
 import io.crate.data.RowN;
 import io.crate.exceptions.RelationAlreadyExists;
 import io.crate.exceptions.RelationUnknown;
-import io.crate.metadata.BlobTableInfo;
 import io.crate.metadata.blob.BlobSchemaInfo;
 import io.crate.planner.PlannerContext;
 import io.crate.planner.node.ddl.CreateBlobTablePlan;

--- a/server/src/test/java/io/crate/analyze/DropTableAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/DropTableAnalyzerTest.java
@@ -34,8 +34,6 @@ import org.junit.Test;
 import io.crate.exceptions.OperationOnInaccessibleRelationException;
 import io.crate.exceptions.RelationUnknown;
 import io.crate.exceptions.SchemaUnknownException;
-import io.crate.metadata.DocTableInfo;
-import io.crate.metadata.TableInfo;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 

--- a/server/src/test/java/io/crate/analyze/DropTableAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/DropTableAnalyzerTest.java
@@ -97,21 +97,21 @@ public class DropTableAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testDropExistingTable() {
-        AnalyzedDropTable<DocTableInfo> dropTable = e.analyze(String.format(ENGLISH, "drop table %s", USER_TABLE_IDENT.name()));
+        AnalyzedDropTable dropTable = e.analyze(String.format(ENGLISH, "drop table %s", USER_TABLE_IDENT.name()));
         assertThat(dropTable.dropIfExists()).isFalse();
-        assertThat(dropTable.tableName().indexNameOrAlias()).isEqualTo(USER_TABLE_IDENT.name());
+        assertThat(dropTable.tables().get(0).tableName().indexNameOrAlias()).isEqualTo(USER_TABLE_IDENT.name());
     }
 
     @Test
     public void testDropIfExistExistingTable() {
-        AnalyzedDropTable<DocTableInfo> dropTable = e.analyze(String.format(ENGLISH, "drop table if exists %s", USER_TABLE_IDENT.name()));
+        AnalyzedDropTable dropTable = e.analyze(String.format(ENGLISH, "drop table if exists %s", USER_TABLE_IDENT.name()));
         assertThat(dropTable.dropIfExists()).isTrue();
-        assertThat(dropTable.tableName().indexNameOrAlias()).isEqualTo(USER_TABLE_IDENT.name());
+        assertThat(dropTable.tables().get(0).tableName().indexNameOrAlias()).isEqualTo(USER_TABLE_IDENT.name());
     }
 
     @Test
     public void testNonExistentTableIsRecognizedCorrectly() {
-        AnalyzedDropTable<TableInfo> dropTable = e.analyze("drop table if exists unknowntable");
-        assertThat(dropTable.tableName().name()).isEqualTo("unknowntable");
+        AnalyzedDropTable dropTable = e.analyze("drop table if exists unknowntable");
+        assertThat(dropTable.tables().get(0).tableName().name()).isEqualTo("unknowntable");
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
@@ -754,7 +754,7 @@ public class DDLIntegrationTest extends IntegTestCase {
         execute("drop table if exists nonexistent");
         assertThat(response).hasRowCount(0);
     }
-    
+
     @Test
     public void testDropMultipleTables() throws Exception {
         execute("create table t1 (id int) with (number_of_replicas=0)");
@@ -766,11 +766,17 @@ public class DDLIntegrationTest extends IntegTestCase {
         assertThat(response).hasRowCount(3);
 
         Asserts.assertSQLError(() -> execute("select * from t1"))
-            .hasPGError(UNDEFINED_TABLE);
+            .hasPGError(UNDEFINED_TABLE)
+            .hasHTTPError(NOT_FOUND, 4041)
+            .hasMessageContaining("Relation 't1' unknown");
         Asserts.assertSQLError(() -> execute("select * from t2"))
-            .hasPGError(UNDEFINED_TABLE);
+            .hasPGError(UNDEFINED_TABLE)
+            .hasHTTPError(NOT_FOUND, 4041)
+            .hasMessageContaining("Relation 't2' unknown");
         Asserts.assertSQLError(() -> execute("select * from t3"))
-            .hasPGError(UNDEFINED_TABLE);
+            .hasPGError(UNDEFINED_TABLE)
+            .hasHTTPError(NOT_FOUND, 4041)
+            .hasMessageContaining("Relation 't3' unknown");
     }
 
     @Test
@@ -783,9 +789,13 @@ public class DDLIntegrationTest extends IntegTestCase {
         execute("drop table if exists t1, t_missing, t2");
 
         Asserts.assertSQLError(() -> execute("select * from t1"))
-            .hasPGError(UNDEFINED_TABLE);
+            .hasPGError(UNDEFINED_TABLE)
+            .hasHTTPError(NOT_FOUND, 4041)
+            .hasMessageContaining("Relation 't1' unknown");
         Asserts.assertSQLError(() -> execute("select * from t2"))
-            .hasPGError(UNDEFINED_TABLE);
+            .hasPGError(UNDEFINED_TABLE)
+            .hasHTTPError(NOT_FOUND, 4041)
+            .hasMessageContaining("Relation 't2' unknown");
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
@@ -754,6 +754,39 @@ public class DDLIntegrationTest extends IntegTestCase {
         execute("drop table if exists nonexistent");
         assertThat(response).hasRowCount(0);
     }
+    
+    @Test
+    public void testDropMultipleTables() throws Exception {
+        execute("create table t1 (id int) with (number_of_replicas=0)");
+        execute("create table t2 (id int) with (number_of_replicas=0)");
+        execute("create table t3 (id int) with (number_of_replicas=0)");
+        ensureYellow();
+
+        execute("drop table t1, t2, t3");
+        assertThat(response).hasRowCount(3);
+
+        Asserts.assertSQLError(() -> execute("select * from t1"))
+            .hasPGError(UNDEFINED_TABLE);
+        Asserts.assertSQLError(() -> execute("select * from t2"))
+            .hasPGError(UNDEFINED_TABLE);
+        Asserts.assertSQLError(() -> execute("select * from t3"))
+            .hasPGError(UNDEFINED_TABLE);
+    }
+
+    @Test
+    public void testDropMultipleTablesIfExistsWithMissingTable() throws Exception {
+        execute("create table t1 (id int) with (number_of_replicas=0)");
+        execute("create table t2 (id int) with (number_of_replicas=0)");
+        ensureYellow();
+
+        // t_missing does not exist; IF EXISTS should tolerate it
+        execute("drop table if exists t1, t_missing, t2");
+
+        Asserts.assertSQLError(() -> execute("select * from t1"))
+            .hasPGError(UNDEFINED_TABLE);
+        Asserts.assertSQLError(() -> execute("select * from t2"))
+            .hasPGError(UNDEFINED_TABLE);
+    }
 
     @Test
     public void testCreateAlterAndDropBlobTable() throws Exception {

--- a/server/src/test/java/io/crate/planner/DropTablePlannerTest.java
+++ b/server/src/test/java/io/crate/planner/DropTablePlannerTest.java
@@ -51,32 +51,32 @@ public class DropTablePlannerTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testDropTable() throws Exception {
         DropTablePlan plan = e.plan("drop table users");
-        assertThat(plan.dropTable().tableName().name()).isEqualTo("users");
+        assertThat(plan.dropTable().tables().get(0).tableName().name()).isEqualTo("users");
     }
 
     @Test
     public void testDropTableIfExistsWithUnknownSchema() throws Exception {
         DropTablePlan plan = e.plan("drop table if exists unknown_schema.unknown_table");
-        assertThat(plan.dropTable().tableName()).isEqualTo(new RelationName("unknown_schema", "unknown_table"));
+        assertThat(plan.dropTable().tables().get(0).tableName()).isEqualTo(new RelationName("unknown_schema", "unknown_table"));
     }
 
     @Test
     public void testDropTableIfExists() throws Exception {
         DropTablePlan plan = e.plan("drop table if exists users");
-        assertThat(plan.dropTable().tableName().name()).isEqualTo("users");
+        assertThat(plan.dropTable().tables().get(0).tableName().name()).isEqualTo("users");
     }
 
     @Test
     public void testDropTableIfExistsNonExistentTableCreatesPlanWithoutTableInfo() throws Exception {
         DropTablePlan plan = e.plan("drop table if exists groups");
-        assertThat(plan.dropTable().tableName().name()).isEqualTo("groups");
+        assertThat(plan.dropTable().tables().get(0).tableName().name()).isEqualTo("groups");
     }
 
 
     @Test
     public void testDropPartitionedTable() throws Exception {
         DropTablePlan plan = e.plan("drop table parted");
-        assertThat(plan.dropTable().tableName().name()).isEqualTo("parted");
+        assertThat(plan.dropTable().tables().get(0).tableName().name()).isEqualTo("parted");
     }
 
     @Test
@@ -88,6 +88,15 @@ public class DropTablePlannerTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testDropNonExistentBlobTableCreatesPlanWithoutTableInfo() throws Exception {
         DropTablePlan plan = e.plan("drop blob table if exists unknown");
-        assertThat(plan.dropTable().tableName().name()).isEqualTo("unknown");
+        assertThat(plan.dropTable().tables().get(0).tableName().name()).isEqualTo("unknown");
     }
+    
+    @Test
+    public void testDropMultipleTables() throws Exception {
+        DropTablePlan plan = e.plan("drop table users, parted");
+        assertThat(plan.dropTable().tables()).hasSize(2);
+        assertThat(plan.dropTable().tables().get(0).tableName().name()).isEqualTo("users");
+        assertThat(plan.dropTable().tables().get(1).tableName().name()).isEqualTo("parted");
+    }
+
 }

--- a/server/src/test/java/io/crate/planner/DropTablePlannerTest.java
+++ b/server/src/test/java/io/crate/planner/DropTablePlannerTest.java
@@ -94,9 +94,10 @@ public class DropTablePlannerTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testDropMultipleTables() throws Exception {
         DropTablePlan plan = e.plan("drop table users, parted");
-        assertThat(plan.dropTable().tables()).hasSize(2);
-        assertThat(plan.dropTable().tables().get(0).tableName().name()).isEqualTo("users");
-        assertThat(plan.dropTable().tables().get(1).tableName().name()).isEqualTo("parted");
+        assertThat(plan.dropTable().tables()).satisfiesExactly(
+            x -> assertThat(x.tableName().name()).isEqualTo("users"),
+            x -> assertThat(x.tableName().name()).isEqualTo("parted")
+        );
     }
 
 }


### PR DESCRIPTION
Adds support for dropping several tables in a single statement, e.g. DROP TABLE t1, t2, t3. The operation is not atomic: if a drop fails, tables listed earlier may already be dropped.

Closes #2036

## Summary of the changes / Why this improves CrateDB

`DROP TABLE` previously accepted only a single table. This adds support for a comma-separated list of tables, so several can be removed in one statement:

    DROP TABLE t1, t2, t3
    DROP TABLE IF EXISTS t1, t2

This mirrors the existing behaviour of `DROP VIEW` and `DROP SCHEMA`, and improves usability and PostgreSQL familiarity.

### Manual verification
Before (released version rejects the statement):
<img width="659" height="468" alt="Screenshot 2026-09-07 at 3 52 55 PM" src="https://github.com/user-attachments/assets/fff498cd-4f19-4904-b9bc-0b8eb5e9a877" />

After (built from this branch, `DROP TABLE alpha, beta, gamma` succeeds):
<img width="1715" height="506" alt="Screenshot 2026-09-07 at 5 21 35 PM" src="https://github.com/user-attachments/assets/8e1527b6-a7aa-40de-bc5a-9a669abcbc7b" />

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes.
       If you're an external contributor you can give yourself attribution and include your name and Github handle.
       e.g.:
       ```
       `John Doe <https://github.com/John_Doe>`_ added support for ...
       ```
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
