### PR TITLE
Preserve publisher index names when restoring subscription partitions

### DIFF
--- a/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -427,9 +427,17 @@ public class RestoreService implements ClusterStateApplier {
 
                 for (RestoreIndex restoreIndex : restoreRelation.restoreIndices()) {
                     String sourceIndexName = restoreIndex.index().name();
-                    String targetIndexName = restoreIndex.partitionValues().isEmpty()
-                        ? targetName.indexNameOrAlias()
-                        : new PartitionName(targetName, restoreIndex.partitionValues()).asIndexName();
+                    String targetIndexName;
+                    if (restoreIndex.partitionValues().isEmpty()) {
+                        targetIndexName = targetName.indexNameOrAlias();
+                    } else if (targetName.equals(relationName)) {
+                        targetIndexName = sourceIndexName;
+                    } else {
+                        targetIndexName = new PartitionName(
+                            targetName,
+                            restoreIndex.partitionValues()
+                        ).asIndexName();
+                    }
 
                     ensureNotPartial(targetIndexName);
                     SnapshotRecoverySource recoverySource = new SnapshotRecoverySource(

--- a/server/src/test/java/io/crate/integrationtests/LogicalReplicationITest.java
+++ b/server/src/test/java/io/crate/integrationtests/LogicalReplicationITest.java
@@ -448,6 +448,20 @@ public class LogicalReplicationITest extends LogicalReplicationITestCase {
             "1| 1",
             "2| 2"
         );
+
+        executeOnPublisher("INSERT INTO doc.t1 (id) VALUES (3)");
+        assertBusy(() -> {
+            executeOnSubscriber("REFRESH TABLE doc.t1");
+            var res = executeOnSubscriber("SELECT id FROM doc.t1 ORDER BY id");
+            assertThat(res).hasRows("1", "2", "3");
+        });
+
+        executeOnPublisher("INSERT INTO doc.t1 (id) VALUES (4)");
+        assertBusy(() -> {
+            executeOnSubscriber("REFRESH TABLE doc.t1");
+            var res = executeOnSubscriber("SELECT id FROM doc.t1 ORDER BY id");
+            assertThat(res).hasRows("1", "2", "3", "4");
+        });
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Follows https://github.com/crate/crate/pull/19726. Starting with that PR, index names for partitions use the `INDEX_NAME_PREFIX + UUID` format.

During logical replication, the publisher creates table partitions using the new index name format, but the subscriber restores the replicated table partitions using the old format (`.partitioned.*`):
https://github.com/crate/crate/blob/0b81bb788fd4b0849105de69d139c3cac0f55b60/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java#L430-L432

As a result, the following error occurs during replication tracking:
```
[2026-09-10T14:10:25,100][WARN ][i.c.r.l.ShardReplicationChangesTracker] [[cratedb[subscriberd3][netty-worker][T#1]]] Exception renewing retention lease. Stopping tracking (closed=false)
org.elasticsearch.index.seqno.RetentionLeaseNotFoundException: retention lease with ID [logical_replication:subscribing_cluster:[.partitioned.t1.0400][0]] not found
	at org.elasticsearch.index.seqno.ReplicationTracker.renewRetentionLease(ReplicationTracker.java:390)
	at org.elasticsearch.index.shard.IndexShard.renewRetentionLease(IndexShard.java:2081)
	at org.elasticsearch.index.seqno.RetentionLeaseActions$Renew$TransportAction.doRetentionLeaseAction(RetentionLeaseActions.java:188)
	at org.elasticsearch.index.seqno.RetentionLeaseActions$Renew$TransportAction.doRetentionLeaseAction(RetentionLeaseActions.java:166)
	at org.elasticsearch.index.seqno.RetentionLeaseActions$TransportRetentionLeaseAction.lambda$asyncShardOperation$0(RetentionLeaseActions.java:92)
	at org.elasticsearch.action.ActionListener.lambda$withOnResponse$0(ActionListener.java:114)
	at org.elasticsearch.action.ActionListener$SimpleListener.onResponse(ActionListener.java:96)
	at org.elasticsearch.index.shard.IndexShard.lambda$wrapPrimaryOperationPermitListener$0(IndexShard.java:2618)
	at org.elasticsearch.action.ActionListener.lambda$withOnResponse$0(ActionListener.java:114)
	at org.elasticsearch.action.ActionListener$SimpleListener.onResponse(ActionListener.java:96)
	at org.elasticsearch.index.shard.IndexShardOperationPermits.acquire(IndexShardOperationPermits.java:293)
	at org.elasticsearch.index.shard.IndexShardOperationPermits.acquire(IndexShardOperationPermits.java:246)
	at org.elasticsearch.index.shard.IndexShard.acquirePrimaryOperationPermit(IndexShard.java:2594)
	at org.elasticsearch.index.shard.IndexShard.acquirePrimaryOperationPermit(IndexShard.java:2586)
	at org.elasticsearch.index.seqno.RetentionLeaseActions$TransportRetentionLeaseAction.asyncShardOperation(RetentionLeaseActions.java:89)
	at org.elasticsearch.index.seqno.RetentionLeaseActions$TransportRetentionLeaseAction.asyncShardOperation(RetentionLeaseActions.java:57)
	at org.elasticsearch.action.support.single.shard.TransportSingleShardAction$ShardTransportHandler.messageReceived(TransportSingleShardAction.java:299)
	at org.elasticsearch.action.support.single.shard.TransportSingleShardAction$ShardTransportHandler.messageReceived(TransportSingleShardAction.java:292)
	at org.elasticsearch.transport.RequestHandlerRegistry.processMessageReceived(RequestHandlerRegistry.java:59)
	at org.elasticsearch.transport.InboundHandler.handleRequest(InboundHandler.java:211)
	at org.elasticsearch.transport.InboundHandler.messageReceived(InboundHandler.java:108)
	at org.elasticsearch.transport.InboundHandler.inboundMessage(InboundHandler.java:97)
	at org.elasticsearch.transport.TcpTransport.inboundMessage(TcpTransport.java:681)
	at org.elasticsearch.transport.InboundPipeline.forwardFragments(InboundPipeline.java:133)
	at org.elasticsearch.transport.InboundPipeline.doHandleBytes(InboundPipeline.java:108)
	at org.elasticsearch.transport.InboundPipeline.handleBytes(InboundPipeline.java:73)
	at org.elasticsearch.transport.netty4.Netty4MessageChannelHandler.channelRead(Netty4MessageChannelHandler.java:71)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:355)
	at io.netty.handler.logging.LoggingHandler.channelRead(LoggingHandler.java:280)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:355)
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1429)
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:918)
	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:176)
	at io.netty.channel.nio.AbstractNioChannel$AbstractNioUnsafe.handle(AbstractNioChannel.java:445)
	at io.netty.channel.nio.NioIoHandler$DefaultNioRegistration.handle(NioIoHandler.java:388)
	at io.netty.channel.nio.NioIoHandler.processSelectedKey(NioIoHandler.java:596)
	at io.netty.channel.nio.NioIoHandler.processSelectedKeysOptimized(NioIoHandler.java:571)
	at io.netty.channel.nio.NioIoHandler.processSelectedKeys(NioIoHandler.java:512)
	at io.netty.channel.nio.NioIoHandler.run(NioIoHandler.java:484)
	at io.netty.channel.SingleThreadIoEventLoop.runIo(SingleThreadIoEventLoop.java:225)
	at io.netty.channel.SingleThreadIoEventLoop.run(SingleThreadIoEventLoop.java:196)
	at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:1204)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at java.lang.Thread.run(Thread.java:1516)
```

This happens because the publisher adds a retention lease using the index name in the new format, while the subscriber tries to renew the retention lease using the old format.

The approach to fix is to re-use the source index names when the source relation name is equal to the target relation name(when no rename occurs during the restore).

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes.
       If you're an external contributor you can give yourself attribution and include your name and Github handle.
       e.g.:
       ```
       `John Doe <https://github.com/John_Doe>`_ added support for ...
       ```
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
