### PR TITLE
Don't store GenericFunctionQuery in the cache when it's part of a BooleanQuery

### DIFF
--- a/docs/appendices/release-notes/6.4.5.rst
+++ b/docs/appendices/release-notes/6.4.5.rst
@@ -51,3 +51,6 @@ Fixes
 
 - Fixed an issue that could lead to out of memory errors if using the
   ``percentile`` aggregation.
+
+- Fixed an issue causing cache to retain some heavy structures, potentially
+  leading to an ``OutOfMemoryError``.

--- a/server/src/main/java/io/crate/lucene/CustomLRUQueryCache.java
+++ b/server/src/main/java/io/crate/lucene/CustomLRUQueryCache.java
@@ -40,6 +40,8 @@ import org.apache.lucene.index.IndexReaderContext;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.ReaderUtil;
 import org.apache.lucene.index.TieredMergePolicy;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.BoostQuery;
 import org.apache.lucene.search.BulkScorer;
 import org.apache.lucene.search.ConstantScoreQuery;
@@ -492,8 +494,7 @@ public class CustomLRUQueryCache implements QueryCache, Accountable {
         while (weight instanceof CachingWrapperWeight) {
             weight = ((CachingWrapperWeight) weight).in;
         }
-
-        return new CachingWrapperWeight(weight, policy);
+        return new CachingWrapperWeight(weight, toCacheKeyQuery(weight.getQuery()), policy);
     }
 
     @Override
@@ -544,6 +545,26 @@ public class CustomLRUQueryCache implements QueryCache, Accountable {
             0,
             DocIdSetIterator.NO_MORE_DOCS);
         return new CacheAndCount(new BitDocIdSet(bitSet, count[0]), count[0]);
+    }
+
+    /**
+     * @param query is a query that potentially can retain heavy references.
+     * @return query with each inner GenericFunctionQuery instance replaced with its SmallCacheableQuery.
+     */
+    private static Query toCacheKeyQuery(Query query) {
+        // GenericFunctionQuery is only used directly or as a part of BooleanQuery.
+        if (query instanceof GenericFunctionQuery gfc) {
+            return gfc.smallCacheableQuery();
+        }
+        if (query instanceof BooleanQuery bq) {
+            BooleanQuery.Builder builder = new BooleanQuery.Builder()
+                .setMinimumNumberShouldMatch(bq.getMinimumNumberShouldMatch());
+            for (BooleanClause clause : bq.clauses()) {
+                builder.add(toCacheKeyQuery(clause.query()), clause.occur());
+            }
+            return builder.build();
+        }
+        return query;
     }
 
     private static CacheAndCount cacheIntoRoaringDocIdSet(BulkScorer scorer, int maxDoc)
