### PR TITLE
Fix null to bit casts

### DIFF
--- a/docs/appendices/release-notes/6.4.5.rst
+++ b/docs/appendices/release-notes/6.4.5.rst
@@ -46,6 +46,8 @@ series.
 Fixes
 =====
 
+- Fixed an issue that caused casting ``null`` to the ``bit`` type to fail.
+
 - Fixed an issue that caused CrateDB to choose the wrong relation if a parent
   relation alias clashed with a local scoped relation name.
 

--- a/server/src/test/java/io/crate/types/RegclassTypeTest.java
+++ b/server/src/test/java/io/crate/types/RegclassTypeTest.java
@@ -136,4 +136,26 @@ public class RegclassTypeTest extends DataTypeTestCase<Regclass> {
         var regclass = RegclassType.INSTANCE.explicitCast("\"tbl\"", SESSION_SETTINGS, e.schemas());
         assertThat(regclass.oid()).isEqualTo(-579575814);
     }
+
+    @Override
+    public void test_supports_casting_null_to_type() throws Exception {
+        // overridden because regclass doesn't support implicit casts
+
+        DataType<Regclass> type = getDataDef().type();
+        var sessionSettings = CoordinatorTxnCtx.systemTransactionContext().sessionSettings();
+        Regclass explicitCast = type.explicitCast(null, sessionSettings, new RelationLookup() {
+
+            @Override
+            public int getDisplayRelationOid(RelationName relationName) {
+                return Metadata.OID_UNASSIGNED;
+            }
+
+            @Override
+            public @Nullable RelationName getRelationName(int displayOid) {
+                return null;
+            }
+
+        });
+        assertThat(explicitCast).isNull();
+    }
 }

--- a/server/src/testFixtures/java/io/crate/types/DataTypeTestCase.java
+++ b/server/src/testFixtures/java/io/crate/types/DataTypeTestCase.java
@@ -44,11 +44,13 @@ import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.Weight;
 import org.elasticsearch.Version;
+import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.index.mapper.ParsedDocument;
+import org.jspecify.annotations.Nullable;
 import org.junit.Test;
 
 import io.crate.Streamer;
@@ -62,8 +64,10 @@ import io.crate.expression.reference.doc.lucene.LuceneCollectorExpression;
 import io.crate.expression.reference.doc.lucene.LuceneReferenceResolver;
 import io.crate.expression.reference.doc.lucene.StoredRowLookup;
 import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.DocTableInfo;
 import io.crate.metadata.Reference;
+import io.crate.metadata.RelationLookup;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.SimpleReference;
@@ -294,5 +298,26 @@ public abstract class DataTypeTestCase<T> extends CrateDummyClusterServiceUnitTe
                 fail("Unexpected Sort value");
             }
         }
+    }
+
+    @Test
+    public void test_supports_casting_null_to_type() throws Exception {
+        DataType<T> type = getDataDef().type();
+        var sessionSettings = CoordinatorTxnCtx.systemTransactionContext().sessionSettings();
+        T explicitCast = type.explicitCast(null, sessionSettings, new RelationLookup() {
+
+            @Override
+            public int getDisplayRelationOid(RelationName relationName) {
+                return Metadata.OID_UNASSIGNED;
+            }
+
+            @Override
+            public @Nullable RelationName getRelationName(int displayOid) {
+                return null;
+            }
+
+        });
+        assertThat(explicitCast).isNull();
+        assertThat(type.implicitCast(null)).isNull();
     }
 }


### PR DESCRIPTION
The commit message is a bit misleading, this is adding the changes and test case. The issue was already fixed as a side effect of https://github.com/crate/crate/pull/20068

Will add the actual fix (null check) when backporting.