### PR TITLE
Avoid sources collection in JoinGraph EdgeCollector

### DIFF
--- a/docs/appendices/release-notes/6.4.5.rst
+++ b/docs/appendices/release-notes/6.4.5.rst
@@ -46,6 +46,10 @@ series.
 Fixes
 =====
 
+- Fixed an issue that could cause statements including a cross join and an outer
+  join plus any other join to drop the outer join condition, leading to
+  incorrect results.
+
 - Fixed an issue that caused casting string values to a longer ``bit`` string to
   fail with an ``StringIndexOutOfBoundsException`` instead of filling up the gap
   with ``0``.

--- a/server/src/main/java/io/crate/planner/optimizer/joinorder/JoinGraph.java
+++ b/server/src/main/java/io/crate/planner/optimizer/joinorder/JoinGraph.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.UnaryOperator;
 
 import io.crate.analyze.relations.QuerySplitter;
@@ -38,6 +39,7 @@ import io.crate.expression.symbol.ScopedSymbol;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolVisitor;
 import io.crate.metadata.Reference;
+import io.crate.metadata.RelationName;
 import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.JoinPlan;
 import io.crate.planner.operators.LogicalPlan;
@@ -128,11 +130,7 @@ public record JoinGraph(List<LogicalPlan> nodes,
     }
 
     public List<Edge> edges(LogicalPlan node) {
-        var result = edges.get(node);
-        if (result == null) {
-            return List.of();
-        }
-        return result;
+        return edges.getOrDefault(node, List.of());
     }
 
     public static JoinGraph create(LogicalPlan plan, UnaryOperator<LogicalPlan> resolvePlan) {
@@ -162,43 +160,51 @@ public record JoinGraph(List<LogicalPlan> nodes,
 
         @Override
         public JoinGraph visitFilter(Filter filter, Map<Symbol, LogicalPlan> context) {
-            var source = filter.source().accept(this, context);
+            JoinGraph source = filter.source().accept(this, context);
             return source.withFilters(List.of(filter.query()));
         }
 
         @Override
         public JoinGraph visitJoinPlan(JoinPlan joinPlan, Map<Symbol, LogicalPlan> context) {
-
-            var left = joinPlan.lhs().accept(this, context);
-            var right = joinPlan.rhs().accept(this, context);
+            JoinGraph left = joinPlan.lhs().accept(this, context);
+            JoinGraph right = joinPlan.rhs().accept(this, context);
 
             if (joinPlan.joinType() == JoinType.CROSS) {
                 return left.joinWith(right).withCrossJoin();
             }
 
+            Symbol joinCondition = joinPlan.joinCondition();
             if (joinPlan.joinType() != JoinType.INNER) {
                 return left.joinWith(right);
             }
 
-            var joinCondition = joinPlan.joinCondition();
-            var edgeCollector = new EdgeCollector();
-            var filters = new ArrayList<Symbol>();
-            if (joinCondition != null) {
-                var split = QuerySplitter.split(joinCondition);
+            ArrayList<Symbol> filters = new ArrayList<>();
+            Map<LogicalPlan, List<Edge>> edges;
+            if (joinCondition == null) {
+                edges = Map.of();
+            } else {
+                var edgeCollector = new EdgeCollector();
+                Map<Set<RelationName>, Symbol> split = QuerySplitter.split(joinCondition);
                 for (var entry : split.entrySet()) {
+                    Set<RelationName> relations = entry.getKey();
+                    Symbol expression = entry.getValue();
                     // we are only interested in equi-join conditions between
                     // two tables e.g.: a.x = b.y will result in
                     // (a,b) -> (a.x = b.y) and we can ignore any other
                     // filters. Therefore, we only want entries where we have
                     // two keys.
-                    if (entry.getKey().size() == 2 && isEquiJoin(entry.getValue())) {
-                        entry.getValue().accept(edgeCollector, context);
+                    if (relations.size() == 2 && isEquiJoin(expression)) {
+                        expression.accept(edgeCollector, context);
                     } else {
-                        filters.add(entry.getValue());
+                        filters.add(expression);
                     }
                 }
+                edges = edgeCollector.edges;
             }
-            return left.joinWith(right).withEdges(edgeCollector.edges).withFilters(filters);
+            return left
+                .joinWith(right)
+                .withEdges(edges)
+                .withFilters(filters);
         }
 
         private static class EdgeCollector extends SymbolVisitor<Map<Symbol, LogicalPlan>, Void> {

--- a/server/src/main/java/io/crate/planner/optimizer/joinorder/JoinGraph.java
+++ b/server/src/main/java/io/crate/planner/optimizer/joinorder/JoinGraph.java
@@ -35,10 +35,8 @@ import io.crate.analyze.relations.QuerySplitter;
 import io.crate.common.collections.Lists;
 import io.crate.common.collections.Maps;
 import io.crate.expression.operator.EqOperator;
-import io.crate.expression.symbol.ScopedSymbol;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolVisitor;
-import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
 import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.JoinPlan;
@@ -213,51 +211,37 @@ public record JoinGraph(List<LogicalPlan> nodes,
         private static class EdgeCollector extends SymbolVisitor<Map<Symbol, LogicalPlan>, Void> {
 
             private final Map<LogicalPlan, List<Edge>> edges = new HashMap<>();
-            private final List<LogicalPlan> sources = new ArrayList<>();
-
-            @Override
-            public Void visitField(ScopedSymbol s, Map<Symbol, LogicalPlan> context) {
-                sources.add(context.get(s));
-                return null;
-            }
-
-            @Override
-            public Void visitReference(Reference ref, Map<Symbol, LogicalPlan> context) {
-                sources.add(context.get(ref));
-                return null;
-            }
 
             @Override
             public Void visitFunction(io.crate.expression.symbol.Function f, Map<Symbol, LogicalPlan> context) {
-                var sizeSource = sources.size();
-                f.arguments().forEach(x -> x.accept(this, context));
+                List<Symbol> arguments = f.arguments();
                 if (f.name().equals(EqOperator.NAME)) {
-                    assert sources.size() == sizeSource + 2 : "Source must be collected for each argument";
-                    var fromSymbol = f.arguments().get(0);
-                    var toSymbol = f.arguments().get(1);
-                    var fromRelation = sources.get(sources.size() - 2);
-                    var toRelation = sources.get(sources.size() - 1);
-                    if (fromRelation != null && toRelation != null) {
+                    var lhsSymbol = arguments.get(0);
+                    var rhsSymbol = arguments.get(1);
+                    LogicalPlan lhsRelation = context.get(lhsSymbol);
+                    LogicalPlan rhsRelation = context.get(rhsSymbol);
+                    if (lhsRelation != null && rhsRelation != null) {
                         // Edges are created and indexed for each equi-join condition
                         // from both directions e.g.:
                         // a.x = b.y
                         // becomes:
                         // a -> Edge[b, a.x, b.y]
                         // b -> Edge[a, a.x, b.y]
-                        addEdge(fromRelation, new Edge(toRelation, fromSymbol, toSymbol));
-                        addEdge(toRelation, new Edge(fromRelation, fromSymbol, toSymbol));
+                        addEdge(lhsRelation, new Edge(rhsRelation, lhsSymbol, rhsSymbol));
+                        addEdge(rhsRelation, new Edge(lhsRelation, lhsSymbol, rhsSymbol));
                     }
+                } else {
+                    arguments.forEach(x -> x.accept(this, context));
                 }
                 return null;
             }
 
             private void addEdge(LogicalPlan from, Edge edge) {
-                var values = edges.get(from);
+                List<Edge> values = edges.get(from);
                 if (values == null) {
                     values = List.of(edge);
                 } else {
-                    values = new ArrayList<>(values);
-                    values.add(edge);
+                    values = Lists.concat(values, edge);
                 }
                 edges.put(from, values);
             }

--- a/server/src/main/java/io/crate/planner/optimizer/joinorder/JoinGraph.java
+++ b/server/src/main/java/io/crate/planner/optimizer/joinorder/JoinGraph.java
@@ -175,7 +175,10 @@ public record JoinGraph(List<LogicalPlan> nodes,
 
             Symbol joinCondition = joinPlan.joinCondition();
             if (joinPlan.joinType() != JoinType.INNER) {
-                return left.joinWith(right);
+                JoinGraph result = left.joinWith(right);
+                return joinCondition == null
+                    ? result
+                    : result.withFilters(List.of(joinCondition));
             }
 
             ArrayList<Symbol> filters = new ArrayList<>();

--- a/server/src/main/java/io/crate/planner/optimizer/rule/EliminateCrossJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/EliminateCrossJoin.java
@@ -61,22 +61,22 @@ public class EliminateCrossJoin implements Rule<JoinPlan> {
     public LogicalPlan apply(JoinPlan join,
                              Captures captures,
                              Rule.Context context) {
-        if (join.relationNames().size() >= 3) {
-            var joinGraph = JoinGraph.create(join, context.resolvePlan());
-            if (joinGraph.hasCrossJoin()) {
-                var newOrder = eliminateCrossJoin(joinGraph);
-                if (newOrder != null) {
-                    var newJoinPlan = reorder(joinGraph, newOrder);
-                    if (newJoinPlan != null) {
-                        return Eval.create(
-                            newJoinPlan,
-                            join.outputs()
-                        );
-                    }
-                }
-            }
+        if (join.relationNames().size() < 3) {
+            return null;
         }
-        return null;
+        var joinGraph = JoinGraph.create(join, context.resolvePlan());
+        if (!joinGraph.hasCrossJoin()) {
+            return null;
+        }
+        List<LogicalPlan> newOrder = orderNodes(joinGraph);
+        if (newOrder == null) {
+            return null;
+        }
+        LogicalPlan newJoinPlan = rebuild(joinGraph, newOrder);
+        if (newJoinPlan == null) {
+            return null;
+        }
+        return Eval.create(newJoinPlan, join.outputs());
     }
 
     /**
@@ -87,7 +87,7 @@ public class EliminateCrossJoin implements Rule<JoinPlan> {
      * the original join order.
      **/
     @Nullable
-    static List<LogicalPlan> eliminateCrossJoin(JoinGraph joinGraph) {
+    static List<LogicalPlan> orderNodes(JoinGraph joinGraph) {
         if (joinGraph.edges().isEmpty()) {
             return null;
         }
@@ -96,16 +96,17 @@ public class EliminateCrossJoin implements Rule<JoinPlan> {
             return null;
         }
 
-        var newJoinOrder = new ArrayList<LogicalPlan>();
-
-        var priorities = new HashMap<LogicalPlan, Integer>();
+        ArrayList<LogicalPlan> newJoinOrder = new ArrayList<>();
+        HashMap<LogicalPlan, Integer> priorities = new HashMap<>();
         for (int i = 0; i < joinGraph.size(); i++) {
             priorities.put(joinGraph.nodes().get(i), i);
         }
 
-        var nodesToVisit = new PriorityQueue<LogicalPlan>(joinGraph.size(), comparing(priorities::get));
-        var visited = new HashSet<LogicalPlan>();
-
+        PriorityQueue<LogicalPlan> nodesToVisit = new PriorityQueue<>(
+            joinGraph.size(),
+            comparing(priorities::get)
+        );
+        HashSet<LogicalPlan> visited = new HashSet<LogicalPlan>();
         nodesToVisit.add(joinGraph.nodes().get(0));
 
         while (!nodesToVisit.isEmpty()) {
@@ -131,25 +132,24 @@ public class EliminateCrossJoin implements Rule<JoinPlan> {
     }
 
     @Nullable
-    static LogicalPlan reorder(JoinGraph graph, List<LogicalPlan> order) {
+    static LogicalPlan rebuild(JoinGraph graph, List<LogicalPlan> order) {
         assert graph.nodes().size() == order.size() : "Size must be equal";
 
         if (graph.edges().isEmpty()) {
             throw new InvalidArgumentException("JoinPlan cannot be built with the provided order.");
         }
 
-        var result = order.get(0);
-        var alreadyJoinedNodes = new HashSet<LogicalPlan>();
+        LogicalPlan result = order.get(0);
+        HashSet<LogicalPlan> alreadyJoinedNodes = new HashSet<>();
         alreadyJoinedNodes.add(result);
 
         for (int i = 1; i < order.size(); i++) {
-            var rightNode = order.get(i);
+            LogicalPlan rightNode = order.get(i);
             alreadyJoinedNodes.add(rightNode);
 
-            var criteria = new ArrayList<Symbol>();
-
+            ArrayList<Symbol> criteria = new ArrayList<>();
             for (var edge : graph.edges(rightNode)) {
-                var toNode = edge.to();
+                LogicalPlan toNode = edge.to();
                 if (alreadyJoinedNodes.contains(toNode)) {
                     criteria.add(EqOperator.of(edge.left(), edge.right()));
                 }
@@ -163,7 +163,7 @@ public class EliminateCrossJoin implements Rule<JoinPlan> {
                 joinCondition = null;
             } else {
                 joinType = JoinType.INNER;
-                joinCondition = AndOperator.join(criteria, null);
+                joinCondition = AndOperator.join(criteria);
             }
 
             result = new JoinPlan(

--- a/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
@@ -24,6 +24,7 @@ package io.crate.integrationtests;
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
 import static io.crate.testing.Asserts.assertThat;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Arrays;
@@ -44,6 +45,7 @@ import io.crate.data.Paging;
 import io.crate.execution.engine.join.RamBlockSizeCalculator;
 import io.crate.execution.engine.sort.OrderingByPosition;
 import io.crate.metadata.RelationName;
+import io.crate.planner.optimizer.rule.EliminateCrossJoin;
 import io.crate.statistics.Stats;
 import io.crate.statistics.TableStatsService;
 import io.crate.testing.Asserts;
@@ -1893,5 +1895,34 @@ public class JoinIntegrationTest extends IntegTestCase {
         } finally {
             Paging.PAGE_SIZE = originalPageSize;
         }
+    }
+
+    @Test
+    @UseRandomizedOptimizerRules (alwaysKeep = EliminateCrossJoin.class)
+    public void test_cross_join_mixed_with_left_outer_and_inner_join_preserves_all_filters() throws Exception {
+        // https://github.com/crate/crate/issues/20143
+        execute(
+            """
+            SELECT
+                a.x,
+                b.y,
+                c.z,
+                d.w
+            FROM
+                generate_series(1, 3) AS a (x)
+                INNER JOIN generate_series(1, 3) AS b (y) ON a.x = b.y
+                LEFT JOIN generate_series(1, 3) AS c (z) ON a.x = c.z
+                CROSS JOIN generate_series(1, 1) AS d (w)
+            ORDER BY
+                a.x,
+                c.z;
+
+            """
+        );
+        assertThat(response).hasRows(
+            "1| 1| 1| 1",
+            "2| 2| 2| 1",
+            "3| 3| 3| 1"
+        );
     }
 }

--- a/server/src/test/java/io/crate/planner/optimizer/rule/EliminateCrossJoinTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/rule/EliminateCrossJoinTest.java
@@ -45,6 +45,7 @@ import io.crate.metadata.table.Operation;
 import io.crate.planner.operators.Collect;
 import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.JoinPlan;
+import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.Order;
 import io.crate.planner.operators.Rename;
 import io.crate.planner.operators.Union;
@@ -124,7 +125,7 @@ public class EliminateCrossJoinTest extends CrateDummyClusterServiceUnitTest {
         assertThat(edge.left()).isEqualTo(x);
         assertThat(edge.right()).isEqualTo(y);
 
-        var reordered = EliminateCrossJoin.reorder(joinGraph, List.of(b, a));
+        var reordered = EliminateCrossJoin.rebuild(joinGraph, List.of(b, a));
         assertThat(reordered).hasOperators(
             "Join[INNER | (x = y)]",
             "  ├ Collect[doc.b | [y] | true]",
@@ -167,7 +168,7 @@ public class EliminateCrossJoinTest extends CrateDummyClusterServiceUnitTest {
             new JoinGraph.Edge(c, y, z)
         );
 
-        var reordered = EliminateCrossJoin.reorder(joinGraph, List.of(c, b, a));
+        var reordered = EliminateCrossJoin.rebuild(joinGraph, List.of(c, b, a));
         assertThat(reordered).hasOperators(
             "Join[INNER | (x = y)]",
             "  ├ Join[INNER | (y = z)]",
@@ -176,7 +177,7 @@ public class EliminateCrossJoinTest extends CrateDummyClusterServiceUnitTest {
             "  └ Collect[doc.a | [x] | true]"
         );
 
-        var orderWithCrossJoin = EliminateCrossJoin.reorder(joinGraph, List.of(a, c, b));
+        var orderWithCrossJoin = EliminateCrossJoin.rebuild(joinGraph, List.of(a, c, b));
         assertThat(orderWithCrossJoin).hasOperators(
             "Join[INNER | ((x = y) AND (y = z))]",
             "  ├ Join[CROSS]",
@@ -209,7 +210,7 @@ public class EliminateCrossJoinTest extends CrateDummyClusterServiceUnitTest {
 
         JoinGraph joinGraph = JoinGraph.create(topJoin, UnaryOperator.identity());
 
-        assertThat(EliminateCrossJoin.reorder(joinGraph, List.of(a, c, b, d))).isEqualTo(
+        assertThat(EliminateCrossJoin.rebuild(joinGraph, List.of(a, c, b, d))).isEqualTo(
             "Join[INNER | (y = w)]\n" +
             "  ├ Join[INNER | (x = y)]\n" +
             "  │  ├ Join[INNER | (x = z)]\n" +
@@ -239,7 +240,7 @@ public class EliminateCrossJoinTest extends CrateDummyClusterServiceUnitTest {
 
         JoinGraph joinGraph = JoinGraph.create(filter, UnaryOperator.identity());
 
-        assertThat(EliminateCrossJoin.reorder(joinGraph, List.of(c, b, a))).hasOperators(
+        assertThat(EliminateCrossJoin.rebuild(joinGraph, List.of(c, b, a))).hasOperators(
             "Filter[(x > 1)]",
             "  └ Join[INNER | (x = y)]",
             "    ├ Join[INNER | (y = z)]",
@@ -252,7 +253,7 @@ public class EliminateCrossJoinTest extends CrateDummyClusterServiceUnitTest {
 
         joinGraph = JoinGraph.create(secondFilter, UnaryOperator.identity());
 
-        assertThat(EliminateCrossJoin.reorder(joinGraph, List.of(c, b, a))).hasOperators(
+        assertThat(EliminateCrossJoin.rebuild(joinGraph, List.of(c, b, a))).hasOperators(
             "Filter[(y < 10)]",
             "  └ Filter[(x > 1)]",
             "    └ Join[INNER | (x = y)]",
@@ -279,7 +280,7 @@ public class EliminateCrossJoinTest extends CrateDummyClusterServiceUnitTest {
         var joinGraph = JoinGraph.create(join, UnaryOperator.identity());
         var originalOrder = joinGraph.nodes();
         assertThat(originalOrder).isEqualTo(List.of(a, b, c));
-        var newOrder = EliminateCrossJoin.eliminateCrossJoin(joinGraph);
+        var newOrder = EliminateCrossJoin.orderNodes(joinGraph);
         assertThat(newOrder).isEqualTo(List.of(a, c, b));
 
         var rule = new EliminateCrossJoin();
@@ -316,7 +317,7 @@ public class EliminateCrossJoinTest extends CrateDummyClusterServiceUnitTest {
         );
 
         var joinGraph = JoinGraph.create(join, UnaryOperator.identity());
-        var newOrder = EliminateCrossJoin.eliminateCrossJoin(joinGraph);
+        var newOrder = EliminateCrossJoin.orderNodes(joinGraph);
         var originalOrder = joinGraph.nodes();
         assertThat(originalOrder).isEqualTo(newOrder);
 
@@ -339,6 +340,7 @@ public class EliminateCrossJoinTest extends CrateDummyClusterServiceUnitTest {
         );
     }
 
+    @Test
     public void test_do_not_reorder_with_outer_joins() throws Exception {
         var firstJoin = new JoinPlan(a, b, JoinType.CROSS, null);
         Symbol joinCondition = e.asSymbol("c.z = a.x AND c.z = b.y");
@@ -358,7 +360,7 @@ public class EliminateCrossJoinTest extends CrateDummyClusterServiceUnitTest {
         assertThat(match.isPresent()).isTrue();
         assertThat(match.value()).isEqualTo(join);
 
-        var result = rule.apply(match.value(),
+        LogicalPlan result = rule.apply(match.value(),
             match.captures(),
             e.ruleContext());
 
@@ -476,7 +478,7 @@ public class EliminateCrossJoinTest extends CrateDummyClusterServiceUnitTest {
         JoinGraph joinGraph = JoinGraph.create(join, UnaryOperator.identity());
         assertThat(joinGraph.nodes()).containsExactly(order, b, c);
 
-        var reordered = EliminateCrossJoin.reorder(joinGraph, List.of(c, b, order));
+        var reordered = EliminateCrossJoin.rebuild(joinGraph, List.of(c, b, order));
         assertThat(reordered).hasOperators(
             "Join[INNER | (x = y)]",
             "  ├ Join[INNER | (y = z)]",
@@ -506,7 +508,7 @@ public class EliminateCrossJoinTest extends CrateDummyClusterServiceUnitTest {
         JoinGraph joinGraph = JoinGraph.create(secondJoin, UnaryOperator.identity());
         assertThat(joinGraph.nodes()).containsExactly(union, c, d);
 
-        var reordered = EliminateCrossJoin.reorder(joinGraph, List.of(union, d, c));
+        var reordered = EliminateCrossJoin.rebuild(joinGraph, List.of(union, d, c));
         assertThat(reordered).hasOperators(
             "Join[INNER | (y = z)]",
             "  ├ Join[INNER | (x = w)]",
@@ -538,7 +540,7 @@ public class EliminateCrossJoinTest extends CrateDummyClusterServiceUnitTest {
         assertThat(joinGraph.filters()).hasSize(1);
         assertThat(joinGraph.filters().getFirst()).isEqualTo(e.asSymbol("a.x > 1"));
 
-        var reordered = EliminateCrossJoin.reorder(joinGraph, List.of(b, a));
+        var reordered = EliminateCrossJoin.rebuild(joinGraph, List.of(b, a));
         assertThat(reordered).hasOperators(
             "Filter[(x > 1)]",
             "  └ Join[INNER | (x = y)]",


### PR DESCRIPTION
It always looked up the last two entries, which are equal to doing a
`context.get` lookup directly.