@@ -708,8 +729,8 @@ public class CustomLRUQueryCache implements QueryCache, Accountable {
         // threads when IndexSearcher is created with threads
         private final AtomicBoolean used;
 
-        CachingWrapperWeight(Weight in, QueryCachingPolicy policy) {
-            super(in.getQuery(), 1f);
+        CachingWrapperWeight(Weight in, Query cacheKeyQuery, QueryCachingPolicy policy) {
+            super(cacheKeyQuery, 1f);
             this.in = in;
             this.policy = policy;
             used = new AtomicBoolean(false);
@@ -768,17 +789,17 @@ public class CustomLRUQueryCache implements QueryCache, Accountable {
 
             CacheAndCount cached;
             try {
-                cached = get(in.getQuery(), cacheHelper);
+                cached = get(getQuery(), cacheHelper);
             } finally {
                 readLock.unlock();
             }
 
             int maxDoc = context.reader().maxDoc();
             if (cached == null) {
-                if (policy.shouldCache(in.getQuery())) {
+                if (policy.shouldCache(getQuery())) {
                     final ScorerSupplier supplier = in.scorerSupplier(context);
                     if (supplier == null) {
-                        putIfAbsent(in.getQuery(), CacheAndCount.EMPTY, cacheHelper);
+                        putIfAbsent(getQuery(), CacheAndCount.EMPTY, cacheHelper);
                         return null;
                     }
 
@@ -792,7 +813,7 @@ public class CustomLRUQueryCache implements QueryCache, Accountable {
                             }
 
                             CacheAndCount cached = cacheImpl(supplier.bulkScorer(), maxDoc);
-                            putIfAbsent(in.getQuery(), cached, cacheHelper);
+                            putIfAbsent(getQuery(), cached, cacheHelper);
                             DocIdSetIterator disi = cached.iterator();
                             if (disi == null) {
                                 // docIdSet.iterator() is allowed to return null when empty but we want a non-null
@@ -862,7 +883,7 @@ public class CustomLRUQueryCache implements QueryCache, Accountable {
 
             CacheAndCount cached;
             try {
-                cached = get(in.getQuery(), cacheHelper);
+                cached = get(getQuery(), cacheHelper);
             } finally {
                 readLock.unlock();
             }

--- a/server/src/main/java/io/crate/lucene/GenericFunctionQuery.java
+++ b/server/src/main/java/io/crate/lucene/GenericFunctionQuery.java
@@ -85,6 +85,10 @@ public class GenericFunctionQuery extends Query implements Accountable {
         return function.hashCode();
     }
 
+    public Query smallCacheableQuery() {
+        return smallCacheableQuery;
+    }
+
     /**
      * @return memory usage of the part that is actually passed to the cache.
      * LRUCache uses SmallCacheableQuery's memory accounting directly.

--- a/server/src/test/java/io/crate/lucene/CustomLRUQueryCacheTest.java
+++ b/server/src/test/java/io/crate/lucene/CustomLRUQueryCacheTest.java
@@ -23,12 +23,15 @@ import static org.apache.lucene.util.RamUsageEstimator.LINKED_HASHTABLE_RAM_BYTE
 import static org.apache.lucene.util.RamUsageEstimator.QUERY_DEFAULT_RAM_BYTES_USED;
 
 import java.io.IOException;
+import java.util.List;
 
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.StringField;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.Term;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
@@ -37,9 +40,13 @@ import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.Version;
 import org.junit.Test;
 
-public class CustomLRUQueryCacheTest extends CrateLuceneTestCase {
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.QueryTester;
+
+public class CustomLRUQueryCacheTest extends CrateDummyClusterServiceUnitTest {
 
     private static final QueryCachingPolicy ALWAYS_CACHE =
         new QueryCachingPolicy() {
@@ -109,6 +116,69 @@ public class CustomLRUQueryCacheTest extends CrateLuceneTestCase {
             assertThat(queryCache.cachedQueries().size()).isEqualTo(1);
             assertThat(queryCache.ramBytesUsed()).isGreaterThanOrEqualTo(queryInBytes);
             reader.close();
+        }
+    }
+
+    @Test
+    public void test_standalone_generic_function_query_is_cached_as_small_cacheable_query() throws Exception {
+        QueryTester.Builder builder = new QueryTester.Builder(
+            THREAD_POOL,
+            clusterService,
+            Version.CURRENT,
+            "create table t (a int, b int)"
+        );
+        builder.indexValues(List.of("a", "b"), 1, 1);
+        try (QueryTester tester = builder.build()) {
+            Query query = tester.toQuery("abs(a) * abs(b) = 1");
+            assertThat(query).isInstanceOf(GenericFunctionQuery.class);
+
+            IndexSearcher searcher = tester.searcher();
+            CustomLRUQueryCache queryCache =
+                new CustomLRUQueryCache(1000000, 10000000, _ -> true, Float.POSITIVE_INFINITY);
+            searcher.setQueryCache(queryCache);
+            searcher.setQueryCachingPolicy(ALWAYS_CACHE);
+            searcher.count(query);
+
+            assertThat(queryCache.getUniqueQueries()).hasSize(1);
+            Query cachedQuery = queryCache.getUniqueQueries().keySet().iterator().next();
+            assertThat(cachedQuery).isInstanceOf(GenericFunctionQuery.SmallCacheableQuery.class);
+        }
+    }
+
+    @Test
+    public void test_generic_function_query_in_boolean_query_is_cached_as_small_cacheable_query() throws Exception {
+        QueryTester.Builder builder = new QueryTester.Builder(
+            THREAD_POOL,
+            clusterService,
+            Version.CURRENT,
+            "create table t (a int, b int)"
+        );
+        builder.indexValues(List.of("a", "b"), 1, 1);
+        try (QueryTester tester = builder.build()) {
+            Query query = tester.toQuery("abs(a) = 1 AND abs(b) = 1");
+            assertThat(query).isInstanceOf(BooleanQuery.class);
+            for (BooleanClause clause : ((BooleanQuery) query).clauses()) {
+                assertThat(clause.query()).isInstanceOf(GenericFunctionQuery.class);
+            }
+
+            IndexSearcher searcher = tester.searcher();
+            CustomLRUQueryCache queryCache =
+                new CustomLRUQueryCache(1000000, 10000000, _ -> true, Float.POSITIVE_INFINITY);
+            searcher.setQueryCache(queryCache);
+            searcher.setQueryCachingPolicy(ALWAYS_CACHE);
+            searcher.count(query);
+
+            // Cache has 3 entries: 1 composite BooleanQuery from IndexSearcher.createWeight
+            // and 2 leaf queries created in BooleanWeight ctor.
+            for (Query cachedQuery : queryCache.getUniqueQueries().keySet()) {
+                if (cachedQuery instanceof BooleanQuery booleanQuery) {
+                    for (BooleanClause clause : booleanQuery.clauses()) {
+                        assertThat(clause.query()).isInstanceOf(GenericFunctionQuery.SmallCacheableQuery.class);
+                    }
+                } else {
+                    assertThat(cachedQuery).isInstanceOf(GenericFunctionQuery.SmallCacheableQuery.class);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Follow up to https://github.com/crate/crate/pull/19474

Relates to https://github.com/crate/support/issues/921 and https://github.com/crate/support/issues/914

Standalone `GenericFunctionQuery` is never stored in cache as https://github.com/crate/crate/pull/19474 took care of passing lightweight instance in its `createWeight` implementation.

However, when GFC is a part of some complex BooleanQuery, it still retained by cache. 
On master, cache takes key/query from `CachingWrapperWeight -> weight.getQuery` and this query is stored as is in 
`BooleanQuery.createWeight`

```
 BooleanWeight(BooleanQuery query, IndexSearcher searcher, ScoreMode scoreMode, float boost)
      throws IOException {
      
      
    **super(query); ==> This ends up being used as in.getQuery in CachingWrapperWeight**. 
                    ==>     GFC sits here as a part of BooleanQuery
    
    this.query = query;
    this.scoreMode = scoreMode;
    this.similarity = searcher.getSimilarity();
    weightedClauses = new ArrayList<>();
    for (BooleanClause c : query) {
      // This is good, because GFC.createWeight creates lightweight weightedClauses but it doesn't help
      Weight w =
          searcher.createWeight(
              c.query(), c.isScoring() ? scoreMode : ScoreMode.COMPLETE_NO_SCORES, boost);
      weightedClauses.add(new WeightedBooleanClause(c, w));
    }
  }
```


-----
Other ideas - override `getQuery` in 
` return new Weight(smallCacheableQuery) {` but it's final

Also, maybe could patch BooleanQuery itself, but I think it's too hacky. 

Cache is already our code that we patched to deal with our structures, so patching it looked more appealing.


