### PR TITLE
Ensure that closed state is visible in assertion; add WARN logging

### DIFF
--- a/libs/dex/src/main/java/io/crate/data/breaker/BlockBasedRamAccounting.java
+++ b/libs/dex/src/main/java/io/crate/data/breaker/BlockBasedRamAccounting.java
@@ -23,11 +23,16 @@ package io.crate.data.breaker;
 
 import java.util.function.LongConsumer;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 /**
  * A RamAccounting implementation that reserves blocks of memory up-front.
  * This implementation should be used from a single thread only.
  */
 public final class BlockBasedRamAccounting implements RamAccounting {
+
+    private static final Logger LOGGER = LogManager.getLogger(BlockBasedRamAccounting.class);
 
     public static final int MAX_BLOCK_SIZE_IN_BYTES = 2 * 1024 * 1024;
 
@@ -68,7 +73,11 @@ public final class BlockBasedRamAccounting implements RamAccounting {
 
     @Override
     public void addBytes(long bytes) {
-        assert !closed : "Cannot account bytes if BlockBasedRamAccounting instance was closed";
+        if (closed == true) {
+            LOGGER.warn("BlockBasedRamAccounting added bytes after instance was closed");
+            assert false : "Cannot account bytes if BlockBasedRamAccounting instance was closed";
+        }
+
         usedBytes += bytes;
         if ((reservedBytes - usedBytes) < 0) {
             long reserveBytes = bytes > blockSizeInBytes ? bytes : blockSizeInBytes;

--- a/server/src/main/java/io/crate/breaker/ConcurrentRamAccounting.java
+++ b/server/src/main/java/io/crate/breaker/ConcurrentRamAccounting.java
@@ -25,6 +25,8 @@ import java.util.Locale;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.LongConsumer;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.unit.ByteSizeValue;
@@ -39,13 +41,15 @@ import io.crate.data.breaker.RamAccounting;
 @ThreadSafe
 public final class ConcurrentRamAccounting implements RamAccounting {
 
+    private static final Logger LOGGER = LogManager.getLogger(ConcurrentRamAccounting.class);
+
     private final AtomicLong usedBytes = new AtomicLong(0L);
     private final LongConsumer reserveBytes;
     private final LongConsumer releaseBytes;
     private final String label;
     private final int operationMemoryLimit;
 
-    private boolean closed = false;
+    private volatile boolean closed = false;
 
     public static ConcurrentRamAccounting forCircuitBreaker(String label, CircuitBreaker circuitBreaker, int operationMemoryLimit) {
         return new ConcurrentRamAccounting(
@@ -71,7 +75,12 @@ public final class ConcurrentRamAccounting implements RamAccounting {
         if (bytes == 0) {
             return;
         }
-        assert !closed : "Cannot account bytes if ConcurrentRamAccounting instance was closed";
+        boolean localClose = closed; // 1 volatile read.
+        if (localClose == true) {
+            LOGGER.warn("ConcurrentRamAccounting with label {} added bytes after instance was closed", label);
+            assert false : "Cannot account bytes if ConcurrentRamAccounting instance was closed";
+        }
+
         long currentUsedBytes = usedBytes.addAndGet(bytes);
         if (operationMemoryLimit > 0 && currentUsedBytes > operationMemoryLimit) {
             usedBytes.addAndGet(- bytes);


### PR DESCRIPTION
Also, add WARN logging to catch such issues on prod.

Follow up to https://github.com/crate/crate/pull/18771/

`BlockBasedRamAccounting` doesn't need volatile as it's only used in a single thread


